### PR TITLE
feat: add option cms field type with rename and removal propagation

### DIFF
--- a/app/(builder)/ycode/api/collections/[id]/fields/[field_id]/route.ts
+++ b/app/(builder)/ycode/api/collections/[id]/fields/[field_id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getFieldById, updateField, deleteField } from '@/lib/repositories/collectionFieldRepository';
 import { isValidFieldType, VALID_FIELD_TYPES } from '@/lib/collection-field-utils';
 import { getItemsByCollectionId } from '@/lib/repositories/collectionItemRepository';
+import { clearValuesForField, renameValuesForField } from '@/lib/repositories/collectionItemValueRepository';
 import { deleteTranslationsInBulk } from '@/lib/repositories/translationRepository';
 import { noCache } from '@/lib/api-response';
 
@@ -73,7 +74,49 @@ export async function PUT(
       );
     }
 
+    // Detect option renames and removals (by stable id) for option-type
+    // fields. Item values store the option name, so we propagate renames and
+    // clear any item value whose option was removed from the field config.
+    const optionRenames: { oldName: string; newName: string }[] = [];
+    const removedOptionNames: string[] = [];
+    if (existingField.type === 'option' && Array.isArray(body.data?.options)) {
+      const previousOptions = Array.isArray(existingField.data?.options)
+        ? existingField.data.options
+        : [];
+      const nextOptions = body.data.options as { id: string; name: string }[];
+      const nextIds = new Set(nextOptions.map(o => o.id));
+      const previousById = new Map(previousOptions.map((o: { id: string; name: string }) => [o.id, o.name]));
+
+      for (const next of nextOptions) {
+        const previousName = previousById.get(next.id);
+        const newName = (next.name ?? '').trim();
+        if (typeof previousName === 'string' && previousName !== newName) {
+          optionRenames.push({ oldName: previousName, newName });
+        }
+      }
+
+      for (const previous of previousOptions as { id: string; name: string }[]) {
+        if (!nextIds.has(previous.id)) {
+          removedOptionNames.push(previous.name);
+        }
+      }
+    }
+
     const field = await updateField(fieldId, body);
