### PR TITLE
fix: enable CMS content editing and fix inline variable badges

### DIFF
--- a/app/ycode/components/ExpandableRichTextEditor.tsx
+++ b/app/ycode/components/ExpandableRichTextEditor.tsx
@@ -1,16 +1,10 @@
 'use client';
 
 /**
- * Compact rich-text editor with an "Richtext editor" button that opens
- * a RichTextEditorSheet for full-featured editing.
+ * Compact rich-text editor for inline content editing.
  */
 
-import { useMemo, useState } from 'react';
-import { Button } from '@/components/ui/button';
-import Icon from '@/components/ui/icon';
 import RichTextEditor from './RichTextEditor';
-import RichTextEditorSheet from './RichTextEditorSheet';
-import { hasLinkOrComponent } from '@/lib/tiptap-utils';
 import type { CollectionField, Collection } from '@/types';
 import type { FieldGroup } from '@/lib/collection-field-utils';
 
@@ -35,60 +29,23 @@ export default function ExpandableRichTextEditor({
   onChange,
   onBlur,
   placeholder = 'Enter value...',
-  sheetTitle,
-  sheetDescription,
   fieldGroups,
   allFields,
   collections,
   disabled = false,
 }: ExpandableRichTextEditorProps) {
-  const [sheetOpen, setSheetOpen] = useState(false);
-  const isComplex = useMemo(() => hasLinkOrComponent(value), [value]);
-
   return (
-    <div className="flex flex-col gap-1.5">
-      <Button
-        type="button"
-        size="sm"
-        variant="secondary"
-        className="w-full gap-2.5"
-        onClick={() => setSheetOpen(true)}
-        disabled={disabled}
-      >
-        Richtext editor
-        <span><Icon name="expand" className="size-2.5" /></span>
-      </Button>
-
-      {!isComplex && (
-        <RichTextEditor
-          value={value}
-          onChange={onChange}
-          onBlur={onBlur}
-          placeholder={placeholder}
-          fieldGroups={fieldGroups}
-          allFields={allFields}
-          collections={collections}
-          withFormatting={true}
-          showFormattingToolbar={false}
-          disabled={disabled}
-        />
-      )}
-
-      <RichTextEditorSheet
-        open={sheetOpen}
-        onOpenChange={(open) => {
-          setSheetOpen(open);
-          if (!open) onBlur?.(value);
-        }}
-        title={sheetTitle}
-        description={sheetDescription}
-        value={value}
-        onChange={onChange}
-        placeholder={placeholder}
-        fieldGroups={fieldGroups}
-        allFields={allFields}
-        collections={collections}
-      />
-    </div>
+    <RichTextEditor
+      value={value}
+      onChange={onChange}
+      onBlur={onBlur}
+      placeholder={placeholder}
+      fieldGroups={fieldGroups}
+      allFields={allFields}
+      collections={collections}
+      withFormatting={true}
+      showFormattingToolbar={false}
+      disabled={disabled}
+    />
   );
 }

--- a/app/ycode/components/RichTextEditor.tsx
+++ b/app/ycode/components/RichTextEditor.tsx
@@ -156,10 +156,23 @@ const DynamicVariableWithNodeView = DynamicVariable.extend({
       const updateListener = () => renderBadge();
       editor.on('update', updateListener);
 
+      // Re-render badge when editability changes (setEditable doesn't fire 'update')
+      let lastEditable = editor.isEditable;
+      const transactionListener = () => {
+        if (editor.isEditable !== lastEditable) {
+          lastEditable = editor.isEditable;
+          renderBadge();
+        }
+      };
+      editor.on('transaction', transactionListener);
+
       return {
         dom: container,
+        // Let React handle events inside the badge (prevents ProseMirror from swallowing clicks on the "x" button)
+        stopEvent: () => true,
         destroy: () => {
           editor.off('update', updateListener);
+          editor.off('transaction', transactionListener);
           setTimeout(() => root.unmount(), 0);
         },
       };
@@ -223,6 +236,16 @@ const RichTextComponentWithNodeView = RichTextComponent.extend({
 
       queueMicrotask(renderBlock);
 
+      // Re-render block when editability changes (setEditable doesn't fire 'update')
+      let lastEditable = editor.isEditable;
+      const transactionListener = () => {
+        if (editor.isEditable !== lastEditable) {
+          lastEditable = editor.isEditable;
+          renderBlock();
+        }
+      };
+      editor.on('transaction', transactionListener);
+
       return {
         dom: container,
         stopEvent: () => true,
@@ -239,6 +262,7 @@ const RichTextComponentWithNodeView = RichTextComponent.extend({
           return true;
         },
         destroy: () => {
+          editor.off('transaction', transactionListener);
           setTimeout(() => root.unmount(), 0);
         },
       };
@@ -397,6 +421,7 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
 
   const editor = useEditor({
     immediatelyRender: true,
+    editable: !disabled,
     extensions,
     content: (() => {
       if (withFormatting) {

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1632,6 +1632,23 @@ const LayerItem: React.FC<{
         if (isLockedByOther) return;
         e.stopPropagation();
 
+        // Dynamic/CMS pages: open CollectionItemSheet to edit the CMS item
+        const editorState = useEditorStore.getState();
+        const itemId = editorState.currentPageCollectionItemId;
+        if (itemId) {
+          const currentPageId = editorState.currentPageId;
+          const page = currentPageId
+            ? usePagesStore.getState().pages.find(p => p.id === currentPageId)
+            : null;
+          if (page?.is_dynamic) {
+            const collectionId = page.settings?.cms?.collection_id;
+            if (collectionId) {
+              editorState.openCollectionItemSheet(collectionId, itemId);
+              return;
+            }
+          }
+        }
+
         // Image layers: open file manager for quick image replacement
         if (layer.name === 'image' || htmlTag === 'img') {
           openImageFileManager();


### PR DESCRIPTION
## Summary

Fix inability to edit or remove CMS variable bindings in the sidebar Content editor, and add double-click to open the CMS item editor on dynamic pages.

## Changes

- Open CollectionItemSheet on double-click for any element on a dynamic/CMS page, prioritizing CMS item editing over other double-click behaviors
- Fix DynamicVariable badge "x" button not rendering when editor editability changes after initial mount (setEditable doesn't fire Tiptap's 'update' event, so node views were stuck with stale UI)
- Add `stopEvent: () => true` to DynamicVariable node view so ProseMirror doesn't intercept clicks on the React "x" button inside the badge
- Set `editable: !disabled` in the useEditor config for correct initial state, avoiding timing issues between editor creation and the useEffect
- Apply the same editability tracking fix to RichTextComponent node views
- Simplify ExpandableRichTextEditor by removing the redundant "Richtext editor" sheet button

## Test plan

- [ ] On a dynamic/CMS page, select a text element with a CMS field variable in its Content — verify the badge shows an "x" button
- [ ] Click the "x" button on the badge — verify the CMS binding is removed and the field becomes an empty editable text input
- [ ] Use Cmd+A then Delete inside the Content editor to remove the badge via keyboard
- [ ] Double-click any element on a dynamic page — verify the CollectionItemSheet opens
- [ ] On a regular (non-dynamic) page, verify Content editing still works normally
- [ ] Verify inline variable badges work correctly in the CMS rich text editor (full variant)

Made with [Cursor](https://cursor.com)