### PR TITLE
feat: add search to CMS item selectors in link settings

### DIFF
--- a/app/(builder)/ycode/components/CollectionLinkFieldInput.tsx
+++ b/app/(builder)/ycode/components/CollectionLinkFieldInput.tsx
@@ -69,6 +69,7 @@ export default function CollectionLinkFieldInput({
 }: CollectionLinkFieldInputProps) {
   const [collectionItems, setCollectionItems] = useState<CollectionItemWithValues[]>([]);
   const [loadingItems, setLoadingItems] = useState(false);
+  const [collectionItemSearch, setCollectionItemSearch] = useState('');
 
   // Stores
   const pages = usePagesStore((state) => state.pages);
@@ -339,18 +340,45 @@ export default function CollectionLinkFieldInput({
                 <Label className="text-xs text-muted-foreground">CMS item</Label>
                 <Select
                   value={collectionItemId || ''}
-                  onValueChange={handleCollectionItemChange}
+                  onValueChange={(value) => {
+                    handleCollectionItemChange(value);
+                    setCollectionItemSearch('');
+                  }}
+                  onOpenChange={(open) => {
+                    if (!open) setCollectionItemSearch('');
+                  }}
                   disabled={disabled || loadingItems}
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder={loadingItems ? 'Loading...' : 'Select...'} />
                   </SelectTrigger>
-                  <SelectContent>
-                    {collectionItems.map((item) => (
-                      <SelectItem key={item.id} value={item.id}>
-                        {getItemDisplayName(item.id)}
-                      </SelectItem>
-                    ))}
+                  <SelectContent
+                    searchable
+                    searchValue={collectionItemSearch}
+                    onSearchChange={setCollectionItemSearch}
+                    searchPlaceholder="Search items..."
+                    className="w-72"
+                  >
+                    {(() => {
+                      const query = collectionItemSearch.trim().toLowerCase();
+                      const filtered = query
+                        ? collectionItems.filter(item =>
+                          getItemDisplayName(item.id).toLowerCase().includes(query)
+                        )
+                        : collectionItems;
+                      if (filtered.length === 0) {
+                        return (
+                          <div className="px-2 py-4 text-center text-xs text-muted-foreground">
+                            {query ? 'No items found' : 'No items available'}
+                          </div>
+                        );
+                      }
+                      return filtered.map((item) => (
+                        <SelectItem key={item.id} value={item.id}>
+                          {getItemDisplayName(item.id)}
+                        </SelectItem>
+                      ));
+                    })()}
                   </SelectContent>
                 </Select>
               </div>

--- a/app/(builder)/ycode/components/LinkItemOptions.tsx
+++ b/app/(builder)/ycode/components/LinkItemOptions.tsx
@@ -11,6 +11,8 @@ interface CollectionItemSelectOptionsProps {
   collectionItems: CollectionItemWithValues[];
   /** Fields for the linked page's collection, used to derive display names */
   collectionFields: CollectionField[];
+  /** Optional search string to filter visible options by their display label */
+  searchValue?: string;
 }
 
 /** Derives a human-readable label for a collection item. */
@@ -25,6 +27,9 @@ function getDisplayName(item: CollectionItemWithValues, collectionFields: Collec
  * Shared SelectContent items for CMS item pickers used in link settings.
  * Renders "Current page item", "Current collection item", reference field options,
  * a separator, and the concrete item list.
+ *
+ * When `searchValue` is provided, options are filtered case-insensitively by
+ * their visible label.
  */
 export default function LinkItemOptions({
   canUseCurrentPageItem,
@@ -32,34 +37,52 @@ export default function LinkItemOptions({
   referenceItemOptions,
   collectionItems,
   collectionFields,
+  searchValue,
 }: CollectionItemSelectOptionsProps) {
-  const hasSpecialOptions = canUseCurrentPageItem || canUseCurrentCollectionItem || referenceItemOptions.length > 0;
+  const query = searchValue?.trim().toLowerCase() ?? '';
+  const matches = (label: string) => !query || label.toLowerCase().includes(query);
+
+  const showCurrentPageItem = canUseCurrentPageItem && matches('Current page item');
+  const showCurrentCollectionItem = canUseCurrentCollectionItem && matches('Current collection item');
+  const filteredReferenceOptions = referenceItemOptions.filter(opt => matches(opt.label));
+  const filteredItems = collectionItems.filter(item => matches(getDisplayName(item, collectionFields)));
+
+  const hasSpecialOptions = showCurrentPageItem || showCurrentCollectionItem || filteredReferenceOptions.length > 0;
+  const hasAnyResults = hasSpecialOptions || filteredItems.length > 0;
+
+  if (!hasAnyResults && query) {
+    return (
+      <div className="px-2 py-4 text-center text-xs text-muted-foreground">
+        No items found
+      </div>
+    );
+  }
 
   return (
     <>
-      {canUseCurrentPageItem && (
+      {showCurrentPageItem && (
         <SelectItem value="current-page">
           <div className="flex items-center gap-2">
             Current page item
           </div>
         </SelectItem>
       )}
-      {canUseCurrentCollectionItem && (
+      {showCurrentCollectionItem && (
         <SelectItem value="current-collection">
           <div className="flex items-center gap-2">
             Current collection item
           </div>
         </SelectItem>
       )}
-      {referenceItemOptions.map((opt) => (
+      {filteredReferenceOptions.map((opt) => (
         <SelectItem key={opt.value} value={opt.value}>
           <div className="flex items-center gap-2">
             {opt.label}
           </div>
         </SelectItem>
       ))}
-      {hasSpecialOptions && <SelectSeparator />}
-      {collectionItems.map((item) => (
+      {hasSpecialOptions && filteredItems.length > 0 && <SelectSeparator />}
+      {filteredItems.map((item) => (
         <SelectItem key={item.id} value={item.id}>
           {getDisplayName(item, collectionFields)}
         </SelectItem>

--- a/app/(builder)/ycode/components/LinkSettings.tsx
+++ b/app/(builder)/ycode/components/LinkSettings.tsx
@@ -118,6 +118,7 @@ export default function LinkSettings(props: LinkSettingsProps) {
   const [isOpen, setIsOpen] = useState(true);
   const [collectionItems, setCollectionItems] = useState<CollectionItemWithValues[]>([]);
   const [loadingItems, setLoadingItems] = useState(false);
+  const [collectionItemSearch, setCollectionItemSearch] = useState('');
 
   // Stores
   const pages = usePagesStore((state) => state.pages);
@@ -893,19 +894,32 @@ export default function LinkSettings(props: LinkSettingsProps) {
               <div className={useStackedLayout ? '' : 'col-span-2'}>
                 <Select
                   value={collectionItemId || ''}
-                  onValueChange={handleCollectionItemChange}
+                  onValueChange={(value) => {
+                    handleCollectionItemChange(value);
+                    setCollectionItemSearch('');
+                  }}
+                  onOpenChange={(open) => {
+                    if (!open) setCollectionItemSearch('');
+                  }}
                   disabled={isLockedByOther || loadingItems}
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder={loadingItems ? 'Loading...' : 'Select...'} />
                   </SelectTrigger>
-                  <SelectContent>
+                  <SelectContent
+                    searchable
+                    searchValue={collectionItemSearch}
+                    onSearchChange={setCollectionItemSearch}
+                    searchPlaceholder="Search items..."
+                    className="w-72"
+                  >
                     <LinkItemOptions
                       canUseCurrentPageItem={canUseCurrentPageItem}
                       canUseCurrentCollectionItem={canUseCurrentCollectionItem}
                       referenceItemOptions={referenceItemOptions}
                       collectionItems={collectionItems}
                       collectionFields={linkedPageCollectionFields}
+                      searchValue={collectionItemSearch}
                     />
                   </SelectContent>
                 </Select>

--- a/app/(builder)/ycode/components/RichTextLinkSettings.tsx
+++ b/app/(builder)/ycode/components/RichTextLinkSettings.tsx
@@ -78,6 +78,7 @@ export default function RichTextLinkSettings({
 }: RichTextLinkSettingsProps) {
   const [collectionItems, setCollectionItems] = useState<CollectionItemWithValues[]>([]);
   const [loadingItems, setLoadingItems] = useState(false);
+  const [collectionItemSearch, setCollectionItemSearch] = useState('');
 
   // Stores
   const pages = usePagesStore((state) => state.pages);
@@ -650,19 +651,32 @@ export default function RichTextLinkSettings({
               <div className="col-span-2">
                 <Select
                   value={collectionItemId || ''}
-                  onValueChange={handleCollectionItemChange}
+                  onValueChange={(value) => {
+                    handleCollectionItemChange(value);
+                    setCollectionItemSearch('');
+                  }}
+                  onOpenChange={(open) => {
+                    if (!open) setCollectionItemSearch('');
+                  }}
                   disabled={loadingItems}
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder={loadingItems ? 'Loading...' : 'Select...'} />
                   </SelectTrigger>
-                  <SelectContent>
+                  <SelectContent
+                    searchable
+                    searchValue={collectionItemSearch}
+                    onSearchChange={setCollectionItemSearch}
+                    searchPlaceholder="Search items..."
+                    className="w-72"
+                  >
                     <LinkItemOptions
                       canUseCurrentPageItem={canUseCurrentPageItem}
                       canUseCurrentCollectionItem={canUseCurrentCollectionItem}
                       referenceItemOptions={referenceItemOptions}
                       collectionItems={collectionItems}
                       collectionFields={linkedPageCollectionFields}
+                      searchValue={collectionItemSearch}
                     />
                   </SelectContent>
                 </Select>


### PR DESCRIPTION
## Summary

Adds a search input to the CMS item selectors used in layer link settings, rich text link settings, and collection link field inputs, matching the existing search UX in the canvas collection picker. Makes it faster to find an item when a collection has many entries.

## Changes

- Add `searchable` + search state to the CMS item `Select` in `LinkSettings`, `RichTextLinkSettings`, and `CollectionLinkFieldInput`
- Extend `LinkItemOptions` with an optional `searchValue` prop and filter built-in options, reference options, and concrete items by name
- Filter collection items in `CollectionLinkFieldInput` using the display name resolver and show a "No items found" empty state
- Clear the search query on select/open-change so it resets between interactions

## Test plan

- [ ] In the builder, select a layer, open Link settings, choose a CMS collection, and verify the CMS item dropdown shows a search field that filters items
- [ ] Repeat inside the rich text editor link popover
- [ ] Edit a collection item that has a link field pointing to another collection and verify the item dropdown is searchable
- [ ] Confirm the "Current page item" / "Current collection item" / reference options are also filtered by the search query
- [ ] Verify the search clears after picking an item or closing the dropdown
