### PR TITLE
fix: inject custom head code into document head

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -226,18 +226,6 @@ async function fetchCachedErrorPage(errorCode: 401 | 404) {
   }
 }
 
-async function fetchCachedPublishedCss() {
-  try {
-    return await unstable_cache(
-      async () => getSettingByKey('published_css'),
-      ['data-for-published-css'],
-      { tags: ['all-pages'], revalidate: false }
-    )();
-  } catch {
-    return null;
-  }
-}
-
 interface PageProps {
   params: Promise<{ slug: string | string[] }>;
 }
@@ -267,20 +255,23 @@ export default async function Page({ params }: PageProps) {
   // Cache-first slug path; pagination is served through internal dynamic routes.
   const data = await fetchPublishedPageWithLayers(slugPath);
 
+  // Load all global settings early so error pages also get global custom code
+  const globalSettings = await fetchCachedGlobalSettings();
+
   // If page not found, try to show custom 404 error page
   if (!data) {
     const errorPageData = await fetchCachedErrorPage(404);
 
     if (errorPageData) {
-      const { page, pageLayers, components } = errorPageData;
-      const publishedCSS = await fetchCachedPublishedCss();
+      const { page: errorPage, pageLayers: errorPageLayers, components: errorComponents } = errorPageData;
 
       return (
         <PageRenderer
-          page={page}
-          layers={pageLayers.layers || []}
-          components={components}
-          generatedCss={publishedCSS}
+          page={errorPage}
+          layers={errorPageLayers.layers || []}
+          components={errorComponents}
+          generatedCss={globalSettings.publishedCss || undefined}
+          globalCustomCodeBody={globalSettings.globalCustomCodeBody}
         />
       );
     }
@@ -304,24 +295,24 @@ export default async function Page({ params }: PageProps) {
     // If page is protected and not unlocked, show 401 error page
     if (!protection.isUnlocked) {
       const errorPageData = await fetchCachedErrorPage(401);
-      const publishedCSS = await fetchCachedPublishedCss();
 
       if (errorPageData) {
         const { page: errorPage, pageLayers: errorPageLayers, components: errorComponents } = errorPageData;
 
         return (
-        <PageRenderer
-          page={errorPage}
-          layers={errorPageLayers.layers || []}
-          components={errorComponents}
-          generatedCss={publishedCSS}
-          passwordProtection={{
-            pageId: protection.protectedBy === 'page' ? protection.protectedById : undefined,
-            folderId: protection.protectedBy === 'folder' ? protection.protectedById : undefined,
-            redirectUrl: currentPath,
-            isPublished: true,
-          }}
-        />
+          <PageRenderer
+            page={errorPage}
+            layers={errorPageLayers.layers || []}
+            components={errorComponents}
+            generatedCss={globalSettings.publishedCss || undefined}
+            globalCustomCodeBody={globalSettings.globalCustomCodeBody}
+            passwordProtection={{
+              pageId: protection.protectedBy === 'page' ? protection.protectedById : undefined,
+              folderId: protection.protectedBy === 'folder' ? protection.protectedById : undefined,
+              redirectUrl: currentPath,
+              isPublished: true,
+            }}
+          />
         );
       }
 
@@ -344,9 +335,6 @@ export default async function Page({ params }: PageProps) {
     }
   }
 
-  // Load all global settings in a single query
-  const globalSettings = await fetchCachedGlobalSettings();
-
   return (
     <PageRenderer
       page={page}
@@ -359,7 +347,6 @@ export default async function Page({ params }: PageProps) {
       availableLocales={availableLocales}
       translations={translations}
       gaMeasurementId={globalSettings.gaMeasurementId}
-      globalCustomCodeHead={globalSettings.globalCustomCodeHead}
       globalCustomCodeBody={globalSettings.globalCustomCodeBody}
       ycodeBadge={globalSettings.ycodeBadge}
     />

--- a/app/_dynamic/[...slug]/page.tsx
+++ b/app/_dynamic/[...slug]/page.tsx
@@ -140,7 +140,6 @@ export default async function DynamicSlugPage({ params, searchParams }: DynamicS
       availableLocales={availableLocales}
       translations={translations}
       gaMeasurementId={globalSettings.gaMeasurementId}
-      globalCustomCodeHead={globalSettings.globalCustomCodeHead}
       globalCustomCodeBody={globalSettings.globalCustomCodeBody}
       ycodeBadge={globalSettings.ycodeBadge}
     />

--- a/app/_dynamic/page.tsx
+++ b/app/_dynamic/page.tsx
@@ -117,7 +117,6 @@ export default async function DynamicHome({ searchParams }: DynamicHomeProps) {
       availableLocales={data.availableLocales}
       translations={data.translations}
       gaMeasurementId={globalSettings.gaMeasurementId}
-      globalCustomCodeHead={globalSettings.globalCustomCodeHead}
       globalCustomCodeBody={globalSettings.globalCustomCodeBody}
       ycodeBadge={globalSettings.ycodeBadge}
     />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
+import { unstable_cache } from 'next/cache';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import DarkModeProvider from '@/components/DarkModeProvider';
+import { getSettingsByKeys } from '@/lib/repositories/settingsRepository';
+import { parseHeadHtml, getPageHeadElements } from '@/lib/parse-head-html';
+import { fetchPageByPath, fetchHomepage } from '@/lib/page-fetcher';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -14,15 +19,82 @@ export const metadata: Metadata = {
   description: 'Self-hosted visual website builder',
 };
 
-export default function RootLayout({
+async function fetchCachedCustomHeadCode(): Promise<string | null> {
+  try {
+    return await unstable_cache(
+      async () => {
+        const settings = await getSettingsByKeys(['custom_code_head']);
+        return (settings.custom_code_head as string) || null;
+      },
+      ['data-for-global-custom-head-code'],
+      { tags: ['all-pages'], revalidate: false }
+    )();
+  } catch {
+    return null;
+  }
+}
+
+const PREVIEW_PREFIX = '/ycode/preview/';
+const NON_PAGE_PREFIXES = ['/ycode', '/_next', '/api'];
+
+/** Check if the current route is a public page or preview (not editor, API, etc.) */
+function isPageRoute(pathname: string): boolean {
+  if (pathname.startsWith(PREVIEW_PREFIX)) return true;
+  return !NON_PAGE_PREFIXES.some(p => pathname.startsWith(p));
+}
+
+/**
+ * Fetch page-specific custom head code for the current route.
+ * Uses the same cached fetchers as page components (React cache deduplicates).
+ */
+async function fetchPageCustomHeadCode(pathname: string): Promise<React.ReactNode[] | null> {
+  try {
+    const isPreview = pathname.startsWith(PREVIEW_PREFIX);
+    const isPublished = !isPreview;
+
+    // Determine slug path
+    let slugPath: string;
+    if (isPreview) {
+      slugPath = pathname.slice(PREVIEW_PREFIX.length);
+      if (slugPath.startsWith('error-pages/')) return null;
+    } else {
+      slugPath = pathname.replace(/^\//, '');
+    }
+
+    // Fetch page data (React cache() deduplicates with the page component's call)
+    if (slugPath === '') {
+      const data = await fetchHomepage(isPublished);
+      if (!data) return null;
+      return getPageHeadElements(data.page);
+    }
+
+    const data = await fetchPageByPath(slugPath, isPublished);
+    if (!data) return null;
+    return getPageHeadElements(data.page, data.collectionItem, data.collectionFields);
+  } catch {
+    return null;
+  }
+}
+
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Dark mode is handled client-side by DarkModeProvider
-  // This avoids using headers() which would force all pages to be dynamic
+  const headersList = await headers();
+  const pathname = headersList.get('x-pathname') || '/';
+  const shouldInjectHeadCode = isPageRoute(pathname);
+
+  const [customHeadCode, pageHeadElements] = shouldInjectHeadCode
+    ? await Promise.all([fetchCachedCustomHeadCode(), fetchPageCustomHeadCode(pathname)])
+    : [null, null];
+
   return (
     <html lang="en">
+      <head>
+        {customHeadCode && parseHeadHtml(customHeadCode)}
+        {pageHeadElements}
+      </head>
       <body className={`${inter.variable} font-sans antialiased text-xs`} suppressHydrationWarning>
         <DarkModeProvider>
           {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,6 @@ import PageRenderer from '@/components/PageRenderer';
 import PasswordForm from '@/components/PasswordForm';
 import { generatePageMetadata, fetchGlobalPageSettings } from '@/lib/generate-page-metadata';
 import { parseAuthCookie, getPasswordProtection, fetchFoldersForAuth } from '@/lib/page-auth';
-import { getSettingByKey } from '@/lib/repositories/settingsRepository';
 import type { Metadata } from 'next';
 
 // Static by default for performance, dynamic only when pagination is requested
@@ -82,18 +81,6 @@ async function fetchCachedErrorPage(errorCode: 401) {
   }
 }
 
-async function fetchCachedPublishedCss() {
-  try {
-    return await unstable_cache(
-      async () => getSettingByKey('published_css'),
-      ['data-for-published-css'],
-      { tags: ['all-pages'], revalidate: false }
-    )();
-  } catch {
-    return null;
-  }
-}
-
 export default async function Home() {
   // Cache-first homepage path; pagination is served through internal dynamic routes.
   const data = await fetchPublishedHomepage();
@@ -117,6 +104,9 @@ export default async function Home() {
     );
   }
 
+  // Load all global settings early so error pages also get global custom code
+  const globalSettings = await fetchCachedGlobalSettings();
+
   // Check password protection for homepage.
   // First evaluate without cookies() so non-protected pages can stay cacheable.
   const folders = await fetchCachedFoldersForAuth();
@@ -130,24 +120,24 @@ export default async function Home() {
     // If homepage is protected and not unlocked, show 401 error page
     if (!protection.isUnlocked) {
       const errorPageData = await fetchCachedErrorPage(401);
-      const publishedCSS = await fetchCachedPublishedCss();
 
       if (errorPageData) {
         const { page: errorPage, pageLayers: errorPageLayers, components: errorComponents } = errorPageData;
 
         return (
-        <PageRenderer
-          page={errorPage}
-          layers={errorPageLayers.layers || []}
-          components={errorComponents}
-          generatedCss={publishedCSS}
-          passwordProtection={{
-            pageId: protection.protectedBy === 'page' ? protection.protectedById : undefined,
-            folderId: protection.protectedBy === 'folder' ? protection.protectedById : undefined,
-            redirectUrl: '/',
-            isPublished: true,
-          }}
-        />
+          <PageRenderer
+            page={errorPage}
+            layers={errorPageLayers.layers || []}
+            components={errorComponents}
+            generatedCss={globalSettings.publishedCss || undefined}
+            globalCustomCodeBody={globalSettings.globalCustomCodeBody}
+            passwordProtection={{
+              pageId: protection.protectedBy === 'page' ? protection.protectedById : undefined,
+              folderId: protection.protectedBy === 'folder' ? protection.protectedById : undefined,
+              redirectUrl: '/',
+              isPublished: true,
+            }}
+          />
         );
       }
 
@@ -170,9 +160,6 @@ export default async function Home() {
     }
   }
 
-  // Load all global settings in a single query
-  const globalSettings = await fetchCachedGlobalSettings();
-
   // Render homepage
   return (
     <PageRenderer
@@ -184,7 +171,6 @@ export default async function Home() {
       availableLocales={data.availableLocales}
       translations={data.translations}
       gaMeasurementId={globalSettings.gaMeasurementId}
-      globalCustomCodeHead={globalSettings.globalCustomCodeHead}
       globalCustomCodeBody={globalSettings.globalCustomCodeBody}
       ycodeBadge={globalSettings.ycodeBadge}
     />

--- a/app/ycode/preview/[...slug]/page.tsx
+++ b/app/ycode/preview/[...slug]/page.tsx
@@ -3,9 +3,15 @@ import type { Metadata } from 'next';
 import { fetchPageByPath, fetchErrorPage } from '@/lib/page-fetcher';
 import PageRenderer from '@/components/PageRenderer';
 import PasswordForm from '@/components/PasswordForm';
-import { getSettingByKey } from '@/lib/repositories/settingsRepository';
+import { getSettingsByKeys } from '@/lib/repositories/settingsRepository';
+
 import { generatePageMetadata } from '@/lib/generate-page-metadata';
 import { parseAuthCookie, getPasswordProtection, fetchFoldersForAuth } from '@/lib/page-auth';
+
+async function fetchPreviewDraftCss() {
+  const settings = await getSettingsByKeys(['draft_css']);
+  return (settings.draft_css as string) || undefined;
+}
 
 // Force dynamic rendering - no caching for preview
 export const dynamic = 'force-dynamic';
@@ -21,13 +27,15 @@ export default async function Page({ params }: { params: Promise<{ slug: string 
   // Fetch draft page and layers data (no caching)
   const data = await fetchPageByPath(slugPath, false);
 
+  // Fetch draft CSS (global custom code is handled by the preview layout)
+  const draftCSS = await fetchPreviewDraftCss();
+
   // If page not found, try to show custom 404 error page
   if (!data) {
     const errorPageData = await fetchErrorPage(404, false);
 
     if (errorPageData) {
       const { page, pageLayers, components } = errorPageData;
-      const draftCSS = await getSettingByKey('draft_css');
 
       return (
         <PageRenderer
@@ -54,7 +62,6 @@ export default async function Page({ params }: { params: Promise<{ slug: string 
   // If page is protected and not unlocked, show 401 error page
   if (protection.isProtected && !protection.isUnlocked) {
     const errorPageData = await fetchErrorPage(401, false);
-    const draftCSS = await getSettingByKey('draft_css');
 
     if (errorPageData) {
       const { page: errorPage, pageLayers: errorPageLayers, components: errorComponents } = errorPageData;
@@ -93,9 +100,6 @@ export default async function Page({ params }: { params: Promise<{ slug: string 
       </div>
     );
   }
-
-  // Load draft CSS from settings
-  const draftCSS = await getSettingByKey('draft_css');
 
   // Render the preview page (draft version)
   return (

--- a/app/ycode/preview/error-pages/[code]/page.tsx
+++ b/app/ycode/preview/error-pages/[code]/page.tsx
@@ -1,8 +1,13 @@
 import PageRenderer from '@/components/PageRenderer';
 import { fetchErrorPage } from '@/lib/page-fetcher';
-import { getSettingByKey } from '@/lib/repositories/settingsRepository';
+import { getSettingsByKeys } from '@/lib/repositories/settingsRepository';
 import { generatePageMetadata } from '@/lib/generate-page-metadata';
 import type { Metadata } from 'next';
+
+async function fetchPreviewDraftCss() {
+  const settings = await getSettingsByKeys(['draft_css']);
+  return (settings.draft_css as string) || undefined;
+}
 
 interface ErrorPagePreviewProps {
   params: Promise<{ code: string }>;
@@ -36,15 +41,15 @@ export default async function ErrorPagePreview({ params }: ErrorPagePreviewProps
 
   const { page, pageLayers, components, locale, availableLocales, translations } = pageData;
 
-  // Get the draft CSS
-  const generatedCss = await getSettingByKey('draft_css');
+  // Fetch draft CSS (global custom code is handled by the preview layout)
+  const draftCSS = await fetchPreviewDraftCss();
 
   return (
     <PageRenderer
       page={page}
       layers={pageLayers.layers || []}
       components={components}
-      generatedCss={generatedCss}
+      generatedCss={draftCSS}
       locale={locale}
       availableLocales={availableLocales}
       isPreview={true}

--- a/app/ycode/preview/layout.tsx
+++ b/app/ycode/preview/layout.tsx
@@ -1,0 +1,23 @@
+import { getSettingsByKeys } from '@/lib/repositories/settingsRepository';
+
+/**
+ * Preview layout — injects global custom body code.
+ * Global head code is handled by the root layout for all routes.
+ */
+export default async function PreviewLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const settings = await getSettingsByKeys(['custom_code_body']);
+  const globalCustomCodeBody = settings.custom_code_body as string | null;
+
+  return (
+    <>
+      {children}
+      {globalCustomCodeBody && (
+        <div dangerouslySetInnerHTML={{ __html: globalCustomCodeBody }} />
+      )}
+    </>
+  );
+}

--- a/app/ycode/preview/page.tsx
+++ b/app/ycode/preview/page.tsx
@@ -2,10 +2,15 @@ import Link from 'next/link';
 import { fetchHomepage, fetchErrorPage } from '@/lib/page-fetcher';
 import PageRenderer from '@/components/PageRenderer';
 import PasswordForm from '@/components/PasswordForm';
-import { getSettingByKey } from '@/lib/repositories/settingsRepository';
+import { getSettingsByKeys } from '@/lib/repositories/settingsRepository';
 import { generatePageMetadata } from '@/lib/generate-page-metadata';
 import { parseAuthCookie, getPasswordProtection, fetchFoldersForAuth } from '@/lib/page-auth';
 import type { Metadata } from 'next';
+
+async function fetchPreviewDraftCss() {
+  const settings = await getSettingsByKeys(['draft_css']);
+  return (settings.draft_css as string) || undefined;
+}
 
 // Force dynamic rendering - no caching for preview
 export const dynamic = 'force-dynamic';
@@ -37,6 +42,9 @@ export default async function Home() {
     );
   }
 
+  // Fetch draft CSS (global custom code is handled by the preview layout)
+  const draftCSS = await fetchPreviewDraftCss();
+
   // Check password protection for homepage (using all folders for preview)
   const folders = await fetchFoldersForAuth(false);
   const authCookie = await parseAuthCookie();
@@ -45,7 +53,6 @@ export default async function Home() {
   // If homepage is protected and not unlocked, show 401 error page
   if (protection.isProtected && !protection.isUnlocked) {
     const errorPageData = await fetchErrorPage(401, false);
-    const draftCSS = await getSettingByKey('draft_css');
 
     if (errorPageData) {
       const { page: errorPage, pageLayers: errorPageLayers, components: errorComponents } = errorPageData;
@@ -81,9 +88,6 @@ export default async function Home() {
       </div>
     );
   }
-
-  // Load draft CSS from settings
-  const draftCSS = await getSettingByKey('draft_css');
 
   // Render homepage preview
   return (

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -53,7 +53,6 @@ interface PageRendererProps {
   isPreview?: boolean; // Whether we're in preview mode (use draft data)
   translations?: Record<string, any> | null; // Translations for localized URL generation
   gaMeasurementId?: string | null; // Google Analytics Measurement ID (pre-fetched)
-  globalCustomCodeHead?: string | null; // Global custom code for <head> (pre-fetched)
   globalCustomCodeBody?: string | null; // Global custom code for </body> (pre-fetched)
   ycodeBadge?: boolean; // Whether to show the "Made in Ycode" badge
   passwordProtection?: PasswordProtectionContext; // For 401 error pages - inject password form
@@ -92,7 +91,6 @@ export default async function PageRenderer({
   isPreview = false,
   translations,
   gaMeasurementId,
-  globalCustomCodeHead,
   globalCustomCodeBody,
   ycodeBadge = true,
   passwordProtection,
@@ -194,12 +192,7 @@ export default async function PageRenderer({
   }
 
   // Extract custom code from page settings and resolve placeholders for dynamic pages
-  const rawPageCustomCodeHead = page.settings?.custom_code?.head || '';
   const rawPageCustomCodeBody = page.settings?.custom_code?.body || '';
-
-  const pageCustomCodeHead = page.is_dynamic && collectionItem
-    ? resolveCustomCodePlaceholders(rawPageCustomCodeHead, collectionItem, collectionFields)
-    : rawPageCustomCodeHead;
 
   const pageCustomCodeBody = page.is_dynamic && collectionItem
     ? resolveCustomCodePlaceholders(rawPageCustomCodeBody, collectionItem, collectionFields)
@@ -313,16 +306,6 @@ export default async function PageRenderer({
             }}
           />
         </>
-      )}
-
-      {/* Inject global custom head code (applies to all pages) */}
-      {globalCustomCodeHead && (
-        <div dangerouslySetInnerHTML={{ __html: globalCustomCodeHead }} />
-      )}
-
-      {/* Inject page-specific custom head code */}
-      {pageCustomCodeHead && (
-        <div dangerouslySetInnerHTML={{ __html: pageCustomCodeHead }} />
       )}
 
       {/* Apply body layer classes to <body> synchronously before paint */}

--- a/lib/parse-head-html.ts
+++ b/lib/parse-head-html.ts
@@ -1,0 +1,103 @@
+import React from 'react';
+import { resolveCustomCodePlaceholders } from '@/lib/resolve-cms-variables';
+import type { Page, CollectionItemWithValues, CollectionField } from '@/types';
+
+const VOID_TAGS = new Set(['meta', 'link', 'base']);
+
+const HTML_TO_REACT_ATTRS: Record<string, string> = {
+  'class': 'className',
+  'for': 'htmlFor',
+  'crossorigin': 'crossOrigin',
+  'charset': 'charSet',
+  'http-equiv': 'httpEquiv',
+  'tabindex': 'tabIndex',
+  'nomodule': 'noModule',
+  'referrerpolicy': 'referrerPolicy',
+  'fetchpriority': 'fetchPriority',
+};
+
+const BOOLEAN_ATTRS = new Set([
+  'async', 'defer', 'disabled', 'hidden', 'nomodule',
+  'readonly', 'required', 'reversed', 'scoped',
+]);
+
+function parseAttributes(attrString: string): Record<string, unknown> {
+  const attrs: Record<string, unknown> = {};
+  const regex = /([\w-]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+)))?/g;
+  let match;
+  while ((match = regex.exec(attrString)) !== null) {
+    const rawName = match[1];
+    const value = match[2] ?? match[3] ?? match[4];
+    const reactName = HTML_TO_REACT_ATTRS[rawName.toLowerCase()] || rawName;
+
+    if (BOOLEAN_ATTRS.has(rawName.toLowerCase())) {
+      attrs[reactName] = true;
+    } else {
+      attrs[reactName] = value ?? '';
+    }
+  }
+  return attrs;
+}
+
+/** Parse an HTML string of head elements into individual React elements. */
+export function parseHeadHtml(html: string): React.ReactNode[] {
+  const elements: React.ReactNode[] = [];
+
+  // Matches void tags (meta/link/base) and paired tags (style/script/title/noscript).
+  // Void tag attrs use (?:[^>"']|"[^"]*"|'[^']*')* to handle `>` inside quoted values.
+  const regex =
+    /<(meta|link|base)(\s(?:[^>"']|"[^"]*"|'[^']*')*)?\s*\/?>|<(style|script|title|noscript)(\s[^>]*)?>[\s\S]*?<\/\3\s*>/gi;
+
+  let match;
+  let key = 0;
+
+  while ((match = regex.exec(html)) !== null) {
+    const voidTag = match[1]?.toLowerCase();
+    const voidAttrStr = match[2] || '';
+    const pairedTag = match[3]?.toLowerCase();
+    const pairedAttrStr = match[4] || '';
+
+    if (voidTag) {
+      const attrs = parseAttributes(voidAttrStr.trim());
+      elements.push(React.createElement(voidTag, { key: key++, ...attrs }));
+    } else if (pairedTag) {
+      const attrs = parseAttributes(pairedAttrStr.trim());
+      const full = match[0];
+      const innerMatch = full.match(
+        new RegExp(`<${pairedTag}[^>]*>([\\s\\S]*)<\\/${pairedTag}\\s*>`, 'i'),
+      );
+      const inner = innerMatch ? innerMatch[1] : '';
+
+      if (pairedTag === 'title') {
+        elements.push(React.createElement('title', { key: key++ }, inner));
+      } else {
+        elements.push(
+          React.createElement(pairedTag, {
+            key: key++,
+            ...attrs,
+            dangerouslySetInnerHTML: { __html: inner },
+          }),
+        );
+      }
+    }
+  }
+
+  return elements;
+}
+
+/** Resolve page-specific custom head code with CMS variable substitution. */
+export function getPageHeadElements(
+  page: Page,
+  collectionItem?: CollectionItemWithValues,
+  collectionFields?: CollectionField[],
+): React.ReactNode[] | null {
+  const raw = page.settings?.custom_code?.head || '';
+  if (!raw) return null;
+
+  const resolved = page.is_dynamic && collectionItem
+    ? resolveCustomCodePlaceholders(raw, collectionItem, collectionFields || [])
+    : raw;
+
+  if (!resolved) return null;
+  return parseHeadHtml(resolved);
+}


### PR DESCRIPTION
## Summary

Move global and page-specific custom head code injection from body-level rendering into the root layout's `<head>` element, so scripts, meta tags, and JSON-LD structured data appear in the document head during SSR.

## Changes

- Add `lib/parse-head-html.ts` to parse raw HTML into React elements with proper attribute mapping, boolean handling, and safe regex for quoted `>`
- Update root layout to read `x-pathname` from proxy headers and fetch both global and page-specific custom head code, rendering them in `<head>`
- Skip head code injection on non-page routes (`/ycode/*`, `/api/*`, etc.)
- Remove `globalCustomCodeHead` prop and page head code rendering from `PageRenderer` (body code remains unchanged)
- Remove page-specific head element rendering from all 7 page components
- Add `app/ycode/preview/layout.tsx` for global custom body code on preview routes
- Consolidate preview page CSS fetching into `fetchPreviewDraftCss`

## Test plan

- [ ] Add global custom head code in settings — verify it appears in `<head>` via View Source on published and preview pages
- [ ] Add page-specific custom head code (e.g. JSON-LD) — verify it appears in `<head>` via View Source
- [ ] Verify head code does NOT appear on `/ycode/` editor routes
- [ ] Test a dynamic CMS page with `{{placeholder}}` variables in page head code, verify placeholders are resolved
- [ ] Verify global and page body custom code still renders correctly
- [ ] Check no hydration errors in browser console