### PR TITLE
feat: add webflow cms migration integration

### DIFF
--- a/app/(builder)/ycode/api/apps/webflow/imports/[importId]/route.ts
+++ b/app/(builder)/ycode/api/apps/webflow/imports/[importId]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest } from 'next/server';
+import { removeImport } from '@/lib/apps/webflow/migration-service';
+import { noCache } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * DELETE /ycode/api/apps/webflow/imports/[importId]
+ * Remove an import record. The YCode collections that were created by the
+ * migration are NOT deleted — they stay around for the user to keep using.
+ */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ importId: string }> }
+) {
+  try {
+    const { importId } = await params;
+    const removed = await removeImport(importId);
+
+    if (!removed) {
+      return noCache({ error: 'Import not found' }, 404);
+    }
+
+    return noCache({ data: { success: true } });
+  } catch (error) {
+    console.error('Error removing Webflow import:', error);
+    return noCache(
+      { error: error instanceof Error ? error.message : 'Failed to remove import' },
+      500
+    );
+  }
+}

--- a/app/(builder)/ycode/api/apps/webflow/imports/route.ts
+++ b/app/(builder)/ycode/api/apps/webflow/imports/route.ts
@@ -1,0 +1,22 @@
+import { getImports } from '@/lib/apps/webflow/migration-service';
+import { noCache } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * GET /ycode/api/apps/webflow/imports
+ * List all Webflow site imports stored in app_settings.
+ */
+export async function GET() {
+  try {
+    const imports = await getImports();
+    return noCache({ data: imports });
+  } catch (error) {
+    console.error('Error fetching Webflow imports:', error);
+    return noCache(
+      { error: error instanceof Error ? error.message : 'Failed to fetch imports' },
+      500
+    );
+  }
+}

--- a/app/(builder)/ycode/api/apps/webflow/imports/route.ts
+++ b/app/(builder)/ycode/api/apps/webflow/imports/route.ts
@@ -1,17 +1,35 @@
 import { getImports } from '@/lib/apps/webflow/migration-service';
 import { noCache } from '@/lib/api-response';
