### PR TITLE
perf: replace canvas Tailwind CDN with server-compiled CSS

### DIFF
--- a/app/(builder)/ycode/api/canvas/css/route.ts
+++ b/app/(builder)/ycode/api/canvas/css/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { compileCanvasCss } from '@/lib/server/cssGenerator';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /ycode/api/canvas/css
+ *
+ * Compile Tailwind CSS for the exact set of class candidates currently used
+ * by the live editor canvas. Replaces the Tailwind browser CDN JIT that used
+ * to run inside the canvas iframe.
+ *
+ * Body: { classes: string[] }
+ * Response: text/css (compiled Tailwind output)
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as { classes?: unknown };
+    const raw = Array.isArray(body.classes) ? body.classes : [];
+
+    const classes = raw
+      .filter((cls): cls is string => typeof cls === 'string')
+      .map((cls) => cls.trim())
+      .filter((cls) => cls.length > 0);
+
+    const css = await compileCanvasCss(classes);
+
+    return new NextResponse(css, {
+      status: 200,
+      headers: {
+        'content-type': 'text/css; charset=utf-8',
+        // Content is derived entirely from the request body; the client keys
+        // its Blob URL cache by a hash of the input, so we don't need HTTP
+        // caching here.
+        'cache-control': 'private, no-store',
+      },
+    });
+  } catch (error) {
+    console.error('[canvas-css] Failed to compile canvas CSS:', error);
+
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : 'Failed to compile CSS',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/(builder)/ycode/api/css/generate/route.ts
+++ b/app/(builder)/ycode/api/css/generate/route.ts
@@ -18,6 +18,7 @@ export async function POST() {
       data: {
         message: 'CSS generated and saved to draft_css',
         length: css.length,
+        css,
       },
     });
   } catch (error) {

--- a/app/(builder)/ycode/components/Canvas.tsx
+++ b/app/(builder)/ycode/components/Canvas.tsx
@@ -3,13 +3,16 @@
 /**
  * Canvas Component
  *
- * Renders the layer editor canvas using an embedded iframe with Tailwind Browser CDN.
- * The iframe provides complete style isolation while allowing React-based layer rendering.
+ * Renders the layer editor canvas inside an embedded iframe for full style
+ * isolation. Tailwind utilities are compiled on the server and swapped in via
+ * a single `<link>` tag managed by `useCanvasTailwindCss`; we do not run the
+ * Tailwind browser CDN JIT inside the iframe.
  *
  * Architecture:
- * - An iframe is created with Tailwind Browser CDN loaded
- * - React components are rendered into the iframe via ReactDOM.createRoot
- * - Communication happens via direct function calls (no postMessage needed)
+ * - The iframe is created with a minimal HTML template (see canvas-utils).
+ * - React components are rendered into the iframe via ReactDOM.createRoot.
+ * - `useCanvasTailwindCss` keeps the iframe stylesheet in sync with the
+ *   classes referenced by the current draft, debounced and hash-cached.
  */
 
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
@@ -26,6 +29,8 @@ import { resolveReferenceFieldsSync } from '@/lib/collection-utils';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { useFontsStore } from '@/stores/useFontsStore';
 import { useColorVariablesStore } from '@/stores/useColorVariablesStore';
+import { useComponentsStore } from '@/stores/useComponentsStore';
+import { useCanvasTailwindCss } from '@/hooks/use-canvas-tailwind-css';
 
 import type { Layer, Component, CollectionItemWithValues, CollectionField, Breakpoint, Asset, ComponentVariable } from '@/types';
 import type { UseLiveLayerUpdatesReturn } from '@/hooks/use-live-layer-updates';
@@ -294,13 +299,43 @@ export default function Canvas({
 
   // State
   const [iframeReady, setIframeReady] = useState(false);
+  const [iframeDoc, setIframeDoc] = useState<Document | null>(null);
   const [internalHoveredLayerId, setInternalHoveredLayerId] = useState<string | null>(null);
   const effectiveHoveredLayerId = hoveredLayerId ?? internalHoveredLayerId;
+
+  // Component layers (drafts + saved) are merged in for canvas Tailwind
+  // compilation so classes used only inside components still get CSS.
+  const componentDrafts = useComponentsStore((state) => state.componentDrafts);
+  const storedComponents = useComponentsStore((state) => state.components);
+
+  const allComponentLayers = useMemo(() => {
+    const draftIds = new Set(Object.keys(componentDrafts));
+    const collected: Layer[] = [];
+
+    for (const draftLayers of Object.values(componentDrafts)) {
+      if (draftLayers && Array.isArray(draftLayers)) {
+        collected.push(...draftLayers);
+      }
+    }
+
+    for (const component of storedComponents) {
+      if (draftIds.has(component.id)) continue;
+      if (component.layers && Array.isArray(component.layers)) {
+        collected.push(...component.layers);
+      }
+    }
+
+    return collected;
+  }, [componentDrafts, storedComponents]);
 
   // Resolve component instances in layers
   const { layers: resolvedLayers, componentMap } = useMemo(() => {
     return serializeLayers(layers, components, editingComponentVariables);
   }, [layers, components, editingComponentVariables]);
+
+  // Compile and inject Tailwind CSS for classes actually used on the canvas,
+  // replacing the old browser CDN JIT inside the iframe.
+  useCanvasTailwindCss(iframeDoc, resolvedLayers, allComponentLayers);
 
   // Enrich page collection item data with reference field dotted keys
   // so variables like "refFieldId.targetFieldId" resolve on canvas
@@ -359,7 +394,8 @@ export default function Canvas({
     onLayerHover?.(resolvedLayerId);
   }, [componentMap, editingComponentId, onLayerHover]);
 
-  // Initialize iframe with Tailwind Browser CDN (only once)
+  // Initialize iframe shell (only once). Tailwind CSS is loaded later via
+  // useCanvasTailwindCss swapping the href on <link id="ycode-tw-css">.
   useEffect(() => {
     const iframe = iframeRef.current;
     if (!iframe) return;
@@ -374,7 +410,7 @@ export default function Canvas({
       // Double-check we haven't already initialized
       if (rootRef.current) return;
 
-      // Write the initial HTML with Tailwind Browser CDN (shared template)
+      // Write the initial HTML shell (no Tailwind CDN)
       doc.open();
       doc.write(getCanvasIframeHtml('canvas-mount'));
       doc.close();
@@ -401,18 +437,16 @@ export default function Canvas({
       };
       doc.head.appendChild(gsapScript);
 
-      // Wait for Tailwind to initialize
-      setTimeout(() => {
-        // Final guard before creating root
-        if (rootRef.current) return;
+      // Final guard before creating root
+      if (rootRef.current) return;
 
-        const mountPoint = doc.getElementById('canvas-mount');
-        if (mountPoint) {
-          mountPointRef.current = mountPoint as HTMLDivElement;
-          rootRef.current = createRoot(mountPoint);
-          setIframeReady(true);
-        }
-      }, 100);
+      const mountPoint = doc.getElementById('canvas-mount');
+      if (mountPoint) {
+        mountPointRef.current = mountPoint as HTMLDivElement;
+        rootRef.current = createRoot(mountPoint);
+        setIframeDoc(doc);
+        setIframeReady(true);
+      }
     };
 
     // Initialize when iframe loads
@@ -429,6 +463,7 @@ export default function Canvas({
       rootRef.current = null;
       mountPointRef.current = null;
       setIframeReady(false);
+      setIframeDoc(null);
 
       // Defer unmount to next frame to ensure we're outside React's render cycle
       if (rootToUnmount) {

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -396,22 +396,12 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
       return;
     }
 
-    // Generate initial CSS if it doesn't exist
+    // Generate initial CSS if it doesn't exist. The server reads drafts
+    // authoritatively from the DB, so no layers need to be collected here.
     const generateInitialCSS = async () => {
       try {
         const { generateAndSaveCSS } = await import('@/lib/client/cssGenerator');
-
-        // Collect layers from ALL pages for comprehensive CSS generation
-        // Use current draftsByPageId from store at execution time
-        const currentDrafts = usePagesStore.getState().draftsByPageId;
-        const allLayers: Layer[] = [];
-        Object.values(currentDrafts).forEach(draft => {
-          if (draft.layers) {
-            allLayers.push(...draft.layers);
-          }
-        });
-
-        await generateAndSaveCSS(allLayers);
+        await generateAndSaveCSS();
       } catch (error) {
         console.error('[Editor] Failed to generate initial CSS:', error);
       }

--- a/hooks/use-canvas-tailwind-css.ts
+++ b/hooks/use-canvas-tailwind-css.ts
@@ -1,0 +1,259 @@
+'use client';
+
+/**
+ * useCanvasTailwindCss
+ *
+ * Replaces the Tailwind browser CDN JIT that used to live inside the canvas
+ * iframe. Walks the layer tree for the classes we need, POSTs them to
+ * `/ycode/api/canvas/css`, and swaps the resulting CSS into a single
+ * `<link id="ycode-tw-css">` element inside the iframe head via a Blob URL.
+ *
+ * To avoid a flash of unstyled content on the first paint, the iframe body
+ * starts with `data-tw-pending` (see lib/canvas-utils.ts) which hides it via
+ * CSS; this hook removes the attribute once the first stylesheet has loaded.
+ *
+ * Subsequent edits are debounced so rapid typing coalesces into a single
+ * request, and the resulting Blob URLs are cached in-memory by hash so
+ * flipping between pages or breakpoints with identical class sets is instant.
+ */
+
+import { useEffect, useRef } from 'react';
+
+import type { Layer } from '@/types';
+import { extractCanvasCandidates } from '@/lib/canvas-class-extractor';
+import { compileArbitraryClasses } from '@/lib/client/arbitrary-value-compiler';
+
+const LINK_ELEMENT_ID = 'ycode-tw-css';
+const LIVE_STYLE_ID = 'ycode-tw-live';
+const PENDING_ATTR = 'data-tw-pending';
+const DEBOUNCE_MS = 150;
+/** Fallback reveal timeout — in case the link `load` event never fires. */
+const REVEAL_FALLBACK_MS = 3000;
+const CACHE_MAX_ENTRIES = 16;
+
+/** djb2 string hash — deterministic, collision-safe enough for a cache key. */
+function hashCandidates(candidates: readonly string[]): string {
+  let hash = 5381;
+  for (const cls of candidates) {
+    for (let i = 0; i < cls.length; i++) {
+      hash = ((hash << 5) + hash + cls.charCodeAt(i)) | 0;
+    }
+    hash = ((hash << 5) + hash + 32) | 0;
+  }
+  return (hash >>> 0).toString(36) + ':' + candidates.length.toString(36);
+}
+
+/**
+ * Module-level LRU cache of `hash -> blob URL`. Shared across all hook
+ * instances so remounting the canvas (page switch, breakpoint change, etc.)
+ * reuses compiled CSS when the underlying class set is unchanged.
+ */
+const blobUrlCache = new Map<string, string>();
+
+function cacheSet(key: string, url: string): void {
+  if (blobUrlCache.has(key)) {
+    blobUrlCache.delete(key);
+  } else if (blobUrlCache.size >= CACHE_MAX_ENTRIES) {
+    const oldestKey = blobUrlCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      const oldestUrl = blobUrlCache.get(oldestKey);
+      if (oldestUrl) URL.revokeObjectURL(oldestUrl);
+      blobUrlCache.delete(oldestKey);
+    }
+  }
+  blobUrlCache.set(key, url);
+}
+
+function cacheGet(key: string): string | undefined {
+  const url = blobUrlCache.get(key);
+  if (url) {
+    // Promote to most-recently-used
+    blobUrlCache.delete(key);
+    blobUrlCache.set(key, url);
+  }
+  return url;
+}
+
+function ensureLinkElement(iframeDoc: Document): HTMLLinkElement {
+  let link = iframeDoc.getElementById(LINK_ELEMENT_ID) as HTMLLinkElement | null;
+  if (!link) {
+    link = iframeDoc.createElement('link');
+    link.id = LINK_ELEMENT_ID;
+    link.rel = 'stylesheet';
+    iframeDoc.head.appendChild(link);
+  }
+  return link;
+}
+
+/**
+ * Ensure there's a `<style id="ycode-tw-live">` element positioned *after* the
+ * canonical stylesheet link so its rules win source-order ties while the
+ * server-compiled CSS catches up.
+ */
+function ensureLiveStyleElement(iframeDoc: Document): HTMLStyleElement {
+  let style = iframeDoc.getElementById(LIVE_STYLE_ID) as HTMLStyleElement | null;
+  if (!style) {
+    style = iframeDoc.createElement('style');
+    style.id = LIVE_STYLE_ID;
+    const link = iframeDoc.getElementById(LINK_ELEMENT_ID);
+    if (link?.parentNode) {
+      link.parentNode.insertBefore(style, link.nextSibling);
+    } else {
+      iframeDoc.head.appendChild(style);
+    }
+  }
+  return style;
+}
+
+/**
+ * Rebuild the live-style overlay from the current candidate set. Using the
+ * full candidate list (rather than just newly-added classes) keeps the
+ * overlay bounded — it only ever contains utilities currently in use.
+ */
+function updateLiveStyle(iframeDoc: Document, candidates: readonly string[]): void {
+  const css = compileArbitraryClasses(candidates);
+  const style = ensureLiveStyleElement(iframeDoc);
+  if (style.textContent !== css) style.textContent = css;
+}
+
+function revealBody(iframeDoc: Document): void {
+  iframeDoc.body?.removeAttribute(PENDING_ATTR);
+}
+
+/**
+ * Apply a Blob URL to the iframe's stylesheet link and schedule the body
+ * reveal once the browser has loaded and applied the stylesheet. A fallback
+ * timer ensures we never leave the canvas hidden if the `load` event never
+ * fires for some reason.
+ */
+function applyStylesheet(iframeDoc: Document, url: string): void {
+  const link = ensureLinkElement(iframeDoc);
+
+  // If the href hasn't changed, the load event won't refire — reveal now.
+  if (link.href === url) {
+    revealBody(iframeDoc);
+    return;
+  }
+
+  const reveal = () => revealBody(iframeDoc);
+
+  const fallback = setTimeout(reveal, REVEAL_FALLBACK_MS);
+  link.addEventListener(
+    'load',
+    () => {
+      clearTimeout(fallback);
+      reveal();
+    },
+    { once: true },
+  );
+  link.addEventListener(
+    'error',
+    () => {
+      clearTimeout(fallback);
+      reveal();
+    },
+    { once: true },
+  );
+
+  link.href = url;
+}
+
+export function useCanvasTailwindCss(
+  iframeDoc: Document | null,
+  layers: Layer[],
+  componentLayers: Layer[],
+): void {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastHashRef = useRef<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!iframeDoc) return;
+
+    const combined = componentLayers.length > 0 ? [...layers, ...componentLayers] : layers;
+    const candidates = extractCanvasCandidates(combined);
+    const hash = hashCandidates(candidates);
+
+    if (hash === lastHashRef.current) return;
+
+    // Instant fast path: compile arbitrary-value utilities in the browser so
+    // interactive edits (color picker drag, numeric sliders) update on the
+    // next frame while the canonical server-compiled stylesheet catches up.
+    // The overlay is rebuilt from the current candidate set each tick so it
+    // never grows beyond what's actually on the canvas.
+    updateLiveStyle(iframeDoc, candidates);
+
+    // Fast path: cached blob URL for this exact class set
+    const cached = cacheGet(hash);
+    if (cached) {
+      applyStylesheet(iframeDoc, cached);
+      lastHashRef.current = hash;
+      return;
+    }
+
+    // Slow path: compile on the server. Skip the debounce on the very first
+    // fetch so the user never sees a flash of unstyled layers.
+    const isFirstLoad = lastHashRef.current === null;
+
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    if (abortRef.current) abortRef.current.abort();
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const runFetch = async () => {
+      try {
+        const response = await fetch('/ycode/api/canvas/css', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ classes: candidates }),
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`canvas css endpoint returned ${response.status}`);
+        }
+
+        const css = await response.text();
+
+        // Bail if another edit already superseded this request or the iframe
+        // document is gone (e.g. page navigation).
+        if (controller.signal.aborted) return;
+        if (!iframeDoc.documentElement) return;
+
+        const blob = new Blob([css], { type: 'text/css' });
+        const url = URL.createObjectURL(blob);
+        cacheSet(hash, url);
+
+        applyStylesheet(iframeDoc, url);
+        lastHashRef.current = hash;
+      } catch (error) {
+        if ((error as { name?: string }).name === 'AbortError') return;
+        console.error('[canvas-css] Failed to load canvas Tailwind CSS:', error);
+        // Never leave the canvas hidden on error.
+        revealBody(iframeDoc);
+      }
+    };
+
+    if (isFirstLoad) {
+      runFetch();
+    } else {
+      timeoutRef.current = setTimeout(runFetch, DEBOUNCE_MS);
+    }
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      controller.abort();
+    };
+  }, [iframeDoc, layers, componentLayers]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, []);
+}

--- a/lib/canvas-class-extractor.ts
+++ b/lib/canvas-class-extractor.ts
@@ -1,0 +1,116 @@
+/**
+ * Canvas Class Extractor
+ *
+ * Shared between client and server: walks a layer tree and returns the unique
+ * set of Tailwind class candidates that need to be compiled so the canvas
+ * iframe (or the published site) can render correctly.
+ *
+ * Used by:
+ * - lib/server/cssGenerator.ts (publish pipeline + API endpoints)
+ * - hooks/use-canvas-tailwind-css.ts (live editor canvas)
+ * - lib/client/thumbnail-capture.tsx (component thumbnails)
+ */
+
+import type { Layer } from '@/types';
+import { DEFAULT_TEXT_STYLES } from '@/lib/text-format-utils';
+
+/**
+ * Tailwind utilities that must always be present in the compiled canvas CSS,
+ * even if no layer currently uses them. These back the context menus and other
+ * editor chrome that React portals into the iframe. They reference the
+ * custom `@theme` tokens defined in `lib/server/canvas-tailwind-input.css`.
+ */
+export const CANVAS_SAFELIST_CLASSES: readonly string[] = [
+  'bg-popover',
+  'text-popover-foreground',
+  'bg-accent',
+  'text-accent-foreground',
+  'text-muted-foreground',
+  'text-foreground',
+  'border-border',
+  'text-destructive',
+];
+
+function addClassString(
+  classes: Set<string>,
+  value: string | string[] | undefined,
+): void {
+  if (!value) return;
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (typeof entry !== 'string') continue;
+      for (const cls of entry.split(/\s+/)) {
+        const trimmed = cls.trim();
+        if (trimmed) classes.add(trimmed);
+      }
+    }
+    return;
+  }
+
+  if (typeof value === 'string') {
+    for (const cls of value.split(/\s+/)) {
+      const trimmed = cls.trim();
+      if (trimmed) classes.add(trimmed);
+    }
+  }
+}
+
+/**
+ * Walk a layer tree and collect every Tailwind candidate we can see.
+ *
+ * Deduplicates component subtrees by `componentId` so a component used many
+ * times only contributes its classes once.
+ */
+export function extractClassesFromLayers(layers: Layer[]): Set<string> {
+  const classes = new Set<string>();
+  const processedComponentIds = new Set<string>();
+
+  function processLayer(layer: Layer): void {
+    if (layer.settings?.hidden) return;
+
+    if (layer.componentId) {
+      if (processedComponentIds.has(layer.componentId)) return;
+      processedComponentIds.add(layer.componentId);
+    }
+
+    addClassString(classes, layer.classes);
+
+    if (layer.textStyles) {
+      for (const style of Object.values(layer.textStyles)) {
+        addClassString(classes, style.classes);
+      }
+    }
+
+    if (layer.variables?.text) {
+      for (const style of Object.values(DEFAULT_TEXT_STYLES)) {
+        addClassString(classes, style.classes);
+      }
+    }
+
+    if (layer.children && Array.isArray(layer.children)) {
+      for (const child of layer.children) {
+        processLayer(child);
+      }
+    }
+  }
+
+  for (const layer of layers) {
+    processLayer(layer);
+  }
+
+  return classes;
+}
+
+/**
+ * Convenience: extract classes from layers and merge in the safelist used by
+ * the editor iframe. Returns a sorted, deduped array, which doubles as a
+ * stable hash input.
+ */
+export function extractCanvasCandidates(layers: Layer[]): string[] {
+  const classes = extractClassesFromLayers(layers);
+  for (const safelisted of CANVAS_SAFELIST_CLASSES) {
+    classes.add(safelisted);
+  }
+  return Array.from(classes).sort();
+}

