### PR TITLE
chore: sync lockfile with package version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ycode",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ycode",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary

Sync package-lock.json with the version bump to 0.2.0 in package.json.
The lockfile was not updated when the version was bumped in commit 92a8de7.

## Changes

- Update version in package-lock.json from 0.1.0 to 0.2.0

## Test plan

- [ ] Verify `npm ci` completes without errors

Made with [Cursor](https://cursor.com)