### PR TITLE
fix: resolve multi-asset image URLs on canvas

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1159,7 +1159,7 @@ const LayerItem: React.FC<{
     }
 
     return items;
-  }, [allCollectionItems, sourceFieldId, sourceFieldType, sourceFieldSource, collectionLayerData, pageCollectionItemData, collectionLayerItemId, pageCollectionItemId, getAsset, collectionVariable?.filters]);
+  }, [allCollectionItems, sourceFieldId, sourceFieldType, sourceFieldSource, collectionLayerData, pageCollectionItemData, collectionLayerItemId, pageCollectionItemId, getAsset, assetsById, collectionVariable?.filters]);
 
   useEffect(() => {
     if (!isEditMode) return;
@@ -2468,7 +2468,11 @@ const LayerItem: React.FC<{
                     collectionItemId={item.id}
                     layerDataMap={updatedLayerDataMap}
                     pageCollectionItemId={pageCollectionItemId}
-                    pageCollectionItemData={pageCollectionItemData}
+                    pageCollectionItemData={
+                      sourceFieldType === 'multi_asset' && sourceFieldSource === 'page'
+                        ? { ...pageCollectionItemData, ...enhancedItemValues }
+                        : pageCollectionItemData
+                    }
                     hiddenLayerInfo={hiddenLayerInfo}
                     editorHiddenLayerIds={editorHiddenLayerIds}
                     editorBreakpoint={editorBreakpoint}


### PR DESCRIPTION
## Summary

Fix multi-asset image fields (multiple=true) not rendering on the canvas
while working correctly in preview. Closes #25

## Changes

- Add `assetsById` to the `collectionItems` useMemo dependency array so
  it recomputes when assets finish loading from the store
- Merge multi-asset virtual values into `pageCollectionItemData` when
  `sourceFieldSource` is `page`, so child field variables with
  `source: "page"` can resolve virtual fields like `__asset_url`

## Root cause

Two issues prevented canvas rendering:

1. The `collectionItems` memo called `getAsset(id)` which returns `null`
   before the asset store loads, but never recomputed after loading
   because `assetsById` wasn't in the dependency array.

2. The image variable has `source: "page"`, causing
   `resolveFieldFromSources` to only check `pageCollectionItemData`.
   But multi-asset virtual values (`__asset_url`) were only placed in
   `collectionItemData`. In SSR this doesn't matter because
   `injectCollectionData` pre-resolves field variables to asset
   variables before rendering.

## Test plan

- [ ] Create a collection with an image field set to allow multiple
- [ ] Create a dynamic CMS page using that collection
- [ ] Add a record with multiple images uploaded
- [ ] Add a collection for the multi-asset images field
- [ ] Add an image layer inside the repeater bound to the image URL
- [ ] Verify images render on the canvas (editor iframe)
- [ ] Verify images still render in preview mode
- [ ] Verify single-image fields still work correctly