### PR TITLE
Add margin-auto button to spacing settings

### DIFF
--- a/app/(builder)/ycode/components/MarginPadding.tsx
+++ b/app/(builder)/ycode/components/MarginPadding.tsx
@@ -3,6 +3,8 @@
 import React, { useCallback, useRef, useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 interface SpacingValues {
@@ -357,7 +359,13 @@ export default function MarginPadding({ values, onChange }: MarginPaddingProps) 
   const dragEnd = useCallback(() => { setDraggingEdge(null); setDragModifiers({ altKey: false, shiftKey: false }); }, []);
   const isDragActive = !!draggingEdge;
 
+  const handleMarginAuto = useCallback(() => {
+    onChange('marginLeft', 'auto');
+    onChange('marginRight', 'auto');
+  }, [onChange]);
+
   return (
+    <div className="flex flex-col items-center gap-3">
     <div className="grid grid-cols-[44px_44px_1fr_44px_44px] grid-rows-[auto_auto_auto_auto_auto] max-w-[214px] mx-auto">
       {/* Margin box (outer, dashed) */}
       <div className="relative col-span-5 row-span-5 col-start-1 row-start-1">
@@ -457,6 +465,24 @@ export default function MarginPadding({ values, onChange }: MarginPaddingProps) 
       <div className="col-start-3 row-start-3 h-full p-0.5">
         <div className="bg-input rounded-[8px] w-full h-full min-h-4 min-w-4" />
       </div>
+    </div>
+
+      {/* Margin-auto button */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            onClick={handleMarginAuto}
+            variant="outline"
+            size="sm"
+            className="text-xs"
+          >
+            Margin Auto
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          Center horizontally (margin-left & margin-right: auto)
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 }


### PR DESCRIPTION
Noticed the margin-auto button wasn't re-implemented after migrating from legacy Ycode. This PR adds it back to the spacing controls panel.

The button makes it super easy to center elements horizontally - just one click to set both margin-left and margin-right to auto. Saves a lot of clicking around in the UI instead of manually setting each value.

The implementation hooks into the existing design sync system which already supported auto values, just never had a quick button for it. I've added a tooltip so users know what it does.

Tested locally and everything works as expected. No breaking changes or side effects.

This fixes #144 