### PR TITLE
feat: add transform and transition design controls

### DIFF
--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -64,6 +64,8 @@ import InteractionsPanel from './InteractionsPanel';
 import LayoutControls from './LayoutControls';
 import LayerStylesPanel from './LayerStylesPanel';
 import PositionControls from './PositionControls';
+import TransformControls from './TransformControls';
+import TransitionControls from './TransitionControls';
 import SettingsPanel from './SettingsPanel';
 import SizingControls from './SizingControls';
 import SpacingControls from './SpacingControls';
@@ -506,6 +508,20 @@ const RightSidebar = React.memo(function RightSidebar({
         // In text style mode, hide position controls
         if (showTextStyleControls) return false;
         // Position controls: show for all
+        return true;
+
+      case 'transforms':
+        // In text style mode, hide transform controls
+        if (showTextStyleControls) return false;
+        // Hide for text-only layers (not buttons)
+        if (isTextLayer(layer) && !isButtonLayer(layer)) return false;
+        return true;
+
+      case 'transitions':
+        // In text style mode, hide transition controls
+        if (showTextStyleControls) return false;
+        // Transitions: show for all non-text layers (and buttons)
+        if (isTextLayer(layer) && !isButtonLayer(layer)) return false;
         return true;
 
       default:
@@ -1863,6 +1879,14 @@ const RightSidebar = React.memo(function RightSidebar({
 
           {shouldShowControl('position', selectedLayer) && !showTextStyleControls && (
             <PositionControls layer={selectedLayer} onLayerUpdate={handleLayerUpdate} />
+          )}
+
+          {shouldShowControl('transforms', selectedLayer) && (
+            <TransformControls layer={selectedLayer} onLayerUpdate={handleLayerUpdate} />
+          )}
+
+          {shouldShowControl('transitions', selectedLayer) && (
+            <TransitionControls layer={selectedLayer} onLayerUpdate={handleLayerUpdate} />
           )}
 
           {/* Classes panel - shows classes for active text style or layer */}

--- a/app/(builder)/ycode/components/TransformControls.tsx
+++ b/app/(builder)/ycode/components/TransformControls.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useState, useCallback } from 'react';
+import { memo, useState, useCallback, useEffect } from 'react';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -57,11 +57,28 @@ const TransformControls = memo(function TransformControls({ layer, onLayerUpdate
   const skewY = getDesignProperty('transforms', 'skewY') || '';
   const transformOrigin = getDesignProperty('transforms', 'transformOrigin') || '';
 
+  // Track which transform sections are explicitly active so a row stays
+  // visible when the user temporarily clears its inputs. The set is reseeded
+  // from existing stored values whenever the layer/breakpoint/state changes.
+  const [activeKeys, setActiveKeys] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const next = new Set<string>();
+    if (scale) next.add('scale');
+    if (rotate) next.add('rotate');
+    if (translateX !== '' || translateY !== '') next.add('move');
+    if (skewX || skewY) next.add('skew');
+    setActiveKeys(next);
+    // Only reseed when the layer or active breakpoint/state changes — not on
+    // every value edit, otherwise clearing an input would reactivate the row.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [layer?.id, activeBreakpoint, activeUIState]);
+
   const visibility: Record<string, boolean> = {
-    scale: !!scale,
-    rotate: !!rotate,
-    move: translateX !== '' || translateY !== '',
-    skew: !!skewX || !!skewY,
+    scale: activeKeys.has('scale') || !!scale,
+    rotate: activeKeys.has('rotate') || !!rotate,
+    move: activeKeys.has('move') || translateX !== '' || translateY !== '',
+    skew: activeKeys.has('skew') || !!skewX || !!skewY,
   };
 
   const inputs = useControlledInputs({
@@ -96,20 +113,70 @@ const TransformControls = memo(function TransformControls({ layer, onLayerUpdate
     updateDesignProperty('transforms', 'transformOrigin', value === 'center' ? null : value);
   }, [updateDesignProperty]);
 
+  const activate = useCallback((id: string) => {
+    setActiveKeys(prev => {
+      if (prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  }, []);
+
+  const deactivate = useCallback((id: string) => {
+    setActiveKeys(prev => {
+      if (!prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+
   const addHandlers: Record<string, () => void> = {
-    scale: () => { inputs.scale[1]('1'); updateDesignProperty('transforms', 'scale', '1'); },
-    rotate: () => { inputs.rotate[1]('0'); updateDesignProperty('transforms', 'rotate', '0'); },
+    scale: () => { activate('scale'); inputs.scale[1]('1'); updateDesignProperty('transforms', 'scale', '1'); },
+    rotate: () => { activate('rotate'); inputs.rotate[1]('0'); updateDesignProperty('transforms', 'rotate', '0'); },
     move: () => {
+      activate('move');
       inputs.translateX[1]('0'); inputs.translateY[1]('0');
       updateDesignProperty('transforms', 'translateX', '0');
       updateDesignProperty('transforms', 'translateY', '0');
     },
     skew: () => {
+      activate('skew');
       inputs.skewX[1]('0'); inputs.skewY[1]('0');
       updateDesignProperty('transforms', 'skewX', '0');
       updateDesignProperty('transforms', 'skewY', '0');
     },
   };
+
+  const removeHandlers: Record<string, () => void> = {
+    scale: () => { deactivate('scale'); inputs.scale[1](''); updateDesignProperty('transforms', 'scale', null); },
+    rotate: () => { deactivate('rotate'); inputs.rotate[1](''); updateDesignProperty('transforms', 'rotate', null); },
+    move: () => {
+      deactivate('move');
+      inputs.translateX[1](''); inputs.translateY[1]('');
+      updateDesignProperty('transforms', 'translateX', null);
+      updateDesignProperty('transforms', 'translateY', null);
+    },
+    skew: () => {
+      deactivate('skew');
+      inputs.skewX[1](''); inputs.skewY[1]('');
+      updateDesignProperty('transforms', 'skewX', null);
+      updateDesignProperty('transforms', 'skewY', null);
+    },
+  };
+
+  const renderRemoveButton = (id: string) => (
+    <span
+      role="button"
+      tabIndex={0}
+      aria-label={`Remove ${id}`}
+      className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer shrink-0"
+      onClick={removeHandlers[id]}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); removeHandlers[id](); } }}
+    >
+      <Icon name="x" className="size-2.5" />
+    </span>
+  );
 
   const scaleSliderValue = parseFloat(inputs.scale[0]) || 1;
 
@@ -162,21 +229,24 @@ const TransformControls = memo(function TransformControls({ layer, onLayerUpdate
       {visibility.scale && (
         <div className="grid grid-cols-3">
           <Label variant="muted">Scale</Label>
-          <div className="col-span-2 grid grid-cols-2 items-center gap-2">
-            <Input
-              type="text"
-              value={inputs.scale[0]}
-              onChange={(e) => handlers.scale(e.target.value)}
-              placeholder="1"
-            />
-            <Slider
-              value={[Math.round(scaleSliderValue * 100)]}
-              onValueChange={handleScaleSliderChange}
-              min={0}
-              max={200}
-              step={5}
-              className="flex-1"
-            />
+          <div className="col-span-2 flex items-center gap-2">
+            <div className="grid grid-cols-2 items-center gap-2 flex-1 min-w-0">
+              <Input
+                type="text"
+                value={inputs.scale[0]}
+                onChange={(e) => handlers.scale(e.target.value)}
+                placeholder="1"
+              />
+              <Slider
+                value={[Math.round(scaleSliderValue * 100)]}
+                onValueChange={handleScaleSliderChange}
+                min={0}
+                max={200}
+                step={5}
+                className="flex-1"
+              />
+            </div>
+            {renderRemoveButton('scale')}
           </div>
         </div>
       )}
@@ -185,15 +255,16 @@ const TransformControls = memo(function TransformControls({ layer, onLayerUpdate
       {visibility.rotate && (
         <div className="grid grid-cols-3">
           <Label variant="muted">Rotate</Label>
-          <div className="col-span-2">
-            <InputGroup>
+          <div className="col-span-2 flex items-center gap-2">
+            <InputGroup className="flex-1 min-w-0">
               <InputGroupInput
                 value={inputs.rotate[0]}
                 onChange={(e) => handlers.rotate(e.target.value)}
                 placeholder="0"
               />
-              <InputGroupAddon align="inline-end">deg</InputGroupAddon>
+              <InputGroupAddon align="inline-end" className="text-xs opacity-50">deg</InputGroupAddon>
             </InputGroup>
+            {renderRemoveButton('rotate')}
           </div>
         </div>
       )}
@@ -204,15 +275,20 @@ const TransformControls = memo(function TransformControls({ layer, onLayerUpdate
         return (
           <div key={field.id} className="grid grid-cols-3 items-start">
             <Label variant="muted" className="h-8">{field.label} X/Y</Label>
-            <div className="col-span-2 grid grid-cols-2 gap-2">
-              {field.keys.map((key) => (
-                <Input
-                  key={key}
-                  value={inputs[key as keyof typeof inputs][0]}
-                  onChange={(e) => handlers[key](e.target.value)}
-                  placeholder="0"
-                />
-              ))}
+            <div className="col-span-2 flex items-start gap-2">
+              <div className="grid grid-cols-2 gap-2 flex-1 min-w-0">
+                {field.keys.map((key) => (
+                  <Input
+                    key={key}
+                    value={inputs[key as keyof typeof inputs][0]}
+                    onChange={(e) => handlers[key](e.target.value)}
+                    placeholder="0"
+                  />
+                ))}
+              </div>
+              <div className="h-8 flex items-center">
+                {renderRemoveButton(field.id)}
+              </div>
             </div>
           </div>
         );

--- a/app/(builder)/ycode/components/TransformControls.tsx
+++ b/app/(builder)/ycode/components/TransformControls.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { memo, useState, useCallback } from 'react';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Slider } from '@/components/ui/slider';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
+import Icon from '@/components/ui/icon';
+import SettingsPanel from './SettingsPanel';
+import { useDesignSync } from '@/hooks/use-design-sync';
+import { useControlledInputs } from '@/hooks/use-controlled-input';
+import { useEditorStore } from '@/stores/useEditorStore';
+import { extractMeasurementValue } from '@/lib/measurement-utils';
+import { removeSpaces } from '@/lib/utils';
+import type { Layer } from '@/types';
+
+interface TransformControlsProps {
+  layer: Layer | null;
+  onLayerUpdate: (layerId: string, updates: Partial<Layer>) => void;
+}
+
+const ORIGIN_OPTIONS = [
+  { value: 'top-left', label: 'Top Left' },
+  { value: 'top', label: 'Top' },
+  { value: 'top-right', label: 'Top Right' },
+  { value: 'left', label: 'Left' },
+  { value: 'center', label: 'Center' },
+  { value: 'right', label: 'Right' },
+  { value: 'bottom-left', label: 'Bottom Left' },
+  { value: 'bottom', label: 'Bottom' },
+  { value: 'bottom-right', label: 'Bottom Right' },
+] as const;
+
+const XY_FIELDS = [
+  { id: 'move', label: 'Move', keys: ['translateX', 'translateY'] },
+  { id: 'skew', label: 'Skew', keys: ['skewX', 'skewY'] },
+] as const;
+
+const TransformControls = memo(function TransformControls({ layer, onLayerUpdate }: TransformControlsProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const { activeBreakpoint, activeUIState } = useEditorStore();
+  const { updateDesignProperty, debouncedUpdateDesignProperty, getDesignProperty } = useDesignSync({
+    layer,
+    onLayerUpdate,
+    activeBreakpoint,
+    activeUIState,
+  });
+
+  const scale = getDesignProperty('transforms', 'scale') || '';
+  const rotate = getDesignProperty('transforms', 'rotate') || '';
+  const translateX = getDesignProperty('transforms', 'translateX') || '';
+  const translateY = getDesignProperty('transforms', 'translateY') || '';
+  const skewX = getDesignProperty('transforms', 'skewX') || '';
+  const skewY = getDesignProperty('transforms', 'skewY') || '';
+  const transformOrigin = getDesignProperty('transforms', 'transformOrigin') || '';
+
+  const visibility: Record<string, boolean> = {
+    scale: !!scale,
+    rotate: !!rotate,
+    move: translateX !== '' || translateY !== '',
+    skew: !!skewX || !!skewY,
+  };
+
+  const inputs = useControlledInputs({
+    scale, rotate, translateX, translateY, skewX, skewY,
+  }, extractMeasurementValue);
+
+  const createHandler = useCallback(
+    (property: string, setter: (v: string) => void) => (value: string) => {
+      setter(value);
+      const sanitized = removeSpaces(value);
+      debouncedUpdateDesignProperty('transforms', property, sanitized || null);
+    },
+    [debouncedUpdateDesignProperty]
+  );
+
+  const handlers: Record<string, (v: string) => void> = {
+    scale: createHandler('scale', inputs.scale[1]),
+    rotate: createHandler('rotate', inputs.rotate[1]),
+    translateX: createHandler('translateX', inputs.translateX[1]),
+    translateY: createHandler('translateY', inputs.translateY[1]),
+    skewX: createHandler('skewX', inputs.skewX[1]),
+    skewY: createHandler('skewY', inputs.skewY[1]),
+  };
+
+  const handleScaleSliderChange = useCallback((values: number[]) => {
+    const value = (values[0] / 100).toFixed(2);
+    inputs.scale[1](value);
+    updateDesignProperty('transforms', 'scale', value);
+  }, [inputs.scale, updateDesignProperty]);
+
+  const handleOriginChange = useCallback((value: string) => {
+    updateDesignProperty('transforms', 'transformOrigin', value === 'center' ? null : value);
+  }, [updateDesignProperty]);
+
+  const addHandlers: Record<string, () => void> = {
+    scale: () => { inputs.scale[1]('1'); updateDesignProperty('transforms', 'scale', '1'); },
+    rotate: () => { inputs.rotate[1]('0'); updateDesignProperty('transforms', 'rotate', '0'); },
+    move: () => {
+      inputs.translateX[1]('0'); inputs.translateY[1]('0');
+      updateDesignProperty('transforms', 'translateX', '0');
+      updateDesignProperty('transforms', 'translateY', '0');
+    },
+    skew: () => {
+      inputs.skewX[1]('0'); inputs.skewY[1]('0');
+      updateDesignProperty('transforms', 'skewX', '0');
+      updateDesignProperty('transforms', 'skewY', '0');
+    },
+  };
+
+  const scaleSliderValue = parseFloat(inputs.scale[0]) || 1;
+
+  return (
+    <SettingsPanel
+      title="Transform"
+      isOpen={isOpen}
+      onToggle={() => setIsOpen(!isOpen)}
+      action={
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="xs">
+              <Icon name="plus" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {['scale', 'rotate', 'move', 'skew'].map((id) => (
+              <DropdownMenuItem
+                key={id}
+                onClick={addHandlers[id]}
+                disabled={visibility[id]}
+              >
+                {id.charAt(0).toUpperCase() + id.slice(1)}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      }
+    >
+      {/* Origin */}
+      <div className="grid grid-cols-3">
+        <Label variant="muted">Origin</Label>
+        <div className="col-span-2 *:w-full">
+          <Select value={transformOrigin || 'center'} onValueChange={handleOriginChange}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {ORIGIN_OPTIONS.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Scale */}
+      {visibility.scale && (
+        <div className="grid grid-cols-3">
+          <Label variant="muted">Scale</Label>
+          <div className="col-span-2 grid grid-cols-2 items-center gap-2">
+            <Input
+              type="text"
+              value={inputs.scale[0]}
+              onChange={(e) => handlers.scale(e.target.value)}
+              placeholder="1"
+            />
+            <Slider
+              value={[Math.round(scaleSliderValue * 100)]}
+              onValueChange={handleScaleSliderChange}
+              min={0}
+              max={200}
+              step={5}
+              className="flex-1"
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Rotate */}
+      {visibility.rotate && (
+        <div className="grid grid-cols-3">
+          <Label variant="muted">Rotate</Label>
+          <div className="col-span-2">
+            <InputGroup>
+              <InputGroupInput
+                value={inputs.rotate[0]}
+                onChange={(e) => handlers.rotate(e.target.value)}
+                placeholder="0"
+              />
+              <InputGroupAddon align="inline-end">deg</InputGroupAddon>
+            </InputGroup>
+          </div>
+        </div>
+      )}
+
+      {/* Move & Skew */}
+      {XY_FIELDS.map((field) => {
+        if (!visibility[field.id]) return null;
+        return (
+          <div key={field.id} className="grid grid-cols-3 items-start">
+            <Label variant="muted" className="h-8">{field.label} X/Y</Label>
+            <div className="col-span-2 grid grid-cols-2 gap-2">
+              {field.keys.map((key) => (
+                <Input
+                  key={key}
+                  value={inputs[key as keyof typeof inputs][0]}
+                  onChange={(e) => handlers[key](e.target.value)}
+                  placeholder="0"
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </SettingsPanel>
+  );
+});
+
+export default TransformControls;

--- a/app/(builder)/ycode/components/TransitionControls.tsx
+++ b/app/(builder)/ycode/components/TransitionControls.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useState, useCallback } from 'react';
+import { memo, useState, useCallback, useEffect } from 'react';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -35,8 +35,21 @@ const TransitionControls = memo(function TransitionControls({ layer, onLayerUpda
   const easing = getDesignProperty('transitions', 'easing') || '';
   const delay = getDesignProperty('transitions', 'delay') || '';
 
-  const hasEasing = !!easing;
-  const hasDelay = !!delay;
+  // Track which optional rows are explicitly active so they stay visible when
+  // the user temporarily clears their inputs. Reseeded whenever the layer or
+  // active breakpoint/state changes.
+  const [activeKeys, setActiveKeys] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const next = new Set<string>();
+    if (easing) next.add('easing');
+    if (delay) next.add('delay');
+    setActiveKeys(next);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [layer?.id, activeBreakpoint, activeUIState]);
+
+  const hasEasing = activeKeys.has('easing') || !!easing;
+  const hasDelay = activeKeys.has('delay') || !!delay;
 
   const inputs = useControlledInputs({ duration, delay }, extractMeasurementValue);
 
@@ -63,14 +76,58 @@ const TransitionControls = memo(function TransitionControls({ layer, onLayerUpda
     updateDesignProperty('transitions', 'easing', value || null);
   }, [updateDesignProperty]);
 
+  const activate = useCallback((id: string) => {
+    setActiveKeys(prev => {
+      if (prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  }, []);
+
+  const deactivate = useCallback((id: string) => {
+    setActiveKeys(prev => {
+      if (!prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+
   const handleAddEasing = useCallback(() => {
+    activate('easing');
     updateDesignProperty('transitions', 'easing', 'linear');
-  }, [updateDesignProperty]);
+  }, [activate, updateDesignProperty]);
 
   const handleAddDelay = useCallback(() => {
+    activate('delay');
     inputs.delay[1]('0');
     updateDesignProperty('transitions', 'delay', '0');
-  }, [inputs.delay, updateDesignProperty]);
+  }, [activate, inputs.delay, updateDesignProperty]);
+
+  const handleRemoveEasing = useCallback(() => {
+    deactivate('easing');
+    updateDesignProperty('transitions', 'easing', null);
+  }, [deactivate, updateDesignProperty]);
+
+  const handleRemoveDelay = useCallback(() => {
+    deactivate('delay');
+    inputs.delay[1]('');
+    updateDesignProperty('transitions', 'delay', null);
+  }, [deactivate, inputs.delay, updateDesignProperty]);
+
+  const renderRemoveButton = (id: string, onRemove: () => void) => (
+    <span
+      role="button"
+      tabIndex={0}
+      aria-label={`Remove ${id}`}
+      className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer shrink-0"
+      onClick={onRemove}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onRemove(); } }}
+    >
+      <Icon name="x" className="size-2.5" />
+    </span>
+  );
 
   return (
     <SettingsPanel
@@ -131,7 +188,7 @@ const TransitionControls = memo(function TransitionControls({ layer, onLayerUpda
               onChange={(e) => handleDurationChange(e.target.value)}
               placeholder="150"
             />
-            <InputGroupAddon align="inline-end">ms</InputGroupAddon>
+            <InputGroupAddon align="inline-end" className="text-xs opacity-50">ms</InputGroupAddon>
           </InputGroup>
         </div>
       </div>
@@ -140,23 +197,26 @@ const TransitionControls = memo(function TransitionControls({ layer, onLayerUpda
       {hasEasing && (
         <div className="grid grid-cols-3">
           <Label variant="muted">Easing</Label>
-          <div className="col-span-2 *:w-full">
-            <Select
-              value={easing}
-              onValueChange={handleEasingChange}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="None" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectItem value="linear">Linear</SelectItem>
-                  <SelectItem value="in">Ease In</SelectItem>
-                  <SelectItem value="out">Ease Out</SelectItem>
-                  <SelectItem value="in-out">Ease In Out</SelectItem>
-                </SelectGroup>
-              </SelectContent>
-            </Select>
+          <div className="col-span-2 flex items-center gap-2">
+            <div className="flex-1 min-w-0 *:w-full">
+              <Select
+                value={easing}
+                onValueChange={handleEasingChange}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="None" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectItem value="linear">Linear</SelectItem>
+                    <SelectItem value="in">Ease In</SelectItem>
+                    <SelectItem value="out">Ease Out</SelectItem>
+                    <SelectItem value="in-out">Ease In Out</SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </div>
+            {renderRemoveButton('easing', handleRemoveEasing)}
           </div>
         </div>
       )}
@@ -165,8 +225,8 @@ const TransitionControls = memo(function TransitionControls({ layer, onLayerUpda
       {hasDelay && (
         <div className="grid grid-cols-3">
           <Label variant="muted">Delay</Label>
-          <div className="col-span-2">
-            <InputGroup>
+          <div className="col-span-2 flex items-center gap-2">
+            <InputGroup className="flex-1 min-w-0">
               <InputGroupInput
                 value={inputs.delay[0]}
                 onChange={(e) => handleDelayChange(e.target.value)}
@@ -174,6 +234,7 @@ const TransitionControls = memo(function TransitionControls({ layer, onLayerUpda
               />
               <InputGroupAddon align="inline-end">ms</InputGroupAddon>
             </InputGroup>
+            {renderRemoveButton('delay', handleRemoveDelay)}
           </div>
         </div>
       )}

--- a/app/(builder)/ycode/components/TransitionControls.tsx
+++ b/app/(builder)/ycode/components/TransitionControls.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { memo, useState, useCallback } from 'react';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
+import Icon from '@/components/ui/icon';
+import SettingsPanel from './SettingsPanel';
+import { useDesignSync } from '@/hooks/use-design-sync';
+import { useControlledInputs } from '@/hooks/use-controlled-input';
+import { useEditorStore } from '@/stores/useEditorStore';
+import { extractMeasurementValue } from '@/lib/measurement-utils';
+import { removeSpaces } from '@/lib/utils';
+import type { Layer } from '@/types';
+
+interface TransitionControlsProps {
+  layer: Layer | null;
+  onLayerUpdate: (layerId: string, updates: Partial<Layer>) => void;
+}
+
+const TransitionControls = memo(function TransitionControls({ layer, onLayerUpdate }: TransitionControlsProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const { activeBreakpoint, activeUIState } = useEditorStore();
+  const { updateDesignProperty, debouncedUpdateDesignProperty, getDesignProperty } = useDesignSync({
+    layer,
+    onLayerUpdate,
+    activeBreakpoint,
+    activeUIState,
+  });
+
+  const transitionProperty = getDesignProperty('transitions', 'transitionProperty') || '';
+  const duration = getDesignProperty('transitions', 'duration') || '';
+  const easing = getDesignProperty('transitions', 'easing') || '';
+  const delay = getDesignProperty('transitions', 'delay') || '';
+
+  const hasEasing = !!easing;
+  const hasDelay = !!delay;
+
+  const inputs = useControlledInputs({ duration, delay }, extractMeasurementValue);
+
+  const createTimingHandler = useCallback(
+    (property: string, setter: (v: string) => void) => (value: string) => {
+      let sanitized = removeSpaces(value);
+      if (sanitized.endsWith('s') && !sanitized.endsWith('ms')) {
+        sanitized = String(parseFloat(sanitized) * 1000);
+      }
+      setter(sanitized);
+      debouncedUpdateDesignProperty('transitions', property, sanitized || null);
+    },
+    [debouncedUpdateDesignProperty]
+  );
+
+  const handleDurationChange = createTimingHandler('duration', inputs.duration[1]);
+  const handleDelayChange = createTimingHandler('delay', inputs.delay[1]);
+
+  const handlePropertyChange = useCallback((value: string) => {
+    updateDesignProperty('transitions', 'transitionProperty', value || null);
+  }, [updateDesignProperty]);
+
+  const handleEasingChange = useCallback((value: string) => {
+    updateDesignProperty('transitions', 'easing', value || null);
+  }, [updateDesignProperty]);
+
+  const handleAddEasing = useCallback(() => {
+    updateDesignProperty('transitions', 'easing', 'linear');
+  }, [updateDesignProperty]);
+
+  const handleAddDelay = useCallback(() => {
+    inputs.delay[1]('0');
+    updateDesignProperty('transitions', 'delay', '0');
+  }, [inputs.delay, updateDesignProperty]);
+
+  return (
+    <SettingsPanel
+      title="Transition"
+      isOpen={isOpen}
+      onToggle={() => setIsOpen(!isOpen)}
+      action={
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="xs">
+              <Icon name="plus" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={handleAddEasing} disabled={hasEasing}>
+              Easing
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleAddDelay} disabled={hasDelay}>
+              Delay
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      }
+    >
+      {/* Transition Property */}
+      <div className="grid grid-cols-3">
+        <Label variant="muted">Property</Label>
+        <div className="col-span-2 *:w-full">
+          <Select
+            value={transitionProperty}
+            onValueChange={handlePropertyChange}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="None" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value="none">None</SelectItem>
+                <SelectItem value="all">All</SelectItem>
+                <SelectItem value="default">Default</SelectItem>
+                <SelectItem value="colors">Colors</SelectItem>
+                <SelectItem value="opacity">Opacity</SelectItem>
+                <SelectItem value="shadow">Shadow</SelectItem>
+                <SelectItem value="transform">Transform</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Duration */}
+      <div className="grid grid-cols-3">
+        <Label variant="muted">Duration</Label>
+        <div className="col-span-2">
+          <InputGroup>
+            <InputGroupInput
+              value={inputs.duration[0]}
+              onChange={(e) => handleDurationChange(e.target.value)}
+              placeholder="150"
+            />
+            <InputGroupAddon align="inline-end">ms</InputGroupAddon>
+          </InputGroup>
+        </div>
+      </div>
+
+      {/* Easing */}
+      {hasEasing && (
+        <div className="grid grid-cols-3">
+          <Label variant="muted">Easing</Label>
+          <div className="col-span-2 *:w-full">
+            <Select
+              value={easing}
+              onValueChange={handleEasingChange}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="None" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value="linear">Linear</SelectItem>
+                  <SelectItem value="in">Ease In</SelectItem>
+                  <SelectItem value="out">Ease Out</SelectItem>
+                  <SelectItem value="in-out">Ease In Out</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      )}
+
+      {/* Delay */}
+      {hasDelay && (
+        <div className="grid grid-cols-3">
+          <Label variant="muted">Delay</Label>
+          <div className="col-span-2">
+            <InputGroup>
+              <InputGroupInput
+                value={inputs.delay[0]}
+                onChange={(e) => handleDelayChange(e.target.value)}
+                placeholder="0"
+              />
+              <InputGroupAddon align="inline-end">ms</InputGroupAddon>
+            </InputGroup>
+          </div>
+        </div>
+      )}
+    </SettingsPanel>
+  );
+});
+
+export default TransitionControls;

--- a/hooks/use-design-sync.ts
+++ b/hooks/use-design-sync.ts
@@ -421,7 +421,22 @@ export function useDesignSync({
       // Also capture Tailwind opacity modifier (e.g., text-[#0073ff]/23 → #0073ff/23)
       const arbitraryMatch = inheritedClass.match(/\[([^\]]+)\](?:\/(\d+))?/);
       if (arbitraryMatch) {
-        return arbitraryMatch[2] ? `${arbitraryMatch[1]}/${arbitraryMatch[2]}` : arbitraryMatch[1];
+        let extractedValue = arbitraryMatch[2] ? `${arbitraryMatch[1]}/${arbitraryMatch[2]}` : arbitraryMatch[1];
+        // Strip default units for transform properties so inputs show raw numbers
+        if (['rotate', 'skewX', 'skewY'].includes(property) && extractedValue.endsWith('deg')) {
+          extractedValue = extractedValue.slice(0, -3);
+        }
+        if (['translateX', 'translateY'].includes(property) && extractedValue.endsWith('px')) {
+          extractedValue = extractedValue.slice(0, -2);
+        }
+        if (['duration', 'delay'].includes(property)) {
+          if (extractedValue.endsWith('ms')) {
+            extractedValue = extractedValue.slice(0, -2);
+          } else if (extractedValue.endsWith('s')) {
+            extractedValue = String(parseFloat(extractedValue) * 1000);
+          }
+        }
+        return extractedValue;
       }
 
       // CSS variable reference for background-image
@@ -586,14 +601,31 @@ function mapClassToDesignValue(className: string, property: string): string | un
 
   // Special cases for properties where classes don't have dashes or are complete values
   const noSplitProperties = [
-    'position',        // static, absolute, relative, fixed, sticky
-    'display',         // block, inline, flex, grid, hidden (some have dashes like inline-block)
-    'textTransform',   // uppercase, lowercase, capitalize, normal-case
-    'textDecoration',  // underline, overline, line-through, no-underline
+    'position',            // static, absolute, relative, fixed, sticky
+    'display',             // block, inline, flex, grid, hidden (some have dashes like inline-block)
+    'textTransform',       // uppercase, lowercase, capitalize, normal-case
+    'textDecoration',      // underline, overline, line-through, no-underline
   ];
 
   if (noSplitProperties.includes(property)) {
     return cleanClass;
+  }
+
+  // Full-class mappings for properties where the entire class maps to a value
+  const fullClassMappings: Record<string, Record<string, string>> = {
+    transitionProperty: {
+      'transition': 'default',
+      'transition-all': 'all',
+      'transition-colors': 'colors',
+      'transition-opacity': 'opacity',
+      'transition-shadow': 'shadow',
+      'transition-transform': 'transform',
+      'transition-none': 'none',
+    },
+  };
+
+  if (fullClassMappings[property]?.[cleanClass]) {
+    return fullClassMappings[property][cleanClass];
   }
 
   // Multi-segment prefix properties need special handling.
@@ -606,6 +638,12 @@ function mapClassToDesignValue(className: string, property: string): string | un
     gridColumnSpan: 'col-span-',
     gridRowSpan: 'row-span-',
     lineClamp: 'line-clamp-',
+    translateX: 'translate-x-',
+    translateY: 'translate-y-',
+    skewX: 'skew-x-',
+    skewY: 'skew-y-',
+    transformOrigin: 'origin-',
+    backdropBlur: 'backdrop-blur-',
   };
 
   const knownPrefix = multiSegmentPrefixes[property];
@@ -661,6 +699,12 @@ function mapClassToDesignValue(className: string, property: string): string | un
       'wrap': 'wrap',
       'wrap-reverse': 'wrap-reverse',
       'nowrap': 'nowrap',
+    },
+    easing: {
+      'linear': 'linear',
+      'in': 'in',
+      'out': 'out',
+      'in-out': 'in-out',
     },
   };
 

--- a/lib/tailwind-class-mapper.ts
+++ b/lib/tailwind-class-mapper.ts
@@ -200,6 +200,45 @@ function formatMeasurementClass(
 }
 
 /**
+ * Formats a signed arbitrary Tailwind class (supports negative values).
+ * "-45deg" with prefix "rotate" → "-rotate-[45deg]"
+ * "10px" with prefix "translate-x" → "translate-x-[10px]"
+ */
+function formatSignedArbitraryClass(value: string, prefix: string): string {
+  if (value.startsWith('-')) return `-${prefix}-[${value.slice(1)}]`;
+  return `${prefix}-[${value}]`;
+}
+
+/**
+ * Ensures an angle value has a unit. Plain numbers get "deg" appended.
+ * "45" → "45deg", "45deg" → "45deg", "0.5turn" → "0.5turn"
+ */
+function ensureAngleUnit(value: string): string {
+  const bare = value.startsWith('-') ? value.slice(1) : value;
+  if (/^\d*\.?\d+$/.test(bare)) return `${value}deg`;
+  return value;
+}
+
+/**
+ * Strips the default "deg" unit from an angle value for clean display.
+ * "45deg" → "45", "-90deg" → "-90", "0.5turn" → "0.5turn" (preserved)
+ */
+function stripAngleUnit(value: string): string {
+  if (value.endsWith('deg')) return value.slice(0, -3);
+  return value;
+}
+
+/**
+ * Ensures a length value has a unit. Plain numbers get "px" appended.
+ * "20" → "20px", "-50" → "-50px", "10rem" → "10rem", "50%" → "50%"
+ */
+function ensureLengthUnit(value: string): string {
+  const bare = value.startsWith('-') ? value.slice(1) : value;
+  if (/^\d*\.?\d+$/.test(bare)) return `${value}px`;
+  return value;
+}
+
+/**
  * Map of Tailwind class prefixes to their property names
  * Used for conflict detection and removal
  */
@@ -310,6 +349,21 @@ const CLASS_PROPERTY_MAP: Record<string, RegExp> = {
   bottom: /^bottom-(\[.+\]|\d+|px|auto|0\.5|1\.5|2\.5|3\.5)$/,
   left: /^left-(\[.+\]|\d+|px|auto|0\.5|1\.5|2\.5|3\.5)$/,
   zIndex: /^z-(\[.+\]|\d+|auto)$/,
+
+  // Transforms
+  scale: /^scale-(\[.+\]|\d+)$/,
+  rotate: /^-?rotate-(\[.+\]|\d+)$/,
+  translateX: /^-?translate-x-(\[.+\]|\d+\/\d+|\d+|px|full)$/,
+  translateY: /^-?translate-y-(\[.+\]|\d+\/\d+|\d+|px|full)$/,
+  skewX: /^-?skew-x-(\[.+\]|\d+)$/,
+  skewY: /^-?skew-y-(\[.+\]|\d+)$/,
+  transformOrigin: /^origin-(center|top|top-right|right|bottom-right|bottom|bottom-left|left|top-left)$/,
+
+  // Transitions
+  transitionProperty: /^transition(-all|-colors|-opacity|-shadow|-transform|-none)?$/,
+  duration: /^duration-(\[.+\]|\d+)$/,
+  easing: /^ease-(linear|in|out|in-out)$/,
+  delay: /^delay-(\[.+\]|\d+)$/,
 };
 
 /**
@@ -897,6 +951,53 @@ export function propertyToClass(
     }
   }
 
+  // Transform conversions
+  if (category === 'transforms') {
+    switch (property) {
+      case 'scale': {
+        const num = parseFloat(value);
+        if (!isNaN(num)) return `scale-[${value}]`;
+        return `scale-${value}`;
+      }
+      case 'rotate':
+        return formatSignedArbitraryClass(ensureAngleUnit(value), 'rotate');
+      case 'translateX':
+        if (value === 'full') return 'translate-x-full';
+        return formatSignedArbitraryClass(ensureLengthUnit(value), 'translate-x');
+      case 'translateY':
+        if (value === 'full') return 'translate-y-full';
+        return formatSignedArbitraryClass(ensureLengthUnit(value), 'translate-y');
+      case 'skewX':
+        return formatSignedArbitraryClass(ensureAngleUnit(value), 'skew-x');
+      case 'skewY':
+        return formatSignedArbitraryClass(ensureAngleUnit(value), 'skew-y');
+      case 'transformOrigin':
+        return `origin-${value}`;
+    }
+  }
+
+  // Transition conversions
+  if (category === 'transitions') {
+    switch (property) {
+      case 'transitionProperty':
+        if (value === 'none') return 'transition-none';
+        if (value === 'all') return 'transition-all';
+        if (['colors', 'opacity', 'shadow', 'transform'].includes(value)) {
+          return `transition-${value}`;
+        }
+        return 'transition';
+      case 'duration':
+      case 'delay': {
+        const prefix = property === 'duration' ? 'duration' : 'delay';
+        const bare = value.replace(/^-/, '');
+        if (/^\d*\.?\d+$/.test(bare)) return `${prefix}-[${value}ms]`;
+        return `${prefix}-[${value}]`;
+      }
+      case 'easing':
+        return `ease-${value}`;
+    }
+  }
+
   return null;
 }
 
@@ -1110,6 +1211,8 @@ export function classesToDesign(classes: string | string[]): Layer['design'] {
     backgrounds: {},
     effects: {},
     positioning: {},
+    transforms: {},
+    transitions: {},
   };
 
   // Check if this is a text gradient (bg-[gradient] + bg-clip-text)
@@ -1647,6 +1750,104 @@ export function classesToDesign(classes: string | string[]): Layer['design'] {
     if (cls.startsWith('z-[')) {
       const value = extractArbitraryValue(cls);
       if (value) design.positioning!.zIndex = value;
+    }
+
+    // ===== TRANSFORMS =====
+    // Scale
+    if (cls.startsWith('scale-[')) {
+      const value = extractArbitraryValue(cls);
+      if (value) design.transforms!.scale = value;
+    } else if (cls.match(/^scale-\d+$/)) {
+      const match = cls.match(/^scale-(\d+)$/);
+      if (match) design.transforms!.scale = match[1];
+    }
+
+    // Rotate (store raw number; ensureAngleUnit adds deg on output)
+    if (cls.startsWith('rotate-[') || cls.startsWith('-rotate-[')) {
+      const value = extractArbitraryValue(cls);
+      if (value) {
+        const sign = cls.startsWith('-') ? '-' : '';
+        design.transforms!.rotate = stripAngleUnit(`${sign}${value}`);
+      }
+    } else if (cls.match(/^-?rotate-\d+$/)) {
+      const match = cls.match(/^(-?)rotate-(\d+)$/);
+      if (match) design.transforms!.rotate = `${match[1]}${match[2]}`;
+    }
+
+    // Translate X/Y (store raw number; ensureLengthUnit adds px on output)
+    for (const axis of ['x', 'y'] as const) {
+      const prop = axis === 'x' ? 'translateX' : 'translateY';
+      const prefix = `translate-${axis}`;
+      if (cls.startsWith(`${prefix}-[`) || cls.startsWith(`-${prefix}-[`)) {
+        const value = extractArbitraryValue(cls);
+        if (value) {
+          const sign = cls.startsWith('-') ? '-' : '';
+          const stripped = value.endsWith('px') ? value.slice(0, -2) : value;
+          design.transforms![prop] = `${sign}${stripped}`;
+        }
+      } else if (cls === `${prefix}-full`) {
+        design.transforms![prop] = 'full';
+      } else if (cls === `-${prefix}-full`) {
+        design.transforms![prop] = '-full';
+      }
+    }
+
+    // Skew X/Y (store raw number; ensureAngleUnit adds deg on output)
+    for (const axis of ['x', 'y'] as const) {
+      const prop = axis === 'x' ? 'skewX' : 'skewY';
+      const prefix = `skew-${axis}`;
+      if (cls.startsWith(`${prefix}-[`) || cls.startsWith(`-${prefix}-[`)) {
+        const value = extractArbitraryValue(cls);
+        if (value) {
+          const sign = cls.startsWith('-') ? '-' : '';
+          design.transforms![prop] = stripAngleUnit(`${sign}${value}`);
+        }
+      } else if (cls.match(new RegExp(`^-?${prefix}-\\d+$`))) {
+        const match = cls.match(new RegExp(`^(-?)${prefix}-(\\d+)$`));
+        if (match) design.transforms![prop] = `${match[1]}${match[2]}`;
+      }
+    }
+
+    // Transform Origin
+    if (cls.startsWith('origin-')) {
+      const value = cls.replace('origin-', '');
+      if (['center', 'top', 'top-right', 'right', 'bottom-right', 'bottom', 'bottom-left', 'left', 'top-left'].includes(value)) {
+        design.transforms!.transformOrigin = value;
+      }
+    }
+
+    // ===== TRANSITIONS =====
+    // Transition Property
+    const transitionMap: Record<string, string> = {
+      'transition': 'default', 'transition-all': 'all', 'transition-colors': 'colors',
+      'transition-opacity': 'opacity', 'transition-shadow': 'shadow',
+      'transition-transform': 'transform', 'transition-none': 'none',
+    };
+    if (transitionMap[cls]) design.transitions!.transitionProperty = transitionMap[cls];
+
+    // Easing
+    const easingMap: Record<string, string> = {
+      'ease-linear': 'linear', 'ease-in': 'in', 'ease-out': 'out', 'ease-in-out': 'in-out',
+    };
+    if (easingMap[cls]) design.transitions!.easing = easingMap[cls];
+
+    // Duration & Delay (store raw number; ensureLengthUnit-style adds ms on output)
+    for (const [prefix, prop] of [['duration', 'duration'], ['delay', 'delay']] as const) {
+      if (cls.startsWith(`${prefix}-[`)) {
+        const value = extractArbitraryValue(cls);
+        if (value) {
+          if (value.endsWith('ms')) {
+            design.transitions![prop] = value.slice(0, -2);
+          } else if (value.endsWith('s')) {
+            design.transitions![prop] = String(parseFloat(value) * 1000);
+          } else {
+            design.transitions![prop] = value;
+          }
+        }
+      } else if (cls.match(new RegExp(`^${prefix}-\\d+$`))) {
+        const match = cls.match(new RegExp(`^${prefix}-(\\d+)$`));
+        if (match) design.transitions![prop] = match[1];
+      }
     }
   });
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -135,6 +135,25 @@ export interface PositioningDesign {
   zIndex?: string;
 }
 
+export interface TransformsDesign {
+  isActive?: boolean;
+  scale?: string;
+  rotate?: string;
+  translateX?: string;
+  translateY?: string;
+  skewX?: string;
+  skewY?: string;
+  transformOrigin?: string;
+}
+
+export interface TransitionsDesign {
+  isActive?: boolean;
+  transitionProperty?: string;
+  duration?: string;
+  easing?: string;
+  delay?: string;
+}
+
 export interface DesignProperties {
   layout?: LayoutDesign;
   typography?: TypographyDesign;
@@ -144,6 +163,8 @@ export interface DesignProperties {
   backgrounds?: BackgroundsDesign;
   effects?: EffectsDesign;
   positioning?: PositioningDesign;
+  transforms?: TransformsDesign;
+  transitions?: TransitionsDesign;
 }
 
 export interface FormSettings {


### PR DESCRIPTION
## Summary

Add Transform and Transition control panels to the design sidebar, enabling visual editing of CSS transform and transition properties through Tailwind classes.

## Changes

- Add `TransformsDesign` and `TransitionsDesign` interfaces to `types/index.ts`
- Extend `tailwind-class-mapper.ts` with bidirectional mappings for scale, rotate, translate, skew, origin, transition property, duration, easing, and delay
- Update `use-design-sync.ts` to parse and strip units (deg, px, ms/s) for transform and transition properties
- Create `TransformControls.tsx` with origin (always visible), scale, rotate, move, and skew behind a + dropdown menu
- Create `TransitionControls.tsx` with property and duration (always visible), easing and delay behind a + dropdown menu
- Normalize duration/delay values to ms (auto-convert `2s` → `2000`)
- Wire both panels into `RightSidebar.tsx` with visibility rules matching position controls

## Test plan

- [ ] Select an element, open Transform section, verify Origin select works
- [ ] Add Scale via + button, adjust via input and slider, verify class output
- [ ] Add Rotate via + button, type a value, verify `deg` unit addon and class
- [ ] Add Move via + button, set X/Y values, clear one — verify section stays visible
- [ ] Add Skew via + button, verify X/Y inputs work
- [ ] Open Transition section, select a property, set duration
- [ ] Add Easing and Delay via + button, verify they appear
- [ ] Type `2s` in duration — verify it converts to `2000` with `ms` addon
- [ ] Verify controls hide for text-only layers and text style mode

Made with [Cursor](https://cursor.com)