+import { getAllCollections } from '@/lib/repositories/collectionRepository';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
 /**
  * GET /ycode/api/apps/webflow/imports
- * List all Webflow site imports stored in app_settings.
+ * List all Webflow site imports stored in app_settings, with stale collection
+ * mappings filtered out so the UI only shows YCode collections that still
+ * exist (the underlying mapping is preserved so re-sync can recreate any
+ * deleted ones on demand).
  */
 export async function GET() {
   try {
-    const imports = await getImports();
-    return noCache({ data: imports });
+    const [imports, existingCollections] = await Promise.all([
+      getImports(),
+      getAllCollections({ is_published: false }),
+    ]);
+
+    const existingIds = new Set(existingCollections.map((c) => c.id));
+    const visibleImports = imports
+      .map((record) => ({
+        ...record,
+        collectionMappings: record.collectionMappings.filter((m) =>
+          existingIds.has(m.ycodeCollectionId)
+        ),
+      }))
+      .filter((record) => record.collectionMappings.length > 0);
+
+    return noCache({ data: visibleImports });
   } catch (error) {
     console.error('Error fetching Webflow imports:', error);
     return noCache(

--- a/app/(builder)/ycode/api/apps/webflow/migrate/route.ts
+++ b/app/(builder)/ycode/api/apps/webflow/migrate/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from 'next/server';
+import { runMigration } from '@/lib/apps/webflow/migration-service';
+import { noCache } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+/** Migrations involve N item-list calls + asset downloads — give them headroom. */
+export const maxDuration = 300;
+
+/**
+ * POST /ycode/api/apps/webflow/migrate
+ * Body: { siteId: string }
+ *
+ * Runs a one-click full migration for a Webflow site: creates YCode
+ * collections + fields, imports items as drafts, resolves references, and
+ * publishes items currently live on Webflow.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const { siteId } = await request.json();
+
+    if (!siteId || typeof siteId !== 'string') {
+      return noCache({ error: 'siteId is required' }, 400);
+    }
+
+    const { import: importRecord, result } = await runMigration(siteId);
+    return noCache({ data: { import: importRecord, result } }, 201);
+  } catch (error) {
+    console.error('Error running Webflow migration:', error);
+    return noCache(
+      { error: error instanceof Error ? error.message : 'Migration failed' },
+      500
+    );
+  }
+}

--- a/app/(builder)/ycode/api/apps/webflow/sites/[siteId]/collections/route.ts
+++ b/app/(builder)/ycode/api/apps/webflow/sites/[siteId]/collections/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest } from 'next/server';
+import { listCollectionsWithFields } from '@/lib/apps/webflow';
+import { requireWebflowToken } from '@/lib/apps/webflow/migration-service';
+import { noCache } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * GET /ycode/api/apps/webflow/sites/[siteId]/collections
+ * Preview the collection schema for a Webflow site — used by the UI to
+ * show "X collections, Y total fields" before the user kicks off a migration.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ siteId: string }> }
+) {
+  try {
+    const { siteId } = await params;
+    const token = await requireWebflowToken();
+    const collections = await listCollectionsWithFields(token, siteId);
+
+    const summary = collections.map((c) => ({
+      id: c.id,
+      displayName: c.displayName,
+      slug: c.slug,
+      fieldCount: c.fields?.length ?? 0,
+    }));
+
+    return noCache({ data: summary });
+  } catch (error) {
+    console.error('Error fetching Webflow collections:', error);
+    return noCache(
+      { error: error instanceof Error ? error.message : 'Failed to fetch collections' },
+      500
+    );
+  }
+}

--- a/app/(builder)/ycode/api/apps/webflow/sites/route.ts
+++ b/app/(builder)/ycode/api/apps/webflow/sites/route.ts
@@ -1,0 +1,24 @@
+import { listSites } from '@/lib/apps/webflow';
+import { requireWebflowToken } from '@/lib/apps/webflow/migration-service';
+import { noCache } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * GET /ycode/api/apps/webflow/sites
+ * List all Webflow sites the stored token has access to.
+ */
+export async function GET() {
+  try {
+    const token = await requireWebflowToken();
+    const sites = await listSites(token);
+    return noCache({ data: sites });
+  } catch (error) {
+    console.error('Error fetching Webflow sites:', error);
+    return noCache(
+      { error: error instanceof Error ? error.message : 'Failed to fetch sites' },
+      500
+    );
+  }
+}

--- a/app/(builder)/ycode/api/apps/webflow/sync/route.ts
+++ b/app/(builder)/ycode/api/apps/webflow/sync/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest } from 'next/server';
+import { runResync } from '@/lib/apps/webflow/migration-service';
+import { noCache } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const maxDuration = 300;
+
+/**
+ * POST /ycode/api/apps/webflow/sync
+ * Body: { importId: string }
+ *
+ * Re-sync items + publish state for an existing import. Schema diffs are
+ * NOT applied to keep re-sync safe — use a fresh migration to capture them.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const { importId } = await request.json();
+
+    if (!importId || typeof importId !== 'string') {
+      return noCache({ error: 'importId is required' }, 400);
+    }
+
+    const result = await runResync(importId);
+    return noCache({ data: result });
+  } catch (error) {
+    console.error('Error re-syncing Webflow import:', error);
+    return noCache(
+      { error: error instanceof Error ? error.message : 'Re-sync failed' },
+      500
+    );
+  }
+}

--- a/app/(builder)/ycode/api/apps/webflow/test/route.ts
+++ b/app/(builder)/ycode/api/apps/webflow/test/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from 'next/server';
+import { testToken } from '@/lib/apps/webflow';
+import { noCache } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * POST /ycode/api/apps/webflow/test
+ * Validate a Webflow API token by hitting `/token/authorized_by`.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const { api_token } = await request.json();
+
+    if (!api_token || typeof api_token !== 'string') {
+      return noCache({ error: 'API token is required' }, 400);
+    }
+
+    const result = await testToken(api_token);
+    return noCache({ data: result });
+  } catch (error) {
+    console.error('Error testing Webflow token:', error);
+    return noCache(
+      { error: error instanceof Error ? error.message : 'Failed to test token' },
+      500
+    );
+  }
+}

--- a/app/(builder)/ycode/integrations/apps/page.tsx
+++ b/app/(builder)/ycode/integrations/apps/page.tsx
@@ -44,6 +44,7 @@ import { useSettingsStore } from '@/stores/useSettingsStore';
 import { MAILERLITE_SUBSCRIBER_FIELDS } from '@/lib/apps/mailerlite/types';
 import type { MailerLiteConnection, MailerLiteFieldMapping } from '@/lib/apps/mailerlite/types';
 import AirtableSettings from './airtable-settings';
+import WebflowSettings from './webflow-settings';
 
 // =============================================================================
 // Types
@@ -340,6 +341,8 @@ export default function AppsPage() {
       loadGroupsAndForms();
     } else if (appId === 'airtable') {
       // AirtableSettings handles its own loading
+    } else if (appId === 'webflow') {
+      // WebflowSettings handles its own loading
     } else if (TOKEN_APP_CONFIGS[appId]) {
       loadTokenApp(appId);
     }
@@ -1080,6 +1083,18 @@ export default function AppsPage() {
               <AirtableSettings
                 onDisconnect={() => updateAppStatus('airtable', false)}
                 onConnectionChange={(connected) => updateAppStatus('airtable', connected)}
+                onCloseAndNavigate={(path) => {
+                  setIsSheetMounted(false);
+                  closeAppSettings();
+                  router.push(path);
+                }}
+              />
+            )}
+
+            {selectedAppId === 'webflow' && (
+              <WebflowSettings
+                onDisconnect={() => updateAppStatus('webflow', false)}
+                onConnectionChange={(connected) => updateAppStatus('webflow', connected)}
                 onCloseAndNavigate={(path) => {
                   setIsSheetMounted(false);
                   closeAppSettings();

--- a/app/(builder)/ycode/integrations/apps/webflow-settings.tsx
+++ b/app/(builder)/ycode/integrations/apps/webflow-settings.tsx
@@ -319,8 +319,8 @@ export default function WebflowSettings({
     return (
       <>
         <SheetHeader>
-          <SheetTitle>Webflow</SheetTitle>
-          <SheetDescription className="sr-only">Webflow integration settings</SheetDescription>
+          <SheetTitle>Webflow CMS</SheetTitle>
+          <SheetDescription className="sr-only">Webflow CMS integration settings</SheetDescription>
         </SheetHeader>
         <div className="flex items-center justify-center py-12">
           <Spinner />
@@ -332,7 +332,7 @@ export default function WebflowSettings({
   return (
     <>
       <SheetHeader>
-        <SheetTitle className="mr-auto">Webflow</SheetTitle>
+        <SheetTitle className="mr-auto">Webflow CMS</SheetTitle>
         {isConnected && (
           <Button
             variant="secondary"

--- a/app/(builder)/ycode/integrations/apps/webflow-settings.tsx
+++ b/app/(builder)/ycode/integrations/apps/webflow-settings.tsx
@@ -1,0 +1,632 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Empty, EmptyDescription, EmptyTitle } from '@/components/ui/empty';
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+} from '@/components/ui/field';
+import Icon from '@/components/ui/icon';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Spinner } from '@/components/ui/spinner';
+
+import { webflowApi, type WebflowCollectionPreview } from '@/lib/apps/webflow/client';
+import { formatRelativeTime } from '@/lib/utils';
+import type { WebflowImport, WebflowSite } from '@/lib/apps/webflow/types';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface WebflowSettingsProps {
+  onDisconnect: () => void;
+  onConnectionChange: (connected: boolean) => void;
+  onCloseAndNavigate?: (path: string) => void;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export default function WebflowSettings({
+  onDisconnect,
+  onConnectionChange,
+  onCloseAndNavigate,
+}: WebflowSettingsProps) {
+  const router = useRouter();
+
+  // Token state
+  const [token, setToken] = useState('');
+  const [savedToken, setSavedToken] = useState('');
+  const [isTesting, setIsTesting] = useState(false);
+  const [isSavingToken, setIsSavingToken] = useState(false);
+  const [isConnected, setIsConnected] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Sites + selection
+  const [sites, setSites] = useState<WebflowSite[]>([]);
+  const [isLoadingSites, setIsLoadingSites] = useState(false);
+  const [selectedSiteId, setSelectedSiteId] = useState<string>('');
+
+  // Collection preview
+  const [preview, setPreview] = useState<WebflowCollectionPreview[] | null>(null);
+  const [isLoadingPreview, setIsLoadingPreview] = useState(false);
+
+  // Imports + sync state
+  const [imports, setImports] = useState<WebflowImport[]>([]);
+  const [isMigrating, setIsMigrating] = useState(false);
+  const [syncingIds, setSyncingIds] = useState<Set<string>>(new Set());
+  const [importToRemove, setImportToRemove] = useState<WebflowImport | null>(null);
+
+  // Disconnect dialog
+  const [showDisconnect, setShowDisconnect] = useState(false);
+
+  // =========================================================================
+  // Load settings on mount
+  // =========================================================================
+
+  useEffect(() => {
+    loadSettings();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const loadSettings = async () => {
+    setIsLoading(true);
+    try {
+      const [settings, importsList] = await Promise.all([
+        webflowApi.getSettings(),
+        webflowApi.listImports().catch(() => [] as WebflowImport[]),
+      ]);
+
+      if (settings?.api_token) {
+        setSavedToken(settings.api_token);
+        setToken(settings.api_token);
+        setIsConnected(true);
+        onConnectionChange(true);
+        loadSites();
+      }
+
+      setImports(importsList || []);
+    } catch {
+      toast.error('Failed to load Webflow settings');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // =========================================================================
+  // Token management
+  // =========================================================================
+
+  const handleTestToken = async () => {
+    setIsTesting(true);
+    try {
+      const result = await webflowApi.testToken(token);
+
+      if (result?.valid) {
+        toast.success('Connection successful', {
+          description: 'Your token is valid.',
+        });
+      } else {
+        toast.error('Connection failed', {
+          description: result?.error || 'Check your token and try again.',
+        });
+      }
+    } catch {
+      toast.error('Connection failed', {
+        description: 'Could not reach Webflow. Check your network connection.',
+      });
+    } finally {
+      setIsTesting(false);
+    }
+  };
+
+  const handleSaveToken = async () => {
+    setIsSavingToken(true);
+    try {
+      await webflowApi.saveSettings({ api_token: token });
+      setSavedToken(token);
+      setIsConnected(true);
+      onConnectionChange(true);
+      loadSites();
+    } catch {
+      toast.error('Failed to save token');
+    } finally {
+      setIsSavingToken(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    try {
+      await webflowApi.deleteSettings();
+      setToken('');
+      setSavedToken('');
+      setIsConnected(false);
+      setSites([]);
+      setSelectedSiteId('');
+      setPreview(null);
+      setImports([]);
+      onConnectionChange(false);
+      onDisconnect();
+    } catch {
+      toast.error('Failed to disconnect');
+    } finally {
+      setShowDisconnect(false);
+    }
+  };
+
+  // =========================================================================
+  // Sites + preview
+  // =========================================================================
+
+  const loadSites = useCallback(async () => {
+    setIsLoadingSites(true);
+    try {
+      const data = await webflowApi.listSites();
+      setSites(data || []);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to load sites');
+    } finally {
+      setIsLoadingSites(false);
+    }
+  }, []);
+
+  const handleSiteChange = async (siteId: string) => {
+    setSelectedSiteId(siteId);
+    setPreview(null);
+    if (!siteId) return;
+
+    setIsLoadingPreview(true);
+    try {
+      const data = await webflowApi.previewCollections(siteId);
+      setPreview(data || []);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to preview collections');
+    } finally {
+      setIsLoadingPreview(false);
+    }
+  };
+
+  // =========================================================================
+  // Migration + re-sync
+  // =========================================================================
+
+  const handleMigrate = async () => {
+    if (!selectedSiteId) return;
+
+    setIsMigrating(true);
+    const toastId = toast.loading('Migrating Webflow site...', {
+      description: 'This can take a few minutes for large sites.',
+    });
+
+    try {
+      const { import: importRecord, result } = await webflowApi.migrate(selectedSiteId);
+
+      const totalCreated = result.collections.reduce((sum, c) => sum + c.created, 0);
+      const totalPublished = result.collections.reduce((sum, c) => sum + c.published, 0);
+
+      toast.success('Migration complete', {
+        id: toastId,
+        description: `${result.collections.length} collections, ${totalCreated} items imported (${totalPublished} published).`,
+      });
+
+      // Refresh state.
+      const refreshed = await webflowApi.listImports().catch(() => imports);
+      setImports(refreshed.length > 0 ? refreshed : [...imports, importRecord]);
+      setSelectedSiteId('');
+      setPreview(null);
+    } catch (error) {
+      toast.error('Migration failed', {
+        id: toastId,
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setIsMigrating(false);
+    }
+  };
+
+  const handleResync = async (importRecord: WebflowImport) => {
+    setSyncingIds((prev) => new Set(prev).add(importRecord.id));
+    const toastId = toast.loading(`Re-syncing ${importRecord.siteName}...`);
+
+    try {
+      const result = await webflowApi.resync(importRecord.id);
+      const created = result.collections.reduce((s, c) => s + c.created, 0);
+      const updated = result.collections.reduce((s, c) => s + c.updated, 0);
+      const deleted = result.collections.reduce((s, c) => s + c.deleted, 0);
+
+      toast.success('Re-sync complete', {
+        id: toastId,
+        description: `${created} created, ${updated} updated, ${deleted} removed.`,
+      });
+
+      const refreshed = await webflowApi.listImports().catch(() => imports);
+      setImports(refreshed);
+    } catch (error) {
+      toast.error('Re-sync failed', {
+        id: toastId,
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setSyncingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(importRecord.id);
+        return next;
+      });
+    }
+  };
+
+  const handleRemoveImport = async () => {
+    if (!importToRemove) return;
+    try {
+      await webflowApi.removeImport(importToRemove.id);
+      setImports((prev) => prev.filter((i) => i.id !== importToRemove.id));
+      toast.success('Import removed');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to remove import');
+    } finally {
+      setImportToRemove(null);
+    }
+  };
+
+  // =========================================================================
+  // Render
+  // =========================================================================
+
+  if (isLoading) {
+    return (
+      <>
+        <SheetHeader>
+          <SheetTitle>Webflow</SheetTitle>
+          <SheetDescription className="sr-only">Webflow integration settings</SheetDescription>
+        </SheetHeader>
+        <div className="flex items-center justify-center py-12">
+          <Spinner />
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SheetHeader>
+        <SheetTitle className="mr-auto">Webflow</SheetTitle>
+        {isConnected && (
+          <Button
+            variant="secondary"
+            size="xs"
+            onClick={() => setShowDisconnect(true)}
+          >
+            Disconnect
+          </Button>
+        )}
+        <SheetDescription className="sr-only">
+          Webflow integration settings
+        </SheetDescription>
+      </SheetHeader>
+
+      <div className="mt-3 space-y-8">
+        {/* Token Section */}
+        <div className="space-y-4">
+          <FieldDescription className="flex flex-col gap-2">
+            <span>
+              Enter a Webflow site API token. Required scopes:{' '}
+              <span className="text-foreground">sites:read</span> and{' '}
+              <span className="text-foreground">cms:read</span>.
+            </span>
+            <span>
+              Create a token from your site&apos;s{' '}
+              <span className="text-foreground">
+                Site settings → Apps &amp; Integrations → API access
+              </span>{' '}
+              page in Webflow.
+            </span>
+          </FieldDescription>
+
+          <Field>
+            <FieldLabel htmlFor="webflow-token">API Token</FieldLabel>
+            <Input
+              id="webflow-token"
+              type="password"
+              placeholder="Enter your Webflow API token"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              className="font-mono text-xs"
+            />
+            <div className="flex gap-2 mt-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleTestToken}
+                disabled={!token.trim() || isTesting}
+              >
+                {isTesting && <Spinner className="size-3" />}
+                Test connection
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleSaveToken}
+                disabled={!token.trim() || token === savedToken || isSavingToken}
+              >
+                {isSavingToken && <Spinner className="size-3" />}
+                Save
+              </Button>
+            </div>
+          </Field>
+        </div>
+
+        {/* Migrate a site */}
+        {isConnected && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <FieldLabel>Migrate a Webflow site</FieldLabel>
+              {sites.length > 0 && (
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={loadSites}
+                  disabled={isLoadingSites}
+                >
+                  <Icon name="refresh" />
+                  Refresh
+                </Button>
+              )}
+            </div>
+
+            <FieldDescription>
+              Pick a site to import its CMS collections, items and assets into Ycode. Items
+              that are live in Webflow will be auto-published in Ycode.
+            </FieldDescription>
+
+            <Field>
+              <Select
+                value={selectedSiteId}
+                onValueChange={handleSiteChange}
+                disabled={isLoadingSites || isMigrating}
+              >
+                <SelectTrigger>
+                  {isLoadingSites ? (
+                    <span className="flex items-center gap-1.5">
+                      <Spinner className="size-3" />
+                      <span>Loading...</span>
+                    </span>
+                  ) : (
+                    <SelectValue placeholder="Select a site" />
+                  )}
+                </SelectTrigger>
+                <SelectContent>
+                  {sites.map((site) => (
+                    <SelectItem
+                      key={site.id}
+                      value={site.id}
+                    >
+                      {site.displayName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+
+            {/* Preview */}
+            {selectedSiteId && (
+              <div className="border rounded-lg bg-secondary/30 p-3 space-y-2">
+                {isLoadingPreview && (
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Spinner className="size-3" />
+                    <span>Loading collections...</span>
+                  </div>
+                )}
+
+                {!isLoadingPreview && preview && preview.length === 0 && (
+                  <p className="text-xs text-muted-foreground">
+                    This site has no CMS collections to migrate.
+                  </p>
+                )}
+
+                {!isLoadingPreview && preview && preview.length > 0 && (
+                  <>
+                    <p className="text-xs text-muted-foreground">
+                      {preview.length} {preview.length === 1 ? 'collection' : 'collections'} ready to migrate.
+                    </p>
+                    <ul className="space-y-1">
+                      {preview.map((c) => (
+                        <li
+                          key={c.id}
+                          className="flex items-center justify-between text-xs"
+                        >
+                          <span className="font-medium truncate">{c.displayName}</span>
+                          <span className="text-muted-foreground shrink-0">
+                            {c.fieldCount} {c.fieldCount === 1 ? 'field' : 'fields'}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+
+                    <div className="flex justify-end pt-2">
+                      <Button
+                        size="sm"
+                        onClick={handleMigrate}
+                        disabled={isMigrating || preview.length === 0}
+                      >
+                        {isMigrating && <Spinner className="size-3" />}
+                        Start migration
+                      </Button>
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Imports list */}
+        {isConnected && (
+          <div className="space-y-2">
+            <FieldLabel>Imports</FieldLabel>
+
+            {imports.length === 0 ? (
+              <Empty>
+                <EmptyTitle>No imports yet</EmptyTitle>
+                <EmptyDescription>
+                  Pick a Webflow site above and start your first migration.
+                </EmptyDescription>
+              </Empty>
+            ) : (
+              imports.map((importRecord) => (
+                <ImportCard
+                  key={importRecord.id}
+                  importRecord={importRecord}
+                  isSyncing={syncingIds.has(importRecord.id)}
+                  onResync={() => handleResync(importRecord)}
+                  onRemove={() => setImportToRemove(importRecord)}
+                  onOpenCollection={(collectionId) => {
+                    if (onCloseAndNavigate) {
+                      onCloseAndNavigate(`/ycode/collections/${collectionId}`);
+                    } else {
+                      router.push(`/ycode/collections/${collectionId}`);
+                    }
+                  }}
+                />
+              ))
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Disconnect dialog */}
+      <ConfirmDialog
+        open={showDisconnect}
+        onOpenChange={setShowDisconnect}
+        title="Disconnect Webflow?"
+        description="This removes your token and all import records. The Ycode collections created by past migrations will remain."
+        confirmLabel="Disconnect"
+        cancelLabel="Cancel"
+        confirmVariant="destructive"
+        onConfirm={handleDisconnect}
+        onCancel={() => setShowDisconnect(false)}
+      />
+
+      {/* Remove import dialog */}
+      <ConfirmDialog
+        open={!!importToRemove}
+        onOpenChange={(open: boolean) => { if (!open) setImportToRemove(null); }}
+        title="Remove import?"
+        description={`Removes the link to "${importToRemove?.siteName}". Re-sync won't be possible, but the Ycode collections themselves will stay.`}
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        confirmVariant="destructive"
+        onConfirm={handleRemoveImport}
+        onCancel={() => setImportToRemove(null)}
+      />
+    </>
+  );
+}
+
+// =============================================================================
+// Import Card Sub-component
+// =============================================================================
+
+interface ImportCardProps {
+  importRecord: WebflowImport;
+  isSyncing: boolean;
+  onResync: () => void;
+  onRemove: () => void;
+  onOpenCollection: (collectionId: string) => void;
+}
+
+function ImportCard({
+  importRecord,
+  isSyncing,
+  onResync,
+  onRemove,
+  onOpenCollection,
+}: ImportCardProps) {
+  return (
+    <div className="border rounded-lg bg-secondary/30 overflow-hidden">
+      <div className="flex items-center p-3 gap-2">
+        <div className="flex-1 min-w-0 gap-px flex flex-col">
+          <span className="text-sm font-medium truncate">{importRecord.siteName}</span>
+          <span className="text-[10px] text-muted-foreground">
+            {importRecord.collectionMappings.length}{' '}
+            {importRecord.collectionMappings.length === 1 ? 'collection' : 'collections'}
+            {importRecord.lastSyncedAt && (
+              <> • Last synced {formatRelativeTime(importRecord.lastSyncedAt, false)}</>
+            )}
+          </span>
+        </div>
+
+        {importRecord.syncStatus === 'error' && (
+          <Badge variant="destructive">Error</Badge>
+        )}
+        {importRecord.syncStatus === 'syncing' && (
+          <Badge variant="secondary">Syncing</Badge>
+        )}
+
+        <Button
+          variant="secondary"
+          size="xs"
+          onClick={onResync}
+          disabled={isSyncing}
+        >
+          {isSyncing && <Spinner className="size-3" />}
+          Re-sync
+        </Button>
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={onRemove}
+          aria-label="Remove import"
+        >
+          <Icon name="trash" />
+        </Button>
+      </div>
+
+      {importRecord.syncError && (
+        <div className="px-3 pb-2 text-[10px] text-destructive">
+          {importRecord.syncError}
+        </div>
+      )}
+
+      {importRecord.collectionMappings.length > 0 && (
+        <div className="border-t bg-background/40">
+          <ul>
+            {importRecord.collectionMappings.map((mapping) => (
+              <li
+                key={mapping.webflowCollectionId}
+                className="flex items-center justify-between px-3 py-2 text-xs border-b last:border-b-0"
+              >
+                <span className="truncate">{mapping.ycodeCollectionName}</span>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => onOpenCollection(mapping.ycodeCollectionId)}
+                >
+                  Open
+                  <Icon name="external-link" />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(builder)/ycode/integrations/apps/webflow-settings.tsx
+++ b/app/(builder)/ycode/integrations/apps/webflow-settings.tsx
@@ -31,6 +31,7 @@ import { Spinner } from '@/components/ui/spinner';
 
 import { webflowApi, type WebflowCollectionPreview } from '@/lib/apps/webflow/client';
 import { formatRelativeTime } from '@/lib/utils';
+import { useCollectionsStore } from '@/stores/useCollectionsStore';
 import type { WebflowImport, WebflowSite } from '@/lib/apps/webflow/types';
 
 // =============================================================================
@@ -79,6 +80,23 @@ export default function WebflowSettings({
 
   // Disconnect dialog
   const [showDisconnect, setShowDisconnect] = useState(false);
+
+  // CMS store — used to refresh the sidebar after migrate / re-sync.
+  const loadCollections = useCollectionsStore((s) => s.loadCollections);
+  const loadFields = useCollectionsStore((s) => s.loadFields);
+  const reloadCurrentItems = useCollectionsStore((s) => s.reloadCurrentItems);
+  const selectedCollectionId = useCollectionsStore((s) => s.selectedCollectionId);
+
+  /** Refresh the CMS store so the sidebar + open collection reflect new data. */
+  const refreshCmsStore = useCallback(async () => {
+    await loadCollections();
+    if (selectedCollectionId) {
+      await Promise.all([
+        loadFields(selectedCollectionId),
+        reloadCurrentItems(),
+      ]);
+    }
+  }, [loadCollections, loadFields, reloadCurrentItems, selectedCollectionId]);
 
   // =========================================================================
   // Load settings on mount
@@ -233,6 +251,9 @@ export default function WebflowSettings({
       setImports(refreshed.length > 0 ? refreshed : [...imports, importRecord]);
       setSelectedSiteId('');
       setPreview(null);
+
+      // Refresh CMS store so the new collections show up without a hard reload.
+      refreshCmsStore().catch(() => {});
     } catch (error) {
       toast.error('Migration failed', {
         id: toastId,
@@ -260,6 +281,9 @@ export default function WebflowSettings({
 
       const refreshed = await webflowApi.listImports().catch(() => imports);
       setImports(refreshed);
+
+      // Reload the open collection so updated items show immediately.
+      refreshCmsStore().catch(() => {});
     } catch (error) {
       toast.error('Re-sync failed', {
         id: toastId,

--- a/lib/apps/registry.ts
+++ b/lib/apps/registry.ts
@@ -12,6 +12,7 @@
 import type { StaticImageData } from 'next/image';
 
 import airtableLogo from './airtable/logo.svg';
+import webflowLogo from './webflow/logo.svg';
 import mailerliteLogo from './mailerlite/logo.svg';
 import mailchimpLogo from './mailchimp/logo.svg';
 import zapierLogo from './zapier/logo.svg';
@@ -61,6 +62,14 @@ export const apps: AppDefinition[] = [
     name: 'Airtable',
     description: 'One-way sync from Airtable tables to your Ycode collections with real-time webhook support.',
     logo: airtableLogo,
+    categories: ['popular', 'cms-data'],
+    implemented: true,
+  },
+  {
+    id: 'webflow',
+    name: 'Webflow',
+    description: 'One-click migrate a Webflow CMS site into Ycode collections, including assets and references.',
+    logo: webflowLogo,
     categories: ['popular', 'cms-data'],
     implemented: true,
   },

--- a/lib/apps/registry.ts
+++ b/lib/apps/registry.ts
@@ -67,7 +67,7 @@ export const apps: AppDefinition[] = [
   },
   {
     id: 'webflow',
-    name: 'Webflow',
+    name: 'Webflow CMS',
     description: 'One-click migrate a Webflow CMS site into Ycode collections, including assets and references.',
     logo: webflowLogo,
     categories: ['popular', 'cms-data'],

--- a/lib/apps/webflow/client.ts
+++ b/lib/apps/webflow/client.ts
@@ -1,0 +1,81 @@
+/**
+ * Frontend API client for the Webflow integration.
+ * Mirrors the patterns used in `lib/apps/airtable/client.ts`.
+ */
+
+import { ToastError } from '@/lib/toast-error';
+import type { WebflowImport, WebflowSite, SyncResult } from './types';
+
+const BASE = '/ycode/api/apps/webflow';
+const SETTINGS_BASE = '/ycode/api/apps/webflow/settings';
+const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
+
+async function jsonFetch<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  const body = await res.json();
+  if (body.error) {
+    throw body.detail
+      ? new ToastError(body.error, body.detail)
+      : new Error(body.error);
+  }
+  return body.data as T;
+}
+
+function jsonPost<T>(url: string, payload: unknown): Promise<T> {
+  return jsonFetch<T>(url, {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(payload),
+  });
+}
+
+function jsonPut<T>(url: string, payload: unknown): Promise<T> {
+  return jsonFetch<T>(url, {
+    method: 'PUT',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(payload),
+  });
+}
+
+export interface WebflowCollectionPreview {
+  id: string;
+  displayName: string;
+  slug: string;
+  fieldCount: number;
+}
+
+export const webflowApi = {
+  getSettings: () => jsonFetch<Record<string, string>>(SETTINGS_BASE),
+
+  saveSettings: (settings: Record<string, string>) =>
+    jsonPut<Record<string, string>>(SETTINGS_BASE, settings),
+
+  deleteSettings: () =>
+    jsonFetch<void>(SETTINGS_BASE, { method: 'DELETE' }),
+
+  testToken: (apiToken: string) =>
+    jsonPost<{ valid: boolean; error?: string }>(`${BASE}/test`, {
+      api_token: apiToken,
+    }),
+
+  listSites: () => jsonFetch<WebflowSite[]>(`${BASE}/sites`),
+
+  previewCollections: (siteId: string) =>
+    jsonFetch<WebflowCollectionPreview[]>(`${BASE}/sites/${siteId}/collections`),
+
+  migrate: (siteId: string) =>
+    jsonPost<{ import: WebflowImport; result: SyncResult }>(
+      `${BASE}/migrate`,
+      { siteId }
+    ),
+
+  resync: (importId: string) =>
+    jsonPost<SyncResult>(`${BASE}/sync`, { importId }),
+
+  listImports: () => jsonFetch<WebflowImport[]>(`${BASE}/imports`),
+
+  removeImport: (importId: string) =>
+    jsonFetch<{ success: boolean }>(`${BASE}/imports/${importId}`, {
+      method: 'DELETE',
+    }),
+};

--- a/lib/apps/webflow/field-mapping.ts
+++ b/lib/apps/webflow/field-mapping.ts
@@ -1,0 +1,210 @@
+/**
+ * Webflow -> CMS Field Type Mapping
+ *
+ * Maps Webflow CMS v2 field types to YCode CollectionFieldType and
+ * transforms Webflow field values into CMS-compatible string values for
+ * storage in `collection_item_values.value`.
+ */
+
+import type { CollectionFieldType } from '@/types';
+import type { WebflowFieldType } from './types';
+import { htmlToTiptapJson } from './html-to-tiptap';
+
+// =============================================================================
+// Type Mapping
+// =============================================================================
+
+const FIELD_TYPE_MAP: Record<WebflowFieldType, CollectionFieldType> = {
+  PlainText: 'text',
+  RichText: 'rich_text',
+  Image: 'image',
+  MultiImage: 'image',
+  Video: 'text',
+  Link: 'text',
+  Email: 'email',
+  Phone: 'phone',
+  Number: 'number',
+  DateTime: 'date',
+  Date: 'date_only',
+  Switch: 'boolean',
+  Color: 'color',
+  Option: 'status',
+  Reference: 'reference',
+  MultiReference: 'multi_reference',
+  File: 'document',
+  Set: 'text',
+  User: 'text',
+};
+
+/** Map a Webflow field type to its YCode equivalent. */
+export function getCmsFieldType(webflowType: WebflowFieldType | string): CollectionFieldType {
+  return FIELD_TYPE_MAP[webflowType as WebflowFieldType] ?? 'text';
+}
+
+/** Webflow field types that produce multi-asset YCode fields. */
+const MULTI_ASSET_TYPES = new Set<WebflowFieldType>(['MultiImage']);
+
+/** Returns true if the YCode field for this Webflow type should accept multiple files. */
+export function isMultiAssetType(webflowType: WebflowFieldType | string): boolean {
+  return MULTI_ASSET_TYPES.has(webflowType as WebflowFieldType);
+}
+
+const WEBFLOW_FIELD_TYPE_LABELS: Record<WebflowFieldType, string> = {
+  PlainText: 'Plain text',
+  RichText: 'Rich text',
+  Image: 'Image',
+  MultiImage: 'Multi image',
+  Video: 'Video',
+  Link: 'Link',
+  Email: 'Email',
+  Phone: 'Phone',
+  Number: 'Number',
+  DateTime: 'Date & time',
+  Date: 'Date',
+  Switch: 'Switch',
+  Color: 'Color',
+  Option: 'Option',
+  Reference: 'Reference',
+  MultiReference: 'Multi-reference',
+  File: 'File',
+  Set: 'Set',
+  User: 'User',
+};
+
+export function getWebflowFieldTypeLabel(type: WebflowFieldType | string): string {
+  return WEBFLOW_FIELD_TYPE_LABELS[type as WebflowFieldType] ?? type;
+}
+
+// =============================================================================
+// Value Transformation
+// =============================================================================
+
+/**
+ * Transform a Webflow `fieldData` value into the string form YCode expects
+ * for `collection_item_values.value`. Returns `null` for empty values so
+ * downstream code can short-circuit.
+ *
+ * Reference / MultiReference values are NOT resolved here — they remain raw
+ * Webflow item ids. The migration service runs a second pass to convert them
+ * into YCode item ids.
+ *
+ * Asset values (Image / MultiImage / File / Video) are also pass-through —
+ * the migration service is responsible for downloading and re-uploading
+ * them, then writing the resulting asset id(s) into the value column.
+ */
+export function transformFieldValue(
+  value: unknown,
+  webflowType: WebflowFieldType | string,
+  cmsType: CollectionFieldType
+): string | null {
+  if (value === null || value === undefined) return null;
+
+  switch (webflowType) {
+    case 'PlainText':
+    case 'Email':
+    case 'Phone':
+    case 'Color': {
+      if (typeof value !== 'string') return String(value);
+      return value === '' ? null : value;
+    }
+
+    case 'RichText': {
+      if (typeof value !== 'string') return null;
+      if (cmsType === 'rich_text') return htmlToTiptapJson(value);
+      return value;
+    }
+
+    case 'Number': {
+      if (typeof value === 'number') return Number.isFinite(value) ? String(value) : null;
+      if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = parseFloat(value);
+        return Number.isFinite(parsed) ? String(parsed) : null;
+      }
+      return null;
+    }
+
+    case 'Switch': {
+      if (typeof value === 'boolean') return value ? 'true' : 'false';
+      if (typeof value === 'string') {
+        return value === 'true' || value === '1' || value === 'yes' ? 'true' : 'false';
+      }
+      return value ? 'true' : 'false';
+    }
+
+    case 'Date':
+    case 'DateTime': {
+      if (typeof value !== 'string' || value === '') return null;
+      const d = new Date(value);
+      if (isNaN(d.getTime())) return null;
+      return d.toISOString();
+    }
+
+    case 'Link': {
+      // Webflow Link fields hold a plain URL — stored as text in YCode so the
+      // user can rebind it via the link picker if they want.
+      if (typeof value !== 'string' || value === '') return null;
+      return value;
+    }
+
+    case 'Option': {
+      // Webflow stores the option's id; mapping to its display name is the
+      // caller's job (it has access to the field's `validations.options`).
+      if (typeof value !== 'string') return String(value);
+      return value === '' ? null : value;
+    }
+
+    case 'Reference': {
+      if (typeof value !== 'string') return null;
+      return value === '' ? null : value;
+    }
+
+    case 'MultiReference': {
+      if (!Array.isArray(value)) return null;
+      const ids = value.filter((id): id is string => typeof id === 'string' && id !== '');
+      return ids.length === 0 ? null : JSON.stringify(ids);
+    }
+
+    case 'Image':
+    case 'MultiImage':
+    case 'File': {
+      // Pass-through — replaced by the migration service after upload.
+      if (value === null || value === '') return null;
+      return typeof value === 'string' ? value : JSON.stringify(value);
+    }
+
+    case 'Video': {
+      // Webflow Video fields store an oEmbed URL or `{ url, html }` payload.
+      // We persist just the URL as text so it stays human-readable.
+      if (typeof value === 'string') return value === '' ? null : value;
+      if (value && typeof value === 'object') {
+        const url = (value as Record<string, unknown>).url;
+        return typeof url === 'string' && url !== '' ? url : null;
+      }
+      return null;
+    }
+
+    case 'Set': {
+      if (Array.isArray(value)) return JSON.stringify(value);
+      return typeof value === 'string' ? value : JSON.stringify(value);
+    }
+
+    default: {
+      if (typeof value === 'string') return value === '' ? null : value;
+      if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+      return JSON.stringify(value);
+    }
+  }
+}
+
+/**
+ * Resolve an Option field's id to its display name using the field's
+ * `validations.options` list. Returns the original id if no match is found.
+ */
+export function resolveOptionLabel(
+  optionId: string,
+  options: Array<{ id: string; name: string }> | undefined
+): string {
+  if (!options) return optionId;
+  const match = options.find((o) => o.id === optionId);
+  return match?.name ?? optionId;
+}

--- a/lib/apps/webflow/field-mapping.ts
+++ b/lib/apps/webflow/field-mapping.ts
@@ -28,7 +28,7 @@ const FIELD_TYPE_MAP: Record<WebflowFieldType, CollectionFieldType> = {
   Date: 'date_only',
   Switch: 'boolean',
   Color: 'color',
-  Option: 'status',
+  Option: 'option',
   Reference: 'reference',
   MultiReference: 'multi_reference',
   File: 'document',
@@ -199,6 +199,9 @@ export function transformFieldValue(
 /**
  * Resolve an Option field's id to its display name using the field's
  * `validations.options` list. Returns the original id if no match is found.
+ *
+ * Names are trimmed to match how YCode stores option values (the builder
+ * trims option names on save and uses them as the persisted value).
  */
 export function resolveOptionLabel(
   optionId: string,
@@ -206,5 +209,5 @@ export function resolveOptionLabel(
 ): string {
   if (!options) return optionId;
   const match = options.find((o) => o.id === optionId);
-  return match?.name ?? optionId;
+  return match?.name.trim() ?? optionId;
 }

--- a/lib/apps/webflow/html-to-tiptap.ts
+++ b/lib/apps/webflow/html-to-tiptap.ts
@@ -1,0 +1,193 @@
+/**
+ * Convert Webflow rich-text HTML into a TipTap JSON document string.
+ *
+ * Webflow's CMS RichText fields are returned as raw HTML. YCode's `rich_text`
+ * field expects a serialized TipTap document. This converter handles the
+ * common subset (paragraphs, headings, lists, bold/italic/links) and falls
+ * back to a single paragraph with stripped text for anything unrecognized.
+ *
+ * No DOM is required — uses string parsing only so it's safe to run inside
+ * server-side migrations.
+ */
+
+interface TiptapMark {
+  type: string;
+  attrs?: Record<string, unknown>;
+}
+
+interface TiptapNode {
+  type: string;
+  attrs?: Record<string, unknown>;
+  marks?: TiptapMark[];
+  content?: TiptapNode[];
+  text?: string;
+}
+
+const EMPTY_DOC = JSON.stringify({ type: 'doc', content: [] });
+
+const HEADING_TAGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
+/** Decode the small set of HTML entities Webflow tends to emit. */
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'");
+}
+
+/** Strip all HTML tags from a string and return decoded plain text. */
+function stripTags(html: string): string {
+  return decodeEntities(html.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ')).trim();
+}
+
+/**
+ * Parse the inline content of a block (anything between the open/close tag of
+ * a paragraph, heading, or list item) into TipTap inline nodes. Recognizes
+ * `<a>`, `<strong>`/`<b>`, `<em>`/`<i>`, `<u>`, `<code>`, and `<br>`.
+ */
+function parseInline(html: string): TiptapNode[] {
+  const nodes: TiptapNode[] = [];
+  const inlineRegex = /<a\s+[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>|<(strong|b|em|i|u|code)\b[^>]*>([\s\S]*?)<\/\3>|<br\s*\/?\s*>/gi;
+
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  const pushText = (text: string, marks?: TiptapMark[]) => {
+    const decoded = decodeEntities(text);
+    if (!decoded) return;
+    nodes.push(marks ? { type: 'text', text: decoded, marks } : { type: 'text', text: decoded });
+  };
+
+  while ((match = inlineRegex.exec(html)) !== null) {
+    if (match.index > lastIndex) {
+      pushText(html.slice(lastIndex, match.index));
+    }
+
+    if (match[0].startsWith('<a')) {
+      const href = match[1];
+      const inner = stripTags(match[2]);
+      pushText(inner || href, [{ type: 'link', attrs: { href } }]);
+    } else if (match[3]) {
+      const tag = match[3].toLowerCase();
+      const inner = stripTags(match[4]);
+      const markType =
+        tag === 'strong' || tag === 'b' ? 'bold' :
+          tag === 'em' || tag === 'i' ? 'italic' :
+            tag === 'u' ? 'underline' :
+              tag === 'code' ? 'code' :
+                tag;
+      pushText(inner, [{ type: markType }]);
+    } else {
+      // <br> — TipTap uses an explicit hardBreak node
+      nodes.push({ type: 'hardBreak' });
+    }
+
+    lastIndex = inlineRegex.lastIndex;
+  }
+
+  if (lastIndex < html.length) {
+    pushText(html.slice(lastIndex));
+  }
+
+  return nodes;
+}
+
+/** Convert a list block (`<ul>` / `<ol>`) into a TipTap list node. */
+function parseList(html: string, ordered: boolean): TiptapNode {
+  const items: TiptapNode[] = [];
+  const itemRegex = /<li[^>]*>([\s\S]*?)<\/li>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = itemRegex.exec(html)) !== null) {
+    const inner = match[1].trim();
+    items.push({
+      type: 'listItem',
+      content: [{ type: 'paragraph', content: parseInline(inner) }],
+    });
+  }
+
+  return {
+    type: ordered ? 'orderedList' : 'bulletList',
+    content: items,
+  };
+}
+
+/**
+ * Walk through top-level blocks (paragraphs / headings / lists / blockquotes)
+ * and convert each into a TipTap node. Anything outside a recognized block
+ * wraps into a fallback paragraph.
+ */
+function parseBlocks(html: string): TiptapNode[] {
+  const nodes: TiptapNode[] = [];
+  const blockRegex = /<(p|h1|h2|h3|h4|h5|h6|ul|ol|blockquote)\b[^>]*>([\s\S]*?)<\/\1>/gi;
+  let match: RegExpExecArray | null;
+  let lastIndex = 0;
+
+  const flushText = (text: string) => {
+    const stripped = stripTags(text);
+    if (stripped) {
+      nodes.push({ type: 'paragraph', content: [{ type: 'text', text: stripped }] });
+    }
+  };
+
+  while ((match = blockRegex.exec(html)) !== null) {
+    if (match.index > lastIndex) {
+      flushText(html.slice(lastIndex, match.index));
+    }
+
+    const tag = match[1].toLowerCase();
+    const inner = match[2];
+
+    if (tag === 'p') {
+      const inline = parseInline(inner);
+      nodes.push({ type: 'paragraph', content: inline.length > 0 ? inline : [] });
+    } else if (HEADING_TAGS.has(tag)) {
+      nodes.push({
+        type: 'heading',
+        attrs: { level: parseInt(tag.slice(1), 10) },
+        content: parseInline(inner),
+      });
+    } else if (tag === 'ul' || tag === 'ol') {
+      nodes.push(parseList(inner, tag === 'ol'));
+    } else if (tag === 'blockquote') {
+      nodes.push({
+        type: 'blockquote',
+        content: parseBlocks(inner),
+      });
+    }
+
+    lastIndex = blockRegex.lastIndex;
+  }
+
+  if (lastIndex < html.length) {
+    flushText(html.slice(lastIndex));
+  }
+
+  return nodes;
+}
+
+/** Convert a Webflow HTML rich-text string into TipTap JSON. */
+export function htmlToTiptapJson(html: string): string {
+  if (!html || typeof html !== 'string') return EMPTY_DOC;
+
+  const trimmed = html.trim();
+  if (trimmed.length === 0) return EMPTY_DOC;
+
+  const blocks = parseBlocks(trimmed);
+
+  // No recognized blocks — fall back to a single paragraph with stripped text.
+  if (blocks.length === 0) {
+    const stripped = stripTags(trimmed);
+    if (!stripped) return EMPTY_DOC;
+    return JSON.stringify({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: stripped }] }],
+    });
+  }
+
+  return JSON.stringify({ type: 'doc', content: blocks });
+}

--- a/lib/apps/webflow/index.ts
+++ b/lib/apps/webflow/index.ts
@@ -1,0 +1,250 @@
+/**
+ * Webflow API Client
+ *
+ * Server-side functions for the Webflow REST v2 API.
+ * Handles token validation, sites, collections, and items
+ * (both staged and live variants).
+ *
+ * API Documentation: https://developers.webflow.com/data/reference
+ */
+
+import type {
+  WebflowSite,
+  WebflowSitesResponse,
+  WebflowCollection,
+  WebflowCollectionsResponse,
+  WebflowItem,
+  WebflowItemsResponse,
+} from './types';
+
+const WEBFLOW_API_URL = 'https://api.webflow.com/v2';
+const WEBFLOW_API_VERSION = '2.0.0';
+
+// Webflow rate limit: 60 req/min for v2 (1 req/sec is safe).
+// We pace requests to ~17 req/sec headroom (~60ms between requests),
+// then back off on 429 responses.
+const RATE_LIMIT_DELAY_MS = 60;
+let lastRequestAt = 0;
+
+/** Default page size for paginated item listing (Webflow max is 100). */
+const ITEMS_PAGE_SIZE = 100;
+
+/** Max attempts for transient errors (429 / 5xx). */
+const MAX_RETRIES = 5;
+
+// =============================================================================
+// API Helpers
+// =============================================================================
+
+async function waitForRateLimit(): Promise<void> {
+  const now = Date.now();
+  const elapsed = now - lastRequestAt;
+  if (elapsed < RATE_LIMIT_DELAY_MS) {
+    await new Promise((r) => setTimeout(r, RATE_LIMIT_DELAY_MS - elapsed));
+  }
+  lastRequestAt = Date.now();
+}
+
+interface WebflowRequestOptions {
+  method?: string;
+  body?: unknown;
+  query?: Record<string, string | number | boolean | undefined>;
+}
+
+function buildUrl(path: string, query?: WebflowRequestOptions['query']): string {
+  const url = new URL(`${WEBFLOW_API_URL}${path}`);
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === null) continue;
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+async function webflowRequest<T>(
+  token: string,
+  path: string,
+  options: WebflowRequestOptions = {}
+): Promise<T> {
+  const { method = 'GET', body, query } = options;
+  const url = buildUrl(path, query);
+
+  let attempt = 0;
+  let lastError: Error | null = null;
+
+  while (attempt < MAX_RETRIES) {
+    attempt++;
+    await waitForRateLimit();
+
+    const response = await fetch(url, {
+      method,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'accept-version': WEBFLOW_API_VERSION,
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    // Honor Retry-After on 429 / 503 then retry.
+    if (response.status === 429 || response.status === 503) {
+      const retryAfter = parseInt(response.headers.get('retry-after') || '1', 10);
+      const waitMs = Math.min(Math.max(retryAfter, 1), 30) * 1000;
+      await new Promise((r) => setTimeout(r, waitMs));
+      lastError = new Error(`Webflow rate limited (status ${response.status})`);
+      continue;
+    }
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({}));
+      const detail = (errorBody as Record<string, unknown>)?.message
+        ?? (errorBody as Record<string, unknown>)?.msg
+        ?? `${response.status} ${response.statusText}`;
+      throw new Error(`Webflow API error: ${detail}`);
+    }
+
+    if (response.status === 204) return {} as T;
+    return response.json();
+  }
+
+  throw lastError ?? new Error('Webflow request failed after retries');
+}
+
+// =============================================================================
+// Token Validation
+// =============================================================================
+
+/**
+ * Validate a Webflow API token by calling `GET /sites`. We use this rather
+ * than `/token/authorized_by` because the latter requires the
+ * `authorized_user:read` scope, which most CMS-only tokens don't have.
+ * The migration needs `sites:read` + `cms:read` anyway, so confirming we
+ * can list sites is the most relevant check.
+ */
+export async function testToken(token: string): Promise<{ valid: boolean; error?: string }> {
+  try {
+    await webflowRequest<WebflowSitesResponse>(token, '/sites');
+    return { valid: true };
+  } catch (error) {
+    return {
+      valid: false,
+      error: error instanceof Error ? error.message : 'Invalid token',
+    };
+  }
+}
+
+// =============================================================================
+// Sites
+// =============================================================================
+
+/** List all Webflow sites the token has access to. */
+export async function listSites(token: string): Promise<WebflowSite[]> {
+  const response = await webflowRequest<WebflowSitesResponse>(token, '/sites');
+  return response.sites ?? [];
+}
+
+/** Fetch a single site by id. */
+export async function getSite(token: string, siteId: string): Promise<WebflowSite> {
+  return webflowRequest<WebflowSite>(token, `/sites/${siteId}`);
+}
+
+// =============================================================================
+// Collections
+// =============================================================================
+
+/**
+ * List collection summaries for a site. Note: each entry does NOT include
+ * `fields` — call `getCollection` for the full schema.
+ */
+export async function listCollections(
+  token: string,
+  siteId: string
+): Promise<WebflowCollection[]> {
+  const response = await webflowRequest<WebflowCollectionsResponse>(
+    token,
+    `/sites/${siteId}/collections`
+  );
+  return response.collections ?? [];
+}
+
+/** Fetch a collection's full schema, including its `fields[]`. */
+export async function getCollection(
+  token: string,
+  collectionId: string
+): Promise<WebflowCollection> {
+  return webflowRequest<WebflowCollection>(token, `/collections/${collectionId}`);
+}
+
+/**
+ * Convenience: list all collections for a site WITH their fields populated.
+ * Performs one summary request and one detail request per collection.
+ */
+export async function listCollectionsWithFields(
+  token: string,
+  siteId: string
+): Promise<WebflowCollection[]> {
+  const summaries = await listCollections(token, siteId);
+  const detailed: WebflowCollection[] = [];
+  for (const summary of summaries) {
+    const full = await getCollection(token, summary.id);
+    detailed.push({ ...summary, ...full });
+  }
+  return detailed;
+}
+
+// =============================================================================
+// Items
+// =============================================================================
+
+interface ListItemsOptions {
+  /** When true, list the published/live variant of items. */
+  live?: boolean;
+}
+
+/**
+ * List ALL items for a collection, paging through Webflow's offset-based
+ * pagination. When `live=true` we hit the `/items/live` endpoint, which
+ * returns only items currently published on the site.
+ */
+export async function listItems(
+  token: string,
+  collectionId: string,
+  options: ListItemsOptions = {}
+): Promise<WebflowItem[]> {
+  const path = options.live
+    ? `/collections/${collectionId}/items/live`
+    : `/collections/${collectionId}/items`;
+
+  const all: WebflowItem[] = [];
+  let offset = 0;
+
+  while (true) {
+    const response = await webflowRequest<WebflowItemsResponse>(token, path, {
+      query: { limit: ITEMS_PAGE_SIZE, offset },
+    });
+
+    const batch = response.items ?? [];
+    all.push(...batch);
+
+    if (batch.length < ITEMS_PAGE_SIZE) break;
+    offset += batch.length;
+
+    // Safety net for runaway pagination.
+    if (offset > 100_000) break;
+  }
+
+  return all;
+}
+
+/**
+ * Return the set of item ids currently live for a collection. Used by
+ * the migration / re-sync to decide which YCode draft items to publish.
+ */
+export async function listLiveItemIds(
+  token: string,
+  collectionId: string
+): Promise<Set<string>> {
+  const items = await listItems(token, collectionId, { live: true });
+  return new Set(items.map((item) => item.id));
+}

--- a/lib/apps/webflow/logo.svg
+++ b/lib/apps/webflow/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><rect width="256" height="256" fill="#146EF5"/><g transform="translate(38 72) scale(1.385)"><path fill="#fff" fill-rule="evenodd" clip-rule="evenodd" d="M129.9,0L88.4,81H49.5l17.3-33.6h-0.8C51.8,66,30.4,78.2,0,81V47.9c0,0,19.5-1.1,30.9-13.2H0V0h34.7v28.6l0.8,0L49.7,0h26.3v28.4l0.8,0L91.4,0H129.9z"/></g></svg>

--- a/lib/apps/webflow/migration-service.ts
+++ b/lib/apps/webflow/migration-service.ts
@@ -1,0 +1,992 @@
+/**
+ * Webflow Migration Service
+ *
+ * Orchestrates a one-click migration of a Webflow CMS site into YCode:
+ * creates collections + fields from the Webflow schema, imports items as
+ * drafts, resolves cross-collection references, and publishes the items
+ * that are currently live on Webflow.
+ *
+ * On re-sync we skip schema creation and only reconcile items.
+ */
+
+import { randomUUID } from 'crypto';
+
+import { getAppSettingValue, setAppSetting } from '@/lib/repositories/appSettingsRepository';
+import { uploadFile } from '@/lib/file-upload';
+import { slugify } from '@/lib/collection-utils';
+import {
+  createCollection,
+  getCollectionById,
+} from '@/lib/repositories/collectionRepository';
+import {
+  createField,
+  getFieldsByCollectionId,
+} from '@/lib/repositories/collectionFieldRepository';
+import {
+  createItemsBulk,
+  getItemsByCollectionId,
+  publishItem,
+} from '@/lib/repositories/collectionItemRepository';
+import {
+  insertValuesBulk,
+  getValuesByItemIds,
+} from '@/lib/repositories/collectionItemValueRepository';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+
+import {
+  listCollectionsWithFields,
+  getCollection,
+  listItems,
+  listLiveItemIds,
+  getSite,
+} from './index';
+import {
+  getCmsFieldType,
+  isMultiAssetType,
+  resolveOptionLabel,
+  transformFieldValue,
+} from './field-mapping';
+import type {
+  CollectionMigrationResult,
+  SyncResult,
+  WebflowAsset,
+  WebflowCollection,
+  WebflowCollectionMapping,
+  WebflowField,
+  WebflowImport,
+  WebflowItem,
+} from './types';
+import type { CollectionField } from '@/types';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+export const APP_ID = 'webflow';
+
+/** Hidden YCode field key that stores the Webflow item id for tracking. */
+const HIDDEN_FIELD_KEY = 'webflow_id';
+
+/** Concurrency cap for asset downloads from Webflow's CDN. */
+const ASSET_CONCURRENCY = 5;
+
+/** Bulk insert chunk size to stay well under Supabase row limits. */
+const BULK_CHUNK_SIZE = 500;
+
+// =============================================================================
+// Token + Imports State
+// =============================================================================
+
+/** Get the stored Webflow token, throwing if not configured. */
+export async function requireWebflowToken(): Promise<string> {
+  const token = await getAppSettingValue<string>(APP_ID, 'api_token');
+  if (!token) throw new Error('Webflow token not configured');
+  return token;
+}
+
+export async function getImports(): Promise<WebflowImport[]> {
+  return (await getAppSettingValue<WebflowImport[]>(APP_ID, 'imports')) ?? [];
+}
+
+export async function saveImports(imports: WebflowImport[]): Promise<void> {
+  await setAppSetting(APP_ID, 'imports', imports);
+}
+
+export async function getImportById(importId: string): Promise<WebflowImport | null> {
+  const imports = await getImports();
+  return imports.find((i) => i.id === importId) ?? null;
+}
+
+export async function updateImport(
+  importId: string,
+  patch: Partial<WebflowImport>
+): Promise<WebflowImport | null> {
+  const imports = await getImports();
+  const idx = imports.findIndex((i) => i.id === importId);
+  if (idx === -1) return null;
+
+  imports[idx] = { ...imports[idx], ...patch };
+  await saveImports(imports);
+  return imports[idx];
+}
+
+export async function removeImport(importId: string): Promise<boolean> {
+  const imports = await getImports();
+  const remaining = imports.filter((i) => i.id !== importId);
+  if (remaining.length === imports.length) return false;
+  await saveImports(remaining);
+  return true;
+}
+
+// =============================================================================
+// Status Wrapper
+// =============================================================================
+
+async function withImportStatus(
+  importId: string,
+  syncFn: () => Promise<SyncResult>
+): Promise<SyncResult> {
+  await updateImport(importId, { syncStatus: 'syncing', syncError: null });
+  try {
+    const result = await syncFn();
+    await updateImport(importId, {
+      syncStatus: 'idle',
+      syncError: null,
+      lastSyncedAt: result.syncedAt,
+    });
+    return result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown sync error';
+    await updateImport(importId, { syncStatus: 'error', syncError: message });
+    throw error;
+  }
+}
+
+// =============================================================================
+// Schema Creation
+// =============================================================================
+
+interface CollectionScaffold {
+  webflowCollection: WebflowCollection;
+  ycodeCollectionId: string;
+  ycodeCollectionName: string;
+  fieldIdMap: Record<string, string>;
+  fieldSlugMap: Record<string, string>;
+  recordIdFieldId: string;
+}
+
+/**
+ * Create YCode collections + fields for every Webflow collection in the site.
+ * Reference fields are wired to the freshly created YCode collection ids
+ * (resolved in a second pass once all collections exist).
+ */
+async function createCollectionsFromSchema(
+  webflowCollections: WebflowCollection[]
+): Promise<CollectionScaffold[]> {
+  const scaffolds: CollectionScaffold[] = [];
+
+  // Pass 1 — create the collections themselves so reference fields in pass 2
+  // can point at them via YCode collection ids.
+  const wfToYcodeCollectionId = new Map<string, string>();
+  for (let i = 0; i < webflowCollections.length; i++) {
+    const wf = webflowCollections[i];
+    const collection = await createCollection({
+      name: wf.displayName,
+      order: i,
+      is_published: false,
+    });
+    wfToYcodeCollectionId.set(wf.id, collection.id);
+    scaffolds.push({
+      webflowCollection: wf,
+      ycodeCollectionId: collection.id,
+      ycodeCollectionName: collection.name,
+      fieldIdMap: {},
+      fieldSlugMap: {},
+      recordIdFieldId: '',
+    });
+  }
+
+  // Pass 2 — create fields, including the hidden tracking field.
+  for (const scaffold of scaffolds) {
+    const wf = scaffold.webflowCollection;
+    let order = 0;
+
+    for (const wfField of wf.fields ?? []) {
+      const cmsType = getCmsFieldType(wfField.type);
+      const referenceCollectionId = (wfField.type === 'Reference' || wfField.type === 'MultiReference')
+        ? wfToYcodeCollectionId.get(wfField.validations?.collectionId ?? '') ?? null
+        : null;
+
+      const field = await createField({
+        name: wfField.displayName,
+        key: slugify(wfField.slug),
+        type: cmsType,
+        collection_id: scaffold.ycodeCollectionId,
+        order: order++,
+        reference_collection_id: referenceCollectionId,
+        data: isMultiAssetType(wfField.type) ? { multiple: true } : {},
+        is_published: false,
+      });
+
+      scaffold.fieldIdMap[wfField.id] = field.id;
+      scaffold.fieldSlugMap[wfField.slug] = field.id;
+    }
+
+    // Hidden tracking field — used for re-sync reconciliation and reference resolution.
+    const trackingField = await createField({
+      name: 'Webflow ID',
+      key: HIDDEN_FIELD_KEY,
+      type: 'text',
+      collection_id: scaffold.ycodeCollectionId,
+      order: order++,
+      hidden: true,
+      is_computed: true,
+      fillable: false,
+      is_published: false,
+    });
+    scaffold.recordIdFieldId = trackingField.id;
+  }
+
+  return scaffolds;
+}
+
+// =============================================================================
+// Asset Handling
+// =============================================================================
+
+/** Fingerprint a Webflow asset payload for re-sync caching. */
+function assetFingerprint(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((a) => fingerprintSingle(a as WebflowAsset)).join(',');
+  }
+  return fingerprintSingle(value as WebflowAsset);
+}
+
+function fingerprintSingle(asset: WebflowAsset | null | undefined): string {
+  if (!asset) return '';
+  return `${asset.fileId ?? ''}|${asset.url ?? ''}`;
+}
+
+interface UploadAssetsContext {
+  /** Map url -> YCode asset id for download deduplication within a sync run. */
+  cache: Map<string, string>;
+  isMultiple: boolean;
+}
+
+/**
+ * Download Webflow asset(s) and upload them to YCode storage, returning
+ * either a single asset id (single asset field) or a JSON array of ids
+ * (multi-asset field).
+ */
+async function uploadWebflowAssets(
+  rawValue: unknown,
+  ctx: UploadAssetsContext
+): Promise<string | null> {
+  const assets: WebflowAsset[] = [];
+
+  if (Array.isArray(rawValue)) {
+    for (const a of rawValue) {
+      if (a && typeof a === 'object' && (a as WebflowAsset).url) {
+        assets.push(a as WebflowAsset);
+      }
+    }
+  } else if (rawValue && typeof rawValue === 'object' && (rawValue as WebflowAsset).url) {
+    assets.push(rawValue as WebflowAsset);
+  }
+
+  if (assets.length === 0) return null;
+
+  const targets = ctx.isMultiple ? assets : assets.slice(0, 1);
+  const results: Array<{ index: number; assetId: string }> = [];
+  const tasks: Array<{ asset: WebflowAsset; index: number }> = [];
+
+  for (let i = 0; i < targets.length; i++) {
+    const asset = targets[i];
+    const cached = ctx.cache.get(asset.url);
+    if (cached) {
+      results.push({ index: i, assetId: cached });
+    } else {
+      tasks.push({ asset, index: i });
+    }
+  }
+
+  for (let i = 0; i < tasks.length; i += ASSET_CONCURRENCY) {
+    const batch = tasks.slice(i, i + ASSET_CONCURRENCY);
+    const settled = await Promise.allSettled(
+      batch.map(async ({ asset, index }) => {
+        const res = await fetch(asset.url);
+        if (!res.ok) return null;
+        const buffer = await res.arrayBuffer();
+        const contentType = res.headers.get('content-type') || 'application/octet-stream';
+        const filename = asset.name
+          || asset.fileName
+          || asset.url.split('/').pop()?.split('?')[0]
+          || 'webflow-asset';
+        const file = new File([buffer], filename, { type: contentType });
+        const uploaded = await uploadFile(file, 'webflow-migration');
+        if (!uploaded) return null;
+        ctx.cache.set(asset.url, uploaded.id);
+        return { index, assetId: uploaded.id };
+      })
+    );
+
+    for (const outcome of settled) {
+      if (outcome.status === 'fulfilled' && outcome.value) {
+        results.push(outcome.value);
+      }
+    }
+  }
+
+  if (results.length === 0) return null;
+
+  results.sort((a, b) => a.index - b.index);
+  const ids = results.map((r) => r.assetId);
+  return ctx.isMultiple ? JSON.stringify(ids) : ids[0];
+}
+
+// =============================================================================
+// Item Build / Reconciliation Helpers
+// =============================================================================
+
+interface ItemBuildContext {
+  scaffold: CollectionScaffold;
+  /** Concurrent asset upload cache, shared across an entire collection import. */
+  assetCache: Map<string, string>;
+  /** Persisted fingerprints from a previous run, for re-sync skip-if-unchanged. */
+  prevFingerprints: Map<string, string>;
+  /** Updated fingerprints written back at the end of a sync. */
+  newFingerprints: Map<string, string>;
+}
+
+interface BuiltItemValues {
+  values: Record<string, string | null>;
+  /** Whether this item has any reference / multi-reference values to resolve later. */
+  hasReferences: boolean;
+}
+
+/**
+ * Build the raw values map for a single Webflow item. References stay as raw
+ * Webflow ids — pass 2 (`resolveReferences`) substitutes the YCode item ids.
+ */
+async function buildItemValues(
+  item: WebflowItem,
+  ctx: ItemBuildContext,
+  existingItemValues?: Record<string, string>
+): Promise<BuiltItemValues> {
+  const { scaffold, assetCache, prevFingerprints, newFingerprints } = ctx;
+  const result: Record<string, string | null> = {
+    [scaffold.recordIdFieldId]: item.id,
+  };
+  let hasReferences = false;
+
+  for (const wfField of scaffold.webflowCollection.fields ?? []) {
+    const cmsFieldId = scaffold.fieldIdMap[wfField.id];
+    if (!cmsFieldId) continue;
+
+    const cmsType = getCmsFieldType(wfField.type);
+    const raw = item.fieldData[wfField.slug];
+
+    if (raw === undefined || raw === null) {
+      result[cmsFieldId] = null;
+      continue;
+    }
+
+    // Asset fields — download + re-upload, with fingerprint caching.
+    if (wfField.type === 'Image' || wfField.type === 'MultiImage' || wfField.type === 'File') {
+      const fpKey = `${item.id}:${wfField.id}`;
+      const fp = assetFingerprint(raw);
+      newFingerprints.set(fpKey, fp);
+
+      const prevFp = prevFingerprints.get(fpKey);
+      if (prevFp === fp && existingItemValues?.[cmsFieldId]) {
+        result[cmsFieldId] = existingItemValues[cmsFieldId];
+        continue;
+      }
+
+      result[cmsFieldId] = await uploadWebflowAssets(raw, {
+        cache: assetCache,
+        isMultiple: isMultiAssetType(wfField.type),
+      });
+      continue;
+    }
+
+    // Option fields — resolve id -> human-readable label.
+    if (wfField.type === 'Option') {
+      const label = typeof raw === 'string'
+        ? resolveOptionLabel(raw, wfField.validations?.options)
+        : raw;
+      result[cmsFieldId] = transformFieldValue(label, wfField.type, cmsType);
+      continue;
+    }
+
+    // Reference fields — keep raw Webflow id(s) for now, resolve in pass 2.
+    if (wfField.type === 'Reference' || wfField.type === 'MultiReference') {
+      hasReferences = true;
+      result[cmsFieldId] = transformFieldValue(raw, wfField.type, cmsType);
+      continue;
+    }
+
+    result[cmsFieldId] = transformFieldValue(raw, wfField.type, cmsType);
+  }
+
+  return { values: result, hasReferences };
+}
+
+// =============================================================================
+// Items Pass: Drafts (Create / Update)
+// =============================================================================
+
+interface ImportItemsParams {
+  scaffold: CollectionScaffold;
+  webflowItems: WebflowItem[];
+  prevFingerprints: Map<string, string>;
+  newFingerprints: Map<string, string>;
+  result: CollectionMigrationResult;
+}
+
+/**
+ * Reconcile staged Webflow items into YCode drafts. Creates, updates, or
+ * soft-deletes as needed. Returns a map of `webflowItemId -> ycodeItemId`
+ * so pass 2 can resolve references locally without extra DB hits.
+ */
+async function importItemsAsDrafts(
+  params: ImportItemsParams
+): Promise<Map<string, string>> {
+  const { scaffold, webflowItems, prevFingerprints, newFingerprints, result } = params;
+  const assetCache = new Map<string, string>();
+
+  // Load existing YCode items + their values so we can dirty-check.
+  const { items: existingItems } = await getItemsByCollectionId(scaffold.ycodeCollectionId);
+  const existingValues = existingItems.length > 0
+    ? await getValuesByItemIds(existingItems.map((i) => i.id))
+    : {};
+
+  // webflowItemId -> ycodeItemId for items that already exist.
+  const wfToCmsItem = new Map<string, string>();
+  for (const item of existingItems) {
+    const trackId = existingValues[item.id]?.[scaffold.recordIdFieldId];
+    if (typeof trackId === 'string') {
+      wfToCmsItem.set(trackId, item.id);
+    }
+  }
+
+  const buildCtx: ItemBuildContext = {
+    scaffold,
+    assetCache,
+    prevFingerprints,
+    newFingerprints,
+  };
+
+  // Bulk inserts for new items.
+  const newItemRecords: Array<{ id: string; collection_id: string; manual_order: number; is_published: boolean; is_publishable: boolean }> = [];
+  const newValuesToInsert: Array<{ item_id: string; field_id: string; value: string | null }> = [];
+
+  // Bulk upserts for existing items.
+  const updates: Array<{ cmsItemId: string; values: Record<string, string | null> }> = [];
+
+  for (let i = 0; i < webflowItems.length; i++) {
+    const wfItem = webflowItems[i];
+    const existingCmsItemId = wfToCmsItem.get(wfItem.id);
+
+    if (existingCmsItemId) {
+      const built = await buildItemValues(
+        wfItem,
+        buildCtx,
+        existingValues[existingCmsItemId] as Record<string, string>
+      );
+      if (hasValueChanges(built.values, existingValues[existingCmsItemId])) {
+        updates.push({ cmsItemId: existingCmsItemId, values: built.values });
+      }
+    } else {
+      const cmsItemId = randomUUID();
+      const built = await buildItemValues(wfItem, buildCtx);
+      newItemRecords.push({
+        id: cmsItemId,
+        collection_id: scaffold.ycodeCollectionId,
+        manual_order: i,
+        is_published: false,
+        is_publishable: true,
+      });
+      for (const [fieldId, value] of Object.entries(built.values)) {
+        newValuesToInsert.push({ item_id: cmsItemId, field_id: fieldId, value });
+      }
+      wfToCmsItem.set(wfItem.id, cmsItemId);
+      result.created++;
+    }
+  }
+
+  if (newItemRecords.length > 0) {
+    await createItemsBulk(newItemRecords);
+    for (let i = 0; i < newValuesToInsert.length; i += BULK_CHUNK_SIZE) {
+      await insertValuesBulk(newValuesToInsert.slice(i, i + BULK_CHUNK_SIZE));
+    }
+  }
+
+  if (updates.length > 0) {
+    await batchUpsertValues(updates);
+    result.updated += updates.length;
+  }
+
+  // Soft-delete YCode items whose Webflow counterpart is gone.
+  // An item is "gone" when it has a webflow_id (so it was previously synced)
+  // but wasn't matched against any incoming item in this run.
+  const seenWebflowIds = new Set(webflowItems.map((wi) => wi.id));
+  const toDelete = existingItems
+    .filter((item) => {
+      const wfId = existingValues[item.id]?.[scaffold.recordIdFieldId];
+      return typeof wfId === 'string' && wfId !== '' && !seenWebflowIds.has(wfId);
+    })
+    .map((item) => item.id);
+
+  if (toDelete.length > 0) {
+    await batchSoftDelete(toDelete);
+    result.deleted += toDelete.length;
+  }
+
+  return wfToCmsItem;
+}
+
+/** Compare two value maps for any actual differences. */
+function hasValueChanges(
+  newValues: Record<string, string | null>,
+  existing: Record<string, unknown> | undefined
+): boolean {
+  if (!existing) return true;
+  for (const [fieldId, value] of Object.entries(newValues)) {
+    const next = value ?? '';
+    const prev = existing[fieldId];
+    const prevStr = prev == null
+      ? ''
+      : typeof prev === 'object'
+        ? JSON.stringify(prev)
+        : String(prev);
+    if (next !== prevStr) return true;
+  }
+  return false;
+}
+
+// =============================================================================
+// Items Pass 2: Resolve References
+// =============================================================================
+
+interface ReferenceResolveParams {
+  scaffolds: CollectionScaffold[];
+  /** webflowCollectionId -> Map<webflowItemId, ycodeItemId> from pass 1. */
+  itemMaps: Map<string, Map<string, string>>;
+}
+
+/**
+ * Walk each collection's reference fields and replace the raw Webflow item
+ * ids stored in pass 1 with the matching YCode item ids. Single Reference
+ * fields store a string, MultiReference fields store a JSON array.
+ */
+async function resolveReferences(params: ReferenceResolveParams): Promise<void> {
+  const { scaffolds, itemMaps } = params;
+
+  for (const scaffold of scaffolds) {
+    const refFields = (scaffold.webflowCollection.fields ?? []).filter(
+      (f) => f.type === 'Reference' || f.type === 'MultiReference'
+    );
+    if (refFields.length === 0) continue;
+
+    const itemMap = itemMaps.get(scaffold.webflowCollection.id);
+    if (!itemMap || itemMap.size === 0) continue;
+
+    // Load all current YCode item values once to avoid per-item DB queries.
+    const ycodeItemIds = Array.from(itemMap.values());
+    const valuesByItem = await getValuesByItemIds(ycodeItemIds);
+
+    const updates: Array<{ cmsItemId: string; values: Record<string, string | null> }> = [];
+
+    for (const cmsItemId of ycodeItemIds) {
+      const itemValues = valuesByItem[cmsItemId];
+      if (!itemValues) continue;
+
+      const patch: Record<string, string | null> = {};
+
+      for (const wfField of refFields) {
+        const cmsFieldId = scaffold.fieldIdMap[wfField.id];
+        if (!cmsFieldId) continue;
+
+        const targetCollectionId = wfField.validations?.collectionId;
+        if (!targetCollectionId) continue;
+        const targetItemMap = itemMaps.get(targetCollectionId);
+        if (!targetItemMap) continue;
+
+        const raw = itemValues[cmsFieldId];
+
+        if (wfField.type === 'Reference') {
+          if (typeof raw !== 'string' || !raw) {
+            patch[cmsFieldId] = null;
+            continue;
+          }
+          patch[cmsFieldId] = targetItemMap.get(raw) ?? null;
+        } else {
+          // MultiReference — value is JSON array of Webflow ids
+          let ids: string[] = [];
+          if (typeof raw === 'string') {
+            try {
+              const parsed = JSON.parse(raw);
+              if (Array.isArray(parsed)) ids = parsed.filter((v): v is string => typeof v === 'string');
+            } catch {
+              // Not JSON — skip
+            }
+          } else if (Array.isArray(raw)) {
+            ids = raw.filter((v): v is string => typeof v === 'string');
+          }
+
+          const resolved = ids
+            .map((wfId) => targetItemMap.get(wfId))
+            .filter((id): id is string => !!id);
+          patch[cmsFieldId] = resolved.length > 0 ? JSON.stringify(resolved) : null;
+        }
+      }
+
+      if (Object.keys(patch).length > 0) {
+        updates.push({ cmsItemId, values: patch });
+      }
+    }
+
+    if (updates.length > 0) {
+      await batchUpsertValues(updates);
+    }
+  }
+}
+
+// =============================================================================
+// Items Pass 3: Publish Live Items
+// =============================================================================
+
+/**
+ * For each Webflow item that's currently live on the site, publish the
+ * corresponding YCode draft so both rows (`is_published` true + false)
+ * exist in the database.
+ */
+async function publishLiveItems(
+  token: string,
+  scaffold: CollectionScaffold,
+  itemMap: Map<string, string>,
+  result: CollectionMigrationResult
+): Promise<void> {
+  const liveIds = await listLiveItemIds(token, scaffold.webflowCollection.id);
+  for (const wfId of liveIds) {
+    const cmsItemId = itemMap.get(wfId);
+    if (!cmsItemId) continue;
+
+    try {
+      await publishItem(cmsItemId);
+      result.published++;
+    } catch (error) {
+      result.errors.push(
+        `Failed to publish item ${wfId}: ${error instanceof Error ? error.message : 'unknown'}`
+      );
+    }
+  }
+}
+
+// =============================================================================
+// Public Orchestration: Migrate + Re-sync
+// =============================================================================
+
+/**
+ * Run a full one-click migration of a Webflow site into YCode.
+ * Creates a fresh `WebflowImport` row in `app_settings` regardless of
+ * whether the site has been imported before — re-importing the same site
+ * will produce a second set of YCode collections.
+ */
+export async function runMigration(siteId: string): Promise<{ import: WebflowImport; result: SyncResult }> {
+  const token = await requireWebflowToken();
+
+  const [site, webflowCollections] = await Promise.all([
+    getSite(token, siteId),
+    listCollectionsWithFields(token, siteId),
+  ]);
+
+  // Persist a placeholder import early so the UI can show progress and a
+  // crash mid-migration leaves a recoverable record.
+  const importId = randomUUID();
+  const placeholder: WebflowImport = {
+    id: importId,
+    siteId: site.id,
+    siteName: site.displayName,
+    collectionMappings: [],
+    lastSyncedAt: null,
+    syncStatus: 'syncing',
+    syncError: null,
+    assetFingerprints: {},
+  };
+  const allImports = await getImports();
+  allImports.push(placeholder);
+  await saveImports(allImports);
+
+  try {
+    const result: SyncResult = { collections: [], syncedAt: new Date().toISOString(), errors: [] };
+
+    // Build YCode collections + fields from the Webflow schema.
+    const scaffolds = await createCollectionsFromSchema(webflowCollections);
+
+    const newFingerprints = new Map<string, string>();
+    const prevFingerprints = new Map<string, string>();
+
+    // Pass 1 — import items as drafts.
+    const itemMaps = new Map<string, Map<string, string>>();
+    const collectionResults = new Map<string, CollectionMigrationResult>();
+
+    for (const scaffold of scaffolds) {
+      const collectionResult: CollectionMigrationResult = {
+        webflowCollectionId: scaffold.webflowCollection.id,
+        webflowCollectionName: scaffold.webflowCollection.displayName,
+        ycodeCollectionId: scaffold.ycodeCollectionId,
+        created: 0,
+        updated: 0,
+        deleted: 0,
+        published: 0,
+        errors: [],
+      };
+      collectionResults.set(scaffold.webflowCollection.id, collectionResult);
+
+      try {
+        const webflowItems = await listItems(token, scaffold.webflowCollection.id);
+        const itemMap = await importItemsAsDrafts({
+          scaffold,
+          webflowItems,
+          prevFingerprints,
+          newFingerprints,
+          result: collectionResult,
+        });
+        itemMaps.set(scaffold.webflowCollection.id, itemMap);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        collectionResult.errors.push(`Item import failed: ${message}`);
+        result.errors.push(`[${scaffold.webflowCollection.displayName}] ${message}`);
+      }
+    }
+
+    // Pass 2 — resolve references now that all collections have their items.
+    try {
+      await resolveReferences({ scaffolds, itemMaps });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      result.errors.push(`Reference resolution failed: ${message}`);
+    }
+
+    // Pass 3 — publish items currently live in Webflow.
+    for (const scaffold of scaffolds) {
+      const collectionResult = collectionResults.get(scaffold.webflowCollection.id);
+      const itemMap = itemMaps.get(scaffold.webflowCollection.id);
+      if (!collectionResult || !itemMap) continue;
+      try {
+        await publishLiveItems(token, scaffold, itemMap, collectionResult);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        collectionResult.errors.push(`Publish pass failed: ${message}`);
+      }
+    }
+
+    result.collections = Array.from(collectionResults.values());
+
+    // Persist final import state — collection mappings + asset fingerprints.
+    const collectionMappings: WebflowCollectionMapping[] = scaffolds.map((scaffold) => ({
+      webflowCollectionId: scaffold.webflowCollection.id,
+      webflowCollectionName: scaffold.webflowCollection.displayName,
+      webflowSlug: scaffold.webflowCollection.slug,
+      ycodeCollectionId: scaffold.ycodeCollectionId,
+      ycodeCollectionName: scaffold.ycodeCollectionName,
+      recordIdFieldId: scaffold.recordIdFieldId,
+      fieldIdMap: scaffold.fieldIdMap,
+      fieldSlugMap: scaffold.fieldSlugMap,
+      referenceFieldIds: (scaffold.webflowCollection.fields ?? [])
+        .filter((f) => f.type === 'Reference' || f.type === 'MultiReference')
+        .map((f) => f.id),
+    }));
+
+    const finalImport: WebflowImport = {
+      ...placeholder,
+      collectionMappings,
+      lastSyncedAt: result.syncedAt,
+      syncStatus: 'idle',
+      syncError: null,
+      assetFingerprints: Object.fromEntries(newFingerprints),
+    };
+
+    const updatedImports = (await getImports()).map((i) => (i.id === importId ? finalImport : i));
+    await saveImports(updatedImports);
+
+    return { import: finalImport, result };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    await updateImport(importId, { syncStatus: 'error', syncError: message });
+    throw error;
+  }
+}
+
+/**
+ * Re-sync an existing import. Skips schema creation — only reconciles items
+ * and republishes the live ones. Schema diffs in Webflow are NOT applied to
+ * keep re-sync safe; the user can run a fresh migration to capture them.
+ */
+export async function runResync(importId: string): Promise<SyncResult> {
+  const importRecord = await getImportById(importId);
+  if (!importRecord) throw new Error('Webflow import not found');
+
+  return withImportStatus(importId, async () => {
+    const token = await requireWebflowToken();
+    const result: SyncResult = { collections: [], syncedAt: new Date().toISOString(), errors: [] };
+
+    // Rebuild scaffolds from the persisted mapping + freshly fetched Webflow schemas.
+    const scaffolds: CollectionScaffold[] = [];
+    for (const mapping of importRecord.collectionMappings) {
+      // Skip mappings whose YCode collection was deleted out from under us.
+      const collection = await getCollectionById(mapping.ycodeCollectionId);
+      if (!collection) {
+        result.errors.push(`Skipped ${mapping.webflowCollectionName}: YCode collection no longer exists.`);
+        continue;
+      }
+
+      const wfCollection = await getCollection(token, mapping.webflowCollectionId);
+
+      // Build fieldIdMap from persisted mapping plus any new fields not yet
+      // mapped — for new Webflow fields we look up the YCode field by slug.
+      const ycodeFields = await getFieldsByCollectionId(mapping.ycodeCollectionId);
+      const ycodeFieldBySlug = new Map<string, CollectionField>();
+      for (const f of ycodeFields) {
+        if (f.key) ycodeFieldBySlug.set(f.key, f);
+      }
+
+      const fieldIdMap: Record<string, string> = { ...mapping.fieldIdMap };
+      const fieldSlugMap: Record<string, string> = { ...mapping.fieldSlugMap };
+
+      for (const wfField of wfCollection.fields ?? []) {
+        if (fieldIdMap[wfField.id]) continue;
+        const ycodeField = ycodeFieldBySlug.get(slugify(wfField.slug));
+        if (ycodeField) {
+          fieldIdMap[wfField.id] = ycodeField.id;
+          fieldSlugMap[wfField.slug] = ycodeField.id;
+        }
+      }
+
+      scaffolds.push({
+        webflowCollection: wfCollection,
+        ycodeCollectionId: mapping.ycodeCollectionId,
+        ycodeCollectionName: mapping.ycodeCollectionName,
+        fieldIdMap,
+        fieldSlugMap,
+        recordIdFieldId: mapping.recordIdFieldId,
+      });
+    }
+
+    const prevFingerprints = new Map(Object.entries(importRecord.assetFingerprints ?? {}));
+    const newFingerprints = new Map<string, string>();
+    const itemMaps = new Map<string, Map<string, string>>();
+    const collectionResults = new Map<string, CollectionMigrationResult>();
+
+    for (const scaffold of scaffolds) {
+      const collectionResult: CollectionMigrationResult = {
+        webflowCollectionId: scaffold.webflowCollection.id,
+        webflowCollectionName: scaffold.webflowCollection.displayName,
+        ycodeCollectionId: scaffold.ycodeCollectionId,
+        created: 0,
+        updated: 0,
+        deleted: 0,
+        published: 0,
+        errors: [],
+      };
+      collectionResults.set(scaffold.webflowCollection.id, collectionResult);
+
+      try {
+        const webflowItems = await listItems(token, scaffold.webflowCollection.id);
+        const itemMap = await importItemsAsDrafts({
+          scaffold,
+          webflowItems,
+          prevFingerprints,
+          newFingerprints,
+          result: collectionResult,
+        });
+        itemMaps.set(scaffold.webflowCollection.id, itemMap);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        collectionResult.errors.push(`Item import failed: ${message}`);
+        result.errors.push(`[${scaffold.webflowCollection.displayName}] ${message}`);
+      }
+    }
+
+    try {
+      await resolveReferences({ scaffolds, itemMaps });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      result.errors.push(`Reference resolution failed: ${message}`);
+    }
+
+    for (const scaffold of scaffolds) {
+      const collectionResult = collectionResults.get(scaffold.webflowCollection.id);
+      const itemMap = itemMaps.get(scaffold.webflowCollection.id);
+      if (!collectionResult || !itemMap) continue;
+      try {
+        await publishLiveItems(token, scaffold, itemMap, collectionResult);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        collectionResult.errors.push(`Publish pass failed: ${message}`);
+      }
+    }
+
+    result.collections = Array.from(collectionResults.values());
+
+    await updateImport(importId, {
+      assetFingerprints: { ...importRecord.assetFingerprints, ...Object.fromEntries(newFingerprints) },
+    });
+
+    return result;
+  });
+}
+
+// =============================================================================
+// Bulk DB Helpers
+// =============================================================================
+
+/**
+ * Bulk upsert values via raw SQL. Supabase's `.upsert()` can't target the
+ * partial unique index that excludes soft-deleted rows, so we drop into
+ * Knex for the ON CONFLICT clause — same approach used by the Airtable sync.
+ */
+async function batchUpsertValues(
+  items: Array<{ cmsItemId: string; values: Record<string, string | null> }>
+): Promise<void> {
+  if (items.length === 0) return;
+
+  const { getKnexClient } = await import('@/lib/knex-client');
+  const { getTenantIdFromHeaders } = await import('@/lib/supabase-server');
+  const knex = await getKnexClient();
+  const tenantId = await getTenantIdFromHeaders();
+
+  const now = new Date().toISOString();
+  const rows = items.flatMap(({ cmsItemId, values }) =>
+    Object.entries(values).map(([fieldId, value]) => ({
+      id: randomUUID(),
+      item_id: cmsItemId,
+      field_id: fieldId,
+      value,
+      is_published: false,
+      created_at: now,
+      updated_at: now,
+      ...(tenantId ? { tenant_id: tenantId } : {}),
+    }))
+  );
+
+  const cols = tenantId
+    ? 'id, item_id, field_id, value, is_published, created_at, updated_at, tenant_id'
+    : 'id, item_id, field_id, value, is_published, created_at, updated_at';
+  const placeholders = tenantId
+    ? '(?, ?, ?, ?, ?, ?, ?, ?)'
+    : '(?, ?, ?, ?, ?, ?, ?)';
+
+  for (let i = 0; i < rows.length; i += BULK_CHUNK_SIZE) {
+    const chunk = rows.slice(i, i + BULK_CHUNK_SIZE);
+    const params = tenantId
+      ? chunk.flatMap((r) => [r.id, r.item_id, r.field_id, r.value, r.is_published, r.created_at, r.updated_at, tenantId])
+      : chunk.flatMap((r) => [r.id, r.item_id, r.field_id, r.value, r.is_published, r.created_at, r.updated_at]);
+
+    await knex.raw(
+      `INSERT INTO collection_item_values (${cols})
+       VALUES ${chunk.map(() => placeholders).join(', ')}
+       ON CONFLICT (item_id, field_id, is_published) WHERE deleted_at IS NULL
+       DO UPDATE SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at`,
+      params
+    );
+  }
+}
+
+/** Soft-delete a batch of YCode items. */
+async function batchSoftDelete(itemIds: string[]): Promise<void> {
+  if (itemIds.length === 0) return;
+  const client = await getSupabaseAdmin();
+  if (!client) throw new Error('Supabase not configured');
+
+  const now = new Date().toISOString();
+  const { error } = await client
+    .from('collection_items')
+    .update({ deleted_at: now, updated_at: now })
+    .in('id', itemIds)
+    .eq('is_published', false);
+
+  if (error) throw new Error(`Batch delete failed: ${error.message}`);
+}

--- a/lib/apps/webflow/migration-service.ts
+++ b/lib/apps/webflow/migration-service.ts
@@ -35,7 +35,6 @@ import { getSupabaseAdmin } from '@/lib/supabase-server';
 
 import {
   listCollectionsWithFields,
-  getCollection,
   listItems,
   listLiveItemIds,
   getSite,
@@ -119,30 +118,6 @@ export async function removeImport(importId: string): Promise<boolean> {
 }
 
 // =============================================================================
-// Status Wrapper
-// =============================================================================
-
-async function withImportStatus(
-  importId: string,
-  syncFn: () => Promise<SyncResult>
-): Promise<SyncResult> {
-  await updateImport(importId, { syncStatus: 'syncing', syncError: null });
-  try {
-    const result = await syncFn();
-    await updateImport(importId, {
-      syncStatus: 'idle',
-      syncError: null,
-      lastSyncedAt: result.syncedAt,
-    });
-    return result;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown sync error';
-    await updateImport(importId, { syncStatus: 'error', syncError: message });
-    throw error;
-  }
-}
-
-// =============================================================================
 // Schema Creation
 // =============================================================================
 
@@ -156,42 +131,93 @@ interface CollectionScaffold {
 }
 
 /**
- * Create YCode collections + fields for every Webflow collection in the site.
- * Reference fields are wired to the freshly created YCode collection ids
- * (resolved in a second pass once all collections exist).
+ * Idempotently ensure a YCode collection + field exists for every Webflow
+ * collection / field in the site. Reuses existing mappings (from a prior
+ * migration of the same site) when available; only creates what's new.
+ *
+ * - New Webflow collection → create YCode collection + fields + tracking field.
+ * - Existing Webflow collection (mapping present) → reuse YCode collection,
+ *   add any new fields that appeared in Webflow since last migration.
+ * - Existing collection whose YCode counterpart was deleted → recorded as an
+ *   error and skipped.
  */
-async function createCollectionsFromSchema(
-  webflowCollections: WebflowCollection[]
+async function ensureScaffolds(
+  webflowCollections: WebflowCollection[],
+  existingMappings: WebflowCollectionMapping[],
+  errors: string[]
 ): Promise<CollectionScaffold[]> {
-  const scaffolds: CollectionScaffold[] = [];
+  const mappingByWebflowId = new Map<string, WebflowCollectionMapping>(
+    existingMappings.map((m) => [m.webflowCollectionId, m])
+  );
 
-  // Pass 1 — create the collections themselves so reference fields in pass 2
-  // can point at them via YCode collection ids.
+  const scaffolds: CollectionScaffold[] = [];
   const wfToYcodeCollectionId = new Map<string, string>();
+
+  // Pass 1 — ensure YCode collections exist, so pass 2 can wire reference
+  // fields to the right YCode collection id.
   for (let i = 0; i < webflowCollections.length; i++) {
     const wf = webflowCollections[i];
-    const collection = await createCollection({
-      name: wf.displayName,
-      order: i,
-      is_published: false,
-    });
-    wfToYcodeCollectionId.set(wf.id, collection.id);
-    scaffolds.push({
-      webflowCollection: wf,
-      ycodeCollectionId: collection.id,
-      ycodeCollectionName: collection.name,
-      fieldIdMap: {},
-      fieldSlugMap: {},
-      recordIdFieldId: '',
-    });
+    const existing = mappingByWebflowId.get(wf.id);
+
+    if (existing) {
+      const collection = await getCollectionById(existing.ycodeCollectionId);
+      if (!collection) {
+        errors.push(
+          `Skipped ${wf.displayName}: previously mapped YCode collection no longer exists.`
+        );
+        continue;
+      }
+      wfToYcodeCollectionId.set(wf.id, collection.id);
+      scaffolds.push({
+        webflowCollection: wf,
+        ycodeCollectionId: collection.id,
+        ycodeCollectionName: collection.name,
+        fieldIdMap: { ...existing.fieldIdMap },
+        fieldSlugMap: { ...existing.fieldSlugMap },
+        recordIdFieldId: existing.recordIdFieldId,
+      });
+    } else {
+      const collection = await createCollection({
+        name: wf.displayName,
+        order: i,
+        is_published: false,
+      });
+      wfToYcodeCollectionId.set(wf.id, collection.id);
+      scaffolds.push({
+        webflowCollection: wf,
+        ycodeCollectionId: collection.id,
+        ycodeCollectionName: collection.name,
+        fieldIdMap: {},
+        fieldSlugMap: {},
+        recordIdFieldId: '',
+      });
+    }
   }
 
-  // Pass 2 — create fields, including the hidden tracking field.
+  // Pass 2 — ensure each Webflow field has a matching YCode field, and that
+  // a hidden tracking field exists. Missing-by-slug matching lets us recover
+  // the mapping if a Webflow field was renamed or the mapping was lost.
   for (const scaffold of scaffolds) {
     const wf = scaffold.webflowCollection;
-    let order = 0;
+    const ycodeFields = await getFieldsByCollectionId(scaffold.ycodeCollectionId);
+    const ycodeFieldBySlug = new Map<string, CollectionField>();
+    for (const f of ycodeFields) {
+      if (f.key) ycodeFieldBySlug.set(f.key, f);
+    }
+    let order = ycodeFields.reduce((max, f) => Math.max(max, (f.order ?? 0) + 1), 0);
 
     for (const wfField of wf.fields ?? []) {
+      if (scaffold.fieldIdMap[wfField.id]) continue;
+
+      // Try to recover the mapping by slug before creating a duplicate field.
+      const slug = slugify(wfField.slug);
+      const matched = ycodeFieldBySlug.get(slug);
+      if (matched) {
+        scaffold.fieldIdMap[wfField.id] = matched.id;
+        scaffold.fieldSlugMap[wfField.slug] = matched.id;
+        continue;
+      }
+
       const cmsType = getCmsFieldType(wfField.type);
       const referenceCollectionId = (wfField.type === 'Reference' || wfField.type === 'MultiReference')
         ? wfToYcodeCollectionId.get(wfField.validations?.collectionId ?? '') ?? null
@@ -199,7 +225,7 @@ async function createCollectionsFromSchema(
 
       const field = await createField({
         name: wfField.displayName,
-        key: slugify(wfField.slug),
+        key: slug,
         type: cmsType,
         collection_id: scaffold.ycodeCollectionId,
         order: order++,
@@ -210,21 +236,30 @@ async function createCollectionsFromSchema(
 
       scaffold.fieldIdMap[wfField.id] = field.id;
       scaffold.fieldSlugMap[wfField.slug] = field.id;
+      ycodeFieldBySlug.set(slug, field);
     }
 
-    // Hidden tracking field — used for re-sync reconciliation and reference resolution.
-    const trackingField = await createField({
-      name: 'Webflow ID',
-      key: HIDDEN_FIELD_KEY,
-      type: 'text',
-      collection_id: scaffold.ycodeCollectionId,
-      order: order++,
-      hidden: true,
-      is_computed: true,
-      fillable: false,
-      is_published: false,
-    });
-    scaffold.recordIdFieldId = trackingField.id;
+    // Ensure the hidden tracking field exists. The mapping may have been
+    // dropped by a manual edit, so we re-resolve by key as a fallback.
+    if (!scaffold.recordIdFieldId) {
+      const existingTracking = ycodeFieldBySlug.get(HIDDEN_FIELD_KEY);
+      if (existingTracking) {
+        scaffold.recordIdFieldId = existingTracking.id;
+      } else {
+        const trackingField = await createField({
+          name: 'Webflow ID',
+          key: HIDDEN_FIELD_KEY,
+          type: 'text',
+          collection_id: scaffold.ycodeCollectionId,
+          order: order++,
+          hidden: true,
+          is_computed: true,
+          fillable: false,
+          is_published: false,
+        });
+        scaffold.recordIdFieldId = trackingField.id;
+      }
+    }
   }
 
   return scaffolds;
@@ -669,254 +704,218 @@ async function publishLiveItems(
 // =============================================================================
 
 /**
- * Run a full one-click migration of a Webflow site into YCode.
- * Creates a fresh `WebflowImport` row in `app_settings` regardless of
- * whether the site has been imported before — re-importing the same site
- * will produce a second set of YCode collections.
+ * Look up an import by Webflow site id.
  */
-export async function runMigration(siteId: string): Promise<{ import: WebflowImport; result: SyncResult }> {
+function findImportBySiteId(imports: WebflowImport[], siteId: string): WebflowImport | undefined {
+  return imports.find((i) => i.siteId === siteId);
+}
+
+/**
+ * Build the final `WebflowCollectionMapping[]` list from scaffolds.
+ * Preserves any prior mappings that were skipped this run (e.g. because the
+ * Webflow collection is gone) so we don't lose history.
+ */
+function buildCollectionMappings(
+  scaffolds: CollectionScaffold[],
+  prior: WebflowCollectionMapping[]
+): WebflowCollectionMapping[] {
+  const seen = new Set(scaffolds.map((s) => s.webflowCollection.id));
+  const fresh: WebflowCollectionMapping[] = scaffolds.map((scaffold) => ({
+    webflowCollectionId: scaffold.webflowCollection.id,
+    webflowCollectionName: scaffold.webflowCollection.displayName,
+    webflowSlug: scaffold.webflowCollection.slug,
+    ycodeCollectionId: scaffold.ycodeCollectionId,
+    ycodeCollectionName: scaffold.ycodeCollectionName,
+    recordIdFieldId: scaffold.recordIdFieldId,
+    fieldIdMap: scaffold.fieldIdMap,
+    fieldSlugMap: scaffold.fieldSlugMap,
+    referenceFieldIds: (scaffold.webflowCollection.fields ?? [])
+      .filter((f) => f.type === 'Reference' || f.type === 'MultiReference')
+      .map((f) => f.id),
+  }));
+  // Keep mappings for prior collections we didn't touch so re-running migration
+  // doesn't lose history (e.g. a temporarily-archived Webflow collection).
+  const carried = prior.filter((m) => !seen.has(m.webflowCollectionId));
+  return [...fresh, ...carried];
+}
+
+/**
+ * Core sync loop — runs items / references / publish passes against an
+ * already-built set of scaffolds. Shared between fresh migration and re-sync.
+ */
+async function runItemsSync(
+  token: string,
+  scaffolds: CollectionScaffold[],
+  prevFingerprints: Map<string, string>,
+  newFingerprints: Map<string, string>,
+  result: SyncResult
+): Promise<void> {
+  const itemMaps = new Map<string, Map<string, string>>();
+  const collectionResults = new Map<string, CollectionMigrationResult>();
+
+  // Pass 1 — import items as drafts.
+  for (const scaffold of scaffolds) {
+    const collectionResult: CollectionMigrationResult = {
+      webflowCollectionId: scaffold.webflowCollection.id,
+      webflowCollectionName: scaffold.webflowCollection.displayName,
+      ycodeCollectionId: scaffold.ycodeCollectionId,
+      created: 0,
+      updated: 0,
+      deleted: 0,
+      published: 0,
+      errors: [],
+    };
+    collectionResults.set(scaffold.webflowCollection.id, collectionResult);
+
+    try {
+      const webflowItems = await listItems(token, scaffold.webflowCollection.id);
+      const itemMap = await importItemsAsDrafts({
+        scaffold,
+        webflowItems,
+        prevFingerprints,
+        newFingerprints,
+        result: collectionResult,
+      });
+      itemMaps.set(scaffold.webflowCollection.id, itemMap);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      collectionResult.errors.push(`Item import failed: ${message}`);
+      result.errors.push(`[${scaffold.webflowCollection.displayName}] ${message}`);
+    }
+  }
+
+  // Pass 2 — resolve references now that all collections have their items.
+  try {
+    await resolveReferences({ scaffolds, itemMaps });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    result.errors.push(`Reference resolution failed: ${message}`);
+  }
+
+  // Pass 3 — publish items currently live in Webflow.
+  for (const scaffold of scaffolds) {
+    const collectionResult = collectionResults.get(scaffold.webflowCollection.id);
+    const itemMap = itemMaps.get(scaffold.webflowCollection.id);
+    if (!collectionResult || !itemMap) continue;
+    try {
+      await publishLiveItems(token, scaffold, itemMap, collectionResult);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      collectionResult.errors.push(`Publish pass failed: ${message}`);
+    }
+  }
+
+  result.collections = Array.from(collectionResults.values());
+}
+
+/**
+ * Idempotent migration / re-sync of a Webflow site into YCode.
+ *
+ * - First run: creates the YCode collections + fields and imports items.
+ * - Subsequent runs against the same site: reuse the existing YCode
+ *   collections, add any new collections / fields that appeared in Webflow,
+ *   and reconcile items.
+ *
+ * Always returns the (created or updated) `WebflowImport` and a `SyncResult`
+ * summarising the work done per collection.
+ */
+export async function runMigration(
+  siteId: string
+): Promise<{ import: WebflowImport; result: SyncResult }> {
   const token = await requireWebflowToken();
 
+  const allImports = await getImports();
+  const existing = findImportBySiteId(allImports, siteId);
+
+  // Fetch site + schema in parallel; we always need both whether this is a
+  // fresh import or a re-run.
   const [site, webflowCollections] = await Promise.all([
     getSite(token, siteId),
     listCollectionsWithFields(token, siteId),
   ]);
 
-  // Persist a placeholder import early so the UI can show progress and a
-  // crash mid-migration leaves a recoverable record.
-  const importId = randomUUID();
-  const placeholder: WebflowImport = {
-    id: importId,
-    siteId: site.id,
-    siteName: site.displayName,
-    collectionMappings: [],
-    lastSyncedAt: null,
-    syncStatus: 'syncing',
-    syncError: null,
-    assetFingerprints: {},
-  };
-  const allImports = await getImports();
-  allImports.push(placeholder);
-  await saveImports(allImports);
+  // Find or create the import record. Reusing the same id on re-run keeps the
+  // UI's import list stable.
+  let importRecord: WebflowImport;
+  if (existing) {
+    importRecord = {
+      ...existing,
+      siteName: site.displayName,
+      syncStatus: 'syncing',
+      syncError: null,
+    };
+    await saveImports(allImports.map((i) => (i.id === existing.id ? importRecord : i)));
+  } else {
+    importRecord = {
+      id: randomUUID(),
+      siteId: site.id,
+      siteName: site.displayName,
+      collectionMappings: [],
+      lastSyncedAt: null,
+      syncStatus: 'syncing',
+      syncError: null,
+      assetFingerprints: {},
+    };
+    await saveImports([...allImports, importRecord]);
+  }
 
   try {
-    const result: SyncResult = { collections: [], syncedAt: new Date().toISOString(), errors: [] };
+    const result: SyncResult = {
+      collections: [],
+      syncedAt: new Date().toISOString(),
+      errors: [],
+    };
 
-    // Build YCode collections + fields from the Webflow schema.
-    const scaffolds = await createCollectionsFromSchema(webflowCollections);
+    // Build / augment the scaffolds — creates new YCode collections + fields
+    // only for things that don't already exist in the import mapping.
+    const scaffolds = await ensureScaffolds(
+      webflowCollections,
+      importRecord.collectionMappings,
+      result.errors
+    );
 
+    const prevFingerprints = new Map(
+      Object.entries(importRecord.assetFingerprints ?? {})
+    );
     const newFingerprints = new Map<string, string>();
-    const prevFingerprints = new Map<string, string>();
 
-    // Pass 1 — import items as drafts.
-    const itemMaps = new Map<string, Map<string, string>>();
-    const collectionResults = new Map<string, CollectionMigrationResult>();
-
-    for (const scaffold of scaffolds) {
-      const collectionResult: CollectionMigrationResult = {
-        webflowCollectionId: scaffold.webflowCollection.id,
-        webflowCollectionName: scaffold.webflowCollection.displayName,
-        ycodeCollectionId: scaffold.ycodeCollectionId,
-        created: 0,
-        updated: 0,
-        deleted: 0,
-        published: 0,
-        errors: [],
-      };
-      collectionResults.set(scaffold.webflowCollection.id, collectionResult);
-
-      try {
-        const webflowItems = await listItems(token, scaffold.webflowCollection.id);
-        const itemMap = await importItemsAsDrafts({
-          scaffold,
-          webflowItems,
-          prevFingerprints,
-          newFingerprints,
-          result: collectionResult,
-        });
-        itemMaps.set(scaffold.webflowCollection.id, itemMap);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        collectionResult.errors.push(`Item import failed: ${message}`);
-        result.errors.push(`[${scaffold.webflowCollection.displayName}] ${message}`);
-      }
-    }
-
-    // Pass 2 — resolve references now that all collections have their items.
-    try {
-      await resolveReferences({ scaffolds, itemMaps });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      result.errors.push(`Reference resolution failed: ${message}`);
-    }
-
-    // Pass 3 — publish items currently live in Webflow.
-    for (const scaffold of scaffolds) {
-      const collectionResult = collectionResults.get(scaffold.webflowCollection.id);
-      const itemMap = itemMaps.get(scaffold.webflowCollection.id);
-      if (!collectionResult || !itemMap) continue;
-      try {
-        await publishLiveItems(token, scaffold, itemMap, collectionResult);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        collectionResult.errors.push(`Publish pass failed: ${message}`);
-      }
-    }
-
-    result.collections = Array.from(collectionResults.values());
-
-    // Persist final import state — collection mappings + asset fingerprints.
-    const collectionMappings: WebflowCollectionMapping[] = scaffolds.map((scaffold) => ({
-      webflowCollectionId: scaffold.webflowCollection.id,
-      webflowCollectionName: scaffold.webflowCollection.displayName,
-      webflowSlug: scaffold.webflowCollection.slug,
-      ycodeCollectionId: scaffold.ycodeCollectionId,
-      ycodeCollectionName: scaffold.ycodeCollectionName,
-      recordIdFieldId: scaffold.recordIdFieldId,
-      fieldIdMap: scaffold.fieldIdMap,
-      fieldSlugMap: scaffold.fieldSlugMap,
-      referenceFieldIds: (scaffold.webflowCollection.fields ?? [])
-        .filter((f) => f.type === 'Reference' || f.type === 'MultiReference')
-        .map((f) => f.id),
-    }));
+    await runItemsSync(token, scaffolds, prevFingerprints, newFingerprints, result);
 
     const finalImport: WebflowImport = {
-      ...placeholder,
-      collectionMappings,
+      ...importRecord,
+      collectionMappings: buildCollectionMappings(scaffolds, importRecord.collectionMappings),
       lastSyncedAt: result.syncedAt,
       syncStatus: 'idle',
       syncError: null,
-      assetFingerprints: Object.fromEntries(newFingerprints),
+      assetFingerprints: {
+        ...(importRecord.assetFingerprints ?? {}),
+        ...Object.fromEntries(newFingerprints),
+      },
     };
 
-    const updatedImports = (await getImports()).map((i) => (i.id === importId ? finalImport : i));
-    await saveImports(updatedImports);
+    const refreshed = await getImports();
+    await saveImports(
+      refreshed.map((i) => (i.id === finalImport.id ? finalImport : i))
+    );
 
     return { import: finalImport, result };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
-    await updateImport(importId, { syncStatus: 'error', syncError: message });
+    await updateImport(importRecord.id, { syncStatus: 'error', syncError: message });
     throw error;
   }
 }
 
 /**
- * Re-sync an existing import. Skips schema creation — only reconciles items
- * and republishes the live ones. Schema diffs in Webflow are NOT applied to
- * keep re-sync safe; the user can run a fresh migration to capture them.
+ * Re-sync an existing import by id. Delegates to `runMigration` (which is
+ * idempotent on `siteId`) so schema additions in Webflow are picked up too.
  */
 export async function runResync(importId: string): Promise<SyncResult> {
   const importRecord = await getImportById(importId);
   if (!importRecord) throw new Error('Webflow import not found');
 
-  return withImportStatus(importId, async () => {
-    const token = await requireWebflowToken();
-    const result: SyncResult = { collections: [], syncedAt: new Date().toISOString(), errors: [] };
-
-    // Rebuild scaffolds from the persisted mapping + freshly fetched Webflow schemas.
-    const scaffolds: CollectionScaffold[] = [];
-    for (const mapping of importRecord.collectionMappings) {
-      // Skip mappings whose YCode collection was deleted out from under us.
-      const collection = await getCollectionById(mapping.ycodeCollectionId);
-      if (!collection) {
-        result.errors.push(`Skipped ${mapping.webflowCollectionName}: YCode collection no longer exists.`);
-        continue;
-      }
-
-      const wfCollection = await getCollection(token, mapping.webflowCollectionId);
-
-      // Build fieldIdMap from persisted mapping plus any new fields not yet
-      // mapped — for new Webflow fields we look up the YCode field by slug.
-      const ycodeFields = await getFieldsByCollectionId(mapping.ycodeCollectionId);
-      const ycodeFieldBySlug = new Map<string, CollectionField>();
-      for (const f of ycodeFields) {
-        if (f.key) ycodeFieldBySlug.set(f.key, f);
-      }
-
-      const fieldIdMap: Record<string, string> = { ...mapping.fieldIdMap };
-      const fieldSlugMap: Record<string, string> = { ...mapping.fieldSlugMap };
-
-      for (const wfField of wfCollection.fields ?? []) {
-        if (fieldIdMap[wfField.id]) continue;
-        const ycodeField = ycodeFieldBySlug.get(slugify(wfField.slug));
-        if (ycodeField) {
-          fieldIdMap[wfField.id] = ycodeField.id;
-          fieldSlugMap[wfField.slug] = ycodeField.id;
-        }
-      }
-
-      scaffolds.push({
-        webflowCollection: wfCollection,
-        ycodeCollectionId: mapping.ycodeCollectionId,
-        ycodeCollectionName: mapping.ycodeCollectionName,
-        fieldIdMap,
-        fieldSlugMap,
-        recordIdFieldId: mapping.recordIdFieldId,
-      });
-    }
-
-    const prevFingerprints = new Map(Object.entries(importRecord.assetFingerprints ?? {}));
-    const newFingerprints = new Map<string, string>();
-    const itemMaps = new Map<string, Map<string, string>>();
-    const collectionResults = new Map<string, CollectionMigrationResult>();
-
-    for (const scaffold of scaffolds) {
-      const collectionResult: CollectionMigrationResult = {
-        webflowCollectionId: scaffold.webflowCollection.id,
-        webflowCollectionName: scaffold.webflowCollection.displayName,
-        ycodeCollectionId: scaffold.ycodeCollectionId,
-        created: 0,
-        updated: 0,
-        deleted: 0,
-        published: 0,
-        errors: [],
-      };
-      collectionResults.set(scaffold.webflowCollection.id, collectionResult);
-
-      try {
-        const webflowItems = await listItems(token, scaffold.webflowCollection.id);
-        const itemMap = await importItemsAsDrafts({
-          scaffold,
-          webflowItems,
-          prevFingerprints,
-          newFingerprints,
-          result: collectionResult,
-        });
-        itemMaps.set(scaffold.webflowCollection.id, itemMap);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        collectionResult.errors.push(`Item import failed: ${message}`);
-        result.errors.push(`[${scaffold.webflowCollection.displayName}] ${message}`);
-      }
-    }
-
-    try {
-      await resolveReferences({ scaffolds, itemMaps });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      result.errors.push(`Reference resolution failed: ${message}`);
-    }
-
-    for (const scaffold of scaffolds) {
-      const collectionResult = collectionResults.get(scaffold.webflowCollection.id);
-      const itemMap = itemMaps.get(scaffold.webflowCollection.id);
-      if (!collectionResult || !itemMap) continue;
-      try {
-        await publishLiveItems(token, scaffold, itemMap, collectionResult);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        collectionResult.errors.push(`Publish pass failed: ${message}`);
-      }
-    }
-
-    result.collections = Array.from(collectionResults.values());
-
-    await updateImport(importId, {
-      assetFingerprints: { ...importRecord.assetFingerprints, ...Object.fromEntries(newFingerprints) },
-    });
-
-    return result;
-  });
+  const { result } = await runMigration(importRecord.siteId);
+  return result;
 }
 
 // =============================================================================

--- a/lib/apps/webflow/migration-service.ts
+++ b/lib/apps/webflow/migration-service.ts
@@ -264,23 +264,42 @@ async function ensureScaffolds(
   // Pass 2 — ensure each Webflow field has a matching YCode field, and that
   // a hidden tracking field exists. Missing-by-slug matching lets us recover
   // the mapping if a Webflow field was renamed or the mapping was lost.
+  //
+  // Imported fields are created with `key: null` (just like user-created
+  // fields) so they remain editable / deletable in the CMS UI — the YCode
+  // builder gates field editing behind `field.key`, treating any keyed field
+  // as a built-in / system field.
   for (const scaffold of scaffolds) {
     const wf = scaffold.webflowCollection;
     const ycodeFields = await getFieldsByCollectionId(scaffold.ycodeCollectionId);
     const ycodeFieldBySlug = new Map<string, CollectionField>();
     for (const f of ycodeFields) {
+      // Index by both `key` (legacy imports + system fields) and slugified
+      // `name` so we can recover mappings for newly-imported user-style fields.
       if (f.key) ycodeFieldBySlug.set(f.key, f);
+      const nameSlug = slugify(f.name);
+      if (nameSlug && !ycodeFieldBySlug.has(nameSlug)) {
+        ycodeFieldBySlug.set(nameSlug, f);
+      }
     }
     let order = ycodeFields.reduce((max, f) => Math.max(max, (f.order ?? 0) + 1), 0);
 
     for (const wfField of wf.fields ?? []) {
       const existingFieldId = scaffold.fieldIdMap[wfField.id];
       if (existingFieldId) {
-        // Re-sync: keep YCode's option list in step with Webflow when Webflow
-        // adds new choices to an Option field after the initial migration.
-        if (wfField.type === 'Option') {
-          const existingField = ycodeFields.find((f) => f.id === existingFieldId);
-          if (existingField) {
+        const existingField = ycodeFields.find((f) => f.id === existingFieldId);
+        if (existingField) {
+          // Backfill: earlier versions of this migration set `key: slug` on
+          // every imported field, which made the YCode CMS treat them as
+          // built-in fields and block editing. Clear the key so users can
+          // edit / duplicate / delete them like any user-created field.
+          if (existingField.key && existingField.id !== scaffold.recordIdFieldId) {
+            await updateField(existingField.id, { key: null });
+            existingField.key = null;
+          }
+          // Re-sync: keep YCode's option list in step with Webflow when
+          // Webflow adds new choices to an Option field after migration.
+          if (wfField.type === 'Option') {
             await syncOptionFieldChoices(existingField, wfField);
           }
         }
@@ -293,6 +312,10 @@ async function ensureScaffolds(
       if (matched) {
         scaffold.fieldIdMap[wfField.id] = matched.id;
         scaffold.fieldSlugMap[wfField.slug] = matched.id;
+        if (matched.key && matched.id !== scaffold.recordIdFieldId) {
+          await updateField(matched.id, { key: null });
+          matched.key = null;
+        }
         if (wfField.type === 'Option') {
           await syncOptionFieldChoices(matched, wfField);
         }
@@ -306,7 +329,6 @@ async function ensureScaffolds(
 
       const field = await createField({
         name: wfField.displayName,
-        key: slug,
         type: cmsType,
         collection_id: scaffold.ycodeCollectionId,
         order: order++,

--- a/lib/apps/webflow/migration-service.ts
+++ b/lib/apps/webflow/migration-service.ts
@@ -21,6 +21,7 @@ import {
 import {
   createField,
   getFieldsByCollectionId,
+  updateField,
 } from '@/lib/repositories/collectionFieldRepository';
 import {
   createItemsBulk,
@@ -55,7 +56,7 @@ import type {
   WebflowImport,
   WebflowItem,
 } from './types';
-import type { CollectionField } from '@/types';
+import type { CollectionField, CollectionFieldData } from '@/types';
 
 // =============================================================================
 // Constants
@@ -120,6 +121,72 @@ export async function removeImport(importId: string): Promise<boolean> {
 // =============================================================================
 // Schema Creation
 // =============================================================================
+
+/**
+ * Build the `data` payload for a YCode field from a Webflow field. Carries
+ * over `validations.options` for Option fields and flags multi-asset fields.
+ */
+function buildFieldData(wfField: WebflowField): CollectionFieldData {
+  if (isMultiAssetType(wfField.type)) {
+    return { multiple: true };
+  }
+
+  if (wfField.type === 'Option') {
+    const wfOptions = wfField.validations?.options ?? [];
+    return {
+      options: wfOptions.map((o) => ({ id: o.id, name: o.name.trim() })),
+    };
+  }
+
+  return {};
+}
+
+/**
+ * Merge Webflow option choices into an existing YCode Option field. Adds new
+ * choices and refreshes renamed labels, keeping existing options to avoid
+ * orphaning item values that reference them.
+ */
+async function syncOptionFieldChoices(
+  ycodeField: CollectionField,
+  wfField: WebflowField
+): Promise<void> {
+  const wfOptions = wfField.validations?.options ?? [];
+  if (wfOptions.length === 0) return;
+
+  const existing = Array.isArray(ycodeField.data?.options)
+    ? ycodeField.data.options
+    : [];
+  const existingById = new Map(existing.map((o) => [o.id, o]));
+
+  const merged: { id: string; name: string }[] = [];
+  let changed = false;
+
+  for (const wfOption of wfOptions) {
+    const trimmed = wfOption.name.trim();
+    const prev = existingById.get(wfOption.id);
+    if (!prev) {
+      merged.push({ id: wfOption.id, name: trimmed });
+      changed = true;
+    } else {
+      if (prev.name !== trimmed) changed = true;
+      merged.push({ id: wfOption.id, name: trimmed });
+    }
+  }
+
+  // Carry over any YCode-only options (added manually in YCode) so we don't
+  // lose them on re-sync.
+  for (const opt of existing) {
+    if (!wfOptions.some((wf) => wf.id === opt.id)) {
+      merged.push(opt);
+    }
+  }
+
+  if (!changed) return;
+
+  await updateField(ycodeField.id, {
+    data: { ...(ycodeField.data ?? {}), options: merged },
+  });
+}
 
 interface CollectionScaffold {
   webflowCollection: WebflowCollection;
@@ -207,7 +274,18 @@ async function ensureScaffolds(
     let order = ycodeFields.reduce((max, f) => Math.max(max, (f.order ?? 0) + 1), 0);
 
     for (const wfField of wf.fields ?? []) {
-      if (scaffold.fieldIdMap[wfField.id]) continue;
+      const existingFieldId = scaffold.fieldIdMap[wfField.id];
+      if (existingFieldId) {
+        // Re-sync: keep YCode's option list in step with Webflow when Webflow
+        // adds new choices to an Option field after the initial migration.
+        if (wfField.type === 'Option') {
+          const existingField = ycodeFields.find((f) => f.id === existingFieldId);
+          if (existingField) {
+            await syncOptionFieldChoices(existingField, wfField);
+          }
+        }
+        continue;
+      }
 
       // Try to recover the mapping by slug before creating a duplicate field.
       const slug = slugify(wfField.slug);
@@ -215,6 +293,9 @@ async function ensureScaffolds(
       if (matched) {
         scaffold.fieldIdMap[wfField.id] = matched.id;
         scaffold.fieldSlugMap[wfField.slug] = matched.id;
+        if (wfField.type === 'Option') {
+          await syncOptionFieldChoices(matched, wfField);
+        }
         continue;
       }
 
@@ -230,7 +311,7 @@ async function ensureScaffolds(
         collection_id: scaffold.ycodeCollectionId,
         order: order++,
         reference_collection_id: referenceCollectionId,
-        data: isMultiAssetType(wfField.type) ? { multiple: true } : {},
+        data: buildFieldData(wfField),
         is_published: false,
       });
 

--- a/lib/apps/webflow/migration-service.ts
+++ b/lib/apps/webflow/migration-service.ts
@@ -211,7 +211,7 @@ interface CollectionScaffold {
 async function ensureScaffolds(
   webflowCollections: WebflowCollection[],
   existingMappings: WebflowCollectionMapping[],
-  errors: string[]
+  _errors: string[]
 ): Promise<CollectionScaffold[]> {
   const mappingByWebflowId = new Map<string, WebflowCollectionMapping>(
     existingMappings.map((m) => [m.webflowCollectionId, m])
@@ -226,19 +226,20 @@ async function ensureScaffolds(
     const wf = webflowCollections[i];
     const existing = mappingByWebflowId.get(wf.id);
 
-    if (existing) {
-      const collection = await getCollectionById(existing.ycodeCollectionId);
-      if (!collection) {
-        errors.push(
-          `Skipped ${wf.displayName}: previously mapped YCode collection no longer exists.`
-        );
-        continue;
-      }
-      wfToYcodeCollectionId.set(wf.id, collection.id);
+    // Reuse the existing YCode collection only if it's still present (and not
+    // soft-deleted). If the user deleted the YCode collection after a previous
+    // migration, drop the stale mapping and recreate the collection from
+    // scratch so re-importing actually brings the collection back.
+    const existingCollection = existing
+      ? await getCollectionById(existing.ycodeCollectionId)
+      : null;
+
+    if (existing && existingCollection) {
+      wfToYcodeCollectionId.set(wf.id, existingCollection.id);
       scaffolds.push({
         webflowCollection: wf,
-        ycodeCollectionId: collection.id,
-        ycodeCollectionName: collection.name,
+        ycodeCollectionId: existingCollection.id,
+        ycodeCollectionName: existingCollection.name,
         fieldIdMap: { ...existing.fieldIdMap },
         fieldSlugMap: { ...existing.fieldSlugMap },
         recordIdFieldId: existing.recordIdFieldId,

--- a/lib/apps/webflow/types.ts
+++ b/lib/apps/webflow/types.ts
@@ -1,0 +1,196 @@
+/**
+ * Webflow Integration Types
+ *
+ * Type definitions for the Webflow CMS migration integration.
+ * Covers Webflow REST v2 API responses, import/migration state,
+ * and per-collection mapping records persisted in app_settings.
+ */
+
+// =============================================================================
+// Webflow Field Types
+// =============================================================================
+
+/**
+ * Subset of Webflow CMS v2 field types we actively map. Unknown types fall
+ * back to plain text so a migration never aborts on a new field type.
+ */
+export type WebflowFieldType =
+  | 'PlainText'
+  | 'RichText'
+  | 'Image'
+  | 'MultiImage'
+  | 'Video'
+  | 'Link'
+  | 'Email'
+  | 'Phone'
+  | 'Number'
+  | 'DateTime'
+  | 'Date'
+  | 'Switch'
+  | 'Color'
+  | 'Option'
+  | 'Reference'
+  | 'MultiReference'
+  | 'File'
+  | 'Set'
+  | 'User';
+
+// =============================================================================
+// Webflow API Response Types
+// =============================================================================
+
+export interface WebflowSite {
+  id: string;
+  displayName: string;
+  shortName: string;
+  previewUrl?: string;
+  timeZone?: string;
+  createdOn?: string;
+  lastUpdated?: string;
+  lastPublished?: string | null;
+}
+
+export interface WebflowSitesResponse {
+  sites: WebflowSite[];
+}
+
+export interface WebflowFieldValidations {
+  /** For Option fields: list of `{ id, name }` choices. */
+  options?: Array<{ id: string; name: string }>;
+  /** For Reference / MultiReference fields. */
+  collectionId?: string;
+  /** Number / formatting metadata. */
+  format?: string;
+  precision?: number;
+}
+
+export interface WebflowField {
+  id: string;
+  isEditable: boolean;
+  isRequired: boolean;
+  type: WebflowFieldType;
+  slug: string;
+  displayName: string;
+  helpText?: string;
+  validations?: WebflowFieldValidations;
+}
+
+export interface WebflowCollection {
+  id: string;
+  displayName: string;
+  singularName: string;
+  slug: string;
+  createdOn?: string;
+  lastUpdated?: string;
+  /** Present on `getCollection`, absent on `listCollections` summaries. */
+  fields?: WebflowField[];
+}
+
+export interface WebflowCollectionsResponse {
+  collections: WebflowCollection[];
+}
+
+/**
+ * Item shape returned by both `/items` (staged) and `/items/live`.
+ * Webflow's static fields (`name`, `slug`) live alongside user-defined
+ * fields inside `fieldData`, keyed by each field's `slug`.
+ */
+export interface WebflowItem {
+  id: string;
+  cmsLocaleId?: string;
+  lastPublished?: string | null;
+  lastUpdated?: string;
+  createdOn?: string;
+  isArchived?: boolean;
+  isDraft?: boolean;
+  fieldData: Record<string, unknown>;
+}
+
+export interface WebflowItemsResponse {
+  items: WebflowItem[];
+  pagination?: {
+    limit: number;
+    offset: number;
+    total: number;
+  };
+}
+
+/** Asset reference returned for Image / File / MultiImage fields. */
+export interface WebflowAsset {
+  fileId?: string;
+  url: string;
+  alt?: string | null;
+  /** Webflow occasionally returns `name`/`fileName` instead of a direct file name in the URL. */
+  name?: string;
+  fileName?: string;
+}
+
+// =============================================================================
+// Migration / Import State (stored in app_settings)
+// =============================================================================
+
+export type WebflowSyncStatus = 'idle' | 'syncing' | 'error';
+
+/**
+ * One row inside a `WebflowImport.collectionMappings` array — links a single
+ * Webflow CMS collection to the YCode collection that was created for it.
+ */
+export interface WebflowCollectionMapping {
+  webflowCollectionId: string;
+  webflowCollectionName: string;
+  webflowSlug: string;
+  ycodeCollectionId: string;
+  ycodeCollectionName: string;
+  /** YCode field ID of the hidden `webflow_id` tracking field. */
+  recordIdFieldId: string;
+  /**
+   * Mapping of Webflow field id -> YCode field id, captured at migration time.
+   * Used by re-sync so it doesn't have to re-derive the mapping.
+   */
+  fieldIdMap: Record<string, string>;
+  /** Mapping of Webflow slug -> YCode field id (lookup by slug for `fieldData`). */
+  fieldSlugMap: Record<string, string>;
+  /** Webflow field ids whose YCode counterpart is a Reference / MultiReference. */
+  referenceFieldIds: string[];
+}
+
+/**
+ * Top-level import record — one per migrated Webflow site. Stored as a JSON
+ * array under `app_settings (app_id='webflow', key='imports')`.
+ */
+export interface WebflowImport {
+  id: string;
+  siteId: string;
+  siteName: string;
+  collectionMappings: WebflowCollectionMapping[];
+  lastSyncedAt: string | null;
+  syncStatus: WebflowSyncStatus;
+  syncError: string | null;
+  /**
+   * Cached asset fingerprints from the most recent sync, keyed by
+   * `<webflowItemId>:<webflowFieldId>`. Avoids re-downloading assets that
+   * haven't changed on the Webflow side.
+   */
+  assetFingerprints?: Record<string, string>;
+}
+
+// =============================================================================
+// Sync / Migration Result
+// =============================================================================
+
+export interface CollectionMigrationResult {
+  webflowCollectionId: string;
+  webflowCollectionName: string;
+  ycodeCollectionId: string;
+  created: number;
+  updated: number;
+  deleted: number;
+  published: number;
+  errors: string[];
+}
+
+export interface SyncResult {
+  collections: CollectionMigrationResult[];
+  syncedAt: string;
+  errors: string[];
+}


### PR DESCRIPTION
## Summary

Add a one-click Webflow CMS migration integration that imports an entire Webflow site's CMS schema and content into Ycode collections — fields, items, assets, references, options, and publish state — using a Site-level Webflow API token.

## Changes

### New integration

- **App registry entry** for `webflow` (categories: `popular`, `cms-data`) with logo and settings panel
- **Webflow API v2 client** (`lib/apps/webflow/index.ts`) with token-bucket rate limiting and 429/503 retry — covers `GET /sites`, `GET /sites/{id}/collections`, `GET /collections/{id}`, `GET /collections/{id}/items` (staged) and `/items/live`
- **Migration service** (`lib/apps/webflow/migration-service.ts`) orchestrating the full flow: schema → draft items → reference resolution → publish-live
- **Field mapping** Webflow → Ycode types; `Option` maps to native Ycode `option` fields with the choice list carried over into `data.options`; `Link` and `Video` are mapped to `text` so their URLs survive migration cleanly (manual rebind afterwards)
- **HTML → TipTap converter** for Webflow rich-text fields
- **Settings UI** (`webflow-settings.tsx`) with token input, site picker, schema preview, migration trigger, imports list, re-sync and remove
- **API routes** under `app/(builder)/ycode/api/apps/webflow/*` for token test, sites, collections preview, migrate, sync, and imports CRUD

### Sync semantics

- Both **staged (drafts)** and **live (published)** items are imported — staged go into Ycode drafts, live items are auto-published in Ycode
- Each Ycode collection gets a hidden, computed `webflow_id` field for re-sync reconciliation and reference resolution
- Assets are downloaded once, fingerprinted, and re-used across re-syncs to avoid redundant uploads
- Option field choices are reconciled on re-sync — new Webflow choices are added, renamed labels are refreshed, and Ycode-only options added manually are preserved

### Idempotent re-runs

- Migration is **idempotent per Webflow site**: re-running it on an already-imported site reuses the existing Ycode collections and only adds new collections / fields that appeared in Webflow since the last run
- Fields are recovered first by stored Webflow field id, then by slug as a fallback (handles dropped mappings or manual edits)
- Re-sync delegates to the same code path so it also picks up Webflow schema additions
- The hidden `webflow_id` tracking field is recovered by key if its mapping was lost
- If the user deletes a previously-migrated Ycode collection, re-running migration recreates it from scratch instead of silently skipping

### UX

- After a migration or re-sync, the CMS sidebar and the currently-open collection's items refresh automatically — no hard reload required
- Settings panel labelled **"Webflow CMS"** to make clear this is CMS data only, not full site/page migration
- Token input documents the required scopes (`sites:read`, `cms:read`) and points users at the Site-level token page (Workspace tokens don't carry these scopes)
- Imports list filters out collection mappings whose Ycode collection has been deleted, so the card only ever shows collections the user can actually open

## Out of scope

- No webhooks — sync is manual via the re-sync button
- No reverse sync (Ycode → Webflow)
- Pages, styles and other non-CMS Webflow data

## Test plan

- [ ] Connect a Site-level Webflow API token with `sites:read` and `cms:read` scopes — token validation should succeed
- [ ] Pick a site, preview its collections, and run migration — Ycode collections appear with matching fields and the sidebar refreshes
- [ ] Verify items import as drafts and items live in Webflow are auto-published in Ycode
- [ ] Verify rich-text fields render correctly (paragraphs, headings, links, formatting)
- [ ] Verify single + multi-image fields download and render via Ycode storage
- [ ] Verify reference and multi-reference fields resolve to the right Ycode items
- [ ] Verify Option fields import as native Ycode option fields with the full choice list, and item values render the correct selection in the item editor
- [ ] Add a new option to a Webflow Option field, re-sync, and confirm the new choice appears in Ycode without losing existing values
- [ ] Add a new collection and a new field in Webflow, then run migration on the same site again — the original Ycode collection is reused (not duplicated), and the new collection / field appear
- [ ] Hit the **Re-sync** button on an existing import — items reconcile, deleted Webflow items are soft-deleted in Ycode, and any new Webflow schema is picked up
- [ ] Delete a Ycode collection that came from a Webflow migration, then re-run migration on the same site — the collection is recreated with its fields and items, and the imports card stops listing the deleted entry
- [ ] Remove an import and confirm the Ycode collections are left intact (only the mapping is dropped)
- [ ] Disconnect the integration and confirm the token is cleared