### PR TITLE
feat: add searchable dropdown for collection items

### DIFF
--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -716,6 +716,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
   const components = useComponentsStore((state) => state.components);
   const componentDrafts = useComponentsStore((state) => state.componentDrafts);
   const [collectionItems, setCollectionItems] = useState<Array<{ id: string; label: string }>>([]);
+  const [collectionItemSearch, setCollectionItemSearch] = useState('');
 
   // Get editing component's variables for default value display
   // Depends on `components` array to react to variable changes
@@ -1946,7 +1947,13 @@ const CenterCanvas = React.memo(function CenterCanvas({
             {currentPage?.is_dynamic && collectionId && (
               <Select
                 value={currentPageCollectionItemId || ''}
-                onValueChange={setCurrentPageCollectionItemId}
+                onValueChange={(value) => {
+                  setCurrentPageCollectionItemId(value);
+                  setCollectionItemSearch('');
+                }}
+                onOpenChange={(open) => {
+                  if (!open) setCollectionItemSearch('');
+                }}
                 disabled={isLoadingItems || collectionItems.length === 0}
               >
                 <SelectTrigger className="w-24 justify-between" size="sm">
@@ -1969,18 +1976,31 @@ const CenterCanvas = React.memo(function CenterCanvas({
                   )}
                 </SelectTrigger>
 
-                <SelectContent>
-                  {collectionItems.length > 0 ? (
-                    collectionItems.map((item) => (
+                <SelectContent
+                  searchable
+                  searchValue={collectionItemSearch}
+                  onSearchChange={setCollectionItemSearch}
+                  searchPlaceholder="Search items..."
+                  align="start"
+                  className="w-72"
+                >
+                  {(() => {
+                    const filtered = collectionItems.filter(item =>
+                      item.label.toLowerCase().includes(collectionItemSearch.toLowerCase())
+                    );
+                    if (filtered.length === 0) {
+                      return (
+                        <div className="px-2 py-4 text-center text-xs text-muted-foreground">
+                          {collectionItemSearch ? 'No items found' : 'No items available'}
+                        </div>
+                      );
+                    }
+                    return filtered.map((item) => (
                       <SelectItem key={item.id} value={item.id}>
                         {item.label}
                       </SelectItem>
-                    ))
-                  ) : (
-                    <div className="px-2 py-1.5 text-sm text-muted-foreground">
-                      No items available
-                    </div>
-                  )}
+                    ));
+                  })()}
                 </SelectContent>
               </Select>
             )}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -7,6 +7,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 import Icon from '@/components/ui/icon';
+import { Input } from '@/components/ui/input';
 
 function Select({
   ...props
@@ -103,14 +104,27 @@ function SelectContent({
   children,
   position = 'popper',
   align = 'center',
+  searchable,
+  searchValue,
+  onSearchChange,
+  searchPlaceholder,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+}: React.ComponentProps<typeof SelectPrimitive.Content> & {
+  searchable?: boolean;
+  searchValue?: string;
+  onSearchChange?: (value: string) => void;
+  searchPlaceholder?: string;
+}) {
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+  const isSearchFocusedRef = React.useRef(false);
+
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
           'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border border-transparent shadow-md',
+          searchable && '[&_[data-slot=select-item]:hover]:bg-accent [&_[data-slot=select-item]:hover]:text-accent-foreground',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className
@@ -119,6 +133,30 @@ function SelectContent({
         align={align}
         {...props}
       >
+        {searchable && (
+          <div
+            className="sticky top-0 z-10 bg-popover p-1"
+            onPointerDown={(e) => e.stopPropagation()}
+            onPointerUp={(e) => e.stopPropagation()}
+          >
+            <Input
+              ref={searchInputRef}
+              size="xs"
+              placeholder={searchPlaceholder || 'Search...'}
+              value={searchValue}
+              onChange={(e) => onSearchChange?.(e.target.value)}
+              onKeyDown={(e) => e.stopPropagation()}
+              onFocus={() => { isSearchFocusedRef.current = true; }}
+              onBlur={() => {
+                requestAnimationFrame(() => {
+                  if (isSearchFocusedRef.current) {
+                    searchInputRef.current?.focus();
+                  }
+                });
+              }}
+            />
+          </div>
+        )}
         <SelectScrollUpButton />
         <SelectPrimitive.Viewport
           className={cn(
@@ -126,6 +164,7 @@ function SelectContent({
             position === 'popper' &&
               'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1'
           )}
+          onPointerDown={searchable ? () => { isSearchFocusedRef.current = false; } : undefined}
         >
           {children}
         </SelectPrimitive.Viewport>
@@ -157,7 +196,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-xs outline-hidden select-none data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-xs outline-hidden select-none overflow-hidden data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}
@@ -167,7 +206,9 @@ function SelectItem({
           <Icon name="check" className="size-3 opacity-50" />
         </SelectPrimitive.ItemIndicator>
       </span>
-      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap [&>span]:overflow-hidden [&>span]:text-ellipsis [&>span]:whitespace-nowrap">
+        <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      </span>
     </SelectPrimitive.Item>
   )
 }


### PR DESCRIPTION
## Summary

Add search/filter capability to the Select component and use it for the collection item picker on the canvas toolbar, making it easier to find items in large collections.

## Changes

- Extend `SelectContent` with `searchable`, `searchValue`, `onSearchChange`, and `searchPlaceholder` props
- Add sticky search input inside Select dropdown with Radix focus management workarounds
- Add CSS `:hover` styles for SelectItem when search input holds focus
- Add text truncation with ellipsis for long SelectItem names
- Use searchable Select for the collection item picker in CenterCanvas
- Align collection item dropdown to the left

## Test plan

- [x] Open a dynamic page with a collection bound — verify the item dropdown shows a search input
- [x] Type in the search field — verify items filter correctly and input stays focused
- [x] Hover over items while search input is focused — verify hover highlight appears
- [x] Select an item — verify it selects correctly and search clears
- [x] Verify long item names truncate with ellipsis in the dropdown
- [x] Verify existing non-searchable Select components are unaffected

Made with [Cursor](https://cursor.com)