### PR TITLE
fix: correct filter behavior on preview pages

### DIFF
--- a/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
+++ b/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
@@ -497,6 +497,7 @@ export async function POST(
       localeCode,
       collectionLayerClasses,
       collectionLayerTag,
+      published: isPublished = true,
     } = body;
 
     if (!layerTemplate || !Array.isArray(layerTemplate)) {
@@ -508,7 +509,7 @@ export async function POST(
 
     const { matchingIds, total: filteredTotal } = await getFilteredItemIds(
       collectionId,
-      true,
+      isPublished,
       filterGroups,
     );
 
@@ -525,7 +526,7 @@ export async function POST(
 
     if (!sortBy || sortBy === 'none' || sortBy === 'manual') {
       // Let DB do ordering and pagination for cheap paths.
-      const { items } = await getItemsByCollectionId(collectionId, true, {
+      const { items } = await getItemsByCollectionId(collectionId, isPublished, {
         itemIds: matchingIds,
         limit: pageLimit,
         offset: pageOffset,
@@ -536,7 +537,7 @@ export async function POST(
       const randomizedIds = [...matchingIds].sort(() => Math.random() - 0.5);
       pageItemIds = randomizedIds.slice(pageOffset, pageOffset + pageLimit);
       if (pageItemIds.length > 0) {
-        const { items } = await getItemsByCollectionId(collectionId, true, {
+        const { items } = await getItemsByCollectionId(collectionId, isPublished, {
           itemIds: pageItemIds,
         });
         pageRawItems = reorderItemsById(items, pageItemIds);
@@ -544,7 +545,7 @@ export async function POST(
     } else {
       // For field-based sort, sort IDs using just the sort field values first,
       // then hydrate only the requested page window.
-      const sortValueByItem = await getFieldValuesForItems(sortBy, true, matchingIds);
+      const sortValueByItem = await getFieldValuesForItems(sortBy, isPublished, matchingIds);
       const sortedIds = [...matchingIds].sort((a, b) => {
         const aStr = String(sortValueByItem.get(a) || '');
         const bStr = String(sortValueByItem.get(b) || '');
@@ -559,7 +560,7 @@ export async function POST(
       });
       pageItemIds = sortedIds.slice(pageOffset, pageOffset + pageLimit);
       if (pageItemIds.length > 0) {
-        const { items } = await getItemsByCollectionId(collectionId, true, {
+        const { items } = await getItemsByCollectionId(collectionId, isPublished, {
           itemIds: pageItemIds,
         });
         pageRawItems = reorderItemsById(items, pageItemIds);
@@ -568,7 +569,7 @@ export async function POST(
 
     const valuesByItem = await getValuesByItemIds(
       pageRawItems.map(i => i.id),
-      true,
+      isPublished,
     );
     const paginatedItems: CollectionItemWithValues[] = pageRawItems.map(item => ({
       ...item,
@@ -576,7 +577,7 @@ export async function POST(
     }));
     const hasMore = pageOffset + paginatedItems.length < filteredTotal;
 
-    const collectionFields = await getFieldsByCollectionId(collectionId, true, { excludeComputed: true });
+    const collectionFields = await getFieldsByCollectionId(collectionId, isPublished, { excludeComputed: true });
     const slugField = collectionFields.find(f => f.key === 'slug');
     const collectionItemSlugs: Record<string, string> = {};
     if (slugField) {
@@ -595,7 +596,7 @@ export async function POST(
     let locale = null;
     let translations: Record<string, any> | undefined;
     if (localeCode) {
-      const localeData = await loadTranslationsForLocale(localeCode, true);
+      const localeData = await loadTranslationsForLocale(localeCode, isPublished);
       locale = localeData.locale;
       translations = localeData.translations;
     }
@@ -605,7 +606,7 @@ export async function POST(
       layerTemplate as Layer[],
       collectionId,
       collectionLayerId,
-      true,
+      isPublished,
       pages,
       folders,
       collectionItemSlugs,

--- a/components/FilterableCollection.tsx
+++ b/components/FilterableCollection.tsx
@@ -19,6 +19,7 @@ interface FilterableCollectionProps {
   layerTemplate: Layer[];
   collectionLayerClasses?: string[];
   collectionLayerTag?: string;
+  isPublished?: boolean;
 }
 
 const FC_FILTERED_ATTR = 'data-fc-filtered';
@@ -37,6 +38,7 @@ export default function FilterableCollection({
   layerTemplate,
   collectionLayerClasses,
   collectionLayerTag,
+  isPublished = true,
 }: FilterableCollectionProps) {
   const markerRef = useRef<HTMLSpanElement>(null);
   const ssrChildrenRef = useRef<Element[]>([]);
@@ -185,9 +187,10 @@ export default function FilterableCollection({
           if (inputValue && inputValue.includes(',')) {
             const checkedValues = inputValue.split(',').filter(Boolean);
             if (checkedValues.length > 0) {
+              const arrayOperators = ['is_one_of', 'is_not_one_of', 'contains_all_of', 'contains_exactly'];
               activeInGroup.push({
                 fieldId: condition.fieldId,
-                operator: 'is_one_of',
+                operator: arrayOperators.includes(condition.operator) ? condition.operator : 'is_one_of',
                 value: JSON.stringify(checkedValues),
                 fieldType: condition.fieldType,
               });
@@ -529,7 +532,7 @@ export default function FilterableCollection({
         sortOrder: effectiveSortOrder,
         limit,
         offset,
-        published: true,
+        published: isPublished,
         collectionLayerClasses,
         collectionLayerTag,
       }),
@@ -582,7 +585,7 @@ export default function FilterableCollection({
           abortRef.current = null;
         }
       });
-  }, [collectionId, collectionLayerId, layerTemplate, effectiveSortBy, effectiveSortOrder, limit, paginationMode, updateEmptyStateElements, injectFilteredHTML, collectionLayerClasses, collectionLayerTag]);
+  }, [collectionId, collectionLayerId, layerTemplate, effectiveSortBy, effectiveSortOrder, limit, paginationMode, updateEmptyStateElements, injectFilteredHTML, collectionLayerClasses, collectionLayerTag, isPublished]);
 
   const fetchFilteredRef = useRef(fetchFiltered);
   useEffect(() => { fetchFilteredRef.current = fetchFiltered; }, [fetchFiltered]);

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -246,6 +246,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
               layerTemplate={layer._filterConfig!.layerTemplate}
               collectionLayerClasses={layer._filterConfig!.collectionLayerClasses}
               collectionLayerTag={layer._filterConfig!.collectionLayerTag}
+              isPublished={layer._filterConfig!.isPublished}
             >
               {content}
             </FilterableCollection>
@@ -803,7 +804,7 @@ const LayerItem: React.FC<{
         if (!inputLayerId) return;
         const nameAttr = inputEl.getAttribute('name');
         if (nameAttr) nameMap[inputLayerId] = nameAttr;
-        if (inputEl.type === 'checkbox') {
+        if (inputEl.type === 'checkbox' || inputEl.type === 'radio') {
           const checked = (inputEl as HTMLInputElement).checked;
           const val = checked ? ((inputEl as HTMLInputElement).value || 'true') : '';
           inputValues[inputLayerId] = val;

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -1980,6 +1980,7 @@ export async function resolveCollectionLayers(
               layerTemplate: layer.children || [],
               collectionLayerClasses: Array.isArray(layer.classes) ? layer.classes : (layer.classes ? [layer.classes] : []),
               collectionLayerTag: layer.name || 'div',
+              isPublished,
             } : undefined,
           };
         } catch (error) {

--- a/types/index.ts
+++ b/types/index.ts
@@ -428,6 +428,7 @@ export interface Layer {
     layerTemplate: Layer[];
     collectionLayerClasses?: string[];
     collectionLayerTag?: string;
+    isPublished?: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary

Fix collection filters not working correctly on preview/generated pages due to the filter API always querying published data and incorrect operator handling for multi-select inputs.

## Changes

- Pass `isPublished` flag from `_filterConfig` through `FilterableCollection` to the filter API so preview pages query draft data instead of published
- Preserve the original filter operator for checkbox groups instead of always forcing `is_one_of`
- Register radio button value changes in the filter store alongside checkboxes

## Test plan

- [ ] Open a page with collection filters in preview — verify filters return results
- [ ] Test checkbox filter with `contains_all_of` operator — confirm it uses the correct operator
- [ ] Test radio button filter — confirm selecting an option filters the collection
- [ ] Verify published pages still work with filters (client-side filtering)
