### PR TITLE
feat: add drag-and-drop reordering to multi-asset fields

### DIFF
--- a/app/(builder)/ycode/components/AssetFieldCard.tsx
+++ b/app/(builder)/ycode/components/AssetFieldCard.tsx
@@ -6,11 +6,18 @@
  */
 
 import React from 'react';
+
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import Icon from '@/components/ui/icon';
+
 import { getFieldIcon } from '@/lib/collection-field-utils';
 import { ASSET_CATEGORIES, getOptimizedImageUrl, isAssetOfType, formatFileSize, getFileExtension } from '@/lib/asset-utils';
+import { cn } from '@/lib/utils';
+
 import type { Asset, CollectionFieldType } from '@/types';
 
 export interface AssetFieldCardProps {
@@ -18,10 +25,12 @@ export interface AssetFieldCardProps {
   fieldType: CollectionFieldType;
   onChangeFile: () => void;
   onRemove: () => void;
+  /** Drag handle props — when set, the preview thumbnail becomes the drag handle */
+  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 /** Card for a single asset with preview, filename, metadata, and Change/Remove actions */
-function AssetFieldCard({ asset, fieldType, onChangeFile, onRemove }: AssetFieldCardProps) {
+function AssetFieldCard({ asset, fieldType, onChangeFile, onRemove, dragHandleProps }: AssetFieldCardProps) {
   const isImageField = fieldType === 'image' && asset;
   const isSvgIcon = isImageField && (!!asset!.content || (asset!.mime_type && isAssetOfType(asset!.mime_type, ASSET_CATEGORIES.ICONS)));
   const imageUrl = isImageField && asset!.public_url ? asset!.public_url : null;
@@ -29,7 +38,13 @@ function AssetFieldCard({ asset, fieldType, onChangeFile, onRemove }: AssetField
 
   return (
     <div className="bg-input p-2 rounded-lg flex items-center gap-4">
-      <div className="relative group bg-secondary/30 rounded-md w-full aspect-square overflow-hidden max-w-24 shrink-0">
+      <div
+        className={cn(
+          'relative group bg-secondary/30 rounded-md w-full aspect-square overflow-hidden max-w-24 shrink-0',
+          dragHandleProps && 'cursor-grab active:cursor-grabbing'
+        )}
+        {...dragHandleProps}
+      >
         {showCheckerboard && (
           <div className="absolute inset-0 opacity-10 bg-checkerboard" />
         )}
@@ -96,6 +111,40 @@ function AssetFieldCard({ asset, fieldType, onChangeFile, onRemove }: AssetField
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+export interface SortableAssetFieldCardProps extends AssetFieldCardProps {
+  id: string;
+}
+
+/** Sortable wrapper around AssetFieldCard for drag-and-drop reordering */
+export function SortableAssetFieldCard({ id, ...cardProps }: SortableAssetFieldCardProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(isDragging && 'opacity-50 z-10')}
+    >
+      <AssetFieldCard
+        {...cardProps}
+        dragHandleProps={{ ...attributes, ...listeners }}
+      />
     </div>
   );
 }

--- a/app/(builder)/ycode/components/CMS.tsx
+++ b/app/(builder)/ycode/components/CMS.tsx
@@ -36,6 +36,7 @@ import { useSettingsStore } from '@/stores/useSettingsStore';
 import { slugify, isTruthyBooleanValue, parseMultiReferenceValue, getSortParams } from '@/lib/collection-utils';
 import { getSampleCollectionOptions } from '@/lib/sample-collections';
 import { ASSET_CATEGORIES, getOptimizedImageUrl, isAssetOfType } from '@/lib/asset-utils';
+import { parseMultiAssetFieldValue } from '@/lib/multi-asset-utils';
 import { type FieldType, findDisplayField, getItemDisplayName, getFieldIcon, isMultipleAssetField, findStatusFieldId, isDateFieldType } from '@/lib/collection-field-utils';
 import { CollectionStatusPill, parseStatusValue } from './CollectionStatusPill';
 import { extractPlainTextFromTiptap } from '@/lib/tiptap-utils';
@@ -1627,9 +1628,8 @@ const CMS = React.memo(function CMS() {
 
                       // Image fields - show thumbnail (match file manager: SVG inline, raster via img + checkerboard)
                       if (field.type === 'image' && value) {
-                        // Handle multi-asset fields (value is an array)
                         const assetIds: string[] = isMultipleAssetField(field)
-                          ? (Array.isArray(value) ? value : [])
+                          ? parseMultiAssetFieldValue(value)
                           : [value as string];
 
                         if (assetIds.length === 0) {
@@ -1706,9 +1706,8 @@ const CMS = React.memo(function CMS() {
 
                       // Audio/Video/Document fields - show icon with filename in tooltip
                       if ((field.type === 'audio' || field.type === 'video' || field.type === 'document') && value) {
-                        // Handle multi-asset fields (value is an array)
                         const assetIds: string[] = isMultipleAssetField(field)
-                          ? (Array.isArray(value) ? value : [])
+                          ? parseMultiAssetFieldValue(value)
                           : [value as string];
 
                         if (assetIds.length === 0) {

--- a/app/(builder)/ycode/components/CollectionItemSheet.tsx
+++ b/app/(builder)/ycode/components/CollectionItemSheet.tsx
@@ -53,7 +53,10 @@ import { toast } from 'sonner';
 import ReferenceFieldCombobox from './ReferenceFieldCombobox';
 import CollectionLinkFieldInput from './CollectionLinkFieldInput';
 import ColorFieldInput from './ColorFieldInput';
-import AssetFieldCard from './AssetFieldCard';
+import AssetFieldCard, { SortableAssetFieldCard } from './AssetFieldCard';
+import { DndContext, closestCenter, useSensor, useSensors, PointerSensor } from '@dnd-kit/core';
+import type { DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, rectSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 import type { Asset, CollectionItemWithValues } from '@/types';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Label } from '@/components/ui/label';
@@ -104,6 +107,10 @@ export default function CollectionItemSheet({
   const [expandedRichTextField, setExpandedRichTextField] = useState<string | null>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
   const pendingStatusActionRef = useRef<StatusAction | null>(null);
+
+  const dndSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  );
 
   const collection = collections.find(c => c.id === collectionId);
   const collectionFields = useMemo(
@@ -736,21 +743,51 @@ export default function CollectionItemSheet({
                                 formField.onChange(JSON.stringify(assetIds.filter(id => id !== assetId)));
                               };
 
+                              const handleAssetDragEnd = (event: DragEndEvent) => {
+                                const { active, over } = event;
+                                if (!over || active.id === over.id) return;
+                                const oldIndex = assetIds.indexOf(String(active.id));
+                                const newIndex = assetIds.indexOf(String(over.id));
+                                if (oldIndex === -1 || newIndex === -1) return;
+                                formField.onChange(JSON.stringify(arrayMove(assetIds, oldIndex, newIndex)));
+                              };
+
                               return (
                                 <div className="space-y-2">
-                                  {assetIds.length > 0 && (
+                                  {assetIds.length > 1 ? (
+                                    <DndContext
+                                      sensors={dndSensors}
+                                      collisionDetection={closestCenter}
+                                      onDragEnd={handleAssetDragEnd}
+                                    >
+                                      <SortableContext
+                                        items={assetIds}
+                                        strategy={rectSortingStrategy}
+                                      >
+                                        <div className="grid gap-2 grid-cols-[repeat(auto-fill,minmax(min(100%,320px),1fr))]">
+                                          {assetIds.map((assetId) => (
+                                            <SortableAssetFieldCard
+                                              key={assetId}
+                                              id={assetId}
+                                              asset={getAsset(assetId)}
+                                              fieldType={field.type}
+                                              onChangeFile={() => handleReplaceAsset(assetId)}
+                                              onRemove={() => handleRemoveAsset(assetId)}
+                                            />
+                                          ))}
+                                        </div>
+                                      </SortableContext>
+                                    </DndContext>
+                                  ) : assetIds.length === 1 ? (
                                     <div className="grid gap-2 grid-cols-[repeat(auto-fill,minmax(min(100%,320px),1fr))]">
-                                      {assetIds.map((assetId) => (
-                                        <AssetFieldCard
-                                          key={assetId}
-                                          asset={getAsset(assetId)}
-                                          fieldType={field.type}
-                                          onChangeFile={() => handleReplaceAsset(assetId)}
-                                          onRemove={() => handleRemoveAsset(assetId)}
-                                        />
-                                      ))}
+                                      <AssetFieldCard
+                                        asset={getAsset(assetIds[0])}
+                                        fieldType={field.type}
+                                        onChangeFile={() => handleReplaceAsset(assetIds[0])}
+                                        onRemove={() => handleRemoveAsset(assetIds[0])}
+                                      />
                                     </div>
-                                  )}
+                                  ) : null}
                                   <Button
                                     type="button"
                                     variant="secondary"


### PR DESCRIPTION
## Summary

Add drag-and-drop reordering support for multi-asset fields in the CMS
collection item sheet, and fix a rendering flash when saving reordered assets.

## Changes

- Add `SortableAssetFieldCard` wrapper using dnd-kit with the preview thumbnail as drag handle
- Wrap multi-asset grid in `DndContext` + `SortableContext` with `rectSortingStrategy`
- Use `parseMultiAssetFieldValue` in CMS table to handle JSON string values during optimistic updates

## Test plan

- [ ] Open a collection item with a multi-asset field containing 2+ assets
- [ ] Drag an asset by its preview thumbnail to reorder
- [ ] Verify the new order persists after saving
- [ ] Verify the CMS table row shows assets correctly immediately after save (no flash)
- [ ] Verify single-asset fields are unaffected (no drag handle shown)


Made with [Cursor](https://cursor.com)