### PR TITLE
fix: show correct sublayers for rich-text layers

### DIFF
--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -59,7 +59,7 @@ import RichTextEditorSheet from './RichTextEditorSheet';
 import { buildLocalizedSlugPath, buildLocalizedDynamicPageUrl } from '@/lib/page-utils';
 import { getTranslationValue } from '@/lib/localisation-utils';
 import { cn } from '@/lib/utils';
-import { getCollectionVariable, canDeleteLayer, findLayerById, findParentCollectionLayer, canLayerHaveLink, updateLayerProps, removeRichTextSublayer } from '@/lib/layer-utils';
+import { getCollectionVariable, canDeleteLayer, findLayerById, findParentCollectionLayer, canLayerHaveLink, updateLayerProps, removeRichTextSublayer, isRichTextLayer, getLayerCmsFieldBinding } from '@/lib/layer-utils';
 import { CANVAS_BORDER, CANVAS_PADDING, updateViewportOverrides } from '@/lib/canvas-utils';
 import { BREAKPOINTS } from '@/lib/breakpoint-utils';
 import { buildFieldGroupsForLayer, flattenFieldGroups, filterFieldGroupsByType, SIMPLE_TEXT_FIELD_TYPES } from '@/lib/collection-field-utils';
@@ -1321,12 +1321,15 @@ const CenterCanvas = React.memo(function CenterCanvas({
 
       if (event) {
         let target = event.target as HTMLElement;
+        let blockLevelStyleKey: string | null = null;
 
-        // Walk up the DOM tree to find data-style, data-block-index, data-list-item-index
+        // Walk up the DOM tree to find data-style, data-block-index, data-list-item-index.
+        // The textStyleKey from the element with data-block-index is the actual content
+        // block type (e.g. blockquote), not an inner element's style (e.g. paragraph).
         while (target && target !== event.currentTarget) {
-          if (!textStyleKey) {
-            const styleAttr = target.getAttribute?.('data-style');
-            if (styleAttr) textStyleKey = styleAttr;
+          const styleAttr = target.getAttribute?.('data-style');
+          if (styleAttr && !textStyleKey) {
+            textStyleKey = styleAttr;
           }
           if (listItemIndex === null) {
             const listItemAttr = target.getAttribute?.('data-list-item-index');
@@ -1334,20 +1337,45 @@ const CenterCanvas = React.memo(function CenterCanvas({
           }
           if (blockIndex === null) {
             const blockAttr = target.getAttribute?.('data-block-index');
-            if (blockAttr !== null) blockIndex = parseInt(blockAttr, 10);
+            if (blockAttr !== null) {
+              blockIndex = parseInt(blockAttr, 10);
+              if (styleAttr) blockLevelStyleKey = styleAttr;
+            }
           }
           target = target.parentElement as HTMLElement;
         }
+
+        // Prefer the block-level style over structural inner elements (e.g.
+        // paragraph inside blockquote), but keep inline marks and sub-block
+        // styles like listItem that shouldn't be overridden by their container
+        const INNER_STYLE_KEYS = new Set(['bold', 'italic', 'underline', 'strike', 'link', 'subscript', 'superscript']);
+        if (blockLevelStyleKey && (!textStyleKey || !INNER_STYLE_KEYS.has(textStyleKey))) {
+          textStyleKey = blockLevelStyleKey;
+        }
       }
 
-      // Use atomic state update to prevent transient null activeTextStyleKey
+      // For non-CMS-bound rich text, sublayers are style-based (unique types),
+      // so skip block-level sublayerIndex/listItemIndex — only set textStyleKey
+      let resolvedSublayerIndex = Number.isFinite(blockIndex) ? blockIndex : null;
+      let resolvedListItemIndex = Number.isFinite(listItemIndex) ? listItemIndex : null;
+      if (resolvedSublayerIndex !== null && textStyleKey) {
+        const layers = editingComponentId
+          ? (componentDrafts[editingComponentId] || [])
+          : (currentDraft?.layers || []);
+        const layer = findLayerById(layers, layerId);
+        if (layer && isRichTextLayer(layer) && !getLayerCmsFieldBinding(layer)) {
+          resolvedSublayerIndex = null;
+          resolvedListItemIndex = null;
+        }
+      }
+
       selectLayerWithSublayer(layerId, {
         textStyleKey,
-        sublayerIndex: Number.isFinite(blockIndex) ? blockIndex : null,
-        listItemIndex: Number.isFinite(listItemIndex) ? listItemIndex : null,
+        sublayerIndex: resolvedSublayerIndex,
+        listItemIndex: resolvedListItemIndex,
       });
     }
-  }, [isPreviewMode, setActiveSidebarTab, selectLayerWithSublayer]);
+  }, [isPreviewMode, setActiveSidebarTab, selectLayerWithSublayer, editingComponentId, componentDrafts, currentDraft]);
 
   const handleCanvasLayerUpdate = useCallback((layerId: string, updates: Partial<Layer>) => {
     if (editingComponentId) {

--- a/app/(builder)/ycode/components/LayersTree.tsx
+++ b/app/(builder)/ycode/components/LayersTree.tsx
@@ -1808,8 +1808,10 @@ export default function LayersTree({
         n => n.sublayer && n.sublayer.kind === 'content' && n.parentId === selectedLayerId && n.index === storeActiveSublayerIndex
       );
       activeSublayerNodeId = contentMatch?.id ?? null;
-    } else if (hasStyleSublayerActive) {
-      // Direct style sublayers (text/heading) or nested mark sublayers
+    }
+
+    // Fall through to style matching when no content sublayer matched (non-CMS rich text)
+    if (!activeSublayerNodeId && hasStyleSublayerActive) {
       activeSublayerNodeId = flattenedNodes.find(
         n => n.sublayer && n.sublayer.kind === 'style' && n.sublayer.styleKey === storeActiveTextStyleKey && n.layer.id === selectedLayerId
       )?.id ?? null;

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -694,18 +694,14 @@ export function getRichTextSublayers(layer: Layer, cmsContent?: any): RichTextSu
   const layerDoc = (textVar.data as any)?.content;
   if (!layerDoc?.content || !Array.isArray(layerDoc.content)) return [];
 
-  // When content is bound to a CMS field, use the resolved CMS content for sublayers
+  // CMS-bound: show all possible element types since content is dynamic
   const binding = getCmsFieldBinding(layerDoc);
   if (binding) {
-    let resolvedDoc = cmsContent;
-    if (typeof resolvedDoc === 'string') {
-      try { resolvedDoc = JSON.parse(resolvedDoc); } catch { resolvedDoc = null; }
-    }
-    if (!resolvedDoc?.content || !Array.isArray(resolvedDoc.content)) return [];
-    return buildSublayersFromDoc(resolvedDoc, layer);
+    return buildAllStyleSublayers(layer);
   }
 
-  return buildSublayersFromDoc(layerDoc, layer);
+  // Non-CMS: show unique element types only (styling one applies to all of same type)
+  return buildUniqueStyleSublayersFromDoc(layerDoc, layer);
 }
 
 /** Build sublayer metadata from a Tiptap document's content blocks. */
@@ -809,6 +805,122 @@ function buildSublayersFromDoc(doc: any, layer: Layer): RichTextSublayer[] {
     });
 }
 
+/**
+ * Build a flat list of unique element types found in a Tiptap doc.
+ * Used for non-CMS-bound rich text where styling one element styles all of the same type.
+ */
+function buildUniqueStyleSublayersFromDoc(doc: any, layer: Layer): RichTextSublayer[] {
+  const seenStyleKeys = new Set<string>();
+  const sublayers: RichTextSublayer[] = [];
+
+  const allStyles = { ...DEFAULT_TEXT_STYLES, ...layer.textStyles };
+
+  function collectBlockTypes(blocks: any[]) {
+    for (const block of blocks) {
+      const styleKey = contentBlockToStyleKey(block);
+      if (styleKey && !seenStyleKeys.has(styleKey)) {
+        seenStyleKeys.add(styleKey);
+        sublayers.push({
+          type: block.type,
+          label: allStyles[styleKey]?.label || styleKey,
+          icon: STYLE_SUBLAYER_ICON_MAP[styleKey] || SUBLAYER_ICON_MAP[block.type] || 'box',
+          kind: 'style' as const,
+          styleKey,
+        });
+      }
+
+      // For lists, add listItem as a unique style target
+      const isList = block.type === 'bulletList' || block.type === 'orderedList';
+      if (isList && !seenStyleKeys.has('listItem') && block.content?.some((c: any) => c.type === 'listItem')) {
+        seenStyleKeys.add('listItem');
+        sublayers.push({
+          type: 'listItem',
+          label: allStyles.listItem?.label || 'List Item',
+          icon: STYLE_SUBLAYER_ICON_MAP.listItem || 'text',
+          kind: 'style' as const,
+          styleKey: 'listItem',
+        });
+      }
+
+      // For tables, add tableRow / tableHeader / tableCell as unique style targets
+      if (block.type === 'table' && Array.isArray(block.content)) {
+        for (const row of block.content) {
+          if (row.type !== 'tableRow') continue;
+          if (!seenStyleKeys.has('tableRow')) {
+            seenStyleKeys.add('tableRow');
+            sublayers.push({
+              type: 'tableRow',
+              label: allStyles.tableRow?.label || 'Table Row',
+              icon: 'table-row',
+              kind: 'style' as const,
+              styleKey: 'tableRow',
+            });
+          }
+          if (!Array.isArray(row.content)) continue;
+          for (const cell of row.content) {
+            const cellKey = cell.type === 'tableHeader' ? 'tableHeader' : 'tableCell';
+            if (!seenStyleKeys.has(cellKey)) {
+              seenStyleKeys.add(cellKey);
+              sublayers.push({
+                type: cell.type,
+                label: allStyles[cellKey]?.label || cellKey,
+                icon: 'table-cell',
+                kind: 'style' as const,
+                styleKey: cellKey,
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  collectBlockTypes(doc.content.filter((b: any) => b.type !== 'paragraph' || b.content?.length));
+
+  // Collect unique inline marks across all blocks
+  const allMarks = extractInlineMarks(doc);
+  INLINE_STYLE_KEYS
+    .filter(k => allMarks.includes(k))
+    .forEach(markType => {
+      sublayers.push({
+        type: markType,
+        label: allStyles[markType]?.label || markType,
+        icon: STYLE_SUBLAYER_ICON_MAP[markType] || 'type',
+        kind: 'style' as const,
+        styleKey: markType,
+      });
+    });
+
+  return sublayers.sort((a, b) => {
+    const ia = SUBLAYER_SORT_ORDER.indexOf(a.styleKey!);
+    const ib = SUBLAYER_SORT_ORDER.indexOf(b.styleKey!);
+    return (ia === -1 ? 999 : ia) - (ib === -1 ? 999 : ib);
+  });
+}
+
+/** Build the full list of stylable element types for CMS-bound rich text. */
+function buildAllStyleSublayers(layer: Layer): RichTextSublayer[] {
+  const allStyles = { ...DEFAULT_TEXT_STYLES, ...layer.textStyles };
+
+  return SUBLAYER_SORT_ORDER.map(styleKey => ({
+    type: styleKey,
+    label: allStyles[styleKey]?.label || styleKey,
+    icon: STYLE_SUBLAYER_ICON_MAP[styleKey] || SUBLAYER_ICON_MAP[styleKey] || 'box',
+    kind: 'style' as const,
+    styleKey,
+  }));
+}
+
+const SUBLAYER_SORT_ORDER = [
+  'paragraph', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'link',
+  'bold', 'italic', 'underline', 'strike', 'superscript', 'subscript',
+  'bulletList', 'orderedList', 'listItem',
+  'blockquote',
+  'table', 'tableRow', 'tableHeader', 'tableCell',
+  'richTextImage', 'horizontalRule',
+];
+
 const STYLE_SUBLAYER_ICON_MAP: Record<string, string> = {
   paragraph: 'paragraph',
   h1: 'heading',
@@ -821,6 +933,8 @@ const STYLE_SUBLAYER_ICON_MAP: Record<string, string> = {
   italic: 'italic',
   underline: 'underline',
   strike: 'strikethrough',
+  superscript: 'superscript',
+  subscript: 'subscript',
   link: 'link',
   bulletList: 'listUnordered',
   orderedList: 'listOrdered',
@@ -835,7 +949,7 @@ const STYLE_SUBLAYER_ICON_MAP: Record<string, string> = {
 };
 
 /** Inline mark style keys shown for all text layers */
-const INLINE_STYLE_KEYS = ['bold', 'italic', 'underline', 'strike', 'link'];
+const INLINE_STYLE_KEYS = ['bold', 'italic', 'underline', 'strike', 'superscript', 'subscript', 'link'];
 
 /**
  * Get text style sublayers for a layer.

--- a/lib/text-format-utils.ts
+++ b/lib/text-format-utils.ts
@@ -154,14 +154,14 @@ export const DEFAULT_TEXT_STYLES: Record<string, TextStyle> = {
     },
   },
   bulletList: {
-    label: 'Bullet List',
+    label: 'Bullet list',
     classes: 'ml-[8px] pl-[16px] list-disc',
     design: {
       spacing: { marginLeft: '8px', paddingLeft: '16px' },
     },
   },
   orderedList: {
-    label: 'Ordered List',
+    label: 'Ordered list',
     classes: 'ml-[8px] pl-[20px] list-decimal',
     design: {
       spacing: { marginLeft: '8px', paddingLeft: '20px' },
@@ -206,7 +206,7 @@ export const DEFAULT_TEXT_STYLES: Record<string, TextStyle> = {
     },
   },
   tableHeader: {
-    label: 'Table Header Cell',
+    label: 'Table header cell',
     classes: 'text-left font-[500] pt-[12px] pr-[12px] pb-[12px] pl-[12px] bg-[#000000]/5',
     design: {
       borders: { isActive: true, borderWidthMode: 'all' },
@@ -216,7 +216,7 @@ export const DEFAULT_TEXT_STYLES: Record<string, TextStyle> = {
     },
   },
   tableCell: {
-    label: 'Table Cell',
+    label: 'Table cell',
     classes: 'pt-[12px] pr-[12px] pb-[12px] pl-[12px]',
     design: {
       borders: { isActive: true, borderWidthMode: 'individual', borderRadiusMode: 'individual' },
@@ -226,7 +226,7 @@ export const DEFAULT_TEXT_STYLES: Record<string, TextStyle> = {
     },
   },
   tableRow: {
-    label: 'Table Row',
+    label: 'Table row',
     classes: '',
     design: {
       borders: { isActive: true },


### PR DESCRIPTION
## Summary

Fix rich-text sublayers not showing for CMS-bound elements, and change non-CMS-bound rich-text layers to display unique element types instead of per-block content sublayers (since styling one applies to all of the same type).

## Changes

- Show unique style-based sublayers for non-CMS rich text instead of per-block content sublayers (styling one paragraph styles all)
- Show all stylable element types for CMS-bound rich text since content is dynamic and sublayers were previously not appearing
- Fix canvas click to resolve correct sublayer for nested elements (blockquote wrapping paragraph, list wrapping listItem, inline marks)
- Sort sublayers to match toolbar order (headings, marks, lists, etc.)
- Add superscript/subscript to inline style detection and icon map

## Test plan

- [ ] Select a non-CMS rich text with multiple paragraphs — tree shows one "Paragraph" sublayer
- [ ] Add headings, lists, bold text — only unique types appear in tree
- [ ] Select a CMS-bound rich text — all element types are listed
- [ ] Click a blockquote on canvas — "Blockquote" sublayer is selected (not "Paragraph")
- [ ] Click bold text on canvas — "Bold" sublayer is selected
- [ ] Click list text on canvas — list container sublayer is selected
- [ ] Click "List Item" in tree — list item sublayer is selected
- [ ] Verify sublayer order matches toolbar order

Made with [Cursor](https://cursor.com)