### PR TITLE
feat: add date_only collection field type

### DIFF
--- a/app/ycode/components/CMS.tsx
+++ b/app/ycode/components/CMS.tsx
@@ -30,13 +30,13 @@ import { useLiveCollectionUpdates } from '@/hooks/use-live-collection-updates';
 import { useResourceLock } from '@/hooks/use-resource-lock';
 import { collectionsApi } from '@/lib/api';
 import { formatDate } from '@/lib/utils';
-import { formatDateInTimezone } from '@/lib/date-format-utils';
+import { formatDateInTimezone, formatDateOnly } from '@/lib/date-format-utils';
 import { toast } from 'sonner';
 import { useSettingsStore } from '@/stores/useSettingsStore';
 import { slugify, isTruthyBooleanValue, parseMultiReferenceValue } from '@/lib/collection-utils';
 import { getSampleCollectionOptions } from '@/lib/sample-collections';
 import { ASSET_CATEGORIES, getOptimizedImageUrl, isAssetOfType } from '@/lib/asset-utils';
-import { type FieldType, findDisplayField, getItemDisplayName, getFieldIcon, isMultipleAssetField, findStatusFieldId } from '@/lib/collection-field-utils';
+import { type FieldType, findDisplayField, getItemDisplayName, getFieldIcon, isMultipleAssetField, findStatusFieldId, isDateFieldType } from '@/lib/collection-field-utils';
 import { CollectionStatusPill, parseStatusValue } from './CollectionStatusPill';
 import { extractPlainTextFromTiptap } from '@/lib/tiptap-utils';
 import { parseCollectionLinkValue, resolveCollectionLinkValue } from '@/lib/link-utils';
