### PR TITLE
feat: add multi-unit support to animation properties

### DIFF
--- a/app/(builder)/ycode/components/InteractionsPanel.tsx
+++ b/app/(builder)/ycode/components/InteractionsPanel.tsx
@@ -66,8 +66,10 @@ import {
   updateInteractionById,
   updateInteractionTweens,
   updateTweenById,
+  parseAnimationValue,
+  formatAnimationValue,
 } from '@/lib/animation-utils';
-import type { TriggerType, PropertyType } from '@/lib/animation-utils';
+import type { TriggerType, PropertyType, ParsedAnimationValue } from '@/lib/animation-utils';
 
 // 4. Types
 import type { Layer, LayerInteraction, InteractionTimeline, InteractionTween, TweenProperties, Breakpoint } from '@/types';
@@ -2078,25 +2080,8 @@ export default function InteractionsPanel({
                         });
                       };
 
-                      const applyFromPreview = (value: string | null) => {
-                        // Skip display
+                      const applyPreview = (value: string | null) => {
                         if (prop.key === 'display') return;
-
-                        if (value === null || value === undefined) return;
-                        const gsapValue = toGsapValue(value, prop);
-                        if (gsapValue !== undefined) {
-                          applyPreviewStyles(
-                            selectedTween.layer_id,
-                            { [prop.key]: gsapValue },
-                            { splitText: selectedTween.splitText, duration: selectedTween.duration }
-                          );
-                        }
-                      };
-
-                      const applyToPreview = (value: string | null) => {
-                        // Skip display
-                        if (prop.key === 'display') return;
-
                         if (value === null || value === undefined) return;
                         const gsapValue = toGsapValue(value, prop);
                         if (gsapValue !== undefined) {
@@ -2110,29 +2095,23 @@ export default function InteractionsPanel({
 
                       const handlePreviewFrom = () => {
                         if (isFromCurrent) return;
-                        // Clear any existing preview (e.g., from played animation) before applying
                         clearAllPreviewStyles();
-                        applyFromPreview(fromValue as string);
+                        applyPreview(fromValue as string);
                       };
 
                       const handlePreviewTo = () => {
-                        // Clear any existing preview (e.g., from played animation) before applying
                         clearAllPreviewStyles();
-                        const toValue = selectedTween.to[prop.key];
-                        applyToPreview(toValue as string);
+                        applyPreview(selectedTween.to[prop.key] as string);
                       };
 
                       /** Helper to update property and apply preview after iframe re-renders */
                       const handlePropertyChange = (updateFn: () => void, applyPreviewFn: () => void) => {
                         isChangingPropertyRef.current = true;
                         updateFn();
-                        // Apply preview after iframe re-renders (double RAF to ensure DOM is updated)
                         requestAnimationFrame(() => {
                           requestAnimationFrame(() => {
-                            // Update originalStyle after iframe re-renders (element may have been recreated)
                             const element = getIframeElement(selectedTween.layer_id);
                             if (element && previewedElementRef.current?.layerId === selectedTween.layer_id) {
-                              // If element was recreated, clear any cached SplitText instance
                               if (element !== previewedElementRef.current.element) {
                                 const oldSplitInstance = splitTextInstancesRef.current.get(selectedTween.layer_id);
                                 if (oldSplitInstance) {
@@ -2156,20 +2135,54 @@ export default function InteractionsPanel({
                         });
                       };
 
+                      // Parse stored values into number + unit for multi-unit properties
+                      const parsedFrom = prop.units ? parseAnimationValue(fromValue, prop.unit) : null;
+                      const parsedTo = prop.units ? parseAnimationValue(toValue, prop.unit) : null;
+
+                      /** Resolve the stored value: combine number+unit for multi-unit props, pass through otherwise */
+                      const resolveValue = (inputValue: string, parsed: ParsedAnimationValue | null): string => {
+                        if (prop.units && parsed) return formatAnimationValue(inputValue, parsed.unit);
+                        return inputValue;
+                      };
+
+                      const setToValue = (value: string | null) => {
+                        handleUpdateTween(selectedTween.id, {
+                          to: { ...selectedTween.to, [prop.key]: value },
+                        });
+                      };
+
                       const handleFromChange = (value: string) => {
-                        handlePropertyChange(
-                          () => setFromValue(value),
-                          () => applyFromPreview(value)
-                        );
+                        const resolved = resolveValue(value, parsedFrom);
+                        handlePropertyChange(() => setFromValue(resolved), () => applyPreview(resolved));
+                      };
+
+                      const handleFromUnitChange = (newUnit: string) => {
+                        if (!parsedFrom) return;
+                        const resolved = formatAnimationValue(parsedFrom.number, newUnit);
+                        handlePropertyChange(() => setFromValue(resolved), () => applyPreview(resolved));
                       };
 
                       const handleToChange = (value: string) => {
-                        handlePropertyChange(
-                          () => handleUpdateTween(selectedTween.id, {
-                            to: { ...selectedTween.to, [prop.key]: value },
-                          }),
-                          () => applyToPreview(value)
-                        );
+                        const resolved = resolveValue(value, parsedTo);
+                        handlePropertyChange(() => setToValue(resolved), () => applyPreview(resolved));
+                      };
+
+                      const handleToUnitChange = (newUnit: string) => {
+                        if (!parsedTo) return;
+                        const resolved = formatAnimationValue(parsedTo.number, newUnit);
+                        handlePropertyChange(() => setToValue(resolved), () => applyPreview(resolved));
+                      };
+
+                      /** Deferred blur: clears preview after pending RAF callbacks complete */
+                      const handleBlur = () => {
+                        const rafId1 = requestAnimationFrame(() => {
+                          const rafId2 = requestAnimationFrame(() => {
+                            clearPreviewStyles();
+                            pendingClearRAFsRef.current = pendingClearRAFsRef.current.filter(id => id !== rafId1 && id !== rafId2);
+                          });
+                          pendingClearRAFsRef.current.push(rafId2);
+                        });
+                        pendingClearRAFsRef.current.push(rafId1);
                       };
 
                       return (
@@ -2230,25 +2243,46 @@ export default function InteractionsPanel({
                                       ))}
                                     </SelectContent>
                                   </Select>
+                                ) : prop.units ? (
+                                  <Select
+                                    value={parsedFrom?.unit || prop.unit}
+                                    onValueChange={handleFromUnitChange}
+                                  >
+                                    <InputGroup className="flex-1 h-7">
+                                      <InputGroupInput
+                                        value={parsedFrom?.number ?? ''}
+                                        onChange={(e) => handleFromChange(e.target.value)}
+                                        onFocus={handlePreviewFrom}
+                                        onBlur={handleBlur}
+                                        placeholder="0"
+                                        className="text-xs pr-0.5"
+                                      />
+                                      <SelectTrigger className="h-full w-auto min-w-0 gap-0 border-0 border-l rounded-none bg-transparent pl-0.5 pr-1.5 text-xs text-muted-foreground shadow-none focus:ring-0 [&>svg]:hidden">
+                                        <SelectValue />
+                                      </SelectTrigger>
+                                    </InputGroup>
+                                    <SelectContent
+                                      align="end"
+                                      className="min-w-[--radix-select-trigger-width]"
+                                    >
+                                      {prop.units.map((u) => (
+                                        <SelectItem
+                                          key={u}
+                                          value={u}
+                                          className="text-xs"
+                                        >
+                                          {u}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectContent>
+                                  </Select>
                                 ) : prop.unit ? (
                                   <InputGroup className="flex-1 h-7">
                                     <InputGroupInput
                                       value={fromValue ?? ''}
                                       onChange={(e) => handleFromChange(e.target.value)}
                                       onFocus={handlePreviewFrom}
-                                      onBlur={() => {
-                                        // Defer clearing to ensure any pending RAF callbacks complete first
-                                        // Store RAF IDs so they can be canceled if a new preview is applied
-                                        const rafId1 = requestAnimationFrame(() => {
-                                          const rafId2 = requestAnimationFrame(() => {
-                                            clearPreviewStyles();
-                                            // Remove this RAF ID from the pending list
-                                            pendingClearRAFsRef.current = pendingClearRAFsRef.current.filter(id => id !== rafId1 && id !== rafId2);
-                                          });
-                                          pendingClearRAFsRef.current.push(rafId2);
-                                        });
-                                        pendingClearRAFsRef.current.push(rafId1);
-                                      }}
+                                      onBlur={handleBlur}
                                       placeholder="0"
                                       className="text-xs"
                                     />
@@ -2261,19 +2295,7 @@ export default function InteractionsPanel({
                                     value={fromValue ?? ''}
                                     onChange={(e) => handleFromChange(e.target.value)}
                                     onFocus={handlePreviewFrom}
-                                    onBlur={() => {
-                                      // Defer clearing to ensure any pending RAF callbacks complete first
-                                      // Store RAF IDs so they can be canceled if a new preview is applied
-                                      const rafId1 = requestAnimationFrame(() => {
-                                        const rafId2 = requestAnimationFrame(() => {
-                                          clearPreviewStyles();
-                                          // Remove this RAF ID from the pending list
-                                          pendingClearRAFsRef.current = pendingClearRAFsRef.current.filter(id => id !== rafId1 && id !== rafId2);
-                                        });
-                                        pendingClearRAFsRef.current.push(rafId2);
-                                      });
-                                      pendingClearRAFsRef.current.push(rafId1);
-                                    }}
+                                    onBlur={handleBlur}
                                     placeholder="0"
                                     className="flex-1 h-7 text-xs"
                                   />
@@ -2341,25 +2363,46 @@ export default function InteractionsPanel({
                                   ))}
                                 </SelectContent>
                               </Select>
+                            ) : prop.units ? (
+                              <Select
+                                value={parsedTo?.unit || prop.unit}
+                                onValueChange={handleToUnitChange}
+                              >
+                                <InputGroup className="flex-1 h-7">
+                                  <InputGroupInput
+                                    value={parsedTo?.number ?? ''}
+                                    onChange={(e) => handleToChange(e.target.value)}
+                                    onFocus={handlePreviewTo}
+                                    onBlur={handleBlur}
+                                    placeholder="0"
+                                    className="text-xs pr-0.5"
+                                  />
+                                  <SelectTrigger className="h-full w-auto min-w-0 gap-0 border-0 border-l rounded-none bg-transparent pl-0.5 pr-1.5 text-xs text-muted-foreground shadow-none focus:ring-0 [&>svg]:hidden">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                </InputGroup>
+                                <SelectContent
+                                  align="end"
+                                  className="min-w-[--radix-select-trigger-width]"
+                                >
+                                  {prop.units.map((u) => (
+                                    <SelectItem
+                                      key={u}
+                                      value={u}
+                                      className="text-xs"
+                                    >
+                                      {u}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
                             ) : prop.unit ? (
                               <InputGroup className="flex-1 h-7">
                                 <InputGroupInput
                                   value={toValue ?? ''}
                                   onChange={(e) => handleToChange(e.target.value)}
                                   onFocus={handlePreviewTo}
-                                  onBlur={() => {
-                                    // Defer clearing to ensure any pending RAF callbacks complete first
-                                    // Store RAF IDs so they can be canceled if a new preview is applied
-                                    const rafId1 = requestAnimationFrame(() => {
-                                      const rafId2 = requestAnimationFrame(() => {
-                                        clearPreviewStyles();
-                                        // Remove this RAF ID from the pending list
-                                        pendingClearRAFsRef.current = pendingClearRAFsRef.current.filter(id => id !== rafId1 && id !== rafId2);
-                                      });
-                                      pendingClearRAFsRef.current.push(rafId2);
-                                    });
-                                    pendingClearRAFsRef.current.push(rafId1);
-                                  }}
+                                  onBlur={handleBlur}
                                   placeholder="0"
                                   className="text-xs"
                                 />
@@ -2372,19 +2415,7 @@ export default function InteractionsPanel({
                                 value={toValue ?? ''}
                                 onChange={(e) => handleToChange(e.target.value)}
                                 onFocus={handlePreviewTo}
-                                onBlur={() => {
-                                  // Defer clearing to ensure any pending RAF callbacks complete first
-                                  // Store RAF IDs so they can be canceled if a new preview is applied
-                                  const rafId1 = requestAnimationFrame(() => {
-                                    const rafId2 = requestAnimationFrame(() => {
-                                      clearPreviewStyles();
-                                      // Remove this RAF ID from the pending list
-                                      pendingClearRAFsRef.current = pendingClearRAFsRef.current.filter(id => id !== rafId1 && id !== rafId2);
-                                    });
-                                    pendingClearRAFsRef.current.push(rafId2);
-                                  });
-                                  pendingClearRAFsRef.current.push(rafId1);
-                                }}
+                                onBlur={handleBlur}
                                 placeholder="0"
                                 className="flex-1 h-7 text-xs"
                               />

--- a/lib/animation-utils.ts
+++ b/lib/animation-utils.ts
@@ -49,7 +49,7 @@ export function createSplitTextAnimation(
 
 // Types
 export type TriggerType = 'click' | 'hover' | 'scroll-into-view' | 'while-scrolling' | 'load';
-export type PropertyType = 'position-x' | 'position-y' | 'scale' | 'rotation' | 'skew-x' | 'skew-y' | 'opacity' | 'height' | 'display' | 'split-text';
+export type PropertyType = 'position-x' | 'position-y' | 'scale' | 'rotation' | 'skew-x' | 'skew-y' | 'opacity' | 'width' | 'height' | 'display' | 'split-text';
 
 export interface PropertyConfig {
   key: keyof TweenProperties;
@@ -60,12 +60,51 @@ export interface PropertyConfig {
   options?: Array<{ value: string; label: string }>;
   /** If true, only show the "to" value in UI (no "from" input) */
   toOnly?: boolean;
+  /** Available units for this property — enables unit selector in UI */
+  units?: string[];
 }
 
 export interface PropertyOption {
   type: PropertyType;
   label: string;
   properties: PropertyConfig[];
+}
+
+// Unit constants
+const POSITION_UNITS = ['px', '%', 'rem', 'em', 'vw', 'vh', 'svh', 'dvh'];
+const ANGLE_UNITS = ['deg', 'rad', 'turn'];
+const SIZE_UNITS = ['px', '%', 'rem', 'em', 'vh', 'svh', 'dvh'];
+
+export interface ParsedAnimationValue {
+  number: string;
+  unit: string;
+}
+
+/** Splits a CSS value into number and unit parts. Falls back to defaultUnit for bare numbers. */
+export function parseAnimationValue(value: string | null | undefined, defaultUnit: string): ParsedAnimationValue {
+  if (!value) return { number: '', unit: defaultUnit };
+
+  const trimmed = value.trim();
+  if (!trimmed) return { number: '', unit: defaultUnit };
+
+  // Special non-numeric values (auto, etc.) — return as-is with empty unit
+  if (!/^-?[\d.]/.test(trimmed)) return { number: trimmed, unit: '' };
+
+  // Match number followed by optional unit
+  const match = trimmed.match(/^(-?[\d.]+)\s*(.*)$/);
+  if (!match) return { number: trimmed, unit: defaultUnit };
+
+  const num = match[1];
+  const unitPart = match[2] || defaultUnit;
+
+  return { number: num, unit: unitPart };
+}
+
+/** Combines a number and unit into a single CSS value string */
+export function formatAnimationValue(number: string, unit: string): string {
+  if (!number) return '';
+  if (!unit) return number;
+  return `${number}${unit}`;
 }
 
 // Constants
@@ -76,9 +115,10 @@ export const PROPERTY_OPTIONS: PropertyOption[] = [
     properties: [{
       key: 'x',
       unit: 'px',
-      defaultFrom: '0',
-      defaultFromAfterCurrent: '0',
-      defaultTo: '100',
+      units: POSITION_UNITS,
+      defaultFrom: '0px',
+      defaultFromAfterCurrent: '0px',
+      defaultTo: '100px',
     }],
   },
   {
@@ -87,9 +127,10 @@ export const PROPERTY_OPTIONS: PropertyOption[] = [
     properties: [{
       key: 'y',
       unit: 'px',
-      defaultFrom: '0',
-      defaultFromAfterCurrent: '0',
-      defaultTo: '100',
+      units: POSITION_UNITS,
+      defaultFrom: '0px',
+      defaultFromAfterCurrent: '0px',
+      defaultTo: '100px',
     }],
   },
   {
@@ -109,9 +150,10 @@ export const PROPERTY_OPTIONS: PropertyOption[] = [
     properties: [{
       key: 'rotation',
       unit: 'deg',
-      defaultFrom: '0',
-      defaultFromAfterCurrent: '0',
-      defaultTo: '45',
+      units: ANGLE_UNITS,
+      defaultFrom: '0deg',
+      defaultFromAfterCurrent: '0deg',
+      defaultTo: '45deg',
     }],
   },
   {
@@ -120,9 +162,10 @@ export const PROPERTY_OPTIONS: PropertyOption[] = [
     properties: [{
       key: 'skewX',
       unit: 'deg',
-      defaultFrom: '0',
-      defaultFromAfterCurrent: '0',
-      defaultTo: '30',
+      units: ANGLE_UNITS,
+      defaultFrom: '0deg',
+      defaultFromAfterCurrent: '0deg',
+      defaultTo: '30deg',
     }],
   },
   {
@@ -131,9 +174,10 @@ export const PROPERTY_OPTIONS: PropertyOption[] = [
     properties: [{
       key: 'skewY',
       unit: 'deg',
-      defaultFrom: '0',
-      defaultFromAfterCurrent: '0',
-      defaultTo: '30',
+      units: ANGLE_UNITS,
+      defaultFrom: '0deg',
+      defaultFromAfterCurrent: '0deg',
+      defaultTo: '30deg',
     }],
   },
   {
@@ -152,7 +196,20 @@ export const PROPERTY_OPTIONS: PropertyOption[] = [
     label: 'Height',
     properties: [{
       key: 'height',
-      unit: '',
+      unit: 'px',
+      units: SIZE_UNITS,
+      defaultFrom: '0px',
+      defaultFromAfterCurrent: '0px',
+      defaultTo: '100px',
+    }],
+  },
+  {
+    type: 'width',
+    label: 'Width',
+    properties: [{
+      key: 'width',
+      unit: 'px',
+      units: SIZE_UNITS,
       defaultFrom: '0px',
       defaultFromAfterCurrent: '0px',
       defaultTo: '100px',
@@ -235,15 +292,25 @@ export function calculateTweenStartTime(tweens: InteractionTween[], index: numbe
   return 0;
 }
 
+/**
+ * Resolve a stored value into a CSS-compatible string.
+ * Multi-unit properties store value with unit (e.g. "100px"); bare numbers get the default unit.
+ */
+export function resolveCssValue(value: string, prop: PropertyConfig): string {
+  if (prop.units) {
+    if (/^-?[\d.]+$/.test(value)) return `${value}${prop.unit}`;
+    return value;
+  }
+  return prop.unit ? `${value}${prop.unit}` : value;
+}
+
 /** Convert a property value to GSAP-compatible format */
 export function toGsapValue(value: string | null | undefined, prop: PropertyConfig): string | number | undefined {
   if (value === null || value === undefined) return undefined;
-  // autoAlpha is stored as percentage (0-100), convert to decimal (0-1) for GSAP
   if (prop.key === 'autoAlpha') {
     return Number(value) / 100;
   }
-  // For other properties with units, append the unit
-  return prop.unit ? `${value}${prop.unit}` : value;
+  return resolveCssValue(value, prop);
 }
 
 /** Get all property options that are set in a tween (check both from and to) */
@@ -474,27 +541,31 @@ export function generateInitialAnimationCSS(layers: Layer[]): InitialAnimationRe
                 const value = tween.from[prop.key];
                 if (value === null || value === undefined) return;
 
+                const cssVal = resolveCssValue(value, prop);
+
                 // Convert to CSS property - collect transforms separately to combine them
                 if (prop.key === 'x') {
-                  transforms.push(`translateX(${value}${prop.unit})`);
+                  transforms.push(`translateX(${cssVal})`);
                 } else if (prop.key === 'y') {
-                  transforms.push(`translateY(${value}${prop.unit})`);
+                  transforms.push(`translateY(${cssVal})`);
                 } else if (prop.key === 'rotation') {
-                  transforms.push(`rotate(${value}${prop.unit})`);
+                  transforms.push(`rotate(${cssVal})`);
                 } else if (prop.key === 'scale') {
                   transforms.push(`scale(${value})`);
                 } else if (prop.key === 'skewX') {
-                  transforms.push(`skewX(${value}${prop.unit})`);
+                  transforms.push(`skewX(${cssVal})`);
                 } else if (prop.key === 'skewY') {
-                  transforms.push(`skewY(${value}${prop.unit})`);
+                  transforms.push(`skewY(${cssVal})`);
                 } else if (prop.key === 'autoAlpha') {
                   const opacity = Number(value) / 100;
                   styles.push(`opacity: ${opacity}`);
                   if (opacity === 0) {
                     styles.push(`visibility: hidden`);
                   }
+                } else if (prop.key === 'width') {
+                  styles.push(`width: ${cssVal}`);
                 } else if (prop.key === 'height') {
-                  styles.push(`height: ${value}${prop.unit}`);
+                  styles.push(`height: ${cssVal}`);
                 } else if (prop.key === 'display') {
                   // Track elements that should start hidden using data attribute
                   if (value === 'hidden') {

--- a/types/index.ts
+++ b/types/index.ts
@@ -307,7 +307,7 @@ export interface InteractionTween {
 
 export type ApplyStyles = 'on-load' | 'on-trigger';
 
-export type TweenPropertyKey = 'x' | 'y' | 'rotation' | 'scale' | 'skewX' | 'skewY' | 'autoAlpha' | 'display' | 'height';
+export type TweenPropertyKey = 'x' | 'y' | 'rotation' | 'scale' | 'skewX' | 'skewY' | 'autoAlpha' | 'display' | 'width' | 'height';
 
 export type InteractionApplyStyles = Partial<Record<TweenPropertyKey, ApplyStyles>>;
 


### PR DESCRIPTION
## Summary

Add per-property unit selection to animation interactions, allowing users to pick from available CSS units (px, rem, %, vw, vh, svh, dvh, deg, rad, turn) instead of being locked to a single hardcoded unit. Also add width as a new animatable property.

## Changes

- Add `units` array to `PropertyConfig` and unit selector dropdown for position, rotation, skew, width, and height properties
- Store animation values with unit included (e.g. `100px`, `10rem`) — GSAP handles CSS units natively
- Extract `resolveCssValue()` to share value resolution logic between GSAP runtime and SSR CSS generation
- Add `parseAnimationValue()` / `formatAnimationValue()` utilities for splitting and combining number+unit
- Add width as a new animatable property (same unit options as height)
- Add `width` to `TweenPropertyKey` type union
- DRY up InteractionsPanel: deduplicate preview, blur handler, and value change logic
- Backward compatible: bare numbers from existing animation data get default unit appended

## Test plan

- [ ] Add a Position X property and verify the unit dropdown shows px, %, rem, em, vw, vh, svh, dvh
- [ ] Change the unit to `rem` and verify the value stores correctly (e.g. `10rem`)
- [ ] Add a Rotation property and verify deg, rad, turn are available
- [ ] Add width and height properties and verify they animate correctly
- [ ] Preview an animation in the editor — verify the preview applies correctly
- [ ] Publish a page with animations and verify they work on the published page
- [ ] Test with existing animations (bare number values) — verify backward compatibility
- [ ] Verify SSR initial animation CSS renders correctly (no flicker on load)

Made with [Cursor](https://cursor.com)