+
+    if (optionRenames.length > 0) {
+      await Promise.all(
+        optionRenames.map(({ oldName, newName }) =>
+          renameValuesForField(fieldId, oldName, newName)
+        )
+      );
+    }
+
+    if (removedOptionNames.length > 0) {
+      await Promise.all(
+        removedOptionNames.map((name) => clearValuesForField(fieldId, name))
+      );
+    }
 
     return noCache({ data: field });
   } catch (error) {

--- a/app/(builder)/ycode/components/CMS.tsx
+++ b/app/(builder)/ycode/components/CMS.tsx
@@ -362,6 +362,7 @@ const CMS = React.memo(function CMS() {
     reorderCollections,
     setItemPublishable,
     setItemStatus,
+    reloadCurrentItems,
   } = useCollectionsStore();
 
   // Collection collaboration sync
@@ -1225,12 +1226,36 @@ const CMS = React.memo(function CMS() {
           ? { ...editingField.data, ...data.data }
           : editingField.data;
 
+        // Detect option renames or removals so we refresh the item list
+        // after the server propagates renames / clears removed values.
+        const previousOptions = Array.isArray(editingField.data?.options)
+          ? editingField.data.options
+          : [];
+        const nextOptions = Array.isArray(data.data?.options)
+          ? data.data.options
+          : [];
+        const previousById = new Map(previousOptions.map(o => [o.id, o.name]));
+        const nextIds = new Set(nextOptions.map(o => o.id));
+        const isOptionField = editingField.type === 'option';
+        const hasOptionRename =
+          isOptionField &&
+          nextOptions.some((next) => {
+            const previousName = previousById.get(next.id);
+            return typeof previousName === 'string' && previousName.trim() !== next.name.trim();
+          });
+        const hasOptionRemoval =
+          isOptionField && previousOptions.some(prev => !nextIds.has(prev.id));
+
         await updateField(selectedCollectionId, editingField.id, {
           name: data.name,
           default: data.default || null,
           reference_collection_id: data.reference_collection_id,
           data: mergedData,
         });
+
+        if (hasOptionRename || hasOptionRemoval) {
+          await reloadCurrentItems();
+        }
       } else {
         // Create new field
         await createField(selectedCollectionId, {
@@ -1872,6 +1897,25 @@ const CMS = React.memo(function CMS() {
                                 aria-hidden="true"
                               />
                             </div>
+                          </td>
+                        );
+                      }
+
+                      // Option fields - display as Badge with the option name
+                      if (field.type === 'option') {
+                        return (
+                          <td
+                            key={field.id}
+                            className="px-4 py-5"
+                            onClick={() => handleEditItem(item)}
+                          >
+                            {value ? (
+                              <Badge variant="secondary" className="font-normal">
+                                <span className="line-clamp-1 truncate max-w-[200px]">{value}</span>
+                              </Badge>
+                            ) : (
+                              <span className="text-muted-foreground">-</span>
+                            )}
                           </td>
                         );
                       }

--- a/app/(builder)/ycode/components/CollectionItemSheet.tsx
+++ b/app/(builder)/ycode/components/CollectionItemSheet.tsx
@@ -844,7 +844,19 @@ export default function CollectionItemSheet({
                               return (
                                 <Select
                                   value={currentValue || '__none__'}
-                                  onValueChange={(value) => formField.onChange(value === '__none__' ? '' : value)}
+                                  onValueChange={(value) => {
+                                    // Radix Select renders a hidden native <select> for form
+                                    // integration that dispatches a spurious change event with
+                                    // an empty value when the controlled `value` prop changes
+                                    // externally (e.g. via form.reset) before the SelectItem
+                                    // for that value has registered (the items live in a
+                                    // Portal that mounts only when the select is open).
+                                    // Ignore that spurious empty change so it can't clobber
+                                    // the loaded form value. SelectItem disallows value="",
+                                    // so an empty string is never user-initiated.
+                                    if (value === '') return;
+                                    formField.onChange(value === '__none__' ? '' : value);
+                                  }}
                                   disabled={options.length === 0}
                                 >
                                   <SelectTrigger className="w-full">

--- a/app/(builder)/ycode/components/CollectionItemSheet.tsx
+++ b/app/(builder)/ycode/components/CollectionItemSheet.tsx
@@ -33,6 +33,14 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import RichTextEditor from './RichTextEditor';
 import RichTextEditorSheet from './RichTextEditorSheet';
 import { useCollectionsStore } from '@/stores/useCollectionsStore';
@@ -828,6 +836,40 @@ export default function CollectionItemSheet({
                                 Value is set to <span className="text-foreground">{formField.value === 'true' ? 'YES' : 'NO'}</span>
                               </Label>
                             </div>
+                          ) : field.type === 'option' ? (
+                            (() => {
+                              const options = field.data?.options ?? [];
+                              const currentValue = formField.value || '';
+                              const hasMatchingOption = options.some(o => o.name.trim() === currentValue);
+                              return (
+                                <Select
+                                  value={currentValue || '__none__'}
+                                  onValueChange={(value) => formField.onChange(value === '__none__' ? '' : value)}
+                                  disabled={options.length === 0}
+                                >
+                                  <SelectTrigger className="w-full">
+                                    <SelectValue placeholder={options.length === 0 ? 'No options available' : `Select ${field.name.toLowerCase()}...`} />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    <SelectGroup>
+                                      <SelectItem value="__none__">None</SelectItem>
+                                      {options
+                                        .filter(o => o.name.trim().length > 0)
+                                        .map((option) => (
+                                          <SelectItem key={option.id} value={option.name.trim()}>
+                                            {option.name.trim()}
+                                          </SelectItem>
+                                        ))}
+                                      {currentValue && !hasMatchingOption && (
+                                        <SelectItem value={currentValue} disabled>
+                                          {currentValue} (deleted)
+                                        </SelectItem>
+                                      )}
+                                    </SelectGroup>
+                                  </SelectContent>
+                                </Select>
+                              );
+                            })()
                           ) : field.key === 'name' ? (
                             <Input
                               ref={nameInputRef}

--- a/app/(builder)/ycode/components/FieldFormDialog.tsx
+++ b/app/(builder)/ycode/components/FieldFormDialog.tsx
@@ -26,6 +26,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import Icon from '@/components/ui/icon';
+import { Spinner } from '@/components/ui/spinner';
 import { Checkbox } from '@/components/ui/checkbox';
 import { FIELD_TYPES_BY_CATEGORY, ASSET_FIELD_TYPES, supportsDefaultValue, isAssetFieldType, getFileManagerCategory, getAssetFieldLabel, type FieldType } from '@/lib/collection-field-utils';
 import { parseMultiReferenceValue } from '@/lib/collection-utils';
@@ -80,7 +81,9 @@ export default function FieldFormDialog({
   const [fieldDefault, setFieldDefault] = useState('');
   const [referenceCollectionId, setReferenceCollectionId] = useState<string | null>(null);
   const [fieldMultiple, setFieldMultiple] = useState(false);
+  const [fieldOptions, setFieldOptions] = useState<{ id: string; name: string }[]>([]);
   const [hasChangedType, setHasChangedType] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Stores
   const { collections } = useCollectionsStore();
@@ -108,8 +111,21 @@ export default function FieldFormDialog({
   // Derived flags
   const isReferenceType = fieldType === 'reference' || fieldType === 'multi_reference';
   const isAssetType = ASSET_FIELD_TYPES.includes(fieldType);
+  const isOptionType = fieldType === 'option';
   const hasDefault = supportsDefaultValue(fieldType);
-  const isSubmitDisabled = !fieldName.trim() || (isReferenceType && !referenceCollectionId);
+
+  const hasInvalidOptions = isOptionType && (() => {
+    if (fieldOptions.length === 0) return true;
+    const names = fieldOptions.map(o => o.name.trim());
+    if (names.some(n => !n)) return true;
+    const lowered = names.map(n => n.toLowerCase());
+    return new Set(lowered).size !== lowered.length;
+  })();
+
+  const isSubmitDisabled =
+    !fieldName.trim() ||
+    (isReferenceType && !referenceCollectionId) ||
+    hasInvalidOptions;
 
   // Reset form when dialog opens
   useEffect(() => {
@@ -121,14 +137,21 @@ export default function FieldFormDialog({
       setFieldDefault(field.default || '');
       setReferenceCollectionId(field.reference_collection_id || null);
       setFieldMultiple(field.data?.multiple || false);
+      setFieldOptions(
+        Array.isArray(field.data?.options)
+          ? field.data.options.map(o => ({ id: o.id, name: o.name }))
+          : []
+      );
     } else {
       setFieldName('');
       setFieldType('text');
       setFieldDefault('');
       setReferenceCollectionId(null);
       setFieldMultiple(false);
+      setFieldOptions([]);
     }
     setHasChangedType(false);
+    setIsSubmitting(false);
   }, [open, field]);
 
   // Clear reference collection when switching away from reference types
@@ -144,6 +167,13 @@ export default function FieldFormDialog({
       setFieldMultiple(false);
     }
   }, [isAssetType, hasChangedType]);
+
+  // Clear options when switching away from option type
+  useEffect(() => {
+    if (hasChangedType && !isOptionType) {
+      setFieldOptions([]);
+    }
+  }, [isOptionType, hasChangedType]);
 
   // Clear/reset default value when switching types
   useEffect(() => {
@@ -161,18 +191,62 @@ export default function FieldFormDialog({
   const handleSubmit = async () => {
     if (!fieldName.trim()) return;
     if (isReferenceType && !referenceCollectionId) return;
+    if (hasInvalidOptions) return;
+    if (isSubmitting) return;
 
-    await onSubmit({
-      name: fieldName.trim(),
-      type: fieldType,
-      default: fieldDefault,
-      reference_collection_id: isReferenceType ? referenceCollectionId : null,
-      data: isAssetType ? { multiple: fieldMultiple } : undefined,
+    let data: CollectionFieldData | undefined;
+    if (isAssetType) {
+      data = { multiple: fieldMultiple };
+    } else if (isOptionType) {
+      data = {
+        options: fieldOptions.map(o => ({ id: o.id, name: o.name.trim() })),
+      };
+    }
+
+    try {
+      setIsSubmitting(true);
+      await onSubmit({
+        name: fieldName.trim(),
+        type: fieldType,
+        default: fieldDefault,
+        reference_collection_id: isReferenceType ? referenceCollectionId : null,
+        data,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleAddOption = () => {
+    const id = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `opt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    setFieldOptions(prev => [...prev, { id, name: '' }]);
+  };
+
+  const handleUpdateOptionName = (id: string, name: string) => {
+    setFieldOptions(prev => {
+      const previous = prev.find(o => o.id === id);
+      if (previous && fieldDefault.trim() === previous.name.trim()) {
+        setFieldDefault(name.trim());
+      }
+      return prev.map(o => (o.id === id ? { ...o, name } : o));
     });
   };
 
+  const handleRemoveOption = (id: string) => {
+    setFieldOptions(prev => {
+      const next = prev.filter(o => o.id !== id);
+      return next;
+    });
+    const removed = fieldOptions.find(o => o.id === id);
+    if (removed && fieldDefault === removed.name.trim()) {
+      setFieldDefault('');
+    }
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={(next) => { if (isSubmitting && !next) return; onOpenChange(next); }}>
       <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>
@@ -180,7 +254,7 @@ export default function FieldFormDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <form className="flex flex-col gap-4" onSubmit={(e) => { e.preventDefault(); if (!isSubmitDisabled) handleSubmit(); }}>
+        <form className="flex flex-col gap-4" onSubmit={(e) => { e.preventDefault(); if (!isSubmitDisabled && !isSubmitting) handleSubmit(); }}>
           <div className="grid grid-cols-5 items-center gap-4">
             <Label htmlFor="field-name" className="text-right">
               Name
@@ -291,6 +365,51 @@ export default function FieldFormDialog({
             </div>
           )}
 
+          {/* Options editor */}
+          {isOptionType && (
+            <div className="grid grid-cols-5 items-start gap-4">
+              <Label className="text-right mt-2">
+                Options
+              </Label>
+              <div className="col-span-4 flex flex-col gap-2">
+                {fieldOptions.length > 0 && (
+                  <div className="flex flex-col gap-2">
+                    {fieldOptions.map((option) => (
+                      <div key={option.id} className="flex items-center gap-2">
+                        <Input
+                          value={option.name}
+                          onChange={(e) => handleUpdateOptionName(option.id, e.target.value)}
+                          placeholder="Option name"
+                          autoComplete="off"
+                          className="flex-1"
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleRemoveOption(option.id)}
+                          aria-label="Remove option"
+                        >
+                          <Icon name="trash" className="size-3" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  className="w-fit"
+                  onClick={handleAddOption}
+                >
+                  <Icon name="plus" className="size-3" />
+                  Add option
+                </Button>
+              </div>
+            </div>
+          )}
+
           {/* Default value */}
           {hasDefault && (
             <div className="grid grid-cols-5 items-start gap-4">
@@ -332,6 +451,28 @@ export default function FieldFormDialog({
                     value={fieldDefault}
                     onChange={setFieldDefault}
                   />
+                ) : fieldType === 'option' ? (
+                  <Select
+                    value={fieldDefault || '__none__'}
+                    onValueChange={(value) => setFieldDefault(value === '__none__' ? '' : value)}
+                    disabled={fieldOptions.length === 0}
+                  >
+                    <SelectTrigger id="field-default" className="w-full">
+                      <SelectValue placeholder={fieldOptions.length === 0 ? 'Add options first' : 'Select default...'} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectItem value="__none__">No default</SelectItem>
+                        {fieldOptions
+                          .filter((o) => o.name.trim().length > 0)
+                          .map((option) => (
+                            <SelectItem key={option.id} value={option.name.trim()}>
+                              {option.name.trim()}
+                            </SelectItem>
+                          ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
                 ) : fieldType === 'boolean' ? (
                   <div className="flex items-center gap-2 h-8">
                     <Checkbox
@@ -408,15 +549,19 @@ export default function FieldFormDialog({
               variant="secondary"
               size="sm"
               onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
             >
               Cancel
             </Button>
             <Button
               type="submit"
               size="sm"
-              disabled={isSubmitDisabled}
+              disabled={isSubmitDisabled || isSubmitting}
             >
-              {mode === 'create' ? 'Create field' : 'Update field'}
+              {isSubmitting && <Spinner className="size-3" />}
+              {mode === 'create'
+                ? (isSubmitting ? 'Creating...' : 'Create field')
+                : (isSubmitting ? 'Updating...' : 'Update field')}
             </Button>
           </div>
         </form>

--- a/app/(builder)/ycode/components/FieldFormDialog.tsx
+++ b/app/(builder)/ycode/components/FieldFormDialog.tsx
@@ -375,7 +375,7 @@ export default function FieldFormDialog({
                 {fieldOptions.length > 0 && (
                   <div className="flex flex-col gap-2">
                     {fieldOptions.map((option) => (
-                      <div key={option.id} className="flex items-center gap-2">
+                      <div key={option.id} className="flex items-center gap-1">
                         <Input
                           value={option.name}
                           onChange={(e) => handleUpdateOptionName(option.id, e.target.value)}
@@ -390,7 +390,7 @@ export default function FieldFormDialog({
                           onClick={() => handleRemoveOption(option.id)}
                           aria-label="Remove option"
                         >
-                          <Icon name="trash" className="size-3" />
+                          <Icon name="x" />
                         </Button>
                       </div>
                     ))}

--- a/lib/collection-field-utils.ts
+++ b/lib/collection-field-utils.ts
@@ -46,6 +46,7 @@ export const FIELD_TYPES = [
   { value: 'date', label: 'Date & Time', icon: 'calendar', category: 'basic', hasDefault: true },
   { value: 'date_only', label: 'Date', icon: 'calendar', category: 'basic', hasDefault: true },
   { value: 'color', label: 'Color', icon: 'droplet', category: 'basic', hasDefault: true },
+  { value: 'option', label: 'Option', icon: 'select', category: 'basic', hasDefault: true },
   { value: 'email', label: 'Email', icon: 'email', category: 'contact', hasDefault: true },
   { value: 'phone', label: 'Phone', icon: 'phone', category: 'contact', hasDefault: true },
   { value: 'link', label: 'Link', icon: 'link', category: 'contact', hasDefault: true },
@@ -554,7 +555,7 @@ export const VIDEO_FIELD_TYPES: CollectionFieldType[] = ['video'];
 export const VIDEO_ID_FIELD_TYPES: CollectionFieldType[] = ['text'];
 
 /** Field types that can be bound to simple text content (excludes rich_text and media/asset types) */
-export const SIMPLE_TEXT_FIELD_TYPES: CollectionFieldType[] = ['text', 'number', 'date', 'date_only', 'email', 'phone'];
+export const SIMPLE_TEXT_FIELD_TYPES: CollectionFieldType[] = ['text', 'number', 'date', 'date_only', 'email', 'phone', 'option'];
 
 /** Field types that can be bound to rich text content (excludes media/asset types) */
 export const RICH_TEXT_FIELD_TYPES: CollectionFieldType[] = [...SIMPLE_TEXT_FIELD_TYPES, 'rich_text'];

--- a/lib/csv-utils.ts
+++ b/lib/csv-utils.ts
@@ -631,6 +631,7 @@ export function getFieldTypeLabel(type: CollectionFieldType): string {
     link: 'Link',
     email: 'Email',
     phone: 'Phone',
+    option: 'Option',
     status: 'Status',
   };
   return labels[type] || type;

--- a/lib/repositories/collectionItemValueRepository.ts
+++ b/lib/repositories/collectionItemValueRepository.ts
@@ -501,6 +501,76 @@ export async function deleteValue(
 }
 
 /**
+ * Soft-delete every stored value for a field whose value exactly matches
+ * `value`. Used when an option is removed from an option-type field so item
+ * values storing that option name are cleared from both draft and published
+ * rows.
+ * @returns Number of rows soft-deleted
+ */
+export async function clearValuesForField(
+  field_id: string,
+  value: string
+): Promise<number> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    throw new Error('Supabase client not configured');
+  }
+
+  const now = new Date().toISOString();
+  const { data, error } = await client
+    .from('collection_item_values')
+    .update({ deleted_at: now, updated_at: now })
+    .eq('field_id', field_id)
+    .eq('value', value)
+    .is('deleted_at', null)
+    .select('id');
+
+  if (error) {
+    throw new Error(`Failed to clear values: ${error.message}`);
+  }
+
+  return data?.length || 0;
+}
+
+/**
+ * Replace stored values for a field where the value exactly matches `old_value`.
+ * Used to propagate option renames in option-type fields to all draft and
+ * published item values storing the previous option name.
+ * @returns Number of rows updated
+ */
+export async function renameValuesForField(
+  field_id: string,
+  old_value: string,
+  new_value: string
+): Promise<number> {
+  if (old_value === new_value) return 0;
+
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    throw new Error('Supabase client not configured');
+  }
+
+  const { data, error } = await client
+    .from('collection_item_values')
+    .update({
+      value: new_value,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('field_id', field_id)
+    .eq('value', old_value)
+    .is('deleted_at', null)
+    .select('id');
+
+  if (error) {
+    throw new Error(`Failed to rename values: ${error.message}`);
+  }
+
+  return data?.length || 0;
+}
+
+/**
  * Publish values for an item
  * Copies all draft values to published values for the same item
  * Uses batch upsert for efficiency

--- a/types/index.ts
+++ b/types/index.ts
@@ -944,7 +944,7 @@ export interface ActivityNotification {
 }
 
 // Collection Types (EAV Architecture)
-export type CollectionFieldType = 'text' | 'number' | 'boolean' | 'date' | 'date_only' | 'color' | 'reference' | 'multi_reference' | 'rich_text' | 'image' | 'audio' | 'video' | 'document' | 'link' | 'email' | 'phone' | 'status';
+export type CollectionFieldType = 'text' | 'number' | 'boolean' | 'date' | 'date_only' | 'color' | 'reference' | 'multi_reference' | 'rich_text' | 'image' | 'audio' | 'video' | 'document' | 'link' | 'email' | 'phone' | 'option' | 'status';
 export type CollectionSortDirection = 'asc' | 'desc' | 'manual';
 
 export interface CollectionSorting {
@@ -982,6 +982,7 @@ export interface UpdateCollectionData {
 /** Field-specific settings stored in the data column */
 export interface CollectionFieldData {
   multiple?: boolean; // For asset fields - allow multiple files
+  options?: { id: string; name: string }[]; // For option fields - selectable values
 }
 
 export interface CreateCollectionFieldData {


### PR DESCRIPTION
## Summary

Adds a new **Option** CMS field type for single-select user-defined values, edited in the field dialog and rendered as a badge in the CMS table. Item values store the option name so the field plugs into the existing text rendering path on the builder canvas and generated site without extra resolution. Renaming an option propagates to all draft and published item values; removing an option clears matching values. The field dialog also gained a loading state on the submit action.

## Changes

- Add `'option'` to `CollectionFieldType` and `options?: { id; name }[]` to `CollectionFieldData`
- Register Option in `FIELD_TYPES` (basic category, `select` icon) and include it in `SIMPLE_TEXT_FIELD_TYPES` so it is bindable to text layers, alt text, page metadata, components, etc.
- Add an Options editor (add/remove rows, validation against blanks and duplicates) plus a `Select`-based default-value picker in `FieldFormDialog`
- Render Option fields as a `Select` in `CollectionItemSheet` (with a graceful disabled fallback for orphaned values)
- Render Option cells as a `Badge` in the CMS table
- Propagate option renames in the field PUT route by updating every `collection_item_values` row whose value matches the previous name
- Propagate option removals by soft-deleting every `collection_item_values` row whose value matches the removed option
- Reload the items list on the client after rename or removal so the table reflects the new state immediately
- Show a `Spinner` and disabled state on the submit button while the field dialog is saving, and block closing the dialog mid-save

## Test plan

- [ ] Create a new Option field with two options (`Option 1`, `Option 2`); confirm submit is disabled while options are blank or duplicated
- [ ] Set a default option and verify the Default `Select` reflects the configured options
- [ ] Assign `Option 1` to a CMS item; confirm the table shows it as a badge and the item editor renders a `Select`
- [ ] Bind the field to a text layer and confirm the option name renders on the builder canvas and on `/ycode/preview`
- [ ] Rename `Option 1` to `Option 1 edited`; confirm the CMS table, item editor, and preview all update to the new name
- [ ] Delete `Option 2` while it is assigned to an item; confirm the cell goes empty and the item editor shows no value
- [ ] While saving the field dialog, verify the submit button shows a spinner and the dialog cannot be closed
