### PR TITLE
fix: route preview to layers view from non-design routes

### DIFF
--- a/app/(builder)/ycode/components/HeaderBar.tsx
+++ b/app/(builder)/ycode/components/HeaderBar.tsx
@@ -82,7 +82,7 @@ export default function HeaderBar({
   const router = useRouter();
   const pathname = usePathname();
   const pageDropdownRef = useRef<HTMLDivElement>(null);
-  const { currentPageCollectionItemId, currentPageId: storeCurrentPageId, isPreviewMode, setPreviewMode, openFileManager, setKeyboardShortcutsOpen, setActiveSidebarTab, lastDesignUrl, setLastDesignUrl } = useEditorStore();
+  const { currentPageCollectionItemId, currentPageId: storeCurrentPageId, isPreviewMode, setPreviewMode, openFileManager, setKeyboardShortcutsOpen, setActiveSidebarTab, lastDesignUrl, setLastDesignUrl, previewReturnUrl, previewReturnTab, setPreviewReturn } = useEditorStore();
   const { folders, pages: storePages } = usePagesStore();
   const { items, fields, collections, selectedCollectionId: storeSelectedCollectionId, setSelectedCollectionId } = useCollectionsStore();
   const { locales, selectedLocaleId, setSelectedLocaleId, translations } = useLocalisationStore();
@@ -107,6 +107,16 @@ export default function HeaderBar({
       setOptimisticNav(null);
     }
   }, [routeType, optimisticNav]);
+
+  // Turn off preview mode only after navigation to the return route completes,
+  // keeping the preview overlay visible during the transition to avoid flashing
+  useEffect(() => {
+    if (!isPreviewMode || previewReturnUrl) return;
+    const isDesignRoute = routeType === 'layers' || routeType === 'page' || routeType === 'component' || routeType === null;
+    if (!isDesignRoute) {
+      setPreviewMode(false);
+    }
+  }, [routeType, isPreviewMode, previewReturnUrl, setPreviewMode]);
 
   // Derive active button: optimistic state takes priority, then URL
   const activeNavButton = useMemo((): NavButton | null => {
@@ -590,6 +600,17 @@ export default function HeaderBar({
           variant="secondary"
           onClick={() => {
             if (isPreviewMode) {
+              if (previewReturnUrl) {
+                // Navigate back while keeping preview visible — the useEffect
+                // above will turn off preview once the route change completes
+                if (previewReturnTab) {
+                  setActiveSidebarTab(previewReturnTab);
+                }
+                router.push(previewReturnUrl);
+                setPreviewReturn(null);
+                return;
+              }
+
               setPreviewMode(false);
               updateQueryParams({ preview: undefined });
               return;
@@ -601,6 +622,7 @@ export default function HeaderBar({
             // route (CMS, forms, etc.) we need to jump to the layers view first
             const isDesignRoute = routeType === 'layers' || routeType === 'page' || routeType === 'component' || routeType === null;
             if (!isDesignRoute && currentPageId) {
+              setPreviewReturn(window.location.pathname + window.location.search, activeTab);
               setActiveSidebarTab('layers');
               const params = new URLSearchParams(window.location.search);
               params.set('preview', 'true');

--- a/app/(builder)/ycode/components/HeaderBar.tsx
+++ b/app/(builder)/ycode/components/HeaderBar.tsx
@@ -590,14 +590,25 @@ export default function HeaderBar({
           variant="secondary"
           onClick={() => {
             if (isPreviewMode) {
-              // Exit preview mode
               setPreviewMode(false);
               updateQueryParams({ preview: undefined });
-            } else {
-              // Enter preview mode
-              setPreviewMode(true);
-              updateQueryParams({ preview: 'true' });
+              return;
             }
+
+            setPreviewMode(true);
+
+            // Preview renders the current page, so when invoked from a non-design
+            // route (CMS, forms, etc.) we need to jump to the layers view first
+            const isDesignRoute = routeType === 'layers' || routeType === 'page' || routeType === 'component' || routeType === null;
+            if (!isDesignRoute && currentPageId) {
+              setActiveSidebarTab('layers');
+              const params = new URLSearchParams(window.location.search);
+              params.set('preview', 'true');
+              router.push(`/ycode/layers/${currentPageId}?${params.toString()}`);
+              return;
+            }
+
+            updateQueryParams({ preview: 'true' });
           }}
           disabled={!currentPage || isSaving}
           className={isPreviewMode ? 'bg-black text-white hover:bg-black/90 dark:bg-white dark:text-black dark:hover:bg-white/90' : ''}

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -589,7 +589,22 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
       }
     } else if (routeType === 'collections-base') {
       // On base collections route, don't set a selected collection
-    } else if (routeType === 'component' && resourceId && !isExitingComponentModeRef.current) {
+    }
+
+    // Ensure a currentPageId is set on non-design routes (CMS, Forms) so
+    // preview can navigate to a page — default to homepage if unset
+    if (!currentPageId && pages.length > 0) {
+      const isNonDesignRoute = routeType === 'collection' || routeType === 'collections-base' || routeType === 'forms';
+      if (isNonDesignRoute) {
+        const homePage = findHomepage(pages);
+        const defaultPage = homePage || pages[0];
+        if (defaultPage) {
+          setCurrentPageId(defaultPage.id);
+        }
+      }
+    }
+
+    if (routeType === 'component' && resourceId && !isExitingComponentModeRef.current) {
       const { getComponentById, loadComponentDraft } = useComponentsStore.getState();
       const component = getComponentById(resourceId);
       if (component && editingComponentId !== resourceId) {

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -1860,8 +1860,8 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         signOut={signOut}
         showPageDropdown={showPageDropdown}
         setShowPageDropdown={setShowPageDropdown}
-        currentPage={routeType === 'settings' || routeType === 'profile' || routeType === 'forms' || routeType === 'integrations' ? undefined : currentPage}
-        currentPageId={routeType === 'settings' || routeType === 'profile' || routeType === 'forms' || routeType === 'integrations' ? null : currentPageId}
+        currentPage={routeType === 'settings' || routeType === 'profile' || routeType === 'integrations' ? undefined : currentPage}
+        currentPageId={routeType === 'settings' || routeType === 'profile' || routeType === 'integrations' ? null : currentPageId}
         pages={routeType === 'settings' || routeType === 'profile' || routeType === 'forms' || routeType === 'integrations' ? [] : pages}
         setCurrentPageId={routeType === 'settings' || routeType === 'profile' || routeType === 'forms' || routeType === 'integrations' ? () => {} : setCurrentPageId}
         isSaving={routeType === 'settings' || routeType === 'localization' || routeType === 'profile' || routeType === 'forms' || routeType === 'integrations' ? false : isCurrentlySaving}

--- a/stores/useEditorStore.ts
+++ b/stores/useEditorStore.ts
@@ -80,6 +80,7 @@ interface EditorActions {
   setPreviewMode: (enabled: boolean) => void;
   setActiveSidebarTab: (tab: EditorSidebarTab) => void;
   setLastDesignUrl: (url: string | null) => void;
+  setPreviewReturn: (url: string | null, tab?: EditorSidebarTab | null) => void;
   openFileManager: (onSelect?: ((asset: Asset) => void | false) | null, assetId?: string | null, category?: AssetCategoryFilter) => void;
   closeFileManager: () => void;
   setKeyboardShortcutsOpen: (open: boolean) => void;
@@ -130,6 +131,9 @@ interface EditorStoreWithHistory extends EditorState {
   activeSidebarTab: EditorSidebarTab;
   /** Last visited design route URL for restoring navigation */
   lastDesignUrl: string | null;
+  /** URL and sidebar tab to return to when exiting preview from a non-design route */
+  previewReturnUrl: string | null;
+  previewReturnTab: EditorSidebarTab | null;
   fileManager: {
     open: boolean;
     onSelect: ((asset: Asset) => void | false) | null;
@@ -216,6 +220,8 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
   isPreviewMode: false,
   activeSidebarTab: 'layers' as EditorSidebarTab,
   lastDesignUrl: null,
+  previewReturnUrl: null,
+  previewReturnTab: null,
   fileManager: {
     open: false,
     onSelect: null,
@@ -519,6 +525,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
   setActiveSidebarTab: (tab) => set({ activeSidebarTab: tab }),
   setLastDesignUrl: (url) => set({ lastDesignUrl: url }),
+  setPreviewReturn: (url, tab) => set({ previewReturnUrl: url, previewReturnTab: tab ?? null }),
 
   openFileManager: (onSelect, assetId, category) => set({
     fileManager: {


### PR DESCRIPTION
## Summary

Clicking **Preview** from `/ycode/collections`, forms, or other non-design routes only flipped the `preview=true` query param but left the user on the same route where the canvas doesn't render, so nothing visibly happened. This PR routes the user to `/ycode/layers/<currentPageId>` and syncs the sidebar tab so the preview actually renders the current page.

## Changes

- When entering preview mode from a non-design route (CMS/forms/etc.), push to `/ycode/layers/<currentPageId>?preview=true` instead of just updating the query param
- Set `activeSidebarTab` to `layers` so the store-driven tab matches the new route (prevents the CMS view from sticking around)
- No behavior change when preview is triggered from a design route (layers/pages/component)

## Test plan

- [ ] From `/ycode/collections/<id>`, click Preview → lands on `/ycode/layers/<currentPageId>?preview=true` with the page rendered
- [ ] From `/ycode/forms`, click Preview → same outcome
- [ ] From `/ycode/layers/<id>`, click Preview → stays on the same route, just toggles `preview=true` (unchanged)
- [ ] Exit preview returns to the previous state correctly