--- a/lib/canvas-utils.ts
+++ b/lib/canvas-utils.ts
@@ -124,8 +124,14 @@ export function measureContentExtent(doc: Document): number {
 }
 
 /**
- * Shared HTML template for canvas-style iframes with Tailwind Browser CDN.
- * Used by both the editor Canvas and the thumbnail capture hook.
+ * Shared HTML template for canvas-style iframes.
+ *
+ * Tailwind utilities are compiled on the server and loaded via a single
+ * `<link id="ycode-tw-css">` whose href is populated at runtime
+ * (see hooks/use-canvas-tailwind-css.ts). This replaces the previous
+ * Tailwind browser CDN JIT, matching how legacy Ycode served a precompiled
+ * stylesheet into the canvas iframe.
+ *
  * @param mountId - The ID of the mount point div (default: 'canvas-mount')
  */
 export function getCanvasIframeHtml(mountId: string = 'canvas-mount'): string {
@@ -134,21 +140,18 @@ export function getCanvasIframeHtml(mountId: string = 'canvas-mount'): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-  <style type="text/tailwindcss">
-    @custom-variant current (&[aria-current]);
-    @custom-variant disabled (&:is(:disabled, [aria-disabled]));
-    @theme {
-      /* Editor UI colors for context menus portaled into the iframe */
-      --color-popover: oklch(0.269 0 0);
-      --color-popover-foreground: oklch(0.708 0 0);
-      --color-accent: oklch(0.32 0 0);
-      --color-accent-foreground: oklch(0.985 0 0);
-      --color-muted-foreground: oklch(0.708 0 0);
-      --color-foreground: oklch(0.985 0 0);
-      --color-border: oklch(1 0 0 / 5%);
-      --color-destructive: oklch(0.704 0.191 22.216);
-    }
+  <style id="ycode-canvas-bootstrap">
+    /* Keep the body hidden until the compiled Tailwind stylesheet is in, so
+       the user never sees a flash of unstyled layers. Cleared by
+       hooks/use-canvas-tailwind-css.ts once <link id="ycode-tw-css"> loads. */
+    body[data-tw-pending] { visibility: hidden; }
+  </style>
+  <link id="ycode-tw-css" rel="stylesheet">
+  <style id="ycode-tw-live">
+    /* Short-lived overlay for arbitrary-value utilities compiled in the
+       browser by hooks/use-canvas-tailwind-css.ts + lib/client/
+       arbitrary-value-compiler.ts, so color pickers and sliders update on
+       the next frame without waiting for the server-compiled stylesheet. */
   </style>
   <style id="ycode-fonts-style">
     /* Font CSS (Google @import + custom @font-face) injected dynamically */
@@ -167,7 +170,7 @@ export function getCanvasIframeHtml(mountId: string = 'canvas-mount'): string {
     /* Dynamically populated: overrides vh/svh/dvh/lvh with fixed px values */
   </style>
 </head>
-<body class="h-full">
+<body class="h-full" data-tw-pending>
   <div id="${mountId}" class="contents"></div>
 </body>
 </html>`;

--- a/lib/client/arbitrary-value-compiler.ts
+++ b/lib/client/arbitrary-value-compiler.ts
@@ -1,0 +1,408 @@
+'use client';
+
+/**
+ * Arbitrary-value Tailwind fast path
+ *
+ * Compiles a targeted subset of Tailwind utilities with arbitrary values
+ * (e.g. `text-[#FF0000]`, `w-[137px]`, `p-[24px]`, `max-md:bg-[#00FF00]`) into
+ * CSS directly in the browser so interactive edits (color picker drag, numeric
+ * sliders) get pixel-perfect feedback on the next frame.
+ *
+ * The canonical Tailwind stylesheet is still compiled on the server — this
+ * module only produces a short-lived overlay so users don't wait on the
+ * debounce + network roundtrip for rules that are trivial to derive.
+ *
+ * Classes we can't confidently compile (unknown utility prefix, unexpected
+ * variant, arbitrary URL values, etc.) are silently skipped; the server will
+ * fill them in a moment later.
+ */
+// ============================================================================
+// Utility prefix tables
+// ============================================================================
+
+/** Prefixes that accept an arbitrary color value. */
+const COLOR_UTILITIES: Record<string, string | readonly string[]> = {
+  text: 'color',
+  bg: 'background-color',
+  border: 'border-color',
+  'border-t': 'border-top-color',
+  'border-r': 'border-right-color',
+  'border-b': 'border-bottom-color',
+  'border-l': 'border-left-color',
+  'border-x': ['border-left-color', 'border-right-color'],
+  'border-y': ['border-top-color', 'border-bottom-color'],
+  outline: 'outline-color',
+  decoration: 'text-decoration-color',
+  fill: 'fill',
+  stroke: 'stroke',
+  caret: 'caret-color',
+  accent: 'accent-color',
+};
+
+/** Prefixes that accept an arbitrary length/number value. */
+const LENGTH_UTILITIES: Record<string, string | readonly string[]> = {
+  w: 'width',
+  h: 'height',
+  'min-w': 'min-width',
+  'min-h': 'min-height',
+  'max-w': 'max-width',
+  'max-h': 'max-height',
+  p: 'padding',
+  px: ['padding-left', 'padding-right'],
+  py: ['padding-top', 'padding-bottom'],
+  pt: 'padding-top',
+  pr: 'padding-right',
+  pb: 'padding-bottom',
+  pl: 'padding-left',
+  m: 'margin',
+  mx: ['margin-left', 'margin-right'],
+  my: ['margin-top', 'margin-bottom'],
+  mt: 'margin-top',
+  mr: 'margin-right',
+  mb: 'margin-bottom',
+  ml: 'margin-left',
+  gap: 'gap',
+  'gap-x': 'column-gap',
+  'gap-y': 'row-gap',
+  rounded: 'border-radius',
+  'rounded-t': ['border-top-left-radius', 'border-top-right-radius'],
+  'rounded-r': ['border-top-right-radius', 'border-bottom-right-radius'],
+  'rounded-b': ['border-bottom-left-radius', 'border-bottom-right-radius'],
+  'rounded-l': ['border-top-left-radius', 'border-bottom-left-radius'],
+  'rounded-tl': 'border-top-left-radius',
+  'rounded-tr': 'border-top-right-radius',
+  'rounded-br': 'border-bottom-right-radius',
+  'rounded-bl': 'border-bottom-left-radius',
+  top: 'top',
+  right: 'right',
+  bottom: 'bottom',
+  left: 'left',
+  inset: 'inset',
+  'inset-x': ['left', 'right'],
+  'inset-y': ['top', 'bottom'],
+  leading: 'line-height',
+  tracking: 'letter-spacing',
+  'border-width': 'border-width',
+  'border-t-width': 'border-top-width',
+  'border-r-width': 'border-right-width',
+  'border-b-width': 'border-bottom-width',
+  'border-l-width': 'border-left-width',
+};
+
+/** Prefixes whose arbitrary value is a plain number (no unit). */
+const NUMBER_UTILITIES: Record<string, string> = {
+  z: 'z-index',
+  opacity: 'opacity',
+  'font-weight': 'font-weight',
+  order: 'order',
+  'flex-grow': 'flex-grow',
+  'flex-shrink': 'flex-shrink',
+};
+
+/** `font-[...]` is special: number → font-weight, otherwise font-family. */
+const FONT_UTILITY_PREFIX = 'font';
+
+// ============================================================================
+// Variant handling
+// ============================================================================
+
+type SelectorPiece = { append: string };
+type MediaPiece = { media: string };
+type Variant = SelectorPiece | MediaPiece;
+
+/** Supported breakpoint variants (mirrors lib/breakpoint-utils.ts). */
+const BREAKPOINT_VARIANTS: Record<string, string> = {
+  'max-md': '(max-width: 767px)',
+  'max-lg': '(max-width: 1023px)',
+  sm: '(min-width: 640px)',
+  md: '(min-width: 768px)',
+  lg: '(min-width: 1024px)',
+  xl: '(min-width: 1280px)',
+  '2xl': '(min-width: 1536px)',
+};
+
+/** Supported pseudo-class variants. */
+const PSEUDO_VARIANTS: Record<string, string> = {
+  hover: ':hover',
+  focus: ':focus',
+  'focus-visible': ':focus-visible',
+  'focus-within': ':focus-within',
+  active: ':active',
+  visited: ':visited',
+  checked: ':checked',
+  disabled: ':is(:disabled, [aria-disabled])',
+  // Custom variant defined in lib/server/canvas-tailwind-input.css
+  current: '[aria-current]',
+  first: ':first-child',
+  last: ':last-child',
+  odd: ':nth-child(odd)',
+  even: ':nth-child(even)',
+  empty: ':empty',
+  'placeholder-shown': ':placeholder-shown',
+};
+
+function classifyVariant(token: string): Variant | null {
+  const media = BREAKPOINT_VARIANTS[token];
+  if (media) return { media };
+
+  const pseudo = PSEUDO_VARIANTS[token];
+  if (pseudo) return { append: pseudo };
+
+  return null;
+}
+
+// ============================================================================
+// Parsing
+// ============================================================================
+
+/**
+ * Split a class name into variant tokens and the trailing utility.
+ * Respects brackets so `text-[rgb(0,0,0)]` isn't split on its internal colons.
+ */
+function splitVariantsAndUtility(className: string): {
+  variants: string[];
+  utility: string;
+} {
+  const variants: string[] = [];
+  let start = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < className.length; i++) {
+    const ch = className[i];
+    if (ch === '[') bracketDepth++;
+    else if (ch === ']') bracketDepth--;
+    else if (ch === '(') parenDepth++;
+    else if (ch === ')') parenDepth--;
+    else if (ch === ':' && bracketDepth === 0 && parenDepth === 0) {
+      variants.push(className.slice(start, i));
+      start = i + 1;
+    }
+  }
+
+  return { variants, utility: className.slice(start) };
+}
+
+const ARBITRARY_UTILITY_RE = /^(.+?)-\[(.+)\](?:\/(\d+(?:\.\d+)?))?$/;
+
+function parseArbitraryUtility(
+  utility: string,
+): { prefix: string; value: string; opacity: string | null } | null {
+  const match = ARBITRARY_UTILITY_RE.exec(utility);
+  if (!match) return null;
+  const [, prefix, rawValue, opacity] = match;
+  return { prefix, value: rawValue, opacity: opacity ?? null };
+}
+
+// ============================================================================
+// Value classification
+// ============================================================================
+
+function looksLikeColor(value: string): boolean {
+  if (value.startsWith('#')) return true;
+  if (/^[0-9A-Fa-f]{3}$/.test(value)) return true;
+  if (/^[0-9A-Fa-f]{6}$/.test(value)) return true;
+  if (/^[0-9A-Fa-f]{8}$/.test(value)) return true;
+  if (/^(rgb|rgba|hsl|hsla|oklch|oklab|lab|lch|color)\s*\(/i.test(value)) return true;
+  if (/^(transparent|currentColor|inherit|initial|unset)$/i.test(value)) return true;
+  if (value.startsWith('color:')) return true;
+  return false;
+}
+
+function looksLikeLength(value: string): boolean {
+  if (/^-?\d+(?:\.\d+)?(px|rem|em|%|vh|vw|svh|svw|dvh|dvw|lvh|lvw|ch|ex|cm|mm|in|pt|pc)$/i.test(
+    value,
+  )) {
+    return true;
+  }
+  if (value === '0' || value === 'auto') return true;
+  if (/^-?\d+(?:\.\d+)?$/.test(value)) return true; // bare number → unitless length
+  if (/^calc\(/i.test(value)) return true;
+  if (/^var\(/i.test(value)) return true;
+  return false;
+}
+
+function normalizeColorValue(value: string): string {
+  if (value.startsWith('color:')) return value.slice('color:'.length);
+  if (/^[0-9A-Fa-f]{3}$/.test(value)) return `#${value}`;
+  if (/^[0-9A-Fa-f]{6}$/.test(value)) return `#${value}`;
+  if (/^[0-9A-Fa-f]{8}$/.test(value)) return `#${value}`;
+  return value;
+}
+
+/**
+ * Apply an opacity modifier (0-100) to a color value using `color-mix`, which
+ * matches what Tailwind 4 produces for `text-[#f00]/50` and friends.
+ */
+function applyOpacityModifier(color: string, opacityPercent: string): string {
+  return `color-mix(in oklab, ${color} ${opacityPercent}%, transparent)`;
+}
+
+// ============================================================================
+// Declaration generation
+// ============================================================================
+
+type Declarations = Array<[string, string]>;
+
+function mapColorDeclarations(
+  prefix: string,
+  value: string,
+  opacity: string | null,
+): Declarations | null {
+  const target = COLOR_UTILITIES[prefix];
+  if (!target) return null;
+  if (!looksLikeColor(value)) return null;
+
+  const color = normalizeColorValue(value);
+  const finalColor = opacity ? applyOpacityModifier(color, opacity) : color;
+
+  if (typeof target === 'string') return [[target, finalColor]];
+  return target.map((prop) => [prop, finalColor] as [string, string]);
+}
+
+function mapLengthDeclarations(prefix: string, value: string): Declarations | null {
+  const target = LENGTH_UTILITIES[prefix];
+  if (!target) return null;
+  if (!looksLikeLength(value)) return null;
+
+  if (typeof target === 'string') return [[target, value]];
+  return target.map((prop) => [prop, value] as [string, string]);
+}
+
+function mapNumberDeclarations(prefix: string, value: string): Declarations | null {
+  const target = NUMBER_UTILITIES[prefix];
+  if (!target) return null;
+  if (!/^-?\d+(?:\.\d+)?$/.test(value)) return null;
+  return [[target, value]];
+}
+
+/**
+ * `text-[...]` can be either a color or a font-size. `bg-[...]` can be a
+ * color or a URL/gradient — only handle the color case here.
+ */
+function mapTextFontBgSpecial(
+  prefix: string,
+  value: string,
+  opacity: string | null,
+): Declarations | null {
+  if (prefix === 'text') {
+    if (looksLikeColor(value)) return mapColorDeclarations('text', value, opacity);
+    if (looksLikeLength(value)) return [['font-size', value]];
+    return null;
+  }
+
+  if (prefix === 'bg') {
+    if (looksLikeColor(value)) return mapColorDeclarations('bg', value, opacity);
+    return null;
+  }
+
+  if (prefix === FONT_UTILITY_PREFIX) {
+    if (/^\d+$/.test(value)) return [['font-weight', value]];
+    return null;
+  }
+
+  return null;
+}
+
+function compileUtilityDeclarations(
+  prefix: string,
+  value: string,
+  opacity: string | null,
+): Declarations | null {
+  const special = mapTextFontBgSpecial(prefix, value, opacity);
+  if (special) return special;
+
+  const color = mapColorDeclarations(prefix, value, opacity);
+  if (color) return color;
+
+  const length = mapLengthDeclarations(prefix, value);
+  if (length) return length;
+
+  const number = mapNumberDeclarations(prefix, value);
+  if (number) return number;
+
+  return null;
+}
+
+// ============================================================================
+// Emission
+// ============================================================================
+
+function escapeSelector(className: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(className);
+  }
+  return className.replace(/([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, '\\$1');
+}
+
+function declarationsToBody(decls: Declarations): string {
+  return decls.map(([prop, val]) => `${prop}: ${val};`).join(' ');
+}
+
+function tryCompileClass(className: string): string | null {
+  const { variants, utility } = splitVariantsAndUtility(className);
+  const parsed = parseArbitraryUtility(utility);
+  if (!parsed) return null;
+
+  const decls = compileUtilityDeclarations(parsed.prefix, parsed.value, parsed.opacity);
+  if (!decls || decls.length === 0) return null;
+
+  const resolvedVariants: Variant[] = [];
+  for (const token of variants) {
+    const variant = classifyVariant(token);
+    if (!variant) return null; // Unknown variant → leave for the server
+    resolvedVariants.push(variant);
+  }
+
+  const pseudoSuffix = resolvedVariants
+    .filter((v): v is SelectorPiece => 'append' in v)
+    .map((v) => v.append)
+    .join('');
+  const selector = `.${escapeSelector(className)}${pseudoSuffix}`;
+
+  let rule = `${selector} { ${declarationsToBody(decls)} }`;
+
+  // Wrap in @media blocks (innermost first → outermost last, but order between
+  // independent medias is irrelevant — we emit them outside-in).
+  const medias = resolvedVariants
+    .filter((v): v is MediaPiece => 'media' in v)
+    .map((v) => v.media);
+  for (const media of medias) {
+    rule = `@media ${media} { ${rule} }`;
+  }
+
+  return rule;
+}
+
+/**
+ * Compile every arbitrary-value class we can recognise into a CSS string,
+ * silently skipping anything unsupported. Duplicate rules are deduped.
+ */
+export function compileArbitraryClasses(classNames: readonly string[]): string {
+  const seen = new Set<string>();
+  const rules: string[] = [];
+
+  for (const raw of classNames) {
+    const className = raw.trim();
+    if (!className) continue;
+    if (!className.includes('[')) continue; // Only arbitrary-value utilities
+
+    const rule = tryCompileClass(className);
+    if (!rule) continue;
+    if (seen.has(rule)) continue;
+
+    seen.add(rule);
+    rules.push(rule);
+  }
+
+  return rules.join('\n');
+}
+
+/** Test helpers — exported for unit tests, not part of the public surface. */
+export const __testing = {
+  splitVariantsAndUtility,
+  parseArbitraryUtility,
+  looksLikeColor,
+  looksLikeLength,
+  tryCompileClass,
+};

--- a/lib/client/cssGenerator.ts
+++ b/lib/client/cssGenerator.ts
@@ -1,199 +1,56 @@
 /**
- * Client-Side CSS Generator using Tailwind Browser CDN
+ * Client-Side CSS Generator
  *
- * Uses @tailwindcss/browser in a hidden iframe to generate CSS
- * This avoids all WASM bundling issues
+ * Thin wrapper around the server CSS pipeline. The previous implementation
+ * ran Tailwind's browser CDN JIT inside a hidden iframe to compile CSS for
+ * publishing; that's now replaced with a single call to the existing
+ * `POST /ycode/api/css/generate` endpoint, which runs the same Node
+ * compiler used by the canvas.
  */
 
 'use client';
 
-import type { Component, Layer } from '@/types';
-import { DEFAULT_TEXT_STYLES } from '@/lib/text-format-utils';
-
 /**
- * Extract all classes from layers recursively
- * Includes classes from layer.classes, layer.textStyles, and DEFAULT_TEXT_STYLES
- * Tracks processed componentIds to avoid duplicate extraction
+ * Regenerate the draft CSS on the server using the current draft layers in
+ * the database, save it to the `draft_css` setting, and return the compiled
+ * CSS string.
+ *
+ * The `layers` argument is ignored — it's kept to preserve existing call
+ * sites while the server reads drafts authoritatively from the DB. Callers
+ * can pass anything (or nothing) without changing behavior.
  */
-function extractClassesFromLayers(layers: Layer[]): Set<string> {
-  const classes = new Set<string>();
-  const processedComponentIds = new Set<string>();
+export async function generateAndSaveCSS(_layers?: unknown): Promise<string> {
+  const response = await fetch('/ycode/api/css/generate', {
+    method: 'POST',
+  });
 
-  // Helper to extract classes from a string or array
-  const extractClasses = (classValue: string | string[] | undefined) => {
-    if (!classValue) return;
-
-    if (Array.isArray(classValue)) {
-      classValue.forEach(cls => {
-        if (cls && typeof cls === 'string') {
-          cls.split(/\s+/).forEach(c => c.trim() && classes.add(c.trim()));
-        }
-      });
-    } else if (typeof classValue === 'string') {
-      classValue.split(/\s+/).forEach(cls => cls.trim() && classes.add(cls.trim()));
-    }
-  };
-
-  function processLayer(layer: Layer): void {
-    if (layer.settings?.hidden) return;
-
-    // Skip if we've already processed this component
-    if (layer.componentId) {
-      if (processedComponentIds.has(layer.componentId)) return;
-      processedComponentIds.add(layer.componentId);
-    }
-
-    // Extract layer classes
-    extractClasses(layer.classes);
-
-    // Extract text style classes (from layer.textStyles)
-    if (layer.textStyles) {
-      Object.values(layer.textStyles).forEach(style => {
-        extractClasses(style.classes);
-      });
-    }
-
-    // Extract default text style classes (if layer has text content)
-    if (layer.variables?.text) {
-      Object.values(DEFAULT_TEXT_STYLES).forEach(style => {
-        extractClasses(style.classes);
-      });
-    }
-
-    if (layer.children && Array.isArray(layer.children)) {
-      layer.children.forEach(child => processLayer(child));
-    }
+  if (!response.ok) {
+    const message = await response.text().catch(() => response.statusText);
+    throw new Error(`Failed to generate CSS: ${message}`);
   }
 
-  layers.forEach(layer => processLayer(layer));
-  return classes;
+  const payload = (await response.json().catch(() => null)) as
+    | { data?: { css?: string; length?: number; message?: string } }
+    | null;
+
+  const css = payload?.data?.css ?? '';
+
+  // Keep the settings store in sync so UI reading draft_css reflects the
+  // latest value without an extra fetch.
+  try {
+    const { useSettingsStore } = await import('@/stores/useSettingsStore');
+    useSettingsStore.getState().updateSetting('draft_css', css);
+  } catch {
+    // Non-fatal: settings store update is a convenience, not a correctness
+    // requirement.
+  }
+
+  return css;
 }
 
 /**
- * Generate CSS using Tailwind Browser CDN in a hidden iframe
- */
-export async function generateCSS(layers: Layer[]): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const classes = extractClassesFromLayers(layers);
-    const classesArray = Array.from(classes);
-
-    if (classesArray.length === 0) {
-      resolve('/* No classes to generate */');
-      return;
-    }
-
-    const iframe = document.createElement('iframe');
-    iframe.style.display = 'none';
-    document.body.appendChild(iframe);
-
-    const timeout = setTimeout(() => {
-      window.removeEventListener('message', handleMessage);
-      if (document.body.contains(iframe)) {
-        document.body.removeChild(iframe);
-      }
-      reject(new Error('CSS generation timeout'));
-    }, 30000);
-
-    const handleMessage = (event: MessageEvent) => {
-      if (event.data.type === 'css-ready') {
-        clearTimeout(timeout);
-        window.removeEventListener('message', handleMessage);
-        if (document.body.contains(iframe)) {
-          document.body.removeChild(iframe);
-        }
-        resolve(event.data.css);
-      } else if (event.data.type === 'css-error') {
-        clearTimeout(timeout);
-        window.removeEventListener('message', handleMessage);
-        if (document.body.contains(iframe)) {
-          document.body.removeChild(iframe);
-        }
-        reject(new Error(event.data.error));
-      }
-    };
-    window.addEventListener('message', handleMessage);
-
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc) {
-      clearTimeout(timeout);
-      window.removeEventListener('message', handleMessage);
-      document.body.removeChild(iframe);
-      reject(new Error('Cannot access iframe document'));
-      return;
-    }
-
-    const htmlContent = classesArray.map(cls => `<div class="${cls}"></div>`).join('\n');
-
-    iframeDoc.open();
-    iframeDoc.write(`
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8">
-  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-  <style type="text/tailwindcss">
-    @custom-variant current (&[aria-current]);
-    @custom-variant disabled (&:is(:disabled, [aria-disabled]));
-  </style>
-</head>
-<body>
-  ${htmlContent}
-  <script>
-    let retryCount = 0;
-    const maxRetries = 100;
-
-    function extractCSS() {
-      try {
-        retryCount++;
-        const styleTags = Array.from(document.querySelectorAll('style'));
-
-        const tailwindStyle = styleTags.find(style => {
-          const css = style.textContent || '';
-          return css.length > 100 && (
-            css.includes('*,::after,::before') ||
-            css.includes('tailwindcss') ||
-            css.includes('--tw-')
-          );
-        });
-
-        if (tailwindStyle && tailwindStyle.textContent) {
-          window.parent.postMessage({
-            type: 'css-ready',
-            css: tailwindStyle.textContent
-          }, '*');
-        } else if (retryCount >= maxRetries) {
-          window.parent.postMessage({
-            type: 'css-error',
-            error: 'CSS generation timeout'
-          }, '*');
-        } else {
-          setTimeout(extractCSS, 100);
-        }
-      } catch (error) {
-        window.parent.postMessage({
-          type: 'css-error',
-          error: error.message || 'Unknown error'
-        }, '*');
-      }
-    }
-
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', () => {
-        setTimeout(extractCSS, 1000);
-      });
-    } else {
-      setTimeout(extractCSS, 1000);
-    }
-  </script>
-</body>
-</html>
-    `);
-    iframeDoc.close();
-  });
-}
-
-/**
- * Save CSS to settings via API and update the settings store
+ * Save raw CSS to a settings key. Retained for any callers that already have
+ * CSS in hand (e.g. published_css after publish).
  */
 export async function saveCSS(css: string, key: 'draft_css' | 'published_css'): Promise<void> {
   const response = await fetch(`/ycode/api/settings/${key}`, {
@@ -206,51 +63,6 @@ export async function saveCSS(css: string, key: 'draft_css' | 'published_css'): 
     throw new Error(`Failed to save CSS: ${response.statusText}`);
   }
 
-  // Update settings store to keep it in sync
   const { useSettingsStore } = await import('@/stores/useSettingsStore');
   useSettingsStore.getState().updateSetting(key, css);
-}
-
-/**
- * Collect all layers including component layers for CSS generation
- * Includes both saved components and component drafts (unsaved edits)
- */
-async function collectAllLayers(pageLayers: Layer[]): Promise<Layer[]> {
-  const { useComponentsStore } = await import('@/stores/useComponentsStore');
-  const { components, componentDrafts } = useComponentsStore.getState();
-
-  // Track which components have drafts
-  const draftComponentIds = new Set(Object.keys(componentDrafts));
-
-  // Collect layers from all components (prefer drafts over saved versions)
-  const componentLayers: Layer[] = [];
-
-  // Add component drafts first (these are the latest edits)
-  Object.values(componentDrafts).forEach((layers) => {
-    if (layers && Array.isArray(layers)) {
-      componentLayers.push(...layers);
-    }
-  });
-
-  // Add saved components that don't have drafts
-  components.forEach((component: Component) => {
-    if (!draftComponentIds.has(component.id) && component.layers && Array.isArray(component.layers)) {
-      componentLayers.push(...component.layers);
-    }
-  });
-
-  // Combine page layers and component layers
-  return [...pageLayers, ...componentLayers];
-}
-
-/**
- * Generate CSS and save it to draft_css
- * Automatically includes component layers for comprehensive CSS generation
- */
-export async function generateAndSaveCSS(layers: Layer[]): Promise<string> {
-  // Collect all layers including component layers
-  const allLayers = await collectAllLayers(layers);
-  const css = await generateCSS(allLayers);
-  await saveCSS(css, 'draft_css');
-  return css;
 }

--- a/lib/client/thumbnail-capture.tsx
+++ b/lib/client/thumbnail-capture.tsx
@@ -18,6 +18,7 @@ import { getCanvasIframeHtml } from '@/lib/canvas-utils';
 import { componentsApi } from '@/lib/api';
 import { serializeLayers } from '@/lib/layer-utils';
 import { DEFAULT_ASSETS } from '@/lib/asset-constants';
+import { extractCanvasCandidates } from '@/lib/canvas-class-extractor';
 import type { Layer, Component } from '@/types';
 
 /** Default placeholder image for failed CORS fetches (base64 data URI) */
@@ -26,8 +27,26 @@ const DEFAULT_IMAGE_PLACEHOLDER = DEFAULT_ASSETS.IMAGE;
 /** Viewport width for the thumbnail render */
 const THUMBNAIL_VIEWPORT_WIDTH = 1280;
 
-/** Time to wait for Tailwind CDN to process styles (ms) */
-const TAILWIND_INIT_DELAY = 1500;
+/** Time to wait for React to render + layout before capture (ms) */
+const RENDER_SETTLE_DELAY = 100;
+
+/**
+ * Fetch compiled Tailwind CSS for the given classes from the server
+ * (replaces the old browser CDN JIT used for thumbnails).
+ */
+async function fetchCanvasCss(classes: string[]): Promise<string> {
+  const response = await fetch('/ycode/api/canvas/css', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ classes }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`canvas css endpoint returned ${response.status}`);
+  }
+
+  return response.text();
+}
 
 /** Track in-progress generations to prevent duplicates */
 const pendingGenerations = new Set<string>();
@@ -42,6 +61,11 @@ async function captureLayersAsBlob(
 ): Promise<Blob | null> {
   // Resolve component instances
   const { layers: resolvedLayers } = serializeLayers(layers, components);
+
+  // Pre-compile the Tailwind CSS the thumbnail needs, so html-to-image sees a
+  // fully-styled DOM the moment we mount.
+  const candidates = extractCanvasCandidates(resolvedLayers);
+  const css = await fetchCanvasCss(candidates);
 
   // Create hidden offscreen iframe
   const iframe = document.createElement('iframe');
@@ -66,8 +90,17 @@ async function captureLayersAsBlob(
     doc.write(getCanvasIframeHtml('thumbnail-mount'));
     doc.close();
 
-    // Wait for Tailwind CDN to initialize
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    // Inject the precompiled Tailwind CSS directly as inline <style> so the
+    // styles are synchronously available — no Blob URL loading race.
+    const styleEl = doc.createElement('style');
+    styleEl.id = 'ycode-tw-inline';
+    styleEl.textContent = css;
+    doc.head.appendChild(styleEl);
+
+    // The shared iframe shell hides the body via `data-tw-pending` until the
+    // canvas hook loads <link id="ycode-tw-css">. For thumbnails we just
+    // injected the stylesheet inline, so reveal the body ourselves.
+    doc.body?.removeAttribute('data-tw-pending');
 
     const mountPoint = doc.getElementById('thumbnail-mount');
     if (!mountPoint) throw new Error('Mount point not found');
@@ -96,8 +129,9 @@ async function captureLayersAsBlob(
       </div>
     );
 
-    // Wait for React to render + Tailwind to process all classes
-    await new Promise((resolve) => setTimeout(resolve, TAILWIND_INIT_DELAY));
+    // Let React commit + layout settle before capturing. Tailwind CSS was
+    // already injected synchronously above, so there's no JIT to wait for.
+    await new Promise((resolve) => setTimeout(resolve, RENDER_SETTLE_DELAY));
 
     // Force eager loading — the offscreen iframe won't trigger lazy images
     doc.querySelectorAll('img[loading="lazy"]').forEach((img) => {

--- a/lib/server/canvas-tailwind-input.css
+++ b/lib/server/canvas-tailwind-input.css
@@ -1,0 +1,26 @@
+/*
+ * Canvas-specific Tailwind additions.
+ *
+ * Appended to `node_modules/tailwindcss/index.css` before being passed into
+ * the Tailwind v4 `compile()` API (see lib/server/cssGenerator.ts). Kept
+ * separate from the main Tailwind entry so we can iterate on editor-specific
+ * variants/theme tokens without touching vendor files.
+ *
+ * Ports the variants and `@theme` tokens that previously lived inline in the
+ * canvas iframe template (lib/canvas-utils.ts), so the compiled CSS can back
+ * the editor's context menus and portal-rendered chrome.
+ */
+
+@custom-variant current (&[aria-current]);
+@custom-variant disabled (&:is(:disabled, [aria-disabled]));
+
+@theme {
+  --color-popover: oklch(0.269 0 0);
+  --color-popover-foreground: oklch(0.708 0 0);
+  --color-accent: oklch(0.32 0 0);
+  --color-accent-foreground: oklch(0.985 0 0);
+  --color-muted-foreground: oklch(0.708 0 0);
+  --color-foreground: oklch(0.985 0 0);
+  --color-border: oklch(1 0 0 / 5%);
+  --color-destructive: oklch(0.704 0.191 22.216);
+}

--- a/lib/server/cssGenerator.ts
+++ b/lib/server/cssGenerator.ts
@@ -1,113 +1,95 @@
 /**
  * Server-Side CSS Generator using Tailwind CSS Node API
  *
- * Mirrors the client-side cssGenerator but runs on the server.
- * Used by the /ycode/api/css/generate endpoint so that MCP-created
- * layers (or any API-driven changes) get their CSS generated without
- * needing the browser editor open.
+ * Compiles the Tailwind utility CSS that powers both the editor canvas and
+ * the published sites. The compiler instance is expensive to create but cheap
+ * to invoke, so we cache a single instance for the lifetime of the Node
+ * process.
+ *
+ * Consumers:
+ * - The canvas endpoint (app/(builder)/ycode/api/canvas/css/route.ts) calls
+ *   `compileCanvasCss` with the exact set of classes used by the current
+ *   draft, so the editor iframe never runs Tailwind JIT in the browser.
+ * - The publish pipeline calls `generateAndSaveDraftCSS` to regenerate the
+ *   `draft_css` setting whenever layers change outside the browser editor
+ *   (MCP tools, API-driven changes, etc.).
  */
 
 import { readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { compile } from 'tailwindcss';
 import type { Layer, Component } from '@/types';
-import { DEFAULT_TEXT_STYLES } from '@/lib/text-format-utils';
+import { extractClassesFromLayers, CANVAS_SAFELIST_CLASSES } from '@/lib/canvas-class-extractor';
 import { getAllDraftLayers } from '@/lib/repositories/pageLayersRepository';
 import { getAllComponents } from '@/lib/repositories/componentRepository';
 import { setSetting } from '@/lib/repositories/settingsRepository';
 
-/**
- * Extract all Tailwind classes from a layer tree.
- * Replicates the client-side extractClassesFromLayers logic.
- */
-function extractClassesFromLayers(layers: Layer[]): Set<string> {
-  const classes = new Set<string>();
-  const processedComponentIds = new Set<string>();
-
-  const extractClasses = (classValue: string | string[] | undefined) => {
-    if (!classValue) return;
-
-    if (Array.isArray(classValue)) {
-      classValue.forEach(cls => {
-        if (cls && typeof cls === 'string') {
-          cls.split(/\s+/).forEach(c => c.trim() && classes.add(c.trim()));
-        }
-      });
-    } else if (typeof classValue === 'string') {
-      classValue.split(/\s+/).forEach(cls => cls.trim() && classes.add(cls.trim()));
-    }
-  };
-
-  function processLayer(layer: Layer): void {
-    if (layer.settings?.hidden) return;
-
-    if (layer.componentId) {
-      if (processedComponentIds.has(layer.componentId)) return;
-      processedComponentIds.add(layer.componentId);
-    }
-
-    extractClasses(layer.classes);
-
-    if (layer.textStyles) {
-      Object.values(layer.textStyles).forEach((style: { classes?: string | string[] }) => {
-        extractClasses(style.classes);
-      });
-    }
-
-    if (layer.variables?.text) {
-      Object.values(DEFAULT_TEXT_STYLES).forEach(style => {
-        extractClasses(style.classes);
-      });
-    }
-
-    if (layer.children && Array.isArray(layer.children)) {
-      layer.children.forEach(child => processLayer(child));
-    }
-  }
-
-  layers.forEach(layer => processLayer(layer));
-  return classes;
-}
-
 let compilerCache: { build: (candidates: string[]) => string } | null = null;
+let compilerPromise: Promise<{ build: (candidates: string[]) => string }> | null = null;
 
 /**
- * Get or create a cached Tailwind compiler instance.
- * The compiler only needs to be created once since we always
- * use the same Tailwind config (the default).
+ * Get or create a cached Tailwind compiler instance. The compiler is reused
+ * for every subsequent `compileCanvasCss` / `generateAndSaveDraftCSS` call.
+ *
+ * The input stylesheet is Tailwind's own `index.css` concatenated with
+ * `canvas-tailwind-input.css`, which adds the editor's custom variants and
+ * `@theme` tokens on top of Tailwind's defaults.
  */
-async function getCompiler() {
+async function getCompiler(): Promise<{ build: (candidates: string[]) => string }> {
   if (compilerCache) return compilerCache;
 
-  const twPath = join(process.cwd(), 'node_modules/tailwindcss/index.css');
-  const input = await readFile(twPath, 'utf-8');
+  if (!compilerPromise) {
+    compilerPromise = (async () => {
+      const twPath = join(process.cwd(), 'node_modules/tailwindcss/index.css');
+      const canvasInputPath = join(process.cwd(), 'lib/server/canvas-tailwind-input.css');
 
-  compilerCache = await compile(input, {
-    base: process.cwd(),
-    async loadStylesheet(id: string, base: string) {
-      const fullPath = join(dirname(base), id);
-      const content = await readFile(fullPath, 'utf-8');
-      return { path: fullPath, content, base: dirname(fullPath) };
-    },
-  });
+      const [tailwindCss, canvasAdditions] = await Promise.all([
+        readFile(twPath, 'utf-8'),
+        readFile(canvasInputPath, 'utf-8'),
+      ]);
 
-  return compilerCache;
+      const input = `${tailwindCss}\n${canvasAdditions}`;
+
+      const compiler = await compile(input, {
+        base: process.cwd(),
+        async loadStylesheet(id: string, base: string) {
+          const fullPath = join(dirname(base), id);
+          const content = await readFile(fullPath, 'utf-8');
+          return { path: fullPath, content, base: dirname(fullPath) };
+        },
+      });
+
+      compilerCache = compiler;
+      return compiler;
+    })().catch((error) => {
+      // Reset so the next caller can retry instead of getting a rejected promise forever
+      compilerPromise = null;
+      throw error;
+    });
+  }
+
+  return compilerPromise;
 }
 
 /**
- * Generate CSS from an array of Tailwind class names.
+ * Compile a CSS bundle for the given Tailwind candidate classes.
+ *
+ * Always includes the editor's safelist so context menus and other chrome
+ * portaled into the canvas iframe continue to render even when no user layer
+ * references those utilities.
  */
-async function compileCss(classNames: string[]): Promise<string> {
-  if (classNames.length === 0) return '/* No classes to generate */';
+export async function compileCanvasCss(classNames: string[]): Promise<string> {
   const compiler = await getCompiler();
-  return compiler.build(classNames);
+  const candidates = new Set<string>(classNames);
+  for (const safelisted of CANVAS_SAFELIST_CLASSES) {
+    candidates.add(safelisted);
+  }
+  return compiler.build(Array.from(candidates));
 }
 
 /**
  * Generate CSS from all draft layers and component layers,
  * then save it to the draft_css setting.
- *
- * This is the server-side equivalent of the client's generateAndSaveCSS.
  */
 export async function generateAndSaveDraftCSS(): Promise<string> {
   const allLayers: Layer[] = [];
@@ -127,8 +109,7 @@ export async function generateAndSaveDraftCSS(): Promise<string> {
   }
 
   const classes = extractClassesFromLayers(allLayers);
-  const classNames = Array.from(classes);
-  const css = await compileCss(classNames);
+  const css = await compileCanvasCss(Array.from(classes));
 
   await setSetting('draft_css', css);
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -28,6 +28,26 @@ const nextConfig: NextConfig = {
     'pg-query-stream',
   ],
 
+  // Bundle the CSS files our server-side Tailwind compiler reads at runtime
+  // (lib/server/cssGenerator.ts) into the corresponding serverless functions.
+  // Next.js's static tracer can't see paths built from `process.cwd()`, so we
+  // include them explicitly to guarantee they ship with the lambda on Vercel.
+  outputFileTracingIncludes: {
+    '/ycode/api/canvas/css': [
+      './node_modules/tailwindcss/*.css',
+      './lib/server/canvas-tailwind-input.css',
+    ],
+    '/ycode/api/css/generate': [
+      './node_modules/tailwindcss/*.css',
+      './lib/server/canvas-tailwind-input.css',
+    ],
+    // MCP tools also call generateAndSaveDraftCSS via lib/mcp/tools/publishing.ts
+    '/ycode/mcp/[token]': [
+      './node_modules/tailwindcss/*.css',
+      './lib/server/canvas-tailwind-input.css',
+    ],
+  },
+
   // Turbopack configuration
   // Map unused database drivers to stub modules (we only use PostgreSQL)
   // This prevents Turbopack from trying to resolve packages that aren't installed

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "sonner": "^2.0.7",
         "swiper": "^12.1.2",
         "tailwind-merge": "^3.3.1",
+        "tailwindcss": "^4",
         "zod": "^4.3.6",
         "zustand": "^5.0.8"
       },
@@ -98,7 +99,6 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.2.6",
         "punycode": "^2.3.1",
-        "tailwindcss": "^4",
         "ts-node": "^10.9.2",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5",
@@ -1451,9 +1451,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1469,9 +1466,6 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1489,9 +1483,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1507,9 +1498,6 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -11311,7 +11299,6 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "sonner": "^2.0.7",
     "swiper": "^12.1.2",
     "tailwind-merge": "^3.3.1",
+    "tailwindcss": "^4",
     "zod": "^4.3.6",
     "zustand": "^5.0.8"
   },
@@ -129,7 +130,6 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",
     "punycode": "^2.3.1",
-    "tailwindcss": "^4",
     "ts-node": "^10.9.2",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5",

--- a/stores/useComponentsStore.ts
+++ b/stores/useComponentsStore.ts
@@ -567,21 +567,12 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
           triggerThumbnailGeneration(componentId, draftLayers, get().components);
         }
 
-        // Regenerate CSS to include updated component classes
+        // Regenerate CSS so updated component classes make it into the draft
+        // stylesheet. The server reads drafts from the DB, so no client-side
+        // layer collection is needed.
         try {
           const { generateAndSaveCSS } = await import('@/lib/client/cssGenerator');
-          const { usePagesStore } = await import('./usePagesStore');
-
-          // Collect layers from ALL pages
-          const allLayers: Layer[] = [];
-          const allDrafts = usePagesStore.getState().draftsByPageId;
-          Object.values(allDrafts).forEach((pageDraft) => {
-            if (pageDraft.layers) {
-              allLayers.push(...pageDraft.layers);
-            }
-          });
-
-          await generateAndSaveCSS(allLayers);
+          await generateAndSaveCSS();
         } catch (cssError) {
           console.error('Failed to generate CSS after component save:', cssError);
           // Don't fail the save operation if CSS generation fails

--- a/stores/usePagesStore.ts
+++ b/stores/usePagesStore.ts
@@ -485,20 +485,12 @@ export const usePagesStore = create<PagesStore>((set, get) => ({
           // The new state will trigger another auto-save which will record its own version
         }
 
-        // After successfully saving the draft, generate and save CSS from ALL pages
+        // After successfully saving the draft, trigger server-side CSS
+        // regeneration. The server pulls drafts from the DB, so we don't
+        // need to collect layers here.
         try {
           const { generateAndSaveCSS } = await import('@/lib/client/cssGenerator');
-
-          // Collect layers from ALL pages for comprehensive CSS generation
-          const allLayers: Layer[] = [];
-          const allDrafts = get().draftsByPageId;
-          Object.values(allDrafts).forEach((pageDraft) => {
-            if (pageDraft.layers) {
-              allLayers.push(...pageDraft.layers);
-            }
-          });
-
-          await generateAndSaveCSS(allLayers);
+          await generateAndSaveCSS();
         } catch (cssError) {
           console.error('Failed to generate CSS after save:', cssError);
           // Don't fail the save operation if CSS generation fails


### PR DESCRIPTION
## Summary

The editor canvas used to load `@tailwindcss/browser@4` and JIT-compile
Tailwind in the iframe on every edit, which was the single biggest
contributor to perceived slowness. This PR moves canvas CSS compilation
to the server (matching legacy Ycode), adds a tiny client-side fast
path so interactive edits like color pickers stay frame-perfect, and
wires the publish pipeline to reuse the same compiler.

## Changes

- Add `POST /ycode/api/canvas/css` that compiles a class list with the
  Node Tailwind compiler and returns `text/css`
- Add `hooks/use-canvas-tailwind-css.ts` that walks the layer tree,
  hashes the candidate set, debounces requests, caches Blob URLs (LRU,
  16 entries), and swaps them into a single `<link id="ycode-tw-css">`
- Hide the iframe body via `data-tw-pending` until the first stylesheet
  loads to eliminate the flash of unstyled layers, with a 3s fallback
  reveal in case `load` never fires
- Add `lib/client/arbitrary-value-compiler.ts` plus a
  `<style id="ycode-tw-live">` overlay that compiles arbitrary-value
  utilities (`text-[#hex]`, `w-[Npx]`, `bg-[#hex]/50`, `max-md:`,
  `hover:`, …) in the browser so color pickers and sliders update on
  the next frame while the server stylesheet catches up
- Extract `lib/canvas-class-extractor.ts` shared by the canvas hook,
  the publish pipeline, and thumbnail capture, including a safelist
  for context-menu utilities portaled into the iframe
- Move custom canvas variants/theme tokens into
  `lib/server/canvas-tailwind-input.css` and append them to Tailwind's
  core CSS in `lib/server/cssGenerator.ts`
- Rewrite `lib/client/cssGenerator.ts` as a thin wrapper around
  `POST /ycode/api/css/generate`, removing the hidden-iframe CDN hack
  used during publishing
- Update `Canvas.tsx`, `YCodeBuilderMain.tsx`, `usePagesStore.ts`, and
  `useComponentsStore.ts` to drop the `allLayers` payload — the server
  now reads draft layers authoritatively
- Update `lib/client/thumbnail-capture.tsx` to fetch compiled CSS once
  and inject it inline before snapshotting, replacing the 1500ms
  Tailwind-init wait with a 100ms render-settle wait
- Move `tailwindcss` from `devDependencies` to `dependencies` and add
  `outputFileTracingIncludes` for `/ycode/api/canvas/css`,
  `/ycode/api/css/generate`, and `/ycode/mcp/[token]` so Vercel
  bundles the Tailwind input CSS into the serverless functions

## Test plan

- [ ] Open a page in the editor — canvas appears fully styled with no
      flash of unstyled layers, and no request to `cdn.jsdelivr.net`
- [ ] Drag through the text color picker — color updates on the canvas
      every frame, no perceptible lag
- [ ] Resize a layer with `w-[…px]` and confirm the width updates as
      you drag
- [ ] Switch breakpoints (`max-md:` / `max-lg:`) and verify breakpoint-
      scoped arbitrary values still render correctly
- [ ] Trigger a hover/disabled state and confirm pseudo-variant
      arbitrary values render
- [ ] Publish a page and confirm the generated CSS contains the same
      utilities as before (no regressions in the live site)
- [ ] Capture a component thumbnail and confirm it renders styled
- [ ] Deploy to a Vercel preview and confirm the canvas + publish
      endpoints work (no `ENOENT` for Tailwind input files)

Made with [Cursor](https://cursor.com)