### PR TITLE
feat: add height animation property

### DIFF
--- a/lib/animation-utils.ts
+++ b/lib/animation-utils.ts
@@ -49,7 +49,7 @@ export function createSplitTextAnimation(
 
 // Types
 export type TriggerType = 'click' | 'hover' | 'scroll-into-view' | 'while-scrolling' | 'load';
-export type PropertyType = 'position-x' | 'position-y' | 'scale' | 'rotation' | 'skew-x' | 'skew-y' | 'opacity' | 'display' | 'split-text';
+export type PropertyType = 'position-x' | 'position-y' | 'scale' | 'rotation' | 'skew-x' | 'skew-y' | 'opacity' | 'height' | 'display' | 'split-text';
 
 export interface PropertyConfig {
   key: keyof TweenProperties;
@@ -145,6 +145,17 @@ export const PROPERTY_OPTIONS: PropertyOption[] = [
       defaultFrom: '100',
       defaultFromAfterCurrent: '100',
       defaultTo: '0',
+    }],
+  },
+  {
+    type: 'height',
+    label: 'Height',
+    properties: [{
+      key: 'height',
+      unit: '',
+      defaultFrom: '0px',
+      defaultFromAfterCurrent: '0px',
+      defaultTo: '100px',
     }],
   },
   {
@@ -482,6 +493,8 @@ export function generateInitialAnimationCSS(layers: Layer[]): InitialAnimationRe
                   if (opacity === 0) {
                     styles.push(`visibility: hidden`);
                   }
+                } else if (prop.key === 'height') {
+                  styles.push(`height: ${value}${prop.unit}`);
                 } else if (prop.key === 'display') {
                   // Track elements that should start hidden using data attribute
                   if (value === 'hidden') {

--- a/types/index.ts
+++ b/types/index.ts
@@ -306,9 +306,9 @@ export interface InteractionTween {
 
 export type ApplyStyles = 'on-load' | 'on-trigger';
 
-export type TweenPropertyKey = 'x' | 'y' | 'rotation' | 'scale' | 'skewX' | 'skewY' | 'autoAlpha' | 'display';
+export type TweenPropertyKey = 'x' | 'y' | 'rotation' | 'scale' | 'skewX' | 'skewY' | 'autoAlpha' | 'display' | 'height';
 
-export type InteractionApplyStyles = Record<TweenPropertyKey, ApplyStyles>;
+export type InteractionApplyStyles = Partial<Record<TweenPropertyKey, ApplyStyles>>;
 
 export type TweenProperties = {
   [K in TweenPropertyKey]?: string | null;


### PR DESCRIPTION
## Summary

Add **Height** as an animatable property in the interactions panel, letting users animate an element's height with arbitrary CSS units (`px`, `%`, `vh`, `auto`, etc) — useful for accordion, reveal, and collapse effects.

## Changes

- Add `height` entry to `PROPERTY_OPTIONS` with no fixed unit so the input accepts arbitrary values (mirrors `SizingControls`)
- Extend `TweenPropertyKey` union and `PropertyType` with `height`
- Relax `InteractionApplyStyles` to `Partial<Record<TweenPropertyKey, ApplyStyles>>` since apply-styles isn't set for every key
- Emit `height: <value>` in `generateInitialAnimationCSS` when apply-styles is set to `on-load`, so the from-state is applied pre-hydration (prevents flicker)

## Test plan

- [ ] Add a Height tween to a layer, set From `0px` → To `100%`, trigger on click
- [ ] Set apply-styles to on-load and verify the target element starts collapsed on `/ycode/preview`
- [ ] Click the trigger and confirm the element animates from 0px to 100%
- [ ] Try other units (`vh`, `auto`, `%`) to confirm arbitrary units work
- [ ] Verify existing animation properties (position, opacity, scale, etc.) still behave normally

Made with [Cursor](https://cursor.com)