### PR TITLE
fix: resolve collection filtering issues

### DIFF
--- a/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
+++ b/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
@@ -113,6 +113,17 @@ async function getIdsMatchingFilter(
       return new Set(data.map(d => d.item_id));
     }
     case 'is': {
+      if (filter.fieldType === 'boolean') {
+        const targetBool = value.toLowerCase() === 'true';
+        const data = await chunkedQuery(chunk => selectIdsAndValues(chunk), allItemIds);
+        const result = new Set<string>();
+        for (const row of data) {
+          const raw = String(row.value ?? '').toLowerCase();
+          const isTruthy = raw === 'true' || raw === '1' || raw === 'yes';
+          if (isTruthy === targetBool) result.add(row.item_id);
+        }
+        return result;
+      }
       const data = await chunkedQuery(
         chunk => selectIds(chunk).ilike('value', escapeLikeValue(value)),
         allItemIds,
@@ -144,6 +155,17 @@ async function getIdsMatchingFilter(
       return new Set([...allSet].filter(id => !matchIds.has(id)));
     }
     case 'is_not': {
+      if (filter.fieldType === 'boolean') {
+        const targetBool = value.toLowerCase() === 'true';
+        const data = await chunkedQuery(chunk => selectIdsAndValues(chunk), allItemIds);
+        const result = new Set<string>();
+        for (const row of data) {
+          const raw = String(row.value ?? '').toLowerCase();
+          const isTruthy = raw === 'true' || raw === '1' || raw === 'yes';
+          if (isTruthy !== targetBool) result.add(row.item_id);
+        }
+        return result;
+      }
       const data = await chunkedQuery(
         chunk => selectIds(chunk).ilike('value', escapeLikeValue(value)),
         allItemIds,

--- a/app/(builder)/ycode/components/SelectOptionsSettings.tsx
+++ b/app/(builder)/ycode/components/SelectOptionsSettings.tsx
@@ -169,14 +169,14 @@ function buildOptionLayer(id: string, label: string, value: string): Layer {
 }
 
 /**
- * Build a placeholder option layer (disabled, selected, hidden, value="")
+ * Build a placeholder option layer (value="", selectable to clear selection)
  */
 function buildPlaceholderOption(id: string, text: string): Layer {
   return {
     id,
     name: 'option',
     classes: '',
-    attributes: { value: '', disabled: 'true', hidden: 'true' },
+    attributes: { value: '' },
     settings: { isPlaceholder: true },
     variables: {
       text: {

--- a/components/FilterableCollection.tsx
+++ b/components/FilterableCollection.tsx
@@ -101,6 +101,7 @@ export default function FilterableCollection({
     const parent = getParent();
     if (!parent) return;
     if (!append) {
+      hideSSR();
       clearFilteredDOM();
     }
     const temp = document.createElement('div');
@@ -110,7 +111,7 @@ export default function FilterableCollection({
       if (child instanceof Element) child.setAttribute(FC_FILTERED_ATTR, '');
       parent.appendChild(child);
     }
-  }, [getParent, clearFilteredDOM]);
+  }, [getParent, hideSSR, clearFilteredDOM]);
 
   // Capture SSR children on mount (before paint) and hide if pending
   useLayoutEffect(() => {
@@ -594,7 +595,16 @@ export default function FilterableCollection({
 
   useEffect(() => {
     const filterGroups = buildApiFilters();
-    const hasRuntimeControls = filterGroups.length > 0 || hasRuntimeSortOverride;
+    const hasActiveInputValues = filters.groups.some(g =>
+      g.conditions.some(c => {
+        if (!c.inputLayerId) return false;
+        for (const layerValues of Object.values(filterValues)) {
+          if (c.inputLayerId in layerValues && layerValues[c.inputLayerId]) return true;
+        }
+        return false;
+      })
+    );
+    const hasRuntimeControls = hasActiveInputValues || hasRuntimeSortOverride;
     const filterKey = JSON.stringify({
       filterGroups,
       sortBy: effectiveSortBy,
@@ -624,14 +634,8 @@ export default function FilterableCollection({
         window.history.replaceState({}, '', cleanUrl.toString());
       }
 
-      if (strippedPaginationParamRef.current || (paginationMode === 'load_more' && !wasEmpty)) {
-        strippedPaginationParamRef.current = false;
-        const reloadUrl = new URL(window.location.href);
-        reloadUrl.searchParams.delete(fpKey);
-        reloadUrl.searchParams.delete(pKey);
-        window.location.href = reloadUrl.toString();
-        return;
-      }
+      strippedPaginationParamRef.current = false;
+      useFilterStore.getState().syncToUrl();
 
       setHasActiveFilters(false);
       setIsFiltering(false);
@@ -651,27 +655,7 @@ export default function FilterableCollection({
       return;
     }
 
-    // On initial load, static filters are already applied server-side during SSR.
-    // Only fetch if user-interactive inputs actually have values (e.g. from URL params).
-    if (wasEmpty && !hasRuntimeSortOverride) {
-      const hasActiveInputValues = filters.groups.some(g =>
-        g.conditions.some(c => {
-          if (!c.inputLayerId) return false;
-          for (const layerValues of Object.values(filterValues)) {
-            if (c.inputLayerId in layerValues && layerValues[c.inputLayerId]) return true;
-          }
-          return false;
-        })
-      );
-
-      if (!hasActiveInputValues) {
-        showSSR();
-        return;
-      }
-    }
-
     setHasActiveFilters(true);
-    hideSSR();
 
     const currentUrl = new URL(window.location.href);
     const fpValue = currentUrl.searchParams.get(fpKey);
@@ -698,7 +682,7 @@ export default function FilterableCollection({
 
     const startOffset = (startPage - 1) * (limit || 10);
     fetchFiltered(filterGroups, startOffset, false);
-  }, [filterValues, buildApiFilters, fetchFiltered, paginationMode, attachPaginationIntercept, detachPaginationIntercept, restoreSsrPagination, getSsrPaginationWrapper, updateEmptyStateElements, fpKey, pKey, limit, hasRuntimeSortOverride, effectiveSortBy, effectiveSortOrder, hideSSR, showSSR, clearFilteredDOM]);
+  }, [filterValues, buildApiFilters, fetchFiltered, paginationMode, attachPaginationIntercept, detachPaginationIntercept, restoreSsrPagination, getSsrPaginationWrapper, updateEmptyStateElements, fpKey, pKey, limit, hasRuntimeSortOverride, effectiveSortBy, effectiveSortOrder, showSSR, clearFilteredDOM]);
 
   useEffect(() => {
     if (!hasActiveFilters || paginationMode !== 'pages') return;

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -109,6 +109,7 @@ interface LayerRendererProps {
   parentComponentVariables?: ComponentVariable[]; // Component's variables for default value lookup
   editingComponentVariables?: ComponentVariable[]; // Variables when directly editing a component
   isInsideForm?: boolean; // Whether this layer is inside a form (for button type handling)
+  isInsideLink?: boolean; // Whether this layer is inside an ancestor <a> (prevents nested <a> tags)
   parentFormSettings?: FormSettings; // Form settings from parent form layer
   pages?: any[]; // Pages for link resolution
   folders?: any[]; // Folders for link resolution
@@ -163,6 +164,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
   parentComponentVariables,
   editingComponentVariables,
   isInsideForm = false,
+  isInsideLink = false,
   parentFormSettings,
   pages: pagesProp,
   folders: foldersProp,
@@ -306,6 +308,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
         parentComponentVariables={parentComponentVariables}
         editingComponentVariables={editingComponentVariables}
         isInsideForm={isInsideForm}
+        isInsideLink={isInsideLink}
         parentFormSettings={parentFormSettings}
         pages={pages}
         folders={folders}
@@ -370,6 +373,7 @@ const LayerItem: React.FC<{
   parentComponentVariables?: ComponentVariable[]; // Component's variables for default value lookup
   editingComponentVariables?: ComponentVariable[]; // Variables when directly editing a component
   isInsideForm?: boolean; // Whether this layer is inside a form
+  isInsideLink?: boolean; // Whether this layer is inside an ancestor <a>
   parentFormSettings?: FormSettings; // Form settings from parent form layer
   pages?: any[]; // Pages for link resolution
   folders?: any[]; // Folders for link resolution
@@ -421,6 +425,7 @@ const LayerItem: React.FC<{
   parentComponentVariables,
   editingComponentVariables,
   isInsideForm = false,
+  isInsideLink = false,
   parentFormSettings,
   pages,
   folders,
@@ -516,6 +521,7 @@ const LayerItem: React.FC<{
     liveLayerUpdates,
     liveComponentUpdates,
     isInsideForm,
+    isInsideLink,
     parentFormSettings,
     pages,
     folders,
@@ -529,7 +535,7 @@ const LayerItem: React.FC<{
   // selectedLayerId and hoveredLayerId kept in the object for SSR/published mode
   // but excluded from deps so changes don't cascade re-renders in edit mode.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }), [isEditMode, isPublished, onLayerClick, onLayerUpdate, onLayerHover, pageId, collectionLayerData, collectionLayerItemId, effectiveLayerDataMap, pageCollectionItemId, pageCollectionItemData, pageCollectionSortedItemIds, hiddenLayerInfo, editorHiddenLayerIds, editorBreakpoint, currentLocale, availableLocales, localeSelectorFormat, liveLayerUpdates, liveComponentUpdates, isInsideForm, parentFormSettings, pages, folders, collectionItemSlugs, isPreview, translations, anchorMap, resolvedAssets, componentsProp, serverSettings]);
+  }), [isEditMode, isPublished, onLayerClick, onLayerUpdate, onLayerHover, pageId, collectionLayerData, collectionLayerItemId, effectiveLayerDataMap, pageCollectionItemId, pageCollectionItemData, pageCollectionSortedItemIds, hiddenLayerInfo, editorHiddenLayerIds, editorBreakpoint, currentLocale, availableLocales, localeSelectorFormat, liveLayerUpdates, liveComponentUpdates, isInsideForm, isInsideLink, parentFormSettings, pages, folders, collectionItemSlugs, isPreview, translations, anchorMap, resolvedAssets, componentsProp, serverSettings]);
 
   // Callback for rendering embedded components inside rich-text content
   // Clicks on the embedded component's internal layers should select the text layer
@@ -631,6 +637,7 @@ const LayerItem: React.FC<{
   // wrapped in <a><button></button></a> which is invalid HTML
   const isButtonWithLink = layer.name === 'button'
     && !isInsideForm
+    && !isInsideLink
     && isValidLinkSettings(layer.variables?.link);
   if (isButtonWithLink) {
     htmlTag = 'a';
@@ -641,6 +648,7 @@ const LayerItem: React.FC<{
   // Only match actual div layers (layer.name === 'div'), not other layers
   // whose tag was forced to 'div' by earlier overrides (e.g. headings with lists).
   const isDivWithLink = !isButtonWithLink
+    && !isInsideLink
     && layer.name === 'div'
     && htmlTag === 'div'
     && layer.id !== 'body'
@@ -2689,6 +2697,7 @@ const LayerItem: React.FC<{
               localeSelectorFormat={localeSelectorFormat}
               liveLayerUpdates={liveLayerUpdates}
               isInsideForm={isInsideForm}
+              isInsideLink={isInsideLink}
               parentFormSettings={parentFormSettings}
               components={componentsProp}
               ancestorComponentIds={effectiveAncestorIds}
@@ -2896,6 +2905,7 @@ const LayerItem: React.FC<{
                     parentComponentVariables={parentComponentVariables}
                     editingComponentVariables={editingComponentVariables}
                     isInsideForm={isInsideForm || htmlTag === 'form'}
+                    isInsideLink={isInsideLink || htmlTag === 'a'}
                     parentFormSettings={htmlTag === 'form' ? layer.settings?.form : parentFormSettings}
                     pages={pages}
                     folders={folders}
@@ -2971,6 +2981,7 @@ const LayerItem: React.FC<{
               parentComponentVariables={parentComponentVariables}
               editingComponentVariables={editingComponentVariables}
               isInsideForm={isInsideForm || htmlTag === 'form'}
+              isInsideLink={isInsideLink || htmlTag === 'a'}
               parentFormSettings={htmlTag === 'form' ? layer.settings?.form : parentFormSettings}
               components={componentsProp}
               ancestorComponentIds={effectiveAncestorIds}
@@ -3036,6 +3047,7 @@ const LayerItem: React.FC<{
             parentComponentVariables={parentComponentVariables}
             editingComponentVariables={editingComponentVariables}
             isInsideForm={isInsideForm || htmlTag === 'form'}
+            isInsideLink={isInsideLink || htmlTag === 'a'}
             parentFormSettings={htmlTag === 'form' ? layer.settings?.form : parentFormSettings}
             pages={pages}
             folders={folders}
@@ -3077,6 +3089,7 @@ const LayerItem: React.FC<{
   const linkSettings = layer.variables?.link;
   const shouldWrapWithLink = !isButtonWithLink
     && !isDivWithLink
+    && !isInsideLink
     && htmlTag !== 'a'
     && !subtreeHasInteractiveDescendants
     && isValidLinkSettings(linkSettings);

--- a/lib/escape-html.ts
+++ b/lib/escape-html.ts
@@ -2,8 +2,8 @@
  * Escape HTML special characters to prevent XSS.
  * Shared utility used by page-fetcher, html-layer-converter, and emailService.
  */
-export function escapeHtml(str: string): string {
-  return str
+export function escapeHtml(str: unknown): string {
+  return String(str ?? '')
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -2110,12 +2110,12 @@ export async function resolveCollectionLayers(
           existingPlaceholder?.variables?.text?.type === 'dynamic_text'
             ? existingPlaceholder.variables.text.data.content
             : null
-        ) || 'Select...';
+        ) || 'All';
         const placeholderOption: Layer = {
           id: existingPlaceholder?.id || `${layer.id}-opt-placeholder`,
           name: 'option',
           classes: '',
-          attributes: { value: '', disabled: true, hidden: true },
+          attributes: { value: '' },
           settings: { isPlaceholder: true },
           variables: {
             text: { type: 'dynamic_text' as const, data: { content: placeholderText } },


### PR DESCRIPTION
## Summary
Fix multiple issues with client-side collection filtering on generated pages,
including crashes on non-string values, boolean field mismatches between SSR
and the filter API, UX issues when clearing filters, and nested link prevention.
## Changes
- Coerce `escapeHtml` input to string to prevent `TypeError` on non-string values
- Normalize boolean `is`/`is_not` operators in filter API to accept `"true"`, `"1"`, and `"yes"` as truthy, matching `castValue` behavior used by SSR
- Base `hasRuntimeControls` on active input-linked filter values instead of static conditions, so clearing inputs restores SSR content
- Remove full page reload when clearing filters — restore SSR content in-place for all pagination modes
- Defer `hideSSR()` until filtered results arrive so the opacity loading state is visible during fetch
- Make select placehder option selectable (remove `disabled`/`hidden`) to allow clearing a filter value
- Add `isInsideLink` prop to `LayerRenderer` to prevent invalid nested `<a>` tags
## Test plan
- [ ] Load a collection page with static boolean filters and input-linked search — verify items display
- [ ] Search for a term (e.g. "Senior") — verify matching items are returned
- [ ] Clear the search input — verify all items are restored without page reload
- [ ] Select "All" in a filter dropdown — verify filter is cleared and all items show
- [ ] pacity loading state appears while filter results are loading
- [ ] Verify no nested `<a>` tags in rendered HTML when links are inside other links