### PR TITLE
feat: add inverse reference support to collections

### DIFF
--- a/app/ycode/components/Canvas.tsx
+++ b/app/ycode/components/Canvas.tsx
@@ -108,6 +108,7 @@ interface CanvasContentProps {
   selectedLayerId: string | null;
   hoveredLayerId: string | null;
   pageId: string;
+  pageCollectionItemId?: string;
   pageCollectionItemData: Record<string, string> | null;
   onLayerClick: (layerId: string, event?: React.MouseEvent) => void;
   onLayerUpdate?: (layerId: string, updates: Partial<Layer>) => void;
@@ -125,6 +126,7 @@ function CanvasContent({
   selectedLayerId,
   hoveredLayerId,
   pageId,
+  pageCollectionItemId,
   pageCollectionItemData,
   onLayerClick,
   onLayerUpdate,
@@ -209,6 +211,7 @@ function CanvasContent({
         onLayerUpdate={onLayerUpdate}
         onLayerHover={onLayerHover}
         pageId={pageId}
+        pageCollectionItemId={pageCollectionItemId}
         pageCollectionItemData={pageCollectionItemData}
         liveLayerUpdates={liveLayerUpdates}
         liveComponentUpdates={liveComponentUpdates}
@@ -426,6 +429,7 @@ export default function Canvas({
         selectedLayerId={selectedLayerId}
         hoveredLayerId={effectiveHoveredLayerId}
         pageId={pageId}
+        pageCollectionItemId={pageCollectionItem?.id}
         pageCollectionItemData={pageCollectionItem?.values || null}
         onLayerClick={handleLayerClick}
         onLayerUpdate={onLayerUpdate}

--- a/app/ycode/components/RightSidebar.tsx
+++ b/app/ycode/components/RightSidebar.tsx
@@ -91,6 +91,7 @@ import { createTextComponentVariableValue } from '@/lib/variable-utils';
 import { getRichTextValue } from '@/lib/tiptap-utils';
 import { DEFAULT_TEXT_STYLES, getTextStyle } from '@/lib/text-format-utils';
 import { buildFieldGroupsForLayer, getFieldIcon, isMultipleAssetField, MULTI_ASSET_COLLECTION_ID } from '@/lib/collection-field-utils';
+import { getInverseReferenceFields } from '@/lib/collection-utils';
 
 // 7. Types
 import type { Layer, FieldVariable, CollectionField, CollectionVariable, ComponentVariable } from '@/types';
@@ -909,14 +910,14 @@ const RightSidebar = React.memo(function RightSidebar({
     });
   }, [selectedLayerId, selectedLayer, handleLayerUpdate]);
 
-  // Handle reference field selection (for reference, multi-reference, or multi-asset as collection source)
+  // Handle reference field selection (for reference, multi-reference, inverse, or multi-asset as collection source)
   // Also resets child bindings when source changes
-  const handleReferenceFieldChange = (fieldId: string) => {
+  const handleReferenceFieldChange = (value: string) => {
     if (!selectedLayerId || !selectedLayer) return;
 
     const currentCollectionVariable = getCollectionVariable(selectedLayer);
 
-    if (fieldId === 'none') {
+    if (value === 'none') {
       // Clear the collection source
       handleLayerUpdate(selectedLayerId, {
         variables: {
@@ -924,9 +925,24 @@ const RightSidebar = React.memo(function RightSidebar({
           collection: { id: '', source_field_id: undefined, source_field_type: undefined, source_field_source: undefined }
         }
       });
+    } else if (value.startsWith('inverse:')) {
+      // Inverse reference: "inverse:{fieldId}:{collectionId}"
+      const [, fieldId, collectionId] = value.split(':');
+      handleLayerUpdate(selectedLayerId, {
+        variables: {
+          ...selectedLayer?.variables,
+          collection: {
+            ...currentCollectionVariable,
+            id: collectionId,
+            source_field_id: fieldId,
+            source_field_type: 'inverse_reference',
+            source_field_source: undefined,
+          }
+        }
+      });
     } else {
       // Find the selected field to get its reference_collection_id and type
-      const selectedField = parentCollectionFields.find(f => f.id === fieldId);
+      const selectedField = parentCollectionFields.find(f => f.id === value);
 
       if (selectedField && isMultipleAssetField(selectedField)) {
         handleLayerUpdate(selectedLayerId, {
@@ -935,7 +951,7 @@ const RightSidebar = React.memo(function RightSidebar({
             collection: {
               ...currentCollectionVariable,
               id: MULTI_ASSET_COLLECTION_ID,
-              source_field_id: fieldId,
+              source_field_id: value,
               source_field_type: 'multi_asset',
               source_field_source: 'collection',
             }
@@ -948,7 +964,7 @@ const RightSidebar = React.memo(function RightSidebar({
             collection: {
               ...currentCollectionVariable,
               id: selectedField.reference_collection_id,
-              source_field_id: fieldId,
+              source_field_id: value,
               source_field_type: selectedField.type as 'reference' | 'multi_reference',
               source_field_source: undefined,
             }
@@ -1014,6 +1030,16 @@ const RightSidebar = React.memo(function RightSidebar({
           source_field_source: undefined,
         };
       }
+    } else if (value.startsWith('inverse:')) {
+      // Inverse reference: "inverse:{fieldId}:{collectionId}"
+      const [, fieldId, collectionId] = value.split(':');
+      newCollectionVar = {
+        ...currentCollectionVariable,
+        id: collectionId,
+        source_field_id: fieldId,
+        source_field_type: 'inverse_reference',
+        source_field_source: undefined,
+      };
     } else if (value.startsWith('collection:')) {
       const collectionId = value.replace('collection:', '');
       newCollectionVar = {
@@ -1067,6 +1093,9 @@ const RightSidebar = React.memo(function RightSidebar({
     if (collectionVariable.source_field_id) {
       if (collectionVariable.source_field_type === 'multi_asset') {
         return `multi_asset:${collectionVariable.source_field_id}`;
+      }
+      if (collectionVariable.source_field_type === 'inverse_reference') {
+        return `inverse:${collectionVariable.source_field_id}:${collectionVariable.id}`;
       }
       return `field:${collectionVariable.source_field_id}`;
     }
@@ -1621,6 +1650,28 @@ const RightSidebar = React.memo(function RightSidebar({
     return collectionFields.filter(f => isMultipleAssetField(f));
   }, [currentPage, fields]);
 
+  // Inverse reference fields: fields in OTHER collections that reference the parent collection
+  // E.g., if parent is "Authors" and "Books" has a reference field "author" → Authors,
+  // show "Books (via author)" as a connected relation source option
+  const parentInverseReferenceFields = useMemo(() => {
+    const collectionVariable = parentCollectionLayer ? getCollectionVariable(parentCollectionLayer) : null;
+    let collectionId = collectionVariable?.id;
+    if (collectionId === MULTI_ASSET_COLLECTION_ID) collectionId = undefined;
+    if (!collectionId && currentPage?.is_dynamic) {
+      collectionId = currentPage.settings?.cms?.collection_id || undefined;
+    }
+    if (!collectionId) return [];
+    return getInverseReferenceFields(collectionId, fields, collections);
+  }, [parentCollectionLayer, fields, collections, currentPage]);
+
+  // Inverse reference fields for dynamic page context (top-level collection layers on dynamic pages)
+  const dynamicPageInverseReferenceFields = useMemo(() => {
+    if (!currentPage?.is_dynamic) return [];
+    const collectionId = currentPage.settings?.cms?.collection_id;
+    if (!collectionId) return [];
+    return getInverseReferenceFields(collectionId, fields, collections);
+  }, [currentPage, fields, collections]);
+
   // Handle adding custom attribute
   const handleAddAttribute = () => {
     if (selectedLayerId && newAttributeName.trim()) {
@@ -2127,10 +2178,17 @@ const RightSidebar = React.memo(function RightSidebar({
                   <div className="grid grid-cols-3">
                     <Label variant="muted">Source</Label>
                     <div className="col-span-2 *:w-full">
-                      {/* When inside a parent collection, show reference fields and multi-asset fields as source options */}
+                      {/* When inside a parent collection, show reference fields, multi-asset fields, and inverse reference fields as source options */}
                       {parentCollectionLayer ? (
                         <Select
-                          value={getCollectionVariable(selectedLayer)?.source_field_id || 'none'}
+                          value={(() => {
+                            const cv = getCollectionVariable(selectedLayer);
+                            if (!cv?.source_field_id) return 'none';
+                            if (cv.source_field_type === 'inverse_reference') {
+                              return `inverse:${cv.source_field_id}:${cv.id}`;
+                            }
+                            return cv.source_field_id;
+                          })()}
                           onValueChange={handleReferenceFieldChange}
                         >
                           <SelectTrigger>
@@ -2166,6 +2224,22 @@ const RightSidebar = React.memo(function RightSidebar({
                                     <span className="flex items-center gap-2">
                                       <Icon name={getFieldIcon(field.type)} className="size-3 text-muted-foreground shrink-0" />
                                       {field.name}
+                                    </span>
+                                  </SelectItem>
+                                ))}
+                              </SelectGroup>
+                            )}
+                            {parentInverseReferenceFields.length > 0 && (
+                              <SelectGroup>
+                                <SelectLabel>Connected relations</SelectLabel>
+                                {parentInverseReferenceFields.map(({ field, collection }) => (
+                                  <SelectItem
+                                    key={`inverse-${field.id}`}
+                                    value={`inverse:${field.id}:${field.collection_id}`}
+                                  >
+                                    <span className="flex items-center gap-2">
+                                      <Icon name="database" className="size-3 text-muted-foreground shrink-0" />
+                                      {collection.name} (via {field.name})
                                     </span>
                                   </SelectItem>
                                 ))}
@@ -2212,6 +2286,22 @@ const RightSidebar = React.memo(function RightSidebar({
                                     <span className="flex items-center gap-2">
                                       <Icon name={getFieldIcon(field.type)} className="size-3 text-muted-foreground shrink-0" />
                                       {field.name}
+                                    </span>
+                                  </SelectItem>
+                                ))}
+                              </SelectGroup>
+                            )}
+                            {dynamicPageInverseReferenceFields.length > 0 && (
+                              <SelectGroup>
+                                <SelectLabel>Connected relations</SelectLabel>
+                                {dynamicPageInverseReferenceFields.map(({ field, collection }) => (
+                                  <SelectItem
+                                    key={`inverse-${field.id}`}
+                                    value={`inverse:${field.id}:${field.collection_id}`}
+                                  >
+                                    <span className="flex items-center gap-2">
+                                      <Icon name="database" className="size-3 text-muted-foreground shrink-0" />
+                                      {collection.name} (via {field.name})
                                     </span>
                                   </SelectItem>
                                 ))}

--- a/app/ycode/preview/error.tsx
+++ b/app/ycode/preview/error.tsx
@@ -64,6 +64,7 @@ export default function Error({ error, reset }: ErrorProps) {
             layers={errorPageData.pageLayers.layers || []}
             isEditMode={false}
             isPublished={false}
+            pageCollectionItemId={errorPageData.collectionItem?.id}
             pageCollectionItemData={errorPageData.collectionItem?.values || undefined}
           />
         </div>

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1099,6 +1099,19 @@ const LayerItem: React.FC<{
           values: virtualValues,
         };
       });
+    } else if (sourceFieldType === 'inverse_reference' && sourceFieldId) {
+      // Inverse reference: filter items whose reference field value matches the parent item ID
+      const parentId = collectionLayerItemId || pageCollectionItemId;
+      if (!parentId) return [];
+      items = allCollectionItems.filter(item => {
+        const fieldValue = item.values[sourceFieldId];
+        if (!fieldValue) return false;
+        // Single reference: exact match
+        if (fieldValue === parentId) return true;
+        // Multi-reference: check if JSON array contains the parent ID
+        const ids = parseMultiReferenceValue(fieldValue);
+        return ids.includes(parentId);
+      });
     } else if (!sourceFieldId) {
       items = allCollectionItems;
     } else {
@@ -1146,7 +1159,7 @@ const LayerItem: React.FC<{
     }
 
     return items;
-  }, [allCollectionItems, sourceFieldId, sourceFieldType, sourceFieldSource, collectionLayerData, pageCollectionItemData, getAsset, collectionVariable?.filters]);
+  }, [allCollectionItems, sourceFieldId, sourceFieldType, sourceFieldSource, collectionLayerData, pageCollectionItemData, collectionLayerItemId, pageCollectionItemId, getAsset, collectionVariable?.filters]);
 
   useEffect(() => {
     if (!isEditMode) return;

--- a/lib/collection-utils.ts
+++ b/lib/collection-utils.ts
@@ -225,6 +225,45 @@ export function isValidCollectionName(collectionName: string): boolean {
 }
 
 /**
+ * Inverse reference field descriptor for UI and data resolution
+ */
+export interface InverseReferenceField {
+  field: import('@/types').CollectionField;
+  collection: import('@/types').Collection;
+}
+
+/**
+ * Find fields in other collections that reference a given collection (inverse references).
+ * E.g., if "Books" has a reference field "author" pointing to "Authors",
+ * calling this with the Authors collection ID returns the "author" field from Books.
+ */
+export function getInverseReferenceFields(
+  targetCollectionId: string,
+  allFields: Record<string, import('@/types').CollectionField[]>,
+  allCollections: import('@/types').Collection[]
+): InverseReferenceField[] {
+  const result: InverseReferenceField[] = [];
+  const collectionsMap = new Map(allCollections.map(c => [c.id, c]));
+
+  for (const [collectionId, fields] of Object.entries(allFields)) {
+    if (collectionId === targetCollectionId) continue;
+    const collection = collectionsMap.get(collectionId);
+    if (!collection) continue;
+
+    for (const field of fields) {
+      if (
+        (field.type === 'reference' || field.type === 'multi_reference') &&
+        field.reference_collection_id === targetCollectionId
+      ) {
+        result.push({ field, collection });
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
  * Resolve reference fields synchronously using pre-loaded store data
  * Adds resolved relationship paths (e.g., "refFieldId.targetFieldId") to item values
  * @param itemValues - The item's field values

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -1,7 +1,7 @@
 import { cache } from 'react';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { buildSlugPath, buildDynamicPageUrl, buildLocalizedSlugPath, buildLocalizedDynamicPageUrl, detectLocaleFromPath, matchPageWithTranslatedSlugs, matchDynamicPageWithTranslatedSlugs } from '@/lib/page-utils';
-import { getItemWithValues, getItemsWithValues } from '@/lib/repositories/collectionItemRepository';
+import { getItemWithValues, getItemsWithValues, getItemIdsByFieldValue } from '@/lib/repositories/collectionItemRepository';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import type { Page, PageFolder, PageLayers, Component, ComponentVariable, CollectionItemWithValues, CollectionField, Layer, CollectionPaginationMeta, Translation, Locale } from '@/types';
 import { getCollectionVariable, resolveFieldValue, evaluateVisibility, getLayerHtmlTag, filterDisabledSliderLayers } from '@/lib/layer-utils';
@@ -448,8 +448,9 @@ export const fetchPageByPath = cache(async function fetchPageByPath(
             // Then resolve collection layers (nested collections will handle their own injection)
             // The isPublished parameter controls which collection items to fetch
             // Pass enhanced values so nested collections can filter based on dynamic page data
+            // Pass collectionItem.id so inverse reference layers can query by parent item
             let resolvedLayers = layersWithInjectedData.length > 0
-              ? await resolveCollectionLayers(layersWithInjectedData, isPublished, enhancedItemValues, paginationContext, translations)
+              ? await resolveCollectionLayers(layersWithInjectedData, isPublished, enhancedItemValues, paginationContext, translations, collectionItem.id)
               : [];
 
             // Resolve collections inside rich text embedded components
@@ -1528,7 +1529,8 @@ export async function resolveCollectionLayers(
   isPublished: boolean,
   parentItemValues?: Record<string, string>,
   paginationContext?: PaginationContext,
-  translations?: Record<string, Translation>
+  translations?: Record<string, Translation>,
+  parentCollectionItemId?: string
 ): Promise<Layer[]> {
   // Fetch timezone setting for date formatting
   const timezone = (await getSettingByKey('timezone') as string | null) || 'UTC';
@@ -1536,7 +1538,8 @@ export async function resolveCollectionLayers(
   const resolveLayer = async (
     layer: Layer,
     itemValues?: Record<string, string>,
-    parentLayerDataMap?: Record<string, Record<string, string>>
+    parentLayerDataMap?: Record<string, Record<string, string>>,
+    parentItemId?: string
   ): Promise<Layer> => {
     // Merge parent's layer data map with layer's own map
     const layerDataMap = { ...parentLayerDataMap, ...(layer._layerDataMap || {}) };
@@ -1666,7 +1669,16 @@ export async function resolveCollectionLayers(
           // For reference/multi-reference fields, get allowed item IDs BEFORE fetching
           // This ensures pagination counts and offsets are correct for the filtered set
           let allowedItemIds: string[] | undefined;
-          if (sourceFieldId && itemValues) {
+          if (sourceFieldType === 'inverse_reference' && sourceFieldId && parentItemId) {
+            // Inverse reference: find items in this collection where the reference field
+            // points back to the parent item (the field is on THIS collection, not the parent)
+            allowedItemIds = await getItemIdsByFieldValue(
+              collectionVariable.id,
+              sourceFieldId,
+              parentItemId,
+              isPublished
+            );
+          } else if (sourceFieldId && itemValues) {
             const refValue = itemValues[sourceFieldId];
             if (refValue) {
               if (sourceFieldType === 'reference') {
@@ -1776,8 +1788,9 @@ export async function resolveCollectionLayers(
 
               // Resolve children for THIS specific item's values
               // This ensures nested collection layers filter based on this item's reference fields
+              // Pass item.id so inverse reference children can query by parent item ID
               const resolvedChildren = layer.children?.length
-                ? await Promise.all(layer.children.map(child => resolveLayer(child, enhancedValues, updatedLayerDataMap)))
+                ? await Promise.all(layer.children.map(child => resolveLayer(child, enhancedValues, updatedLayerDataMap, item.id)))
                 : [];
 
               // Then inject field data into the resolved children
@@ -1878,7 +1891,7 @@ export async function resolveCollectionLayers(
           console.error(`Failed to resolve collection layer ${layer.id}:`, error);
           return {
             ...layer,
-            children: layer.children ? await Promise.all(layer.children.map(child => resolveLayer(child, itemValues, layerDataMap))) : undefined,
+            children: layer.children ? await Promise.all(layer.children.map(child => resolveLayer(child, itemValues, layerDataMap, parentItemId))) : undefined,
           };
         }
       }
@@ -1949,14 +1962,14 @@ export async function resolveCollectionLayers(
     if (layer.children) {
       return {
         ...layer,
-        children: await Promise.all(layer.children.map(child => resolveLayer(child, itemValues, layerDataMap))),
+        children: await Promise.all(layer.children.map(child => resolveLayer(child, itemValues, layerDataMap, parentItemId))),
       };
     }
 
     return layer;
   };
 
-  const result = await Promise.all(layers.map(layer => resolveLayer(layer, parentItemValues, undefined)));
+  const result = await Promise.all(layers.map(layer => resolveLayer(layer, parentItemValues, undefined, parentCollectionItemId)));
 
   // Collect pagination metadata from all fragments
   const paginationMetaMap: Record<string, CollectionPaginationMeta> = {};
@@ -2396,7 +2409,8 @@ export async function renderCollectionItemsToHtml(
         isPublished,
         item.values, // Parent item values for multi-reference filtering
         undefined, // No pagination context for Load More rendering
-        undefined // TODO: Add translation support for Load More pagination
+        undefined, // TODO: Add translation support for Load More pagination
+        item.id // Parent item ID for inverse reference resolution
       );
 
       // Resolve all AssetVariables to URLs server-side

--- a/lib/repositories/collectionItemRepository.ts
+++ b/lib/repositories/collectionItemRepository.ts
@@ -483,6 +483,60 @@ export async function getItemWithValues(id: string, is_published: boolean = fals
 }
 
 /**
+ * Find item IDs in a collection where a specific field value matches a target value.
+ * Used for inverse reference resolution: given a parent item ID, find all items
+ * in the child collection whose reference field points to that parent.
+ * Handles both single reference (exact match) and multi_reference (JSON array contains).
+ */
+export async function getItemIdsByFieldValue(
+  collectionId: string,
+  fieldId: string,
+  targetValue: string,
+  isPublished: boolean = false
+): Promise<string[]> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    throw new Error('Supabase client not configured');
+  }
+
+  // Find item IDs where the field value matches (single reference = exact, multi_reference = contains)
+  // For single reference: value = targetValue (exact match)
+  // For multi_reference: value is a JSON string like '["uuid1","uuid2"]' containing targetValue
+  // We query for both patterns using OR with LIKE for JSON array containment
+  const { data, error } = await client
+    .from('collection_item_values')
+    .select('item_id')
+    .eq('field_id', fieldId)
+    .eq('is_published', isPublished)
+    .is('deleted_at', null)
+    .or(`value.eq.${targetValue},value.like.%"${targetValue}"%`);
+
+  if (error) {
+    throw new Error(`Failed to query inverse references: ${error.message}`);
+  }
+
+  if (!data || data.length === 0) return [];
+
+  // Get unique item IDs that also belong to the target collection and are not deleted
+  const candidateIds = [...new Set(data.map(v => v.item_id))];
+
+  const { data: validItems, error: itemError } = await client
+    .from('collection_items')
+    .select('id')
+    .eq('collection_id', collectionId)
+    .eq('is_published', isPublished)
+    .is('deleted_at', null)
+    .in('id', candidateIds);
+
+  if (itemError) {
+    throw new Error(`Failed to validate inverse reference items: ${itemError.message}`);
+  }
+
+  return validItems?.map(i => i.id) || [];
+}
+
+/**
  * Get multiple items with their values
  * @param collection_id - Collection UUID
  * @param is_published - Filter for draft (false) or published (true) items and values. Defaults to false (draft).

--- a/types/index.ts
+++ b/types/index.ts
@@ -1161,8 +1161,8 @@ export interface CollectionVariable {
   sort_order_inputLayerId?: string; // Linked filter input controlling sort_order at runtime
   limit?: number; // Maximum number of items to show (deprecated when pagination enabled)
   offset?: number; // Number of items to skip (deprecated when pagination enabled)
-  source_field_id?: string; // Field ID from parent item (reference or multi-asset field)
-  source_field_type?: 'reference' | 'multi_reference' | 'multi_asset'; // Type of source field
+  source_field_id?: string; // Field ID from parent item (reference or multi-asset field), or field ID on child collection (inverse_reference)
+  source_field_type?: 'reference' | 'multi_reference' | 'multi_asset' | 'inverse_reference'; // Type of source field
   source_field_source?: 'page' | 'collection'; // Source of the field (page data or collection layer)
   filters?: ConditionalVisibility; // Filter conditions to apply to collection items
   pagination?: CollectionPaginationConfig; // Pagination settings for collection


### PR DESCRIPTION
## Summary

Add support for inverse (connected) reference collections, allowing a
collection layer to display items from a child collection that reference
the current parent item. For example, an Authors dynamic page can now
show all Books whose "author" field points to the current author.

## Changes

- Add `inverse_reference` as a `source_field_type` in `CollectionVariable`
- Add `getItemIdsByFieldValue` repository function for SSR inverse queries
- Add `getInverseReferenceFields` utility to discover fields referencing a target collection
- Handle inverse reference resolution in SSR (`page-fetcher.ts`)
- Handle inverse reference filtering in client-side rendering (`LayerRenderer.tsx`)
- Add "Connected relations" group to collection source picker in RightSidebar
- Thread `pageCollectionItemId` through Canvas to LayerRenderer for edit-mode support

## Test plan

- [x] Create two collections (e.g., Authors and Books) where Books has a reference field to Authors
- [x] Create a dynamic page for Authors, add a collection layer, select "Books (via author)" from Connected relations
- [x] Verify items display correctly in the canvas editor
- [x] Verify items display correctly on the published page
- [x] Test with both single reference and multi-reference field types
- [x] Verify inverse references work when nested inside another collection layer