@@ -1613,7 +1613,10 @@ const CMS = React.memo(function CMS() {
                       const value = item.values[field.id];
 
                       // Format date fields in user's timezone
-                      if (field.type === 'date' && value) {
+                      if (isDateFieldType(field.type) && value) {
+                        const displayValue = field.type === 'date_only'
+                          ? formatDateOnly(value)
+                          : formatDateInTimezone(value, timezone, 'display');
                         return (
                           <td
                             key={field.id}
@@ -1621,7 +1624,7 @@ const CMS = React.memo(function CMS() {
                             onClick={() => handleEditItem(item)}
                           >
                             <span className="line-clamp-1 truncate">
-                              {formatDateInTimezone(value, timezone, 'display')}
+                              {displayValue}
                             </span>
                           </td>
                         );

--- a/app/ycode/components/CollectionFiltersSettings.tsx
+++ b/app/ycode/components/CollectionFiltersSettings.tsx
@@ -47,6 +47,7 @@ import {
   findDisplayField,
   getItemDisplayName,
   COMPARE_OPERATORS,
+  isDateFieldType,
 } from '@/lib/collection-field-utils';
 import { getCollectionVariable, isInputInsideFilter, findLayerById } from '@/lib/layer-utils';
 import { useEditorStore } from '@/stores/useEditorStore';
@@ -665,7 +666,7 @@ export default function CollectionFiltersSettings({
                           </SelectGroup>
                         </SelectContent>
                       </Select>
-                    ) : fieldType === 'date' ? (
+                    ) : isDateFieldType(fieldType) ? (
                       <Input
                         type="date"
                         value={condition.value || ''}

--- a/app/ycode/components/CollectionItemSheet.tsx
+++ b/app/ycode/components/CollectionItemSheet.tsx
@@ -46,7 +46,7 @@ import { slugify, normalizeBooleanValue } from '@/lib/collection-utils';
 import { isAssetFieldType, isMultipleAssetField, getFileManagerCategory, getAssetFieldLabel, getAssetFieldTypeLabel, isValidAssetForField, findStatusFieldId } from '@/lib/collection-field-utils';
 import type { StatusAction } from '@/lib/collection-field-utils';
 import { CollectionStatusPill, parseStatusValue } from './CollectionStatusPill';
-import { formatDateInTimezone, localDatetimeToUTC } from '@/lib/date-format-utils';
+import { formatDateInTimezone, localDatetimeToUTC, clampDateInputValue } from '@/lib/date-format-utils';
 import { useSettingsStore } from '@/stores/useSettingsStore';
 import { toast } from 'sonner';
 import ReferenceFieldCombobox from './ReferenceFieldCombobox';
@@ -121,14 +121,14 @@ export default function CollectionItemSheet({
   const currentPage = currentPageId ? pages.find(p => p.id === currentPageId) : null;
   const isPageLevelItem = currentPage?.is_dynamic && currentPage?.settings?.cms?.collection_id === collectionId;
 
-  // Find name and slug fields for validation
+  // Find name and slug fields for validation (only if editable in the form)
   const nameField = useMemo(
-    () => collectionFields.find(f => f.key === 'name'),
+    () => collectionFields.find(f => f.key === 'name' && f.fillable && !f.hidden),
     [collectionFields]
   );
 
   const slugField = useMemo(
-    () => collectionFields.find(f => f.key === 'slug'),
+    () => collectionFields.find(f => f.key === 'slug' && f.fillable && !f.hidden),
     [collectionFields]
   );
 
@@ -623,8 +623,18 @@ export default function CollectionItemSheet({
                               autoComplete="off"
                               value={formatDateInTimezone(formField.value, timezone, 'datetime-local')}
                               onChange={(e) => {
-                                const utcValue = localDatetimeToUTC(e.target.value, timezone);
+                                const clamped = clampDateInputValue(e.target.value);
+                                const utcValue = localDatetimeToUTC(clamped, timezone);
                                 formField.onChange(utcValue);
+                              }}
+                            />
+                          ) : field.type === 'date_only' ? (
+                            <Input
+                              type="date"
+                              autoComplete="off"
+                              value={formField.value?.slice(0, 10) || ''}
+                              onChange={(e) => {
+                                formField.onChange(clampDateInputValue(e.target.value) || '');
                               }}
                             />
                           ) : field.type === 'color' ? (

--- a/app/ycode/components/ConditionalVisibilitySettings.tsx
+++ b/app/ycode/components/ConditionalVisibilitySettings.tsx
@@ -47,6 +47,7 @@ import {
   flattenFieldGroups,
   COMPARE_OPERATORS,
   PAGE_COLLECTION_OPERATORS,
+  isDateFieldType,
 } from '@/lib/collection-field-utils';
 import { findAllCollectionLayers, CollectionLayerInfo } from '@/lib/layer-utils';
 import { usePagesStore } from '@/stores/usePagesStore';
@@ -654,7 +655,7 @@ export default function ConditionalVisibilitySettings({
                     </SelectGroup>
                   </SelectContent>
                 </Select>
-              ) : fieldType === 'date' ? (
+              ) : isDateFieldType(fieldType) ? (
                 <Input
                   type="date"
                   value={condition.value || ''}

--- a/app/ycode/components/FieldFormDialog.tsx
+++ b/app/ycode/components/FieldFormDialog.tsx
@@ -29,6 +29,7 @@ import Icon from '@/components/ui/icon';
 import { Checkbox } from '@/components/ui/checkbox';
 import { FIELD_TYPES_BY_CATEGORY, ASSET_FIELD_TYPES, supportsDefaultValue, isAssetFieldType, getFileManagerCategory, getAssetFieldLabel, type FieldType } from '@/lib/collection-field-utils';
 import { parseMultiReferenceValue } from '@/lib/collection-utils';
+import { clampDateInputValue } from '@/lib/date-format-utils';
 import { useCollectionsStore } from '@/stores/useCollectionsStore';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { useAssetsStore } from '@/stores/useAssetsStore';
@@ -359,7 +360,15 @@ export default function FieldFormDialog({
                     id="field-default"
                     type="datetime-local"
                     value={fieldDefault}
-                    onChange={(e) => setFieldDefault(e.target.value)}
+                    onChange={(e) => setFieldDefault(clampDateInputValue(e.target.value))}
+                    autoComplete="off"
+                  />
+                ) : fieldType === 'date_only' ? (
+                  <Input
+                    id="field-default"
+                    type="date"
+                    value={fieldDefault}
+                    onChange={(e) => setFieldDefault(clampDateInputValue(e.target.value))}
                     autoComplete="off"
                   />
                 ) : fieldType === 'email' ? (

--- a/lib/cms-variables-utils.ts
+++ b/lib/cms-variables-utils.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CollectionField, InlineVariable } from '@/types';
+import { isDateFieldType } from '@/lib/collection-field-utils';
 import { formatDateInTimezone } from '@/lib/date-format-utils';
 import { extractPlainTextFromTiptap } from '@/lib/tiptap-utils';
 import { formatDateWithPreset, formatNumberWithPreset } from '@/lib/variable-format-utils';
@@ -43,7 +44,7 @@ export function formatFieldValue(
   }
 
   // Handle date fields with optional format preset
-  if (fieldType === 'date' && typeof value === 'string') {
+  if (isDateFieldType(fieldType) && typeof value === 'string') {
     if (format) {
       return formatDateWithPreset(value, format, timezone);
     }

--- a/lib/collection-field-utils.ts
+++ b/lib/collection-field-utils.ts
@@ -23,6 +23,11 @@ import { findAllParentCollectionLayers, getCollectionVariable } from '@/lib/laye
 // Field Types Configuration
 // =============================================================================
 
+/** Check if a field type stores date/datetime values (date or date_only) */
+export function isDateFieldType(type: CollectionFieldType | string | null | undefined): boolean {
+  return type === 'date' || type === 'date_only';
+}
+
 /** Field type category for grouping in the type selector */
 export type FieldTypeCategory = 'basic' | 'contact' | 'asset' | 'relation';
 
@@ -38,7 +43,8 @@ export const FIELD_TYPES = [
   { value: 'rich_text', label: 'Rich Text', icon: 'rich-text', category: 'basic', hasDefault: true },
   { value: 'number', label: 'Number', icon: 'hash', category: 'basic', hasDefault: true },
   { value: 'boolean', label: 'Boolean', icon: 'check', category: 'basic', hasDefault: true },
-  { value: 'date', label: 'Date', icon: 'calendar', category: 'basic', hasDefault: true },
+  { value: 'date', label: 'Date & Time', icon: 'calendar', category: 'basic', hasDefault: true },
+  { value: 'date_only', label: 'Date', icon: 'calendar', category: 'basic', hasDefault: true },
   { value: 'color', label: 'Color', icon: 'droplet', category: 'basic', hasDefault: true },
   { value: 'email', label: 'Email', icon: 'email', category: 'contact', hasDefault: true },
   { value: 'phone', label: 'Phone', icon: 'phone', category: 'contact', hasDefault: true },
@@ -169,6 +175,7 @@ export function getOperatorsForFieldType(
     case 'number':
       return NUMBER_OPERATORS;
     case 'date':
+    case 'date_only':
       return DATE_OPERATORS;
     case 'boolean':
       return BOOLEAN_OPERATORS;
@@ -449,7 +456,7 @@ export const VIDEO_FIELD_TYPES: CollectionFieldType[] = ['video'];
 export const VIDEO_ID_FIELD_TYPES: CollectionFieldType[] = ['text'];
 
 /** Field types that can be bound to simple text content (excludes rich_text and media/asset types) */
-export const SIMPLE_TEXT_FIELD_TYPES: CollectionFieldType[] = ['text', 'number', 'date', 'email', 'phone'];
+export const SIMPLE_TEXT_FIELD_TYPES: CollectionFieldType[] = ['text', 'number', 'date', 'date_only', 'email', 'phone'];
 
 /** Field types that can be bound to rich text content (excludes media/asset types) */
 export const RICH_TEXT_FIELD_TYPES: CollectionFieldType[] = [...SIMPLE_TEXT_FIELD_TYPES, 'rich_text'];

--- a/lib/collection-utils.ts
+++ b/lib/collection-utils.ts
@@ -92,7 +92,7 @@ export function castValue(value: string | null, type: CollectionFieldType): any 
       return value === 'true' || value === '1' || value === 'yes';
 
     case 'date':
-      // Return as ISO string for consistency
+    case 'date_only':
       return value;
 
     case 'reference':
@@ -161,7 +161,7 @@ export function valueToString(value: any, type: CollectionFieldType): string | n
       return String(value);
 
     case 'date':
-      // Expect ISO string or Date object
+    case 'date_only':
       if (value instanceof Date) {
         return value.toISOString();
       }

--- a/lib/csv-utils.ts
+++ b/lib/csv-utils.ts
@@ -368,8 +368,8 @@ export function convertValueForFieldType(
       return null;
     }
 
-    case 'date': {
-      // Try to parse as date
+    case 'date':
+    case 'date_only': {
       const date = new Date(trimmedValue);
       if (isNaN(date.getTime())) {
         return null;
@@ -463,7 +463,8 @@ export function getFieldTypeLabel(type: CollectionFieldType): string {
     text: 'Text',
     number: 'Number',
     boolean: 'Boolean',
-    date: 'Date',
+    date: 'Date & Time',
+    date_only: 'Date',
     color: 'Color',
     reference: 'Reference',
     multi_reference: 'Multi Reference',

--- a/lib/date-format-utils.ts
+++ b/lib/date-format-utils.ts
@@ -3,6 +3,7 @@
  */
 
 import type { CollectionField } from '@/types';
+import { isDateFieldType } from '@/lib/collection-field-utils';
 
 /**
  * Format a UTC date in the specified timezone
@@ -139,31 +140,65 @@ export function localDatetimeToUTC(
 
 /**
  * Format date field values in collection item data
- * Converts UTC ISO strings to formatted timezone-aware display strings
+ * Converts UTC ISO strings to formatted timezone-aware display strings.
+ * date_only fields are formatted without time/timezone conversion.
  */
 export function formatDateFieldsInItemValues(
   itemValues: Record<string, string>,
   collectionFields: CollectionField[],
   timezone: string = 'UTC'
 ): Record<string, string> {
-  // Build a set of date field IDs for quick lookup
-  const dateFieldIds = new Set(
-    collectionFields.filter(f => f.type === 'date').map(f => f.id)
-  );
+  const dateFields = collectionFields.filter(f => isDateFieldType(f.type));
 
-  // If no date fields, return original values
-  if (dateFieldIds.size === 0) {
+  if (dateFields.length === 0) {
     return itemValues;
   }
 
-  // Format date values
   const formattedValues = { ...itemValues };
-  for (const fieldId of dateFieldIds) {
-    const value = itemValues[fieldId];
+  for (const field of dateFields) {
+    const value = itemValues[field.id];
     if (value) {
-      formattedValues[fieldId] = formatDateInTimezone(value, timezone, 'display');
+      formattedValues[field.id] = field.type === 'date_only'
+        ? formatDateOnly(value)
+        : formatDateInTimezone(value, timezone, 'display');
     }
   }
 
   return formattedValues;
+}
+
+/** Clamp date input values to valid ranges (4-digit year, month 1-12, day 1-31) */
+export function clampDateInputValue(value: string): string {
+  if (!value) return value;
+  const timeSuffix = value.includes('T') ? value.slice(value.indexOf('T')) : '';
+  const datePart = value.includes('T') ? value.slice(0, value.indexOf('T')) : value;
+  const parts = datePart.split('-');
+  if (parts.length < 3) return value;
+
+  let [yearStr] = parts;
+  const [, monthStr, dayStr] = parts;
+
+  if (yearStr.length > 4) {
+    yearStr = `000${yearStr.slice(-1)}`.slice(-4);
+  }
+
+  const month = Math.min(Math.max(parseInt(monthStr, 10) || 1, 1), 12);
+  const maxDay = new Date(parseInt(yearStr, 10) || 1, month, 0).getDate();
+  const day = Math.min(Math.max(parseInt(dayStr, 10) || 1, 1), maxDay);
+
+  const clamped = `${yearStr}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  return clamped + timeSuffix;
+}
+
+/** Format a date_only value for display (no time, no timezone) */
+export function formatDateOnly(value: string): string {
+  const dateStr = value.slice(0, 10);
+  const [year, month, day] = dateStr.split('-').map(Number);
+  if (!year || !month || !day) return value;
+  const date = new Date(year, month - 1, day);
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
 }

--- a/lib/mcp/tools/collections.ts
+++ b/lib/mcp/tools/collections.ts
@@ -31,11 +31,11 @@ export function registerCollectionTools(server: McpServer) {
     `Add a field to a collection's schema.
 
 FIELD TYPES:
-- text, number, boolean, date, reference, rich-text, color, asset, status`,
+- text, number, boolean, date (datetime), date_only (date without time), reference, rich-text, color, asset, status`,
     {
       collection_id: z.string().describe('The collection ID'),
       name: z.string().describe('Field display name'),
-      type: z.enum(['text', 'number', 'boolean', 'date', 'reference', 'multi_reference', 'rich_text', 'image', 'audio', 'video', 'document', 'link', 'email', 'phone', 'color', 'status']).describe('Field data type'),
+      type: z.enum(['text', 'number', 'boolean', 'date', 'date_only', 'reference', 'multi_reference', 'rich_text', 'image', 'audio', 'video', 'document', 'link', 'email', 'phone', 'color', 'status']).describe('Field data type (date = datetime, date_only = date without time)'),
       key: z.string().optional().describe('Unique field key (auto-generated from name if omitted)'),
       reference_collection_id: z.string().optional().describe('For reference fields: the target collection ID'),
     },
@@ -158,7 +158,7 @@ FIELD TYPES:
     {
       field_id: z.string().describe('The field ID to update'),
       name: z.string().optional().describe('New field name'),
-      type: z.enum(['text', 'number', 'boolean', 'date', 'reference', 'multi_reference', 'rich_text', 'image', 'audio', 'video', 'document', 'link', 'email', 'phone', 'color', 'status']).optional().describe('New field type'),
+      type: z.enum(['text', 'number', 'boolean', 'date', 'date_only', 'reference', 'multi_reference', 'rich_text', 'image', 'audio', 'video', 'document', 'link', 'email', 'phone', 'color', 'status']).optional().describe('New field type (date = datetime, date_only = date without time)'),
       reference_collection_id: z.string().optional().describe('For reference fields: target collection ID'),
     },
     async ({ field_id, ...updates }) => {

--- a/lib/variable-format-utils.ts
+++ b/lib/variable-format-utils.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CollectionFieldType } from '@/types';
+import { isDateFieldType } from '@/lib/collection-field-utils';
 
 // ─── Date Format Presets ────────────────────────────────────────────
 
@@ -123,6 +124,10 @@ export const DATE_FORMAT_SECTIONS: FormatPresetSection<DateFormatPreset>[] = [
   },
 ];
 
+/** Sections for date_only fields (excludes datetime and time presets) */
+export const DATE_ONLY_FORMAT_SECTIONS: FormatPresetSection<DateFormatPreset>[] =
+  DATE_FORMAT_SECTIONS.filter(s => s.title === 'Date');
+
 /** Flat list of all date presets (used for lookup by ID) */
 export const DATE_FORMAT_PRESETS: DateFormatPreset[] =
   DATE_FORMAT_SECTIONS.flatMap(s => s.presets);
@@ -214,7 +219,7 @@ const numberPresetMap = new Map(NUMBER_FORMAT_PRESETS.map(p => [p.id, p]));
 
 /** Check whether a field type supports format selection */
 export function isFormattableFieldType(fieldType: string | null | undefined): boolean {
-  return fieldType === 'date' || fieldType === 'number';
+  return isDateFieldType(fieldType) || fieldType === 'number';
 }
 
 /** Get format preset sections for a field type (grouped with titles) */
@@ -222,13 +227,14 @@ export function getFormatSectionsForFieldType(
   fieldType: string | null | undefined
 ): FormatPresetSection<DateFormatPreset | NumberFormatPreset>[] {
   if (fieldType === 'date') return DATE_FORMAT_SECTIONS;
+  if (fieldType === 'date_only') return DATE_ONLY_FORMAT_SECTIONS;
   if (fieldType === 'number') return NUMBER_FORMAT_SECTIONS;
   return [];
 }
 
 /** Get the default format ID for a field type */
 export function getDefaultFormatId(fieldType: string | null | undefined): string | undefined {
-  if (fieldType === 'date') return 'date-long';
+  if (isDateFieldType(fieldType)) return 'date-long';
   if (fieldType === 'number') return 'number-integer';
   return undefined;
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -899,7 +899,7 @@ export interface ActivityNotification {
 }
 
 // Collection Types (EAV Architecture)
-export type CollectionFieldType = 'text' | 'number' | 'boolean' | 'date' | 'color' | 'reference' | 'multi_reference' | 'rich_text' | 'image' | 'audio' | 'video' | 'document' | 'link' | 'email' | 'phone' | 'status';
+export type CollectionFieldType = 'text' | 'number' | 'boolean' | 'date' | 'date_only' | 'color' | 'reference' | 'multi_reference' | 'rich_text' | 'image' | 'audio' | 'video' | 'document' | 'link' | 'email' | 'phone' | 'status';
 export type CollectionSortDirection = 'asc' | 'desc' | 'manual';
 
 export interface CollectionSorting {


### PR DESCRIPTION
## Summary

Add a new `date_only` collection field type that stores dates without time components, giving users granular control over whether a field captures a full datetime or just a date. The existing `date` type remains unchanged as datetime.

## Changes

- Add `date_only` to `CollectionFieldType` union and `isDateFieldType` helper for DRY type checks
- Render `date_only` inputs as `<input type="date">` (vs `datetime-local` for datetime fields)
- Add `clampDateInputValue` utility to validate and clamp year/month/day while typing
- Add `formatDateOnly` display function that formats without timezone conversion
- Filter format presets for `date_only` fields to exclude time-related options
- Update conditional visibility, collection filters, CSV import/export, and MCP tool schemas
- Rename `date` label to "Date & Time" and label `date_only` as "Date" across UI

## Test plan

- [x] Create a collection with both a "Date & Time" field and a "Date" field
- [x] Add items — verify datetime input shows time picker, date input does not
- [x] Verify CMS table displays datetime with time and date without time
- [x] Set a default value on a date_only field in field settings
- [x] Use inline variables with both field types — confirm format presets exclude time options for date_only
- [x] Add conditional visibility rules using a date_only field
- [x] Add collection filter rules using a date_only field
- [ ] Import CSV with date_only values — verify correct parsing
- [ ] Type partial dates (e.g. 5-digit year, month > 12) — verify clamping works
- [ ] Preview and publish a page using date_only fields — verify correct rendering

Made with [Cursor](https://cursor.com)