### PR TITLE
fix: make body layer selectable from canvas

### DIFF
--- a/app/(builder)/ycode/components/Canvas.tsx
+++ b/app/(builder)/ycode/components/Canvas.tsx
@@ -160,26 +160,34 @@ function CanvasContent({
 
   // Select body layer when clicking on empty canvas space.
   // The #canvas-body div uses display:contents so it has no box — clicks on
-  // empty space land on the iframe <body>, which is outside the React root.
-  // We attach a native listener on the iframe body to handle this.
+  // empty space land on the iframe <body> (or sometimes <html> / one of the
+  // display:contents wrappers), which is outside the React root and therefore
+  // outside the layer onClick chain. We attach a native listener on the iframe
+  // document so any click that doesn't end up on an actual layer element
+  // (i.e. nothing with [data-layer-id] except the body wrapper itself) falls
+  // through to selecting the Body layer.
   useEffect(() => {
     if (!bodyRef.current) return;
-    const iframeBody = bodyRef.current.ownerDocument.body;
+    const iframeDoc = bodyRef.current.ownerDocument;
+    const iframeBody = iframeDoc.body;
 
     setPortalContainer(iframeBody);
 
     const handleBodyClick = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      const isCanvasChrome = target === iframeBody
-        || target.id === 'canvas-mount'
-        || target.id === 'canvas-body';
-      if (isCanvasChrome) {
-        onLayerClick('body');
-      }
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      // Walk up from the click target. If we find any layer element with
+      // data-layer-id !== 'body', that layer's own onClick handles selection
+      // and we should ignore this fallthrough. Otherwise the click landed on
+      // empty body space (or html / the display:contents wrappers) and we
+      // select the Body layer.
+      const layerEl = target.closest?.('[data-layer-id]') as HTMLElement | null;
+      if (layerEl && layerEl.getAttribute('data-layer-id') !== 'body') return;
+      onLayerClick('body');
     };
 
-    iframeBody.addEventListener('click', handleBodyClick);
-    return () => iframeBody.removeEventListener('click', handleBodyClick);
+    iframeDoc.addEventListener('click', handleBodyClick);
+    return () => iframeDoc.removeEventListener('click', handleBodyClick);
   }, [onLayerClick]);
 
   const bodyLayer = layers.find(l => l.id === 'body');

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -2293,7 +2293,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
       {/* Canvas Area */}
       <div
         ref={canvasContainerRef}
-        className="flex-1 relative overflow-hidden bg-neutral-50 dark:bg-neutral-950/80"
+        className="flex-1 relative overflow-hidden bg-neutral-50 dark:bg-neutral-950/80 select-none"
       >
         {/* Loading skeleton overlay when draft is being fetched */}
         {isDraftLoading && (

--- a/components/SelectionOverlay.tsx
+++ b/components/SelectionOverlay.tsx
@@ -83,20 +83,27 @@ export function SelectionOverlay({
   ) => {
     if (!container) return;
 
-    if (!layerId || layerId === 'body') {
+    if (!layerId) {
       container.style.display = 'none';
       return;
     }
 
-    let targetElements: NodeListOf<Element>;
-    if (blockIndex !== undefined && blockIndex !== null && listItemIndex !== undefined && listItemIndex !== null) {
-      targetElements = iframeDoc.querySelectorAll(
+    const isBody = layerId === 'body';
+    let targetElements: Element[];
+    if (isBody) {
+      // The Body layer's wrapper (#canvas-body) uses display:contents and has
+      // no box. Its visible representation on the canvas is the entire iframe
+      // surface. We render a single outline using the iframe element's rect
+      // below, but we still need a non-empty list to drive the loop.
+      targetElements = [iframeElement];
+    } else if (blockIndex !== undefined && blockIndex !== null && listItemIndex !== undefined && listItemIndex !== null) {
+      targetElements = Array.from(iframeDoc.querySelectorAll(
         `[data-layer-id="${layerId}"] [data-block-index="${blockIndex}"] [data-list-item-index="${listItemIndex}"]`
-      );
+      ));
     } else if (blockIndex !== undefined && blockIndex !== null) {
-      targetElements = iframeDoc.querySelectorAll(`[data-layer-id="${layerId}"] [data-block-index="${blockIndex}"]`);
+      targetElements = Array.from(iframeDoc.querySelectorAll(`[data-layer-id="${layerId}"] [data-block-index="${blockIndex}"]`));
     } else {
-      targetElements = iframeDoc.querySelectorAll(`[data-layer-id="${layerId}"]`);
+      targetElements = Array.from(iframeDoc.querySelectorAll(`[data-layer-id="${layerId}"]`));
     }
     if (targetElements.length === 0) {
       container.style.display = 'none';
@@ -120,13 +127,25 @@ export function SelectionOverlay({
     }
 
     targetElements.forEach((targetElement, idx) => {
-      const elementRect = targetElement.getBoundingClientRect();
       const child = container.children[idx] as HTMLElement;
 
-      const top = iframeRect.top - containerRect.top + (elementRect.top * scale);
-      const left = iframeRect.left - containerRect.left + (elementRect.left * scale);
-      const width = elementRect.width * scale;
-      const height = elementRect.height * scale;
+      let top: number;
+      let left: number;
+      let width: number;
+      let height: number;
+      if (isBody) {
+        // Body outline always covers the full visible canvas (iframe area).
+        top = iframeRect.top - containerRect.top;
+        left = iframeRect.left - containerRect.left;
+        width = iframeRect.width;
+        height = iframeRect.height;
+      } else {
+        const elementRect = targetElement.getBoundingClientRect();
+        top = iframeRect.top - containerRect.top + (elementRect.top * scale);
+        left = iframeRect.left - containerRect.left + (elementRect.left * scale);
+        width = elementRect.width * scale;
+        height = elementRect.height * scale;
+      }
 
       child.className = `absolute ${outlineClass}`;
       child.style.display = 'block';


### PR DESCRIPTION
## Summary

Clicking on the Body layer in the canvas did not select or highlight it the way other layers do. This makes Body behave like any other layer: clickable from the canvas, highlighted in the layers tree, and outlined with the standard blue selection.

## Changes

- Broaden the iframe body click handler to fall through to Body whenever the click does not land on a real layer element (covers `<html>` and `display:contents` wrappers, not just `<body>`)
- Render the selection outline for Body using the iframe element's bounding rect so it always covers the full visible canvas
- Add `select-none` to the canvas chrome wrapper to prevent the browser's native double-click selection from painting a blue overlay over the canvas

## Test plan

- [ ] Click on empty Body space in the canvas — Body becomes selected and is highlighted in the layers tree
- [ ] Verify the blue selection outline covers the entire canvas surface at any zoom level
- [ ] Click on a child layer — that layer is selected (Body is not)
- [ ] Click on the gray area surrounding the canvas — selection is unchanged
- [ ] Double-click on the gray area surrounding the canvas — no blue selection overlay appears over the canvas
- [ ] Confirm text selection still works inside the canvas iframe (e.g. when editing text)

Made with [Cursor](https://cursor.com)