### PR TITLE
fix: guard CMS link field against spurious Select reset

### DIFF
--- a/app/(builder)/ycode/components/CollectionLinkFieldInput.tsx
+++ b/app/(builder)/ycode/components/CollectionLinkFieldInput.tsx
@@ -186,6 +186,8 @@ export default function CollectionLinkFieldInput({
   // Handle link type change
   const handleLinkTypeChange = useCallback(
     (newType: CollectionLinkType | 'none') => {
+      if (!newType || newType === linkType) return;
+
       if (newType === 'none') {
         updateLinkValue(null);
         return;
@@ -205,7 +207,7 @@ export default function CollectionLinkFieldInput({
 
       updateLinkValue(newValue);
     },
-    [updateLinkValue]
+    [updateLinkValue, linkType]
   );
 
   // Handle URL change


### PR DESCRIPTION
## Summary

Fix CMS link field (URL type) losing its value when reopening the
collection item sheet. The Radix Select fires a spurious `onValueChange`
with an empty string during controlled value transitions, overwriting the
correct link data.

## Changes

- Guard `handleLinkTypeChange` against empty or unchanged type values
- Add `linkType` to the callback dependency array

## Test plan

- [ ] Create a collection item with a link field set to URL, enter a URL, save
- [ ] Reopen the item — URL type and value should be preserved
- [ ] Change link type from URL to Page and back — should work normally
- [ ] Set link type to "No link" — should clear the value