### PR TITLE
feat: add presigned URL uploads for large files

### DIFF
--- a/app/(builder)/ycode/api/files/presign/route.ts
+++ b/app/(builder)/ycode/api/files/presign/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { validateCategoryMimeType } from '@/lib/asset-utils';
+import { STORAGE_BUCKET, MAX_UPLOAD_FILE_SIZE, generateStoragePath } from '@/lib/asset-constants';
+
+export const runtime = 'nodejs';
+
+/**
+ * POST /ycode/api/files/presign
+ * Generate a signed upload URL for direct browser-to-storage uploads.
+ * Used for large files that exceed serverless body limits.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { filename, mimeType, fileSize, category } = body as {
+      filename: string;
+      mimeType: string;
+      fileSize: number;
+      category?: string | null;
+    };
+
+    if (!filename || !mimeType || !fileSize) {
+      return NextResponse.json(
+        { error: 'filename, mimeType, and fileSize are required' },
+        { status: 400 }
+      );
+    }
+
+    const mimeError = validateCategoryMimeType(mimeType, category);
+    if (mimeError) {
+      return NextResponse.json({ error: mimeError }, { status: 400 });
+    }
+
+    if (fileSize > MAX_UPLOAD_FILE_SIZE) {
+      return NextResponse.json(
+        { error: 'File size must be less than 50MB' },
+        { status: 400 }
+      );
+    }
+
+    const supabase = await getSupabaseAdmin();
+
+    if (!supabase) {
+      return NextResponse.json({ error: 'Supabase not configured' }, { status: 500 });
+    }
+
+    const storagePath = generateStoragePath(filename);
+
+    const { data, error } = await supabase.storage
+      .from(STORAGE_BUCKET)
+      .createSignedUploadUrl(storagePath);
+
+    if (error) {
+      console.error('Error creating signed upload URL:', error);
+      return NextResponse.json({ error: 'Failed to create upload URL' }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      data: {
+        signedUrl: data.signedUrl,
+        token: data.token,
+        storagePath,
+      },
+    });
+  } catch (error) {
+    console.error('Error in presign route:', error);
+    return NextResponse.json({ error: 'Failed to generate upload URL' }, { status: 500 });
+  }
+}

--- a/app/(builder)/ycode/api/files/register/route.ts
+++ b/app/(builder)/ycode/api/files/register/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { createAsset } from '@/lib/repositories/assetRepository';
+import { STORAGE_BUCKET, getDisplayName } from '@/lib/asset-constants';
+
+export const runtime = 'nodejs';
+
+/**
+ * POST /ycode/api/files/register
+ * Create an Asset database record after a direct browser-to-storage upload completes.
+ * Pairs with the presign route for large file uploads.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { storagePath, filename, mimeType, fileSize, source, customName, assetFolderId } = body as {
+      storagePath: string;
+      filename: string;
+      mimeType: string;
+      fileSize: number;
+      source: string;
+      customName?: string;
+      assetFolderId?: string | null;
+    };
+
+    if (!storagePath || !filename || !mimeType || !fileSize || !source) {
+      return NextResponse.json(
+        { error: 'storagePath, filename, mimeType, fileSize, and source are required' },
+        { status: 400 }
+      );
+    }
+
+    const supabase = await getSupabaseAdmin();
+
+    if (!supabase) {
+      return NextResponse.json({ error: 'Supabase not configured' }, { status: 500 });
+    }
+
+    const { data: urlData } = supabase.storage
+      .from(STORAGE_BUCKET)
+      .getPublicUrl(storagePath);
+
+    const asset = await createAsset({
+      filename: getDisplayName(filename, customName),
+      storage_path: storagePath,
+      public_url: urlData.publicUrl,
+      file_size: fileSize,
+      mime_type: mimeType,
+      source,
+      asset_folder_id: assetFolderId,
+    });
+
+    return NextResponse.json({ data: asset }, { status: 200 });
+  } catch (error) {
+    console.error('Error registering asset:', error);
+    return NextResponse.json({ error: 'Failed to register asset' }, { status: 500 });
+  }
+}

--- a/app/(builder)/ycode/api/files/upload/route.ts
+++ b/app/(builder)/ycode/api/files/upload/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { uploadFile } from '@/lib/file-upload';
-import { isAssetOfType, ASSET_CATEGORIES } from '@/lib/asset-utils';
+import { validateCategoryMimeType } from '@/lib/asset-utils';
+import { MAX_UPLOAD_FILE_SIZE } from '@/lib/asset-constants';
 
-// Force Node.js runtime for sharp compatibility
 export const runtime = 'nodejs';
 
 /**
  * POST /ycode/api/files/upload
- * Upload a file to Supabase Storage and create Asset record
+ * Upload a file to Supabase Storage and create Asset record.
+ * Used for small files that fit within serverless body limits.
  */
 export async function POST(request: NextRequest) {
   try {
@@ -19,49 +20,19 @@ export async function POST(request: NextRequest) {
     const assetFolderId = formData.get('asset_folder_id') as string | null;
 
     if (!file) {
-      return NextResponse.json(
-        { error: 'No file provided' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'No file provided' }, { status: 400 });
     }
 
     if (!source) {
-      return NextResponse.json(
-        { error: 'Source is required' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Source is required' }, { status: 400 });
     }
 
-    if (category === ASSET_CATEGORIES.IMAGES && !isAssetOfType(file.type, ASSET_CATEGORIES.IMAGES)) {
-      return NextResponse.json(
-        { error: 'Only image files are allowed' },
-        { status: 400 }
-      );
+    const mimeError = validateCategoryMimeType(file.type, category);
+    if (mimeError) {
+      return NextResponse.json({ error: mimeError }, { status: 400 });
     }
 
-    if (category === ASSET_CATEGORIES.VIDEOS && !isAssetOfType(file.type, ASSET_CATEGORIES.VIDEOS)) {
-      return NextResponse.json(
-        { error: 'Only video files are allowed' },
-        { status: 400 }
-      );
-    }
-
-    if (category === ASSET_CATEGORIES.AUDIO && !isAssetOfType(file.type, ASSET_CATEGORIES.AUDIO)) {
-      return NextResponse.json(
-        { error: 'Only audio files are allowed' },
-        { status: 400 }
-      );
-    }
-
-    if (category === ASSET_CATEGORIES.DOCUMENTS && !isAssetOfType(file.type, ASSET_CATEGORIES.DOCUMENTS)) {
-      return NextResponse.json(
-        { error: 'Only document files are allowed (PDF, Word, Excel, PowerPoint, Text)' },
-        { status: 400 }
-      );
-    }
-
-    const MAX_FILE_SIZE = 50 * 1024 * 1024;
-    if (file.size > MAX_FILE_SIZE) {
+    if (file.size > MAX_UPLOAD_FILE_SIZE) {
       return NextResponse.json(
         { error: 'File size must be less than 50MB' },
         { status: 400 }
@@ -76,18 +47,12 @@ export async function POST(request: NextRequest) {
     );
 
     if (!asset) {
-      return NextResponse.json(
-        { error: 'Failed to upload file' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Failed to upload file' }, { status: 500 });
     }
 
     return NextResponse.json({ data: asset }, { status: 200 });
   } catch (error) {
     console.error('Error uploading file:', error);
-    return NextResponse.json(
-      { error: 'Failed to upload file' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to upload file' }, { status: 500 });
   }
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -805,12 +805,82 @@ export const cacheApi = {
 
 // File Upload API
 
+// Files above this threshold use presigned URLs to bypass serverless body limits
+const DIRECT_UPLOAD_THRESHOLD = 4.5 * 1024 * 1024; // 4.5MB
+
 /**
- * Upload a file and create Asset record
+ * Upload a file via presigned URL (direct browser-to-storage).
+ * Used for large files that exceed serverless function body limits.
+ */
+async function uploadViaPresignedUrl(
+  file: File,
+  source: string,
+  category?: AssetCategory | null,
+  customName?: string,
+  assetFolderId?: string | null
+): Promise<Asset | null> {
+  // 1. Get presigned upload URL from server
+  const presignResponse = await fetch('/ycode/api/files/presign', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      filename: file.name,
+      mimeType: file.type,
+      fileSize: file.size,
+      category,
+    }),
+  });
+
+  if (!presignResponse.ok) {
+    const errorData = await presignResponse.json();
+    throw new Error(errorData.error || 'Failed to get upload URL');
+  }
+
+  const { data: presignData } = await presignResponse.json();
+
+  // 2. Upload directly to Supabase Storage using the signed URL
+  const uploadResponse = await fetch(presignData.signedUrl, {
+    method: 'PUT',
+    headers: { 'Content-Type': file.type },
+    body: file,
+  });
+
+  if (!uploadResponse.ok) {
+    throw new Error('Failed to upload file to storage');
+  }
+
+  // 3. Register the asset record in the database
+  const registerResponse = await fetch('/ycode/api/files/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      storagePath: presignData.storagePath,
+      filename: file.name,
+      mimeType: file.type,
+      fileSize: file.size,
+      source,
+      customName,
+      assetFolderId,
+    }),
+  });
+
+  if (!registerResponse.ok) {
+    const errorData = await registerResponse.json();
+    throw new Error(errorData.error || 'Failed to register asset');
+  }
+
+  const { data } = await registerResponse.json();
+  return data;
+}
+
+/**
+ * Upload a file and create Asset record.
+ * Small files (<4.5MB) go through the server for WebP conversion.
+ * Large files use presigned URLs to upload directly to storage.
  *
  * @param file - File to upload
  * @param source - Source identifier (e.g., 'page-settings', 'components', 'library')
- * @param category - Optional file category for validation ('images', 'videos', 'audio', 'documents', or null for any)
+ * @param category - Optional file category for validation
  * @param customName - Optional custom name for the file
  */
 export async function uploadFileApi(
@@ -821,6 +891,11 @@ export async function uploadFileApi(
   assetFolderId?: string | null
 ): Promise<Asset | null> {
   try {
+    // Large files bypass the serverless function entirely
+    if (file.size > DIRECT_UPLOAD_THRESHOLD) {
+      return await uploadViaPresignedUrl(file, source, category, customName, assetFolderId);
+    }
+
     const formData = new FormData();
     formData.append('file', file);
     formData.append('source', source);

--- a/lib/asset-constants.ts
+++ b/lib/asset-constants.ts
@@ -84,6 +84,9 @@ export const DEFAULT_ASSETS = {
   AUDIO: '',
 } as const;
 
+/** Maximum upload file size in bytes (50MB) */
+export const MAX_UPLOAD_FILE_SIZE = 50 * 1024 * 1024;
+
 /**
  * Get accept attribute string for file input based on category
  */
@@ -92,4 +95,18 @@ export function getAcceptString(category?: AssetCategory): string {
     return Object.values(ALLOWED_MIME_TYPES).flat().join(',');
   }
   return ALLOWED_MIME_TYPES[category].join(',');
+}
+
+/** Generate a unique storage path for a file upload */
+export function generateStoragePath(filename: string, folder: string = STORAGE_FOLDERS.WEBSITE): string {
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).substring(2, 15);
+  const fileExtension = filename.split('.').pop() || '';
+  return `${folder}/${timestamp}-${random}.${fileExtension}`;
+}
+
+/** Extract the display name from a filename (strip extension) */
+export function getDisplayName(filename: string, customName?: string | null): string {
+  const baseName = filename.replace(/\.[^/.]+$/, '');
+  return customName || baseName || filename;
 }

--- a/lib/asset-utils.ts
+++ b/lib/asset-utils.ts
@@ -41,6 +41,34 @@ export function isAssetOfType(
   return ALLOWED_MIME_TYPES[category].includes(mimeType);
 }
 
+/**
+ * Validate a MIME type against a category.
+ * Returns an error message if invalid, or null if valid.
+ */
+export function validateCategoryMimeType(
+  mimeType: string,
+  category: string | null | undefined
+): string | null {
+  if (!category) return null;
+
+  const categoryMap: Record<string, { category: AssetCategory; label: string }> = {
+    [ASSET_CATEGORIES.IMAGES]: { category: ASSET_CATEGORIES.IMAGES, label: 'image' },
+    [ASSET_CATEGORIES.VIDEOS]: { category: ASSET_CATEGORIES.VIDEOS, label: 'video' },
+    [ASSET_CATEGORIES.AUDIO]: { category: ASSET_CATEGORIES.AUDIO, label: 'audio' },
+    [ASSET_CATEGORIES.DOCUMENTS]: { category: ASSET_CATEGORIES.DOCUMENTS, label: 'document' },
+    [ASSET_CATEGORIES.ICONS]: { category: ASSET_CATEGORIES.ICONS, label: 'icon' },
+  };
+
+  const entry = categoryMap[category];
+  if (!entry) return null;
+
+  if (!isAssetOfType(mimeType, entry.category)) {
+    return `Only ${entry.label} files are allowed`;
+  }
+
+  return null;
+}
+
 // Category to label mapping
 const CATEGORY_LABELS: Record<AssetCategory, string> = {
   icons: 'Icon',

--- a/lib/file-upload.ts
+++ b/lib/file-upload.ts
@@ -6,7 +6,7 @@
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { createAsset } from '@/lib/repositories/assetRepository';
 import { isAssetOfType } from './asset-utils';
-import { ASSET_CATEGORIES, STORAGE_BUCKET, STORAGE_FOLDERS } from '@/lib/asset-constants';
+import { ASSET_CATEGORIES, STORAGE_BUCKET, generateStoragePath, getDisplayName } from '@/lib/asset-constants';
 import sharp from 'sharp';
 import type { Asset } from '@/types';
 
@@ -175,8 +175,7 @@ export async function uploadFile(
   assetFolderId?: string | null
 ): Promise<Asset | null> {
   try {
-    const baseName = file.name.replace(/\.[^/.]+$/, '');
-    const filename = customName || baseName || file.name;
+    const filename = getDisplayName(file.name, customName);
 
     // Handle SVG files - store content directly without uploading to storage
     if (file.type === 'image/svg+xml') {
@@ -223,9 +222,6 @@ export async function uploadFile(
       throw new Error('Supabase client not available');
     }
 
-    const timestamp = Date.now();
-    const random = Math.random().toString(36).substring(2, 15);
-
     // Try to convert image to WebP
     const webpConversion = await convertImageToWebP(file);
 
@@ -255,7 +251,10 @@ export async function uploadFile(
       dimensions = await getImageDimensions(file);
     }
 
-    const storagePath = `${STORAGE_FOLDERS.WEBSITE}/${timestamp}-${random}.${fileExtension}`;
+    const effectiveFilename = webpConversion
+      ? `${file.name.replace(/\.[^/.]+$/, '')}.${fileExtension}`
+      : file.name;
+    const storagePath = generateStoragePath(effectiveFilename);
 
     const { data, error } = await supabase.storage
       .from(STORAGE_BUCKET)


### PR DESCRIPTION
## Summary

Add presigned URL upload flow so large files (video, audio, documents) bypass
Vercel's serverless function body size limit (4.5MB) by uploading directly to
Supabase Storage from the browser.

## Changes

- Add `POST /ycode/api/files/presign` route to generate signed upload URLs
- Add `POST /ycode/api/files/register` route to create Asset records after direct upload
- Update `uploadFileApi` to use presigned URLs for files >4.5MB, keeping server-side WebP conversion for small images
- Extract shared upload helpers (`MAX_UPLOAD_FILE_SIZE`, `generateStoragePath`, `getDisplayName`, `validateCategoryMimeType`) to reduce duplication across upload routes
- Refactor `upload/route.ts` to use shared validation and constants

## Test plan

- [ ] Upload a small image (<4.5MB) — should go through server route and get WebP conversion
- [ ] Uploaa large video (>4.5MB, <50MB) — should use presigned URL flow without hitting `FUNCTION_PAYLOAD_TOO_LARGE`
- [ ] Upload a file >50MB — should be rejected with size error
- [ ] Verify uploaded assets appear in the File Manager with correct metadata
- [ ] Test upload with category filter (e.g., videos-only) — wrong types should be rejected