### PR TITLE
feat: reset native form element appearance for custom styling

### DIFF
--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -271,6 +271,12 @@ export default async function PageRenderer({
       {/* Inject page-specific custom head code */}
       {pageCustomCodeHead && renderHeadCode(pageCustomCodeHead, 'page-head')}
 
+      {/* Strip native browser appearance from form elements so Tailwind classes apply */}
+      <style
+        id="ycode-form-reset"
+        dangerouslySetInnerHTML={{ __html: 'input,select,textarea{appearance:none;-webkit-appearance:none}input[type="checkbox"]:checked,input[type="radio"]:checked{background-color:currentColor;border-color:transparent;background-size:100% 100%;background-position:center;background-repeat:no-repeat}input[type="checkbox"]:checked{background-image:url("data:image/svg+xml,%3csvg viewBox=\'0 0 16 16\' fill=\'white\' xmlns=\'http://www.w3.org/2000/svg\'%3e%3cpath d=\'M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z\'/%3e%3c/svg%3e")}input[type="radio"]:checked{background-image:url("data:image/svg+xml,%3csvg viewBox=\'0 0 16 16\' fill=\'white\' xmlns=\'http://www.w3.org/2000/svg\'%3e%3ccircle cx=\'8\' cy=\'8\' r=\'3\'/%3e%3c/svg%3e")}' }}
+      />
+
       {/* Inject CSS directly — React 19 hoists <style> with precedence to <head> */}
       {generatedCss && (
         <style

--- a/public/canvas.css
+++ b/public/canvas.css
@@ -130,6 +130,32 @@
   display: inline !important;
 }
 
+/* Strip native browser appearance from form elements so Tailwind classes apply */
+input,
+select,
+textarea {
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+/* Checked state for custom-styled checkboxes and radios */
+input[type="checkbox"]:checked,
+input[type="radio"]:checked {
+  background-color: currentColor;
+  border-color: transparent;
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+input[type="checkbox"]:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+}
+
+input[type="radio"]:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
+}
+
 /* Remove browser focus outline from form elements in canvas */
 input:focus,
 textarea:focus,


### PR DESCRIPTION
## Summary

Strip native browser appearance from form elements (inputs, selects, textareas)
so Tailwind utility classes fully control visual styling. Add checked state
indicators for checkboxes and radios.

## Changes

- Add `appearance: none` reset for all form elements in canvas and published pages
- Add `:checked` styles with SVG checkmark (checkbox) and dot (radio) indicators
- Use `currentColor` for checked background so `text-[#color]` controls the fill

## Test plan

- [ ] Verify checkboxes render with custom border/background styles in the builder canvas
- [ ] Verify clicking a checkbox on a published page shows a checkmark
- [ ] Verify radio buttons show a dot when selected
- [ ] Verify text inputs and selects still render correctly with custom styles

Made with [Cursor](https://cursor.com)