### PR TITLE
feat: enable preview for all asset types

### DIFF
--- a/app/(builder)/ycode/components/FileManagerDialog.tsx
+++ b/app/(builder)/ycode/components/FileManagerDialog.tsx
@@ -47,7 +47,7 @@ import { cn } from '@/lib/utils';
 import { assetFoldersApi, assetsApi, uploadFileApi } from '@/lib/api';
 import type { AssetFolder, Asset } from '@/types';
 import type { AssetUsageResult, CmsItemUsageEntry, FieldDefaultUsageEntry } from '@/lib/asset-usage-utils';
-import { getAcceptString, getAssetIcon, getOptimizedImageUrl, isAssetOfType, matchesCategoryFilter, normalizeCategoryFilter } from '@/lib/asset-utils';
+import { getAcceptString, getAssetIcon, getAssetProxyUrl, getOptimizedImageUrl, isAssetOfType, matchesCategoryFilter, normalizeCategoryFilter } from '@/lib/asset-utils';
 import { ASSET_CATEGORIES } from '@/lib/asset-constants';
 import type { AssetCategory, AssetCategoryFilter } from '@/types';
 
@@ -473,7 +473,7 @@ function FileGridItem({
               side="bottom"
               className="min-w-24"
             >
-              {isImage && onPreview && (
+              {onPreview && (
                 <DropdownMenuItem
                   onClick={(e) => {
                     e.stopPropagation();
@@ -1536,9 +1536,8 @@ export default function FileManagerDialog({
     }
   };
 
-  // Preview asset (open in new tab)
-  const handlePreviewAsset = (imageUrl: string) => {
-    window.open(imageUrl, '_blank', 'noopener,noreferrer');
+  const handlePreviewAsset = (url: string) => {
+    window.open(url, '_blank', 'noopener,noreferrer');
   };
 
   // Start creating SVG
@@ -2561,8 +2560,8 @@ export default function FileManagerDialog({
                           isSelected={selectedAssetIds.has(asset.id)}
                           onSelectChange={(selected) => handleAssetSelect(asset.id, selected)}
                           onPreview={
-                            asset.mime_type?.startsWith('image/') && asset.public_url
-                              ? () => handlePreviewAsset(asset.public_url!)
+                            asset.public_url || asset.storage_path
+                              ? () => handlePreviewAsset(getAssetProxyUrl(asset) || asset.public_url!)
                               : undefined
                           }
                           onEdit={() => handleEditAsset(asset.id)}


### PR DESCRIPTION
## Summary

Enable the "Preview" context menu option for all asset types in the file
manager, not just images. Uses the asset proxy URL to serve files that
don't have a public URL.

## Changes

- Remove the image-only restriction on the preview dropdown menu item
- Use `getAssetProxyUrl` to generate preview URLs for assets with storage paths
- Fall back to `public_url` when no proxy URL is available

## Test plan

- [ ] Upload a non-image asset (e.g. PDF, video, font) and verify "Preview" appears in the context menu
- [ ] Click "Preview" on a non-image asset and confirm it opens in a new tab
- [ ] Verify image preview still works as before
- [ ] Verify assets with only `storage_path` (no `public_url`) can be previewed via proxy

Made with [Cursor](https://cursor.com)