### PR TITLE
feat: bind slider element to multi-image CMS fields

### DIFF
--- a/app/(builder)/ycode/components/BackgroundsControls.tsx
+++ b/app/(builder)/ycode/components/BackgroundsControls.tsx
@@ -8,7 +8,8 @@ import { useEditorStore } from '@/stores/useEditorStore';
 import { removeSpaces } from '@/lib/utils';
 import { setBreakpointClass, propertyToClass, buildBgImgVarName, buildBgImgClass } from '@/lib/tailwind-class-mapper';
 import { ASSET_CATEGORIES, isAssetOfType } from '@/lib/asset-utils';
-import { IMAGE_FIELD_TYPES, filterFieldGroupsByType, flattenFieldGroups } from '@/lib/collection-field-utils';
+import { IMAGE_FIELD_TYPES, filterFieldGroupsByType, flattenFieldGroups, buildMultiAssetVirtualFields, isVirtualAssetField } from '@/lib/collection-field-utils';
+import { isFieldVariable } from '@/lib/variable-utils';
 import { getCollectionVariable, isTextContentLayer } from '@/lib/layer-utils';
 import {
   createAssetVariable,
@@ -108,7 +109,26 @@ const BackgroundsControls = memo(function BackgroundsControls({ layer, onLayerUp
     const groups: FieldGroup[] = [...(fieldGroups || [])];
 
     const collectionVar = layer ? getCollectionVariable(layer) : null;
-    if (collectionVar?.id && allFields) {
+    const isMultiAssetLayer = collectionVar?.source_field_type === 'multi_asset';
+
+    // Expose virtual per-asset fields whenever this layer (or its existing background
+    // binding) is in a multi-asset context, so the picker stays consistent and the
+    // current binding can always be restored.
+    const bgIsVirtualAsset = !!(
+      bgImageVariable && isFieldVariable(bgImageVariable) && bgImageVariable.data.field_id && isVirtualAssetField(bgImageVariable.data.field_id)
+    );
+
+    if (isMultiAssetLayer || bgIsVirtualAsset) {
+      // Virtual asset field values live in the per-iteration item data only
+      // (never in pageCollectionItemData). Always use 'collection' so the
+      // value resolves correctly even if the parent multi-image field is page-bound.
+      groups.unshift({
+        fields: buildMultiAssetVirtualFields(),
+        label: 'File fields',
+        source: 'collection',
+        layerId: layer?.id,
+      });
+    } else if (collectionVar?.id && allFields) {
       const ownFields = allFields[collectionVar.id] || [];
       const alreadyIncluded = groups.some(g =>
         g.fields.length > 0 && ownFields.length > 0 && g.fields[0]?.id === ownFields[0]?.id
@@ -124,7 +144,7 @@ const BackgroundsControls = memo(function BackgroundsControls({ layer, onLayerUp
     }
 
     return groups.length > 0 ? groups : undefined;
-  }, [fieldGroups, layer, allFields]);
+  }, [fieldGroups, layer, allFields, bgImageVariable]);
 
   // Filter field groups to image-bindable types
   const imageFieldGroups = useMemo(() => {

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -116,6 +116,18 @@ interface RightSidebarProps {
   onLayerUpdate: (layerId: string, updates: Partial<Layer>) => void;
 }
 
+/**
+ * Recursively remove heading/text descendants from a layer subtree.
+ * Used when binding a slide to a multi-image field — the assets are typically
+ * the focus, so any leftover text/heading scaffolding is auto-pruned.
+ */
+function pruneTextDescendants(children: Layer[] | undefined): Layer[] {
+  if (!children?.length) return [];
+  return children
+    .filter(c => !isTextContentLayer(c))
+    .map(c => (c.children?.length ? { ...c, children: pruneTextDescendants(c.children) } : c));
+}
+
 const RightSidebar = React.memo(function RightSidebar({
   selectedLayerId,
   onLayerUpdate,
@@ -1010,7 +1022,7 @@ const RightSidebar = React.memo(function RightSidebar({
       const selectedField = parentCollectionFields.find(f => f.id === value);
 
       if (selectedField && isMultipleAssetField(selectedField)) {
-        handleLayerUpdate(selectedLayerId, {
+        const updates: Partial<Layer> = {
           variables: {
             ...selectedLayer?.variables,
             collection: {
@@ -1021,7 +1033,13 @@ const RightSidebar = React.memo(function RightSidebar({
               source_field_source: 'collection',
             }
           }
-        });
+        };
+        // Slides bound to a multi-image field are typically image-only —
+        // strip any leftover heading/text scaffolding so the user starts clean.
+        if (selectedLayer.name === 'slide') {
+          updates.children = pruneTextDescendants(selectedLayer.children);
+        }
+        handleLayerUpdate(selectedLayerId, updates);
       } else if (selectedField?.reference_collection_id) {
         handleLayerUpdate(selectedLayerId, {
           variables: {
@@ -1101,10 +1119,15 @@ const RightSidebar = React.memo(function RightSidebar({
 
     if (!newCollectionVar) return;
 
-    // Update the collection source on the layer
-    handleLayerUpdate(selectedLayerId, {
-      variables: { ...selectedLayer?.variables, collection: newCollectionVar }
-    });
+    const updates: Partial<Layer> = {
+      variables: { ...selectedLayer?.variables, collection: newCollectionVar },
+    };
+    // Slides bound to a multi-image field are typically image-only —
+    // strip any leftover heading/text scaffolding so the user starts clean.
+    if (newCollectionVar.source_field_type === 'multi_asset' && selectedLayer.name === 'slide') {
+      updates.children = pruneTextDescendants(selectedLayer.children);
+    }
+    handleLayerUpdate(selectedLayerId, updates);
 
     resetChildBindings(selectedLayerId);
   };
@@ -2664,6 +2687,7 @@ const RightSidebar = React.memo(function RightSidebar({
               layer={selectedLayer}
               onLayerUpdate={handleLayerUpdate}
               allLayers={allLayers}
+              fieldGroups={fieldGroups}
             />
 
             <LightboxSettings

--- a/app/(builder)/ycode/components/SliderSettings.tsx
+++ b/app/(builder)/ycode/components/SliderSettings.tsx
@@ -30,6 +30,7 @@ import { EFFECTS_WITH_PER_VIEW } from '@/lib/slider-utils';
 import { slidePrev, slideNext } from '@/hooks/use-canvas-slider';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { usePagesStore } from '@/stores/usePagesStore';
+import { useCollectionLayerStore } from '@/stores/useCollectionLayerStore';
 import {
   MULTI_ASSET_COLLECTION_ID,
   MULTI_ASSET_VIRTUAL_FIELDS,
@@ -89,14 +90,16 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldG
   const handleNext = useCallback(() => slideNext(sliderLayerId), [sliderLayerId]);
 
   const currentPageId = useEditorStore((state) => state.currentPageId);
+  const setSliderSnapCount = useEditorStore((state) => state.setSliderSnapCount);
   const addLayerWithId = usePagesStore((state) => state.addLayerWithId);
   const setSelectedLayerId = useEditorStore((state) => state.setSelectedLayerId);
+  const clearLayerData = useCollectionLayerStore((state) => state.clearLayerData);
 
   // Inner slides wrapper and the first slide inside it (the loop template when CMS-bound)
   const slidesLayer = useMemo(() => sliderLayer?.children?.find(c => c.name === 'slides') ?? null, [sliderLayer]);
   const templateSlide = useMemo(() => slidesLayer?.children?.find(c => c.name === 'slide') ?? null, [slidesLayer]);
   const templateSlideCollection = templateSlide ? getCollectionVariable(templateSlide) : null;
-  const isCmsSource = templateSlideCollection?.source_field_type === 'multi_asset';
+  const isCmsSource = !!templateSlideCollection?.id;
 
   // The CMS source option is only enabled if at least one multi-image field
   // is reachable from this slider's context (page or ancestor collections).
@@ -171,6 +174,9 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldG
         },
       };
 
+      // Clear any stale collection data from a previously-bound real collection
+      clearLayerData(templateSlide.id);
+
       // If extras exist, atomically replace the slides children with just the
       // updated template — collapsing extras and applying the binding in one update.
       if ((slidesLayer.children?.length ?? 0) > 1) {
@@ -188,8 +194,14 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldG
       onLayerUpdate(templateSlide.id, {
         variables: Object.keys(nextVars).length > 0 ? nextVars : undefined,
       });
+
+      // Clear stale collection data and snap count so pagination dots reset
+      clearLayerData(templateSlide.id);
+      if (sliderLayer) {
+        setSliderSnapCount(sliderLayer.id, 0);
+      }
     }
-  }, [slidesLayer, templateSlide, onLayerUpdate]);
+  }, [slidesLayer, templateSlide, onLayerUpdate, sliderLayer, clearLayerData, setSliderSnapCount]);
 
   // Guard: only render for slider-family layers
   if (!layer || !sliderLayer) return null;

--- a/app/(builder)/ycode/components/SliderSettings.tsx
+++ b/app/(builder)/ycode/components/SliderSettings.tsx
@@ -24,20 +24,35 @@ import {
 import SettingsPanel from './SettingsPanel';
 import ToggleGroup from './ToggleGroup';
 
-import { findAncestorByName } from '@/lib/layer-utils';
+import { findAncestorByName, getCollectionVariable } from '@/lib/layer-utils';
 import { isSliderLayerName, DEFAULT_SLIDER_SETTINGS, createSlideLayer } from '@/lib/templates/utilities';
 import { EFFECTS_WITH_PER_VIEW } from '@/lib/slider-utils';
 import { slidePrev, slideNext } from '@/hooks/use-canvas-slider';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { usePagesStore } from '@/stores/usePagesStore';
-
-import type { Layer, SliderSettings as SliderSettingsType, SwiperAnimationEffect, SliderLoopMode, SliderPaginationType } from '@/types';
+import {
+  MULTI_ASSET_COLLECTION_ID,
+  MULTI_ASSET_VIRTUAL_FIELDS,
+  isMultipleAssetField,
+  isVirtualAssetField,
+} from '@/lib/collection-field-utils';
+import { isFieldVariable } from '@/lib/variable-utils';
+import type { FieldGroup } from '@/lib/collection-field-utils';
+import type { FieldVariable, Layer, SliderSettings as SliderSettingsType, SwiperAnimationEffect, SliderLoopMode, SliderPaginationType } from '@/types';
 
 interface SliderSettingsProps {
   layer: Layer | null;
   onLayerUpdate: (layerId: string, updates: Partial<Layer>) => void;
   allLayers: Layer[];
+  /**
+   * Field groups (incl. ancestor + page collection fields) used to detect whether
+   * any multi-image fields are available — needed to enable/disable the CMS source.
+   */
+  fieldGroups?: FieldGroup[];
 }
+
+/** Slider content source: static slides or a CMS multi-image field */
+type SliderSource = 'static' | 'cms';
 
 const ANIMATION_EFFECTS: { label: string; value: SwiperAnimationEffect }[] = [
   { label: 'Slide', value: 'slide' },
@@ -55,8 +70,9 @@ const EASING_OPTIONS: { label: string; value: string; icon: 'ease-linear' | 'eas
   { label: 'Ease out', value: 'ease-out', icon: 'ease-out' },
 ];
 
-export default function SliderSettings({ layer, onLayerUpdate, allLayers }: SliderSettingsProps) {
+export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldGroups }: SliderSettingsProps) {
   const [isOpen, setIsOpen] = useState(true);
+  const [isContentOpen, setIsContentOpen] = useState(true);
 
   // Find the root slider layer: either the current layer or an ancestor
   const sliderLayer = useMemo((): Layer | null => {
@@ -76,9 +92,23 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers }: Slid
   const addLayerWithId = usePagesStore((state) => state.addLayerWithId);
   const setSelectedLayerId = useEditorStore((state) => state.setSelectedLayerId);
 
+  // Inner slides wrapper and the first slide inside it (the loop template when CMS-bound)
+  const slidesLayer = useMemo(() => sliderLayer?.children?.find(c => c.name === 'slides') ?? null, [sliderLayer]);
+  const templateSlide = useMemo(() => slidesLayer?.children?.find(c => c.name === 'slide') ?? null, [slidesLayer]);
+  const templateSlideCollection = templateSlide ? getCollectionVariable(templateSlide) : null;
+  const isCmsSource = templateSlideCollection?.source_field_type === 'multi_asset';
+
+  // The CMS source option is only enabled if at least one multi-image field
+  // is reachable from this slider's context (page or ancestor collections).
+  const hasMultiImageFields = useMemo<boolean>(() => {
+    if (!fieldGroups) return false;
+    return fieldGroups.some(group =>
+      group.fields.some(f => f.type === 'image' && isMultipleAssetField(f))
+    );
+  }, [fieldGroups]);
+
   const handleAddSlide = useCallback(() => {
     if (!currentPageId || !sliderLayer) return;
-    const slidesLayer = sliderLayer.children?.find(c => c.name === 'slides');
     if (!slidesLayer) return;
     const slideNumber = (slidesLayer.children?.length ?? 0) + 1;
     const slide = createSlideLayer(`Slide ${slideNumber}`, '/ycode/layouts/assets/placeholder-2.webp');
@@ -86,11 +116,90 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers }: Slid
       addLayerWithId(currentPageId, slidesLayer.id, slide);
       requestAnimationFrame(() => setSelectedLayerId(slide.id));
     }
-  }, [currentPageId, sliderLayer, addLayerWithId, setSelectedLayerId]);
+  }, [currentPageId, sliderLayer, slidesLayer, addLayerWithId, setSelectedLayerId]);
+
+  /**
+   * Switch slides content source between static and CMS multi-image.
+   *
+   * On 'cms': mark the template slide as a (still-unbound) multi-asset collection
+   * and pre-bind its background to the virtual `__asset_url` field. The actual
+   * multi-image field is then chosen by selecting the slide and using the standard
+   * CMS section in the right sidebar — once bound, the background renders without
+   * any extra step.
+   *
+   * On 'static': clear the multi-asset collection binding and any orphaned
+   * virtual-asset background (it would have no context outside CMS mode).
+   */
+  const handleSourceChange = useCallback((source: SliderSource) => {
+    if (!slidesLayer || !templateSlide) return;
+    if (source === 'cms') {
+      const currentBgVar = templateSlide.variables?.backgroundImage?.src;
+      const isCustomCmsBinding = !!(
+        currentBgVar
+        && isFieldVariable(currentBgVar)
+        && currentBgVar.data.field_id
+        && !isVirtualAssetField(currentBgVar.data.field_id)
+      );
+
+      // Virtual asset field values live in per-iteration item data only,
+      // so always use source='collection' for the binding.
+      const nextBackgroundImage = isCustomCmsBinding
+        ? templateSlide.variables?.backgroundImage
+        : {
+          src: {
+            type: 'field' as const,
+            data: {
+              field_id: MULTI_ASSET_VIRTUAL_FIELDS.URL,
+              relationships: [],
+              field_type: 'image' as const,
+              source: 'collection' as const,
+              collection_layer_id: templateSlide.id,
+            },
+          } satisfies FieldVariable,
+        };
+
+      const updatedTemplateSlide: Layer = {
+        ...templateSlide,
+        variables: {
+          ...templateSlide.variables,
+          collection: {
+            ...(templateSlide.variables?.collection ?? {}),
+            id: MULTI_ASSET_COLLECTION_ID,
+            source_field_type: 'multi_asset',
+          },
+          backgroundImage: nextBackgroundImage,
+        },
+      };
+
+      // If extras exist, atomically replace the slides children with just the
+      // updated template — collapsing extras and applying the binding in one update.
+      if ((slidesLayer.children?.length ?? 0) > 1) {
+        onLayerUpdate(slidesLayer.id, { children: [updatedTemplateSlide] });
+      } else {
+        onLayerUpdate(templateSlide.id, { variables: updatedTemplateSlide.variables });
+      }
+    } else {
+      const nextVars = { ...templateSlide.variables };
+      delete nextVars.collection;
+      const bgSrc = nextVars.backgroundImage?.src;
+      if (bgSrc && isFieldVariable(bgSrc) && bgSrc.data.field_id && isVirtualAssetField(bgSrc.data.field_id)) {
+        delete nextVars.backgroundImage;
+      }
+      onLayerUpdate(templateSlide.id, {
+        variables: Object.keys(nextVars).length > 0 ? nextVars : undefined,
+      });
+    }
+  }, [slidesLayer, templateSlide, onLayerUpdate]);
 
   // Guard: only render for slider-family layers
   if (!layer || !sliderLayer) return null;
   if (!isSliderLayerName(layer.name)) return null;
+
+  // Content panel (Source select) only appears on the root slider — keeps the
+  // intermediate `slides` wrapper clean and routes per-slide CMS binding to the
+  // standard CMS section in the right sidebar.
+  const showContentPanel = layer.name === 'slider';
+  const sourceValue: SliderSource = isCmsSource ? 'cms' : 'static';
 
   const settings: SliderSettingsType = {
     ...DEFAULT_SLIDER_SETTINGS,
@@ -116,21 +225,54 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers }: Slid
   };
 
   return (
-    <SettingsPanel
-      title="Slider"
-      isOpen={isOpen}
-      onToggle={() => setIsOpen(!isOpen)}
-      action={
-        <div className="flex items-center gap-1">
-          <Button
-            variant="secondary"
-            size="xs"
-            className="size-6 p-0"
-            onClick={handleAddSlide}
-            aria-label="Add slide"
-          >
-            <Icon name="plus" className="size-2.5" />
-          </Button>
+    <>
+      {showContentPanel && (
+        <SettingsPanel
+          title="Content"
+          isOpen={isContentOpen}
+          onToggle={() => setIsContentOpen(!isContentOpen)}
+        >
+          <div className="grid grid-cols-3 items-center">
+            <Label variant="muted">Source</Label>
+            <div className="col-span-2">
+              <Select
+                value={sourceValue}
+                onValueChange={(v) => handleSourceChange(v as SliderSource)}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="static">
+                    <Icon name="slides" className="size-3" /> Slides
+                  </SelectItem>
+                  <SelectItem value="cms" disabled={!hasMultiImageFields}>
+                    <Icon name="database" className="size-3" /> CMS
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </SettingsPanel>
+      )}
+
+      <SettingsPanel
+        title="Slider"
+        isOpen={isOpen}
+        onToggle={() => setIsOpen(!isOpen)}
+        action={
+          <div className="flex items-center gap-1">
+            {!isCmsSource && (
+              <Button
+                variant="secondary"
+                size="xs"
+                className="size-6 p-0"
+                onClick={handleAddSlide}
+                aria-label="Add slide"
+              >
+                <Icon name="plus" className="size-2.5" />
+              </Button>
+            )}
           <Button
             variant="secondary"
             size="xs"
@@ -151,7 +293,7 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers }: Slid
           </Button>
         </div>
       }
-    >
+      >
       <div className="flex flex-col gap-2.5">
         {/* Animation */}
         <div className="grid grid-cols-3 items-center">
@@ -525,6 +667,7 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers }: Slid
           </div>
         </div>
       </div>
-    </SettingsPanel>
+      </SettingsPanel>
+    </>
   );
 }

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1222,7 +1222,8 @@ const LayerItem: React.FC<{
         return ids.includes(parentId);
       });
     } else if (!sourceFieldId) {
-      items = allCollectionItems;
+      // Multi-asset without a selected field has no items to render
+      items = sourceFieldType === 'multi_asset' ? [] : allCollectionItems;
     } else {
       // Get the reference field value using source-aware resolution
       const refValue = resolveFieldFromSources(sourceFieldId, undefined, collectionLayerData, pageCollectionItemData);

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -2792,9 +2792,15 @@ const LayerItem: React.FC<{
             };
 
             // Resolve per-item background image from CMS field variable → CSS variable (combined with gradient)
+            // For multi-asset collections, virtual asset fields (__asset_url etc.) live in
+            // enhancedItemValues only. If the binding was authored with source='page' (legacy),
+            // expose those values via pageCollectionItemData so resolution still succeeds.
             let itemElementProps = elementProps;
             if (bgImageVariable && isFieldVariable(bgImageVariable) && bgImageVariable.data.field_id) {
-              const resolvedBgAssetId = resolveFieldValue(bgImageVariable, mergedItemData, pageCollectionItemData, updatedLayerDataMap);
+              const bgPageData = sourceFieldType === 'multi_asset'
+                ? { ...pageCollectionItemData, ...enhancedItemValues }
+                : pageCollectionItemData;
+              const resolvedBgAssetId = resolveFieldValue(bgImageVariable, mergedItemData, bgPageData, updatedLayerDataMap);
               if (resolvedBgAssetId) {
                 const bgAsset = assetsById[resolvedBgAssetId] || getAsset(resolvedBgAssetId);
                 const bgUrl = bgAsset?.public_url || resolvedBgAssetId;

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -196,7 +196,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-xs outline-hidden select-none overflow-hidden data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-xs outline-hidden select-none overflow-hidden data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -206,8 +206,15 @@ function SelectItem({
           <Icon name="check" className="size-3 opacity-50" />
         </SelectPrimitive.ItemIndicator>
       </span>
+      {/*
+        Render ItemText as a flex span so icon + label sit on the same line.
+        Without this, Tailwind preflight forces the icon to display:block and it
+        wraps onto its own line inside Radix's default inline ItemText wrapper.
+      */}
       <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap [&>span]:overflow-hidden [&>span]:text-ellipsis [&>span]:whitespace-nowrap">
-        <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+        <SelectPrimitive.ItemText asChild>
+          <span className="flex items-center gap-2">{children}</span>
+        </SelectPrimitive.ItemText>
       </span>
     </SelectPrimitive.Item>
   )

--- a/lib/collection-field-utils.ts
+++ b/lib/collection-field-utils.ts
@@ -475,12 +475,15 @@ export function buildFieldGroups(config: BuildFieldGroupsConfig): FieldGroup[] |
   const groups: FieldGroup[] = [];
   const addedCollectionIds = new Set<string>();
 
-  // Add multi-asset virtual fields if inside a multi-asset collection context
+  // Add multi-asset virtual fields if inside a multi-asset collection context.
+  // Virtual asset field values live in the per-iteration item data only
+  // (never in pageCollectionItemData), so always use 'collection' source —
+  // even when the parent multi-image field itself is page-bound.
   if (multiAssetContext) {
     groups.push({
       fields: buildMultiAssetVirtualFields(),
       label: 'File fields',
-      source: multiAssetContext.source,
+      source: 'collection',
     });
   }
 


### PR DESCRIPTION
## Summary

Add the ability to drive a Slider element from a multi-image CMS field. The Slider's Source select toggles between static slides and CMS mode; the multi-image field itself is then chosen on the slide layer using the standard CMS section, keeping field selection consistent with every other CMS-bound layer.

## Changes

- Add `Content` panel with `Source` select (Slides / CMS) on the root Slider element
- Pre-bind the slide template's `backgroundImage` to the virtual `__asset_url` field on switching to CMS source so binding is one-step
- Auto-prune `heading`/`text` descendants from a slide when it's bound to a multi-image field (assets are typically the focus)
- Expose multi-asset virtual fields in `BackgroundsControls` when the layer is in a multi-asset context or already bound to one, so the binding can always be restored
- Force `source: 'collection'` on virtual asset fields (`__asset_url`, etc.) — their values live in per-iteration data only, so `source: 'page'` was silently resolving to `undefined` for page-bound multi-image fields
- Render Radix `SelectItem`'s `ItemText` as a flex span via `asChild` so icon + label sit on the same line in every dropdown (previously the icon dropped to its own line because Tailwind preflight forces `svg { display: block }`)

## Test plan

- [ ] On a static page, add a Slider — the CMS source option should be disabled (no multi-image fields available)
- [ ] On a dynamic CMS page with a multi-image field, set Slider Source to CMS, then select the slide and pick the multi-image field via the CMS section. Verify slides render with the iterated images.
- [ ] Repeat the flow inside a parent collection layer where the referenced collection has a multi-image field
- [ ] Switch back to Slides source — multi-asset binding clears, virtual background binding clears, original slides restored
- [ ] Add a heading and text inside a slide, then bind the slide to a multi-image field — the heading and text should be removed
- [ ] Verify icon + label sit on the same line in dropdowns across `BackgroundImageSettings`, `ImageSettings`, `AudioSettings`, `VideoSettings`, `LightboxSettings`, `LocalizationContent`

Made with [Cursor](https://cursor.com)