### PR TITLE
feat: add line-clamp setting to typography controls

### DIFF
--- a/app/(builder)/ycode/components/TypographyControls.tsx
+++ b/app/(builder)/ycode/components/TypographyControls.tsx
@@ -63,6 +63,7 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
   const textDecorationThickness = getDesignProperty('typography', 'textDecorationThickness') || '';
   const underlineOffset = getDesignProperty('typography', 'underlineOffset') || '';
   const placeholderColor = getDesignProperty('typography', 'placeholderColor') || '';
+  const lineClamp = getDesignProperty('typography', 'lineClamp') || '';
 
   // Get available weights for the selected font
   const selectedFont = getFontByFamily(fontFamily);
@@ -73,6 +74,9 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
 
   // Detect if text transform is active
   const hasTransform = textTransform !== 'none' && textTransform !== '';
+
+  // Detect if line clamp is active
+  const hasLineClamp = lineClamp !== '' && lineClamp !== 'none';
 
   // Custom extractor for letter spacing (strips 'em' as default unit, like fontSize strips 'px')
   const extractLetterSpacingValue = (value: string): string => {
@@ -97,6 +101,7 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
   const [lineHeightInput, setLineHeightInput] = useControlledInput(lineHeight);
   const [decorationThicknessInput, setDecorationThicknessInput] = useControlledInput(textDecorationThickness, extractMeasurementValue);
   const [underlineOffsetInput, setUnderlineOffsetInput] = useControlledInput(underlineOffset, extractMeasurementValue);
+  const [lineClampInput, setLineClampInput] = useControlledInput(lineClamp);
 
   // Map numeric font weights to named values
   const fontWeightMap: Record<string, string> = {
@@ -222,6 +227,20 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
     updateDesignProperty('typography', 'textTransform', value);
   };
 
+  const handleAddLineClamp = () => {
+    updateDesignProperty('typography', 'lineClamp', '2');
+  };
+
+  const handleRemoveLineClamp = () => {
+    updateDesignProperty('typography', 'lineClamp', null);
+  };
+
+  const handleLineClampChange = (value: string) => {
+    setLineClampInput(value);
+    const sanitized = removeSpaces(value);
+    debouncedUpdateDesignProperty('typography', 'lineClamp', sanitized || null);
+  };
+
   // Debounced handler for keyboard-typed hex values
   const handleDecorationColorChange = (value: string) => {
     const sanitized = removeSpaces(value);
@@ -321,6 +340,12 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
                 disabled={hasTransform}
               >
                 Transform
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={handleAddLineClamp}
+                disabled={hasLineClamp}
+              >
+                Line clamp
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -633,6 +658,31 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
                 tabIndex={0}
                 className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                 onClick={handleRemoveTransform}
+              >
+                <Icon name="x" className="size-2.5" />
+              </span>
+            </div>
+          </div>
+        )}
+
+        {!isIcon && hasLineClamp && (
+          <div className="grid grid-cols-3 items-start">
+            <Label variant="muted" className="h-8">Line clamp</Label>
+            <div className="col-span-2 flex items-center gap-2">
+              <Input
+                stepper
+                min="1"
+                step="1"
+                value={lineClampInput}
+                onChange={(e) => handleLineClampChange(e.target.value)}
+                placeholder="2"
+                className="flex-1"
+              />
+              <span
+                role="button"
+                tabIndex={0}
+                className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
+                onClick={handleRemoveLineClamp}
               >
                 <Icon name="x" className="size-2.5" />
               </span>

--- a/hooks/use-design-sync.ts
+++ b/hooks/use-design-sync.ts
@@ -605,6 +605,7 @@ function mapClassToDesignValue(className: string, property: string): string | un
     minHeight: 'min-h-',
     gridColumnSpan: 'col-span-',
     gridRowSpan: 'row-span-',
+    lineClamp: 'line-clamp-',
   };
 
   const knownPrefix = multiSegmentPrefixes[property];

--- a/lib/tailwind-class-mapper.ts
+++ b/lib/tailwind-class-mapper.ts
@@ -257,6 +257,7 @@ const CLASS_PROPERTY_MAP: Record<string, RegExp> = {
   textDecorationColor: /^decoration-\[.+\](\/\d+)?$/,
   textDecorationThickness: /^decoration-(\d+|auto|from-font|\[(?!#|rgb|hsl).+\])$/,
   underlineOffset: /^underline-offset-.+$/,
+  lineClamp: /^line-clamp-(none|\d+|\[.+\])$/,
   // Updated to match partial arbitrary values like text-r, text-re, text-red (not just complete text-[#FF0000])
   // Excludes fontSize named values, text-align values, and text-wrap utilities
   // Includes opacity modifier: text-[#cc8d8d]/59
@@ -607,6 +608,10 @@ export function propertyToClass(
         return formatMeasurementClass(value, 'decoration');
       case 'underlineOffset':
         return formatMeasurementClass(value, 'underline-offset');
+      case 'lineClamp':
+        if (value === 'none') return 'line-clamp-none';
+        if (/^\d+$/.test(value)) return `line-clamp-${value}`;
+        return `line-clamp-[${value}]`;
       case 'color':
         // Check if value is a gradient (linear-gradient or radial-gradient)
         if (value.includes('gradient(')) {
@@ -1273,6 +1278,16 @@ export function classesToDesign(classes: string | string[]): Layer['design'] {
     if (cls.startsWith('underline-offset-[')) {
       const value = extractArbitraryValue(cls);
       if (value) design.typography!.underlineOffset = value;
+    }
+
+    // Line Clamp
+    if (cls === 'line-clamp-none') {
+      design.typography!.lineClamp = 'none';
+    } else if (/^line-clamp-\d+$/.test(cls)) {
+      design.typography!.lineClamp = cls.slice('line-clamp-'.length);
+    } else if (cls.startsWith('line-clamp-[')) {
+      const value = extractArbitraryValue(cls);
+      if (value) design.typography!.lineClamp = value;
     }
 
     // Line Height

--- a/types/index.ts
+++ b/types/index.ts
@@ -36,6 +36,7 @@ export interface TypographyDesign {
   textAlign?: string;
   textTransform?: string;
   textDecoration?: string;
+  lineClamp?: string;
   textDecorationColor?: string;
   textDecorationThickness?: string;
   underlineOffset?: string;


### PR DESCRIPTION
## Summary

Adds a line-clamp setting to the Typography controls so users can clamp text to a given number of lines without hand-editing Tailwind classes. Matches the existing Underline / Transform opt-in pattern in the same panel.

## Changes

- Add `lineClamp` to `TypographyDesign`
- Add forward/reverse mapping for `line-clamp-N`, `line-clamp-none`, and `line-clamp-[N]` in the Tailwind class mapper, plus a regex entry in the design property map
- Register the `line-clamp-` multi-segment prefix in `use-design-sync` so class-to-value lookup handles it
- Add a "Line clamp" entry to the Typography add-dropdown and render a stepper input (with an x to clear) when active, defaulting to `2`

## Test plan

- [ ] Select a text layer, open the Typography panel, click the plus menu and add "Line clamp"; confirm the input shows `2` and the canvas clamps to 2 lines
- [ ] Change the value with the stepper and via keyboard input; verify the canvas updates and the resulting class is `line-clamp-N`
- [ ] Clear the value with the x button; verify `line-clamp-*` is removed from the layer classes
- [ ] Verify the menu entry is disabled while line clamp is active and re-enables after clearing
- [ ] Add line-clamp at a breakpoint / state and confirm responsive + state variants write the correct prefixed class
