### PR TITLE
fix: show CMS button for YouTube video ID field

### DIFF
--- a/app/(builder)/ycode/components/VideoSettings.tsx
+++ b/app/(builder)/ycode/components/VideoSettings.tsx
@@ -619,6 +619,7 @@ export default function VideoSettings(props: VideoSettingsProps) {
               fieldGroups={textFieldGroups}
               allFields={allFields}
               collections={collections}
+              allowedFieldTypes={VIDEO_ID_FIELD_TYPES}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary

Fix missing CMS data button on the YouTube Video ID field in Video settings.
The `RichTextEditor` defaults `allowedFieldTypes` to `['rich_text']`, which
filtered out the `text`-type fields passed via `textFieldGroups`.

## Changes

- Pass `allowedFieldTypes={VIDEO_ID_FIELD_TYPES}` to the Video ID `RichTextEditor`

## Test plan

- [ ] Select a video layer, set Source to YouTube
- [ ] Verify the Video ID field shows the CMS data button (database icon)
- [ ] Click the CMS button and confirm text-type fields are listed