### PR TITLE
fix: keep canvas filling height on resize

### DIFF
--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -601,9 +601,6 @@ const CenterCanvas = React.memo(function CenterCanvas({
   const [containerHeight, setContainerHeight] = useState(0);
   const [containerWidth, setContainerWidth] = useState(0);
 
-  // Store initial canvas height on load - used as baseline for iframe height
-  const initialCanvasHeightRef = useRef<number | null>(null);
-
   // Track whether zoom calculation is ready (prevents flash of wrong zoom on initial load)
   const [isCanvasReady, setIsCanvasReady] = useState(false);
 
@@ -747,18 +744,12 @@ const CenterCanvas = React.memo(function CenterCanvas({
     return parseInt(viewportSizes[viewportMode].width);
   }, [viewportMode]);
 
-  // Calculate default iframe height to fill canvas (set once on load)
+  // Calculate default iframe height to fill canvas — track current container height
+  // so the white canvas always fills all the available vertical space, even when the
+  // surrounding panels (sidebar, inspector, etc.) resize the canvas container.
   const defaultCanvasHeight = useMemo(() => {
     if (!containerHeight) return 600;
-    const calculatedHeight = containerHeight - CANVAS_PADDING;
-
-    // Store the initial height when first calculated
-    if (initialCanvasHeightRef.current === null) {
-      initialCanvasHeightRef.current = calculatedHeight;
-    }
-
-    // Always use the initial height - don't change with zoom or container changes
-    return initialCanvasHeightRef.current;
+    return Math.max(0, containerHeight - CANVAS_PADDING);
   }, [containerHeight]);
 
   // Effective iframe height: max of reported content and canvas height
@@ -782,12 +773,6 @@ const CenterCanvas = React.memo(function CenterCanvas({
     }
     return viewportWidth;
   }, [editingComponentId, reportedContentWidth, viewportWidth]);
-
-  // Calculate "zoom to fit" level - where scaled height equals container height
-  const zoomToFitLevel = useMemo(() => {
-    if (!containerHeight || !iframeContentHeight) return 100;
-    return ((containerHeight - CANVAS_PADDING) / iframeContentHeight) * 100;
-  }, [containerHeight, iframeContentHeight]);
 
   // Calculate content height for zoom calculations
   // Use actual iframe content height for both modes
@@ -836,20 +821,16 @@ const CenterCanvas = React.memo(function CenterCanvas({
     iframeRef,
   });
 
-  // Determine if we should center (zoomed out beyond "zoom to fit" level)
-  const shouldCenter = zoom < zoomToFitLevel;
-
-  // Calculate final iframe height - ensure it fills the visible canvas at any zoom level
-  // When zoomed in or at fit level, stretch the iframe so the scaled result fills the canvas.
-  // When zoomed out beyond fit, use content height directly — centering handles the gap.
+  // Calculate final iframe height — always stretch so the scaled canvas fills the
+  // visible viewport at any zoom level. When the actual content is taller than the
+  // viewport, use the content height instead so scrolling works naturally.
   const finalIframeHeight = useMemo(() => {
     if (editingComponentId) return iframeContentHeight;
     if (!containerHeight || zoom <= 0) return iframeContentHeight;
-    if (shouldCenter) return iframeContentHeight;
 
     const minHeightForZoom = (containerHeight - CANVAS_PADDING) / (zoom / 100);
     return Math.max(iframeContentHeight, minHeightForZoom);
-  }, [iframeContentHeight, containerHeight, zoom, editingComponentId, shouldCenter]);
+  }, [iframeContentHeight, containerHeight, zoom, editingComponentId]);
 
   const previewObserverRef = useRef<ResizeObserver | null>(null);
 
@@ -2360,18 +2341,14 @@ const CenterCanvas = React.memo(function CenterCanvas({
                   // Width: exact scaled size, min 100% to fill viewport horizontally
                   width: `${effectiveCanvasWidth * (zoom / 100) + CANVAS_PADDING}px`,
                   minWidth: '100%',
-                  // Height: exact viewport height when centered, scaled size when top-aligned
-                  height: shouldCenter
-                    ? `${containerHeight}px`  // Use actual viewport height
-                    : `${finalIframeHeight * (zoom / 100) + CANVAS_PADDING}px`,
+                  // Height: scaled iframe size + canvas padding. finalIframeHeight is
+                  // already stretched to fill the viewport at any zoom level, so the
+                  // white canvas always fills the available height.
+                  height: `${finalIframeHeight * (zoom / 100) + CANVAS_PADDING}px`,
                   display: 'flex',
-                  // Always use flex-start - we'll handle centering via padding
                   alignItems: 'flex-start',
-                  justifyContent: 'center', // Center horizontally
-                  // Calculate padding: center based on VISUAL (scaled) height, or fixed border when top-aligned
-                  paddingTop: shouldCenter
-                    ? `${Math.max(0, (containerHeight - finalIframeHeight * (zoom / 100)) / 2)}px`
-                    : `${CANVAS_BORDER}px`,
+                  justifyContent: 'center',
+                  paddingTop: `${CANVAS_BORDER}px`,
                   position: 'relative',
                 }}
               >


### PR DESCRIPTION
## Summary

The white canvas inside the builder could end up shorter than the available area, leaving large empty space above and below it (visible as a `padding-top: 243.622px` on the canvas wrapper). It happened in two situations: when surrounding panels resized the canvas container after first load, and when the zoom dropped below the "zoom to fit" level.

## Changes

- Track the live container height for `defaultCanvasHeight` instead of caching the value once via a ref, so the iframe baseline grows when the canvas area resizes
- Always stretch `finalIframeHeight` to fill the viewport at any zoom level — drop the `shouldCenter` short-circuit that returned the raw content height when zoomed out
- Remove the `shouldCenter` layout branch on the canvas wrapper; the wrapper now uses a fixed `CANVAS_BORDER` `paddingTop` and a height derived from the (already stretched) scaled iframe
- Delete now-unused `zoomToFitLevel`, `shouldCenter`, and `initialCanvasHeightRef`

## Test plan

- [ ] Open a page with no layers — the white canvas should fill the full vertical space with only the canvas border around it
- [ ] Resize the inspector / sidebar / window — the white canvas should keep filling the height instead of staying at the original height
- [ ] Zoom out below "fit" — the canvas should still fill the visible area (no large vertical gap above/below)
- [ ] Zoom in past 100% — content should scroll naturally and the canvas should remain top-aligned with the canvas border
- [ ] Open a long page that exceeds the viewport height — scrolling within the canvas should still work as before
- [ ] Enter component edit mode — component canvas sizing should be unchanged

Made with [Cursor](https://cursor.com)