### PR TITLE
feat: allow rich-text fields in SEO title and description

### DIFF
--- a/app/ycode/components/PageSettingsPanel.tsx
+++ b/app/ycode/components/PageSettingsPanel.tsx
@@ -48,7 +48,7 @@ import { useAssetsStore } from '@/stores/useAssetsStore';
 import RichTextEditor from './RichTextEditor';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
-import { getFieldIcon, IMAGE_FIELD_TYPES, SIMPLE_TEXT_FIELD_TYPES } from '@/lib/collection-field-utils';
+import { getFieldIcon, IMAGE_FIELD_TYPES, RICH_TEXT_FIELD_TYPES } from '@/lib/collection-field-utils';
 
 export interface PageSettingsPanelHandle {
   checkUnsavedChanges: () => Promise<boolean>;
@@ -1602,7 +1602,7 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
                           value={seoTitle}
                           onChange={setSeoTitle}
                           placeholder={name || 'Page title'}
-                          allowedFieldTypes={SIMPLE_TEXT_FIELD_TYPES}
+                          allowedFieldTypes={RICH_TEXT_FIELD_TYPES}
                           fieldGroups={(() => {
                             const activeCollectionId = collectionId || currentPage?.settings?.cms?.collection_id || '';
                             const pageFields = fields[activeCollectionId] || [];
@@ -1639,7 +1639,7 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
                               ? 'Describe in more detail what error occurred on this page and why.'
                               : 'Describe your business and/or the content of this page.'
                           }
-                          allowedFieldTypes={SIMPLE_TEXT_FIELD_TYPES}
+                          allowedFieldTypes={RICH_TEXT_FIELD_TYPES}
                           fieldGroups={(() => {
                             const activeCollectionId = collectionId || currentPage?.settings?.cms?.collection_id || '';
                             const pageFields = fields[activeCollectionId] || [];


### PR DESCRIPTION
## Summary

Allow CMS rich-text fields to be used as dynamic variables in SEO title and meta description inputs on dynamic pages.

<img width="1724" height="1305" alt="Screenshot 2026-03-20 at 15 40 54" src="https://github.com/user-attachments/assets/97a1228a-acc8-478a-adc4-5b92dfa9c16c" />


## Changes

- Change `allowedFieldTypes` from `SIMPLE_TEXT_FIELD_TYPES` to `RICH_TEXT_FIELD_TYPES` for both SEO title and meta description RichTextEditor inputs
- Remove unused `SIMPLE_TEXT_FIELD_TYPES` import

## Test plan

- [ ] Open page settings for a dynamic CMS page
- [ ] In SEO title field, click the variable inserter — rich-text fields should appear in the list
- [ ] In meta description field, click the variable inserter — rich-text fields should appear in the list
- [ ] Insert a rich-text field variable and verify it saves correctly

Made with [Cursor](https://cursor.com)