### PR TITLE
perf: speed up editor transitions

### DIFF
--- a/app/(builder)/ycode/components/Canvas.tsx
+++ b/app/(builder)/ycode/components/Canvas.tsx
@@ -98,6 +98,8 @@ interface CanvasProps {
   onLayerHover?: (layerId: string | null) => void;
   /** Callback when any click occurs inside the canvas (for closing panels) */
   onCanvasClick?: () => void;
+  /** Callback when a component instance is double-clicked on the canvas */
+  onComponentEdit?: (componentId: string, instanceLayerId: string) => void;
   /** Component variables when editing a component (for default value display) */
   editingComponentVariables?: ComponentVariable[];
   /** Disable editor hidden layers (e.g., when Interactions panel is active) */
@@ -128,6 +130,7 @@ interface CanvasContentProps {
   editorHiddenLayerIds?: Map<string, Breakpoint[]>;
   editorBreakpoint?: Breakpoint;
   zoom?: number;
+  onComponentEdit?: (componentId: string, instanceLayerId: string) => void;
 }
 
 function CanvasContent({
@@ -147,6 +150,7 @@ function CanvasContent({
   editorHiddenLayerIds,
   editorBreakpoint,
   zoom = 100,
+  onComponentEdit,
 }: CanvasContentProps) {
   const bodyRef = useRef<HTMLDivElement>(null);
   const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null);
@@ -246,6 +250,7 @@ function CanvasContent({
           editorHiddenLayerIds={editorHiddenLayerIds}
           editorBreakpoint={editorBreakpoint}
           ancestorComponentIds={initialAncestorIds}
+          onComponentEdit={onComponentEdit}
         />
       </div>
     </CanvasPortalProvider>
@@ -290,6 +295,7 @@ export default function Canvas({
   onIframeReady,
   onLayerHover,
   onCanvasClick,
+  onComponentEdit,
   editingComponentVariables,
   disableEditorHiddenLayers = false,
   zoom = 100,
@@ -508,6 +514,7 @@ export default function Canvas({
         editorHiddenLayerIds={editorHiddenLayerIds}
         editorBreakpoint={breakpoint}
         zoom={zoom}
+        onComponentEdit={onComponentEdit}
       />
     );
   // selectedLayerId and hoveredLayerId are intentionally excluded from deps:
@@ -530,6 +537,7 @@ export default function Canvas({
     editorHiddenLayerIds,
     breakpoint,
     zoom,
+    onComponentEdit,
   ]);
 
   // Handle keyboard events from iframe

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -681,13 +681,9 @@ const CenterCanvas = React.memo(function CenterCanvas({
     }
   }, [richTextSheetLayerId, selectedLayerId, closeRichTextSheet]);
 
-  // Load draft when page changes (ensure draft exists before rendering)
-  const loadDraft = usePagesStore((state) => state.loadDraft);
-  useEffect(() => {
-    if (currentPageId && !currentDraft) {
-      loadDraft(currentPageId);
-    }
-  }, [currentPageId, loadDraft, currentDraft]);
+  // Draft loading is owned by LeftSidebar (wrapped in startTransition).
+  // The store-level in-flight guard in loadDraft makes any concurrent call
+  // a no-op if LeftSidebar is not mounted.
 
   // Reset content height when page changes to force Canvas to recalculate
   useEffect(() => {

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -34,6 +34,7 @@ import {
 
 // 4. Hooks
 import { useEditorUrl } from '@/hooks/use-editor-url';
+import { useEditComponent } from '@/hooks/use-edit-component';
 import { useZoom } from '@/hooks/use-zoom';
 import { useUndoRedo } from '@/hooks/use-undo-redo';
 
@@ -1524,6 +1525,13 @@ const CenterCanvas = React.memo(function CenterCanvas({
     setHoveredLayerId(layerId);
   }, [setHoveredLayerId]);
 
+  // Open the master component when a component instance is double-clicked.
+  // Mirrors the "Edit component" sidebar button.
+  const editComponent = useEditComponent();
+  const handleCanvasComponentEdit = useCallback((componentId: string, instanceLayerId: string) => {
+    editComponent(componentId, { returnToLayerId: instanceLayerId });
+  }, [editComponent]);
+
   // Undo/Redo handlers
   // Note: We don't auto-save after undo/redo to preserve the redo stack
   // The state will be saved when the user makes the next change
@@ -2436,6 +2444,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
                         onIframeReady={handleIframeReady}
                         onLayerHover={handleCanvasLayerHover}
                         onCanvasClick={handleCanvasClick}
+                        onComponentEdit={handleCanvasComponentEdit}
                         editingComponentVariables={editingComponentVariables}
                         disableEditorHiddenLayers={!!activeInteractionTriggerLayerId}
                         zoom={zoom}

--- a/app/(builder)/ycode/components/ComponentInstanceSidebar.tsx
+++ b/app/(builder)/ycode/components/ComponentInstanceSidebar.tsx
@@ -22,9 +22,8 @@ import SettingsPanel from './SettingsPanel';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { useComponentsStore } from '@/stores/useComponentsStore';
 import { usePagesStore } from '@/stores/usePagesStore';
-import { useEditorActions } from '@/hooks/use-editor-url';
+import { useEditComponent } from '@/hooks/use-edit-component';
 import { detachSpecificLayerFromComponent } from '@/lib/component-utils';
-import { findLayerById } from '@/lib/layer-utils';
 import { EMPTY_OVERRIDES } from '@/lib/variable-utils';
 
 import type { Layer, ComponentVariable, Component, Collection, CollectionField } from '@/types';
@@ -53,7 +52,7 @@ export default function ComponentInstanceSidebar({
   collections,
   isInsideCollectionLayer,
 }: ComponentInstanceSidebarProps) {
-  const { openComponent } = useEditorActions();
+  const editComponent = useEditComponent();
 
   const currentPageId = useEditorStore((state) => state.currentPageId);
   const editingComponentId = useEditorStore((state) => state.editingComponentId);
@@ -87,46 +86,8 @@ export default function ComponentInstanceSidebar({
     .some(cat => Object.keys(overrides?.[cat as keyof typeof overrides] || {}).length > 0);
 
   const handleEditMasterComponent = useCallback(async () => {
-    const { loadComponentDraft, getComponentById: getComp } = useComponentsStore.getState();
-    const { setSelectedLayerId: setLayerId, pushComponentNavigation } = useEditorStore.getState();
-    const { pages: allPages } = usePagesStore.getState();
-
-    setLayerId(null);
-
-    if (editingComponentId) {
-      const currentComponent = getComp(editingComponentId);
-      if (currentComponent) {
-        pushComponentNavigation({
-          type: 'component',
-          id: editingComponentId,
-          name: currentComponent.name,
-          layerId: selectedLayerId,
-        });
-      }
-    } else if (currentPageId) {
-      const currentPage = allPages.find((p) => p.id === currentPageId);
-      if (currentPage) {
-        pushComponentNavigation({
-          type: 'page',
-          id: currentPageId,
-          name: currentPage.name,
-          layerId: selectedLayerId,
-        });
-      }
-    }
-
-    await loadComponentDraft(component.id);
-    openComponent(component.id, currentPageId, undefined, selectedLayerId);
-
-    // Select root layer only if user hasn't already selected a valid component layer during the await
-    if (component.layers && component.layers.length > 0) {
-      const currentSelection = useEditorStore.getState().selectedLayerId;
-      const hasValidSelection = currentSelection && findLayerById(component.layers, currentSelection);
-      if (!hasValidSelection) {
-        setLayerId(component.layers[0].id);
-      }
-    }
-  }, [editingComponentId, currentPageId, selectedLayerId, component, openComponent]);
+    await editComponent(component.id, { returnToLayerId: selectedLayerId });
+  }, [editComponent, component.id, selectedLayerId]);
 
   const handleOverridesChange = useCallback((newOverrides: Layer['componentOverrides']) => {
     onLayerUpdate(selectedLayerId, { componentOverrides: newOverrides });

--- a/app/(builder)/ycode/components/LayersTree.tsx
+++ b/app/(builder)/ycode/components/LayersTree.tsx
@@ -75,7 +75,11 @@ function getLayerDisplayLabel(
     return layer.customName!;
   }
 
-  if (!isTextLayer && layer.customName) {
+  // Component instances: prefer the component's name over the underlying
+  // block's default customName (e.g. a `section` layer converted to a
+  // component would otherwise display as "Section" instead of the
+  // component's actual name).
+  if (!isTextLayer && !layer.componentId && layer.customName) {
     return layer.customName;
   }
 

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -1031,13 +1031,11 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
       // Only sync across pages and broadcast when the user actually edited
       // the component during this editing session.
       if (wasDirty) {
-        const updatedComponent = getComponentById(editingComponentId);
-        if (updatedComponent) {
-          updateComponentOnLayers(editingComponentId, updatedComponent.layers);
+        updateComponentOnLayers(editingComponentId);
 
-          if (liveComponentUpdates) {
-            liveComponentUpdates.broadcastComponentLayersUpdate(editingComponentId, updatedComponent.layers);
-          }
+        const updatedComponent = getComponentById(editingComponentId);
+        if (updatedComponent && liveComponentUpdates) {
+          liveComponentUpdates.broadcastComponentLayersUpdate(editingComponentId, updatedComponent.layers);
         }
       }
 

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -172,7 +172,10 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
     urlState.view || 'desktop'
   );
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const lastLayersByPageRef = useRef<Map<string, string>>(new Map());
+  // Tracks the last-seen layers reference per page. Reference equality is
+  // sufficient because store mutators always produce a new layers array on
+  // actual changes (React relies on this for re-rendering).
+  const lastLayersByPageRef = useRef<Map<string, Layer[]>>(new Map());
   const previousPageIdRef = useRef<string | null>(null);
   const previousResourceIdRef = useRef<string | null>(null); // Track URL resourceId changes
   const hasInitializedLayerFromUrlRef = useRef(false);
@@ -905,11 +908,11 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
       return;
     }
 
-    const currentLayersJSON = JSON.stringify(currentDraft.layers);
-    const lastLayersJSON = lastLayersByPageRef.current.get(currentPageId);
+    const currentLayers = currentDraft.layers;
+    const lastLayers = lastLayersByPageRef.current.get(currentPageId);
 
-    // Only trigger save if layers actually changed for THIS page
-    if (lastLayersJSON && lastLayersJSON !== currentLayersJSON) {
+    // Only trigger save if the layers array reference actually changed for THIS page
+    if (lastLayers && lastLayers !== currentLayers) {
       if (consumePageMcpSync(currentPageId)) {
         // MCP already saved to DB — cancel any pending autosave and accept
         if (saveTimeoutRef.current) {
@@ -923,8 +926,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
       }
     }
 
-    // Update the ref for next comparison (store per page)
-    lastLayersByPageRef.current.set(currentPageId, currentLayersJSON);
+    lastLayersByPageRef.current.set(currentPageId, currentLayers);
   }, [currentPageId, currentDraft, debouncedSave]);
 
   // Cleanup save timeout on unmount only
@@ -1018,18 +1020,24 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         clearTimeout(saveTimeouts[editingComponentId]);
       }
 
-      // Immediately save component draft (ensures all changes are persisted)
+      // Capture whether this draft has any unpersisted edits before saving,
+      // since saveComponentDraft will reset the dirty flag on success.
+      const wasDirty = !!useComponentsStore.getState().componentDraftDirty[editingComponentId];
+
+      // Immediately save component draft (ensures all changes are persisted).
+      // This is a no-op if the draft is not dirty.
       await saveComponentDraft(editingComponentId);
 
-      // Get the updated component to get its layers
-      const updatedComponent = getComponentById(editingComponentId);
-      if (updatedComponent) {
-        // Update all instances across pages with the new layers
-        await updateComponentOnLayers(editingComponentId, updatedComponent.layers);
+      // Only sync across pages and broadcast when the user actually edited
+      // the component during this editing session.
+      if (wasDirty) {
+        const updatedComponent = getComponentById(editingComponentId);
+        if (updatedComponent) {
+          updateComponentOnLayers(editingComponentId, updatedComponent.layers);
 
-        // Broadcast component layers update to collaborators
-        if (liveComponentUpdates) {
-          liveComponentUpdates.broadcastComponentLayersUpdate(editingComponentId, updatedComponent.layers);
+          if (liveComponentUpdates) {
+            liveComponentUpdates.broadcastComponentLayersUpdate(editingComponentId, updatedComponent.layers);
+          }
         }
       }
 
@@ -1073,16 +1081,9 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
           }
         }
       } else {
-        // Returning to a page
-        // Exit edit mode to clear the state and pop the stack
-        setEditingComponentId(null, null);
-
-        // Small delay to ensure state clears
-        await new Promise(resolve => setTimeout(resolve, 10));
         // Returning to a page (or no stack entry)
         let targetPageId = returnToPageId;
         if (!targetPageId) {
-          // No return page - use homepage or first available page
           const homePage = findHomepage(pages);
           const defaultPage = homePage || pages[0];
           targetPageId = defaultPage?.id || null;
@@ -1093,21 +1094,24 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
           return;
         }
 
-        // Navigate to the target page, including the layer ID in the URL
-        // This ensures the URL sync effect will restore the correct layer
+        // Clear edit mode state synchronously, then navigate.
+        // The URL sync effect will restore the correct layer from the URL.
+        setEditingComponentId(null, null);
         navigateToLayers(
           targetPageId,
-          undefined, // view - use current
-          undefined, // rightTab - use current
-          returnToLayerId || returnDestination?.layerId || undefined // layerId - restore the original layer
+          undefined,
+          undefined,
+          returnToLayerId || returnDestination?.layerId || undefined
         );
       }
-
-      // Wait for navigation to complete
-      await new Promise(resolve => setTimeout(resolve, 100));
     } finally {
-      // Clear flag after exit completes
-      isExitingComponentModeRef.current = false;
+      // Defer clearing the guard until after the URL update has propagated.
+      // Otherwise the URL sync effect may re-run with the old `routeType ===
+      // 'component'` (because router.push is async) while the guard is already
+      // cleared, and re-enter component edit mode.
+      setTimeout(() => {
+        isExitingComponentModeRef.current = false;
+      }, 0);
     }
 
     // Selection will be restored by the URL sync effect

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -2774,6 +2774,11 @@ const LayerItem: React.FC<{
       );
     }
 
+    // Resolved parent-component context to pass to child LayerRenderers.
+    // Innermost component wins so double-click-to-edit targets the correct component.
+    const childParentComponentLayerId = layer.componentId ? layer.id : parentComponentLayerId;
+    const childParentComponentId = layer.componentId || parentComponentId;
+
     // Collection layers - repeat the element for each item (design applies to each looped item)
     if (isCollectionLayer && isEditMode) {
       if (isLoadingLayerData) {
@@ -2922,8 +2927,8 @@ const LayerItem: React.FC<{
                     currentLocale={currentLocale}
                     availableLocales={availableLocales}
                     liveLayerUpdates={liveLayerUpdates}
-                    parentComponentLayerId={parentComponentLayerId || (layer.componentId ? layer.id : undefined)}
-                    parentComponentId={parentComponentId || layer.componentId}
+                    parentComponentLayerId={childParentComponentLayerId}
+                    parentComponentId={childParentComponentId}
                     parentComponentOverrides={parentComponentOverrides}
                     parentComponentVariables={parentComponentVariables}
                     editingComponentVariables={editingComponentVariables}
@@ -3000,8 +3005,8 @@ const LayerItem: React.FC<{
               availableLocales={availableLocales}
               localeSelectorFormat={format}
               liveLayerUpdates={liveLayerUpdates}
-              parentComponentLayerId={layer.componentId ? layer.id : parentComponentLayerId}
-              parentComponentId={layer.componentId || parentComponentId}
+              parentComponentLayerId={childParentComponentLayerId}
+              parentComponentId={childParentComponentId}
               parentComponentOverrides={parentComponentOverrides}
               parentComponentVariables={parentComponentVariables}
               editingComponentVariables={editingComponentVariables}
@@ -3068,8 +3073,8 @@ const LayerItem: React.FC<{
             availableLocales={availableLocales}
             localeSelectorFormat={localeSelectorFormat}
             liveLayerUpdates={liveLayerUpdates}
-            parentComponentLayerId={parentComponentLayerId || (layer.componentId ? layer.id : undefined)}
-            parentComponentId={parentComponentId || layer.componentId}
+            parentComponentLayerId={childParentComponentLayerId}
+            parentComponentId={childParentComponentId}
             parentComponentOverrides={parentComponentOverrides}
             parentComponentVariables={parentComponentVariables}
             editingComponentVariables={editingComponentVariables}

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -105,6 +105,7 @@ interface LayerRendererProps {
   liveLayerUpdates?: UseLiveLayerUpdatesReturn | null; // For collaboration broadcasts
   liveComponentUpdates?: UseLiveComponentUpdatesReturn | null; // For component collaboration broadcasts
   parentComponentLayerId?: string; // ID of the parent component layer (if rendering inside a component)
+  parentComponentId?: string; // ID of the parent component (mirror of parentComponentLayerId for double-click-to-edit)
   parentComponentOverrides?: Layer['componentOverrides']; // Override values from parent component instance
   parentComponentVariables?: ComponentVariable[]; // Component's variables for default value lookup
   editingComponentVariables?: ComponentVariable[]; // Variables when directly editing a component
@@ -129,6 +130,8 @@ interface LayerRendererProps {
   serverSettings?: Record<string, unknown>;
   /** When true, the component root layer (layer.id === parentComponentLayerId) renders its own context menu */
   componentRootContextMenu?: boolean;
+  /** Called when a component instance is double-clicked on the canvas (edit mode only). */
+  onComponentEdit?: (componentId: string, instanceLayerId: string) => void;
 }
 
 const LayerRenderer: React.FC<LayerRendererProps> = ({
@@ -160,6 +163,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
   liveLayerUpdates,
   liveComponentUpdates,
   parentComponentLayerId,
+  parentComponentId,
   parentComponentOverrides,
   parentComponentVariables,
   editingComponentVariables,
@@ -177,6 +181,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
   isSlideChild: isSlideChildProp,
   serverSettings,
   componentRootContextMenu,
+  onComponentEdit,
 }) => {
   const [editingLayerId, setEditingLayerId] = useState<string | null>(null);
   const [editingContent, setEditingContent] = useState<string>('');
@@ -304,6 +309,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
         liveLayerUpdates={liveLayerUpdates}
         liveComponentUpdates={liveComponentUpdates}
         parentComponentLayerId={parentComponentLayerId}
+        parentComponentId={parentComponentId}
         parentComponentOverrides={parentComponentOverrides}
         parentComponentVariables={parentComponentVariables}
         editingComponentVariables={editingComponentVariables}
@@ -322,6 +328,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
         isSlideChild={isSlideChildProp}
         serverSettings={serverSettings}
         componentRootContextMenu={componentRootContextMenu}
+        onComponentEdit={onComponentEdit}
       />
     );
   };
@@ -369,6 +376,7 @@ const LayerItem: React.FC<{
   liveLayerUpdates?: UseLiveLayerUpdatesReturn | null;
   liveComponentUpdates?: UseLiveComponentUpdatesReturn | null;
   parentComponentLayerId?: string; // ID of the parent component layer (if this layer is inside a component)
+  parentComponentId?: string; // ID of the parent component (mirrors parentComponentLayerId)
   parentComponentOverrides?: Layer['componentOverrides']; // Override values from parent component instance
   parentComponentVariables?: ComponentVariable[]; // Component's variables for default value lookup
   editingComponentVariables?: ComponentVariable[]; // Variables when directly editing a component
@@ -387,6 +395,7 @@ const LayerItem: React.FC<{
   isSlideChild?: boolean;
   serverSettings?: Record<string, unknown>;
   componentRootContextMenu?: boolean;
+  onComponentEdit?: (componentId: string, instanceLayerId: string) => void;
 }> = ({
   layer,
   isEditMode,
@@ -421,6 +430,7 @@ const LayerItem: React.FC<{
   liveLayerUpdates,
   liveComponentUpdates,
   parentComponentLayerId,
+  parentComponentId,
   parentComponentOverrides,
   parentComponentVariables,
   editingComponentVariables,
@@ -435,6 +445,7 @@ const LayerItem: React.FC<{
   anchorMap,
   resolvedAssets,
   components: componentsProp,
+  onComponentEdit,
   ancestorComponentIds,
   isSlideChild,
   serverSettings,
@@ -532,10 +543,11 @@ const LayerItem: React.FC<{
     resolvedAssets,
     components: componentsProp,
     serverSettings,
+    onComponentEdit,
   // selectedLayerId and hoveredLayerId kept in the object for SSR/published mode
   // but excluded from deps so changes don't cascade re-renders in edit mode.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }), [isEditMode, isPublished, onLayerClick, onLayerUpdate, onLayerHover, pageId, collectionLayerData, collectionLayerItemId, effectiveLayerDataMap, pageCollectionItemId, pageCollectionItemData, pageCollectionSortedItemIds, hiddenLayerInfo, editorHiddenLayerIds, editorBreakpoint, currentLocale, availableLocales, localeSelectorFormat, liveLayerUpdates, liveComponentUpdates, isInsideForm, isInsideLink, parentFormSettings, pages, folders, collectionItemSlugs, isPreview, translations, anchorMap, resolvedAssets, componentsProp, serverSettings]);
+  }), [isEditMode, isPublished, onLayerClick, onLayerUpdate, onLayerHover, pageId, collectionLayerData, collectionLayerItemId, effectiveLayerDataMap, pageCollectionItemId, pageCollectionItemData, pageCollectionSortedItemIds, hiddenLayerInfo, editorHiddenLayerIds, editorBreakpoint, currentLocale, availableLocales, localeSelectorFormat, liveLayerUpdates, liveComponentUpdates, isInsideForm, isInsideLink, parentFormSettings, pages, folders, collectionItemSlugs, isPreview, translations, anchorMap, resolvedAssets, componentsProp, serverSettings, onComponentEdit]);
 
   // Callback for rendering embedded components inside rich-text content
   // Clicks on the embedded component's internal layers should select the text layer
@@ -1607,6 +1619,7 @@ const LayerItem: React.FC<{
           activeLayerId={activeLayerId}
           projected={projected}
           parentComponentLayerId={layer.id}
+          parentComponentId={layer.componentId}
           parentComponentOverrides={effectiveOverrides}
           parentComponentVariables={component?.variables}
           ancestorComponentIds={effectiveAncestorIds}
@@ -1921,6 +1934,15 @@ const LayerItem: React.FC<{
       elementProps.onDoubleClick = (e: React.MouseEvent) => {
         if (isLockedByOther) return;
         e.stopPropagation();
+
+        // Component instance (or any layer inside one): open the master
+        // component for editing. Mirrors the "Edit component" sidebar button.
+        const componentEditTargetId = layer.componentId || parentComponentId;
+        const componentEditInstanceLayerId = layer.componentId ? layer.id : parentComponentLayerId;
+        if (onComponentEdit && componentEditTargetId && componentEditInstanceLayerId) {
+          onComponentEdit(componentEditTargetId, componentEditInstanceLayerId);
+          return;
+        }
 
         // Any element with CMS field binding: open collection item editor
         const cmsBinding = getLayerCmsFieldBinding(layer);
@@ -2901,6 +2923,7 @@ const LayerItem: React.FC<{
                     availableLocales={availableLocales}
                     liveLayerUpdates={liveLayerUpdates}
                     parentComponentLayerId={parentComponentLayerId || (layer.componentId ? layer.id : undefined)}
+                    parentComponentId={parentComponentId || layer.componentId}
                     parentComponentOverrides={parentComponentOverrides}
                     parentComponentVariables={parentComponentVariables}
                     editingComponentVariables={editingComponentVariables}
@@ -2918,6 +2941,7 @@ const LayerItem: React.FC<{
                     ancestorComponentIds={effectiveAncestorIds}
                     isSlideChild={layer.name === 'slides'}
                     serverSettings={serverSettings}
+                    onComponentEdit={onComponentEdit}
                   />
                 )}
               </Tag>
@@ -2977,6 +3001,7 @@ const LayerItem: React.FC<{
               localeSelectorFormat={format}
               liveLayerUpdates={liveLayerUpdates}
               parentComponentLayerId={layer.componentId ? layer.id : parentComponentLayerId}
+              parentComponentId={layer.componentId || parentComponentId}
               parentComponentOverrides={parentComponentOverrides}
               parentComponentVariables={parentComponentVariables}
               editingComponentVariables={editingComponentVariables}
@@ -2986,6 +3011,7 @@ const LayerItem: React.FC<{
               components={componentsProp}
               ancestorComponentIds={effectiveAncestorIds}
               serverSettings={serverSettings}
+              onComponentEdit={onComponentEdit}
             />
           )}
 
@@ -3043,6 +3069,7 @@ const LayerItem: React.FC<{
             localeSelectorFormat={localeSelectorFormat}
             liveLayerUpdates={liveLayerUpdates}
             parentComponentLayerId={parentComponentLayerId || (layer.componentId ? layer.id : undefined)}
+            parentComponentId={parentComponentId || layer.componentId}
             parentComponentOverrides={parentComponentOverrides}
             parentComponentVariables={parentComponentVariables}
             editingComponentVariables={editingComponentVariables}
@@ -3060,6 +3087,7 @@ const LayerItem: React.FC<{
             ancestorComponentIds={effectiveAncestorIds}
             isSlideChild={layer.name === 'slides'}
             serverSettings={serverSettings}
+            onComponentEdit={onComponentEdit}
           />
         )}
       </Tag>

--- a/hooks/use-edit-component.ts
+++ b/hooks/use-edit-component.ts
@@ -1,0 +1,96 @@
+'use client';
+
+/**
+ * useEditComponent
+ *
+ * Returns a callback that opens a component in the editor, handling:
+ * - Pushing the current page or parent component onto the navigation stack
+ * - Loading the component's draft
+ * - Navigating to the component edit URL
+ * - Restoring the user's selection inside the component
+ *
+ * Used by both `ComponentInstanceSidebar` (Edit component button) and
+ * `CenterCanvas` (double-click on a component instance on the canvas).
+ */
+
+import { useCallback } from 'react';
+
+import { useEditorActions } from '@/hooks/use-editor-url';
+import { useComponentsStore } from '@/stores/useComponentsStore';
+import { useEditorStore } from '@/stores/useEditorStore';
+import { usePagesStore } from '@/stores/usePagesStore';
+import { findLayerById } from '@/lib/layer-utils';
+
+export interface EditComponentOptions {
+  /**
+   * Layer to restore on exit (typically the component instance layer that was
+   * interacted with on the page or in a parent component).
+   */
+  returnToLayerId?: string;
+  /**
+   * Layer inside the component to select after entering edit mode.
+   * Defaults to the first child layer of the component.
+   */
+  initialSelectionLayerId?: string;
+}
+
+export function useEditComponent(): (componentId: string, options?: EditComponentOptions) => Promise<void> {
+  const { openComponent } = useEditorActions();
+
+  return useCallback(async (componentId: string, options: EditComponentOptions = {}) => {
+    const { returnToLayerId, initialSelectionLayerId } = options;
+
+    const { loadComponentDraft, getComponentById } = useComponentsStore.getState();
+    const {
+      currentPageId,
+      editingComponentId,
+      setSelectedLayerId,
+      pushComponentNavigation,
+    } = useEditorStore.getState();
+    const { pages } = usePagesStore.getState();
+
+    const component = getComponentById(componentId);
+    if (!component) return;
+
+    setSelectedLayerId(null);
+
+    if (editingComponentId) {
+      const currentComponent = getComponentById(editingComponentId);
+      if (currentComponent) {
+        pushComponentNavigation({
+          type: 'component',
+          id: editingComponentId,
+          name: currentComponent.name,
+          layerId: returnToLayerId ?? null,
+        });
+      }
+    } else if (currentPageId) {
+      const currentPage = pages.find((p) => p.id === currentPageId);
+      if (currentPage) {
+        pushComponentNavigation({
+          type: 'page',
+          id: currentPageId,
+          name: currentPage.name,
+          layerId: returnToLayerId ?? null,
+        });
+      }
+    }
+
+    await loadComponentDraft(componentId);
+    openComponent(componentId, currentPageId, undefined, returnToLayerId);
+
+    // Select an initial layer inside the component if the user hasn't
+    // already selected something valid during the await.
+    if (component.layers && component.layers.length > 0) {
+      const currentSelection = useEditorStore.getState().selectedLayerId;
+      const hasValidSelection = currentSelection && findLayerById(component.layers, currentSelection);
+      if (!hasValidSelection) {
+        const target = initialSelectionLayerId
+          && findLayerById(component.layers, initialSelectionLayerId)
+          ? initialSelectionLayerId
+          : component.layers[0].id;
+        setSelectedLayerId(target);
+      }
+    }
+  }, [openComponent]);
+}

--- a/hooks/use-live-component-updates.ts
+++ b/hooks/use-live-component-updates.ts
@@ -167,7 +167,7 @@ export function useLiveComponentUpdates(): UseLiveComponentUpdatesReturn {
     
     // Also update all instances of this component across all pages
     const { updateComponentOnLayers } = usePagesStore.getState();
-    updateComponentOnLayers(payload.component_id, payload.layers);
+    updateComponentOnLayers(payload.component_id);
   }, []);
   
   // === BROADCAST FUNCTIONS ===

--- a/lib/component-utils.ts
+++ b/lib/component-utils.ts
@@ -282,7 +282,6 @@ export function containsComponent(layers: Layer[], componentId: string): boolean
 export function updateLayersWithComponent(
   layers: Layer[],
   componentId: string,
-  newComponentLayers: Layer[]
 ): Layer[] {
   let changed = false;
   const result = layers.map(layer => {
@@ -292,7 +291,7 @@ export function updateLayersWithComponent(
     }
 
     if (layer.children && layer.children.length > 0) {
-      const newChildren = updateLayersWithComponent(layer.children, componentId, newComponentLayers);
+      const newChildren = updateLayersWithComponent(layer.children, componentId);
       if (newChildren !== layer.children) {
         changed = true;
         return { ...layer, children: newChildren };

--- a/lib/component-utils.ts
+++ b/lib/component-utils.ts
@@ -258,36 +258,51 @@ export function isComponentInstance(layer: Layer): boolean {
 }
 
 /**
+ * Returns true if the layer tree contains an instance of the given component.
+ * Short-circuits on first match.
+ */
+export function containsComponent(layers: Layer[], componentId: string): boolean {
+  for (const layer of layers) {
+    if (layer.componentId === componentId) return true;
+    if (layer.children && layer.children.length > 0) {
+      if (containsComponent(layer.children, componentId)) return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Update all layers using a specific component
  * Recursively traverses layer tree and updates component instances
  * This is used when the master component is updated to sync all instances
+ *
+ * Preserves referential identity for subtrees that contain no matching instance,
+ * so React reconciliation can skip untouched branches.
  */
 export function updateLayersWithComponent(
   layers: Layer[],
   componentId: string,
   newComponentLayers: Layer[]
 ): Layer[] {
-  return layers.map(layer => {
-    // If this layer is an instance of the component, update it
-    // Note: The actual rendering logic will use newComponentLayers
-    // This just ensures the componentId is maintained
+  let changed = false;
+  const result = layers.map(layer => {
     if (layer.componentId === componentId) {
-      return {
-        ...layer,
-        // componentId stays the same, but rendering will use updated component
-      };
+      changed = true;
+      return { ...layer };
     }
 
-    // Recursively update children
     if (layer.children && layer.children.length > 0) {
-      return {
-        ...layer,
-        children: updateLayersWithComponent(layer.children, componentId, newComponentLayers),
-      };
+      const newChildren = updateLayersWithComponent(layer.children, componentId, newComponentLayers);
+      if (newChildren !== layer.children) {
+        changed = true;
+        return { ...layer, children: newChildren };
+      }
     }
 
     return layer;
   });
+
+  return changed ? result : layers;
 }
 
 /**

--- a/lib/schedule-idle.ts
+++ b/lib/schedule-idle.ts
@@ -1,0 +1,17 @@
+/**
+ * Schedule a callback to run when the browser is idle, so it does not block
+ * the current interaction. Falls back to setTimeout in environments without
+ * requestIdleCallback (Safari, SSR) and to a sync call on the server.
+ */
+export function scheduleIdle(callback: () => void): void {
+  if (typeof window === 'undefined') {
+    callback();
+    return;
+  }
+  const ric = (window as unknown as { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number }).requestIdleCallback;
+  if (typeof ric === 'function') {
+    ric(callback, { timeout: 1000 });
+  } else {
+    setTimeout(callback, 0);
+  }
+}

--- a/stores/useComponentsStore.ts
+++ b/stores/useComponentsStore.ts
@@ -13,26 +13,9 @@ import {
   cleanLayersForComponentCreation,
 } from '@/lib/layer-utils';
 import { detachStyleFromLayers, updateLayersWithStyle } from '@/lib/layer-style-utils';
+import { scheduleIdle } from '@/lib/schedule-idle';
 import { generateId } from '@/lib/utils';
 import type { Component, Layer } from '@/types';
-
-/**
- * Schedule a callback to run when the browser is idle, so it does not block
- * the current interaction. Falls back to setTimeout in environments without
- * requestIdleCallback (Safari, SSR) and to a sync call on the server.
- */
-function scheduleIdle(callback: () => void): void {
-  if (typeof window === 'undefined') {
-    callback();
-    return;
-  }
-  const ric = (window as unknown as { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number }).requestIdleCallback;
-  if (typeof ric === 'function') {
-    ric(callback, { timeout: 1000 });
-  } else {
-    setTimeout(callback, 0);
-  }
-}
 
 /** Remove variableLinks entries that point TO a given variable ID (as parent target). */
 function removeVariableLinksPointingTo(layer: Layer, targetVariableId: string): Layer {

--- a/stores/useComponentsStore.ts
+++ b/stores/useComponentsStore.ts
@@ -16,6 +16,24 @@ import { detachStyleFromLayers, updateLayersWithStyle } from '@/lib/layer-style-
 import { generateId } from '@/lib/utils';
 import type { Component, Layer } from '@/types';
 
+/**
+ * Schedule a callback to run when the browser is idle, so it does not block
+ * the current interaction. Falls back to setTimeout in environments without
+ * requestIdleCallback (Safari, SSR) and to a sync call on the server.
+ */
+function scheduleIdle(callback: () => void): void {
+  if (typeof window === 'undefined') {
+    callback();
+    return;
+  }
+  const ric = (window as unknown as { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number }).requestIdleCallback;
+  if (typeof ric === 'function') {
+    ric(callback, { timeout: 1000 });
+  } else {
+    setTimeout(callback, 0);
+  }
+}
+
 /** Remove variableLinks entries that point TO a given variable ID (as parent target). */
 function removeVariableLinksPointingTo(layer: Layer, targetVariableId: string): Layer {
   const links = layer.componentOverrides?.variableLinks;
@@ -73,6 +91,12 @@ interface ComponentsState {
   isLoading: boolean;
   error: string | null;
   componentDrafts: Record<string, Layer[]>;
+  /**
+   * True when a draft has been mutated since it was last loaded or persisted.
+   * Used to skip no-op saves and cross-page sync passes when leaving the
+   * component editor without making any changes.
+   */
+  componentDraftDirty: Record<string, boolean>;
   isSaving: boolean;
   saveTimeouts: Record<string, NodeJS.Timeout>;
 }
@@ -175,6 +199,7 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
     isLoading: false,
     error: null,
     componentDrafts: {},
+    componentDraftDirty: {},
     isSaving: false,
     saveTimeouts: {},
 
@@ -455,6 +480,10 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
             ...state.componentDrafts,
             [componentId]: layers,
           },
+          componentDraftDirty: {
+            ...state.componentDraftDirty,
+            [componentId]: false,
+          },
         }));
 
         // Initialize version tracking with loaded state
@@ -472,6 +501,10 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
         componentDrafts: {
           ...state.componentDrafts,
           [componentId]: layers,
+        },
+        componentDraftDirty: {
+          ...state.componentDraftDirty,
+          [componentId]: true,
         },
       }));
 
@@ -496,11 +529,17 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
 
     // Save component draft to database
     saveComponentDraft: async (componentId) => {
-      const { componentDrafts } = get();
+      const { componentDrafts, componentDraftDirty } = get();
       const draftLayers = componentDrafts[componentId];
 
       if (!draftLayers) {
         console.warn(`No draft found for component ${componentId}`);
+        return;
+      }
+
+      // Skip the round-trip entirely when the draft has not been mutated
+      // since it was loaded or last persisted.
+      if (!componentDraftDirty[componentId]) {
         return;
       }
 
@@ -536,6 +575,7 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
           // Safe to update - no changes made during save
           set((state) => ({
             components: state.components.map((c) => (c.id === componentId ? updatedComponent : c)),
+            componentDraftDirty: { ...state.componentDraftDirty, [componentId]: false },
             isSaving: false,
           }));
 
@@ -567,25 +607,29 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
           triggerThumbnailGeneration(componentId, draftLayers, get().components);
         }
 
-        // Regenerate CSS to include updated component classes
-        try {
-          const { generateAndSaveCSS } = await import('@/lib/client/cssGenerator');
-          const { usePagesStore } = await import('./usePagesStore');
+        // Regenerate CSS to include updated component classes.
+        // Run this off the critical path so navigation/UI is not blocked.
+        // Only collect layers from pages that actually contain an instance
+        // of this component (plus the component's own layers).
+        scheduleIdle(async () => {
+          try {
+            const { generateAndSaveCSS } = await import('@/lib/client/cssGenerator');
+            const { usePagesStore } = await import('./usePagesStore');
+            const { containsComponent } = await import('@/lib/component-utils');
 
-          // Collect layers from ALL pages
-          const allLayers: Layer[] = [];
-          const allDrafts = usePagesStore.getState().draftsByPageId;
-          Object.values(allDrafts).forEach((pageDraft) => {
-            if (pageDraft.layers) {
-              allLayers.push(...pageDraft.layers);
-            }
-          });
+            const allLayers: Layer[] = [...layersBeingSaved];
+            const allDrafts = usePagesStore.getState().draftsByPageId;
+            Object.values(allDrafts).forEach((pageDraft) => {
+              if (pageDraft.layers && containsComponent(pageDraft.layers, componentId)) {
+                allLayers.push(...pageDraft.layers);
+              }
+            });
 
-          await generateAndSaveCSS(allLayers);
-        } catch (cssError) {
-          console.error('Failed to generate CSS after component save:', cssError);
-          // Don't fail the save operation if CSS generation fails
-        }
+            await generateAndSaveCSS(allLayers);
+          } catch (cssError) {
+            console.error('Failed to generate CSS after component save:', cssError);
+          }
+        });
       } catch (error) {
         console.error('Failed to save component draft:', error);
         set({ isSaving: false });
@@ -598,6 +642,9 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
         const newDrafts = { ...state.componentDrafts };
         delete newDrafts[componentId];
 
+        const newDirty = { ...state.componentDraftDirty };
+        delete newDirty[componentId];
+
         const newTimeouts = { ...state.saveTimeouts };
         if (newTimeouts[componentId]) {
           clearTimeout(newTimeouts[componentId]);
@@ -606,6 +653,7 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
 
         return {
           componentDrafts: newDrafts,
+          componentDraftDirty: newDirty,
           saveTimeouts: newTimeouts,
         };
       });

--- a/stores/usePagesStore.ts
+++ b/stores/usePagesStore.ts
@@ -23,13 +23,17 @@ import {
 import { generateId } from '../lib/utils';
 import { getDescendantFolderIds, isHomepage, findHomepage, findNextSelection } from '../lib/page-utils';
 import { updateLayersWithStyle, detachStyleFromLayers } from '../lib/layer-style-utils';
-import { updateLayersWithComponent, detachComponentFromLayers, containsComponent } from '../lib/component-utils';
+import { updateLayersWithComponent, detachComponentFromLayers } from '../lib/component-utils';
 import { useComponentsStore, triggerThumbnailGeneration } from './useComponentsStore';
 
 /**
  * Module-level dedupe map for in-flight loadDraft requests.
  * Kept outside the store so subscribers do not re-render when load
  * state changes, while still preventing duplicate HTTP fetches.
+ *
+ * NOTE: This map lives outside the Zustand store and will NOT be cleared
+ * by store resets (e.g. in tests or HMR). If a store reset/destroy helper
+ * is added, it must also call `inflightDraftLoads.clear()`.
  */
 const inflightDraftLoads = new Map<string, Promise<void>>();
 
@@ -100,7 +104,7 @@ interface PagesActions {
 
   // Component Actions
   createComponentFromLayer: (pageId: string, layerId: string, componentName: string) => Promise<string | null>;
-  updateComponentOnLayers: (componentId: string, newLayers: Layer[]) => void;
+  updateComponentOnLayers: (componentId: string) => void;
   detachComponentFromAllLayers: (componentId: string) => void;
 
   // CMS Binding Cleanup Actions
@@ -2912,7 +2916,7 @@ export const usePagesStore = create<PagesStore>((set, get) => ({
    * Update all layers using a specific component across all pages
    * Used when a component is updated
    */
-  updateComponentOnLayers: (componentId, newLayers) => {
+  updateComponentOnLayers: (componentId) => {
     const { draftsByPageId } = get();
 
     let mutated = false;
@@ -2920,10 +2924,7 @@ export const usePagesStore = create<PagesStore>((set, get) => ({
 
     Object.keys(draftsByPageId).forEach(pageId => {
       const draft = draftsByPageId[pageId];
-      if (!containsComponent(draft.layers, componentId)) {
-        return;
-      }
-      const nextLayers = updateLayersWithComponent(draft.layers, componentId, newLayers);
+      const nextLayers = updateLayersWithComponent(draft.layers, componentId);
       if (nextLayers !== draft.layers) {
         mutated = true;
         updatedDrafts[pageId] = { ...draft, layers: nextLayers };

--- a/stores/usePagesStore.ts
+++ b/stores/usePagesStore.ts
@@ -23,8 +23,15 @@ import {
 import { generateId } from '../lib/utils';
 import { getDescendantFolderIds, isHomepage, findHomepage, findNextSelection } from '../lib/page-utils';
 import { updateLayersWithStyle, detachStyleFromLayers } from '../lib/layer-style-utils';
-import { updateLayersWithComponent, detachComponentFromLayers } from '../lib/component-utils';
+import { updateLayersWithComponent, detachComponentFromLayers, containsComponent } from '../lib/component-utils';
 import { useComponentsStore, triggerThumbnailGeneration } from './useComponentsStore';
+
+/**
+ * Module-level dedupe map for in-flight loadDraft requests.
+ * Kept outside the store so subscribers do not re-render when load
+ * state changes, while still preventing duplicate HTTP fetches.
+ */
+const inflightDraftLoads = new Map<string, Promise<void>>();
 
 interface PagesState {
   pages: Page[];
@@ -304,41 +311,55 @@ export const usePagesStore = create<PagesStore>((set, get) => ({
   },
 
   loadDraft: async (pageId) => {
+    // Dedupe concurrent loads for the same page. Multiple components (e.g.
+    // LeftSidebar and CenterCanvas) may both fire loadDraft on a page switch;
+    // only one HTTP request should be in flight at a time per page.
+    const existing = inflightDraftLoads.get(pageId);
+    if (existing) {
+      return existing;
+    }
+
     // Check if we already have a draft with unsaved changes
     const existingDraft = get().draftsByPageId[pageId];
 
-    set({ isLoading: true, error: null });
-    try {
-      const response = await pageLayersApi.getDraft(pageId);
-      if (response.error) {
-        set({ error: response.error, isLoading: false });
-        return;
-      }
-      if (response.data) {
-        // If we had local changes, we need to decide what to do
-        // For now, we'll prefer server data when explicitly loading (e.g., page switch)
-        // but log a warning if we're overwriting local changes
-        if (existingDraft &&
-            JSON.stringify(existingDraft.layers) !== JSON.stringify(response.data.layers)) {
-          console.warn('⚠️ loadDraft: Overwriting local changes with server data');
+    const promise = (async () => {
+      set({ error: null });
+      try {
+        const response = await pageLayersApi.getDraft(pageId);
+        if (response.error) {
+          set({ error: response.error });
+          return;
         }
+        if (response.data) {
+          // If we had local changes, we need to decide what to do
+          // For now, we'll prefer server data when explicitly loading (e.g., page switch)
+          // but log a warning if we're overwriting local changes
+          if (existingDraft &&
+              JSON.stringify(existingDraft.layers) !== JSON.stringify(response.data.layers)) {
+            console.warn('⚠️ loadDraft: Overwriting local changes with server data');
+          }
 
-        set((state) => ({
-          draftsByPageId: { ...state.draftsByPageId, [pageId]: response.data! },
-          isLoading: false,
-        }));
+          set((state) => ({
+            draftsByPageId: { ...state.draftsByPageId, [pageId]: response.data! },
+          }));
 
-        // Initialize version tracking with loaded state (awaited to ensure it completes before edits)
-        try {
-          const { initializeVersionTracking } = await import('@/lib/version-tracking');
-          initializeVersionTracking('page_layers', pageId, response.data!.layers);
-        } catch (err) {
-          console.error('Failed to initialize version tracking:', err);
+          // Initialize version tracking with loaded state (awaited to ensure it completes before edits)
+          try {
+            const { initializeVersionTracking } = await import('@/lib/version-tracking');
+            initializeVersionTracking('page_layers', pageId, response.data!.layers);
+          } catch (err) {
+            console.error('Failed to initialize version tracking:', err);
+          }
         }
+      } catch (error) {
+        set({ error: 'Failed to load draft' });
+      } finally {
+        inflightDraftLoads.delete(pageId);
       }
-    } catch (error) {
-      set({ error: 'Failed to load draft', isLoading: false });
-    }
+    })();
+
+    inflightDraftLoads.set(pageId, promise);
+    return promise;
   },
 
   loadAllDrafts: async () => {
@@ -2894,17 +2915,24 @@ export const usePagesStore = create<PagesStore>((set, get) => ({
   updateComponentOnLayers: (componentId, newLayers) => {
     const { draftsByPageId } = get();
 
-    const updatedDrafts = { ...draftsByPageId };
+    let mutated = false;
+    const updatedDrafts: typeof draftsByPageId = { ...draftsByPageId };
 
-    Object.keys(updatedDrafts).forEach(pageId => {
-      const draft = updatedDrafts[pageId];
-      updatedDrafts[pageId] = {
-        ...draft,
-        layers: updateLayersWithComponent(draft.layers, componentId, newLayers),
-      };
+    Object.keys(draftsByPageId).forEach(pageId => {
+      const draft = draftsByPageId[pageId];
+      if (!containsComponent(draft.layers, componentId)) {
+        return;
+      }
+      const nextLayers = updateLayersWithComponent(draft.layers, componentId, newLayers);
+      if (nextLayers !== draft.layers) {
+        mutated = true;
+        updatedDrafts[pageId] = { ...draft, layers: nextLayers };
+      }
     });
 
-    set({ draftsByPageId: updatedDrafts });
+    if (mutated) {
+      set({ draftsByPageId: updatedDrafts });
+    }
   },
 
   /**


### PR DESCRIPTION
## Summary

Switching from a component back to a page (and switching between pages) had several blocking operations on the navigation critical path. This PR removes the worst offenders so transitions feel instant. Also adds a small UX win: double-click a component on the canvas to open its editor.

## Why it was slow

```mermaid
sequenceDiagram
  participant User
  participant Exit as handleExitComponentEditMode
  participant Save as saveComponentDraft
  participant CSS as generateAndSaveCSS<br/>(all pages)
  participant Sync as updateComponentOnLayers<br/>(every page draft)
  participant Nav as router.push

  User->>Exit: Click "Back to page"
  Exit->>Save: await save (HTTP PUT)
  Save->>CSS: await regen across ALL pages
  Exit->>Sync: rebuild every page draft tree
  Exit->>Exit: await 10ms timer
  Exit->>Nav: navigateToLayers
  Exit->>Exit: await 100ms timer
  Nav-->>User: page finally renders
```

Five things were stacked on the critical path before navigation could even start. None of them needed to block it.

## Changes

### Component editor exit
- Drop the 10ms + 100ms `setTimeout` awaits before navigation. The guard ref is now cleared via `setTimeout(0)` so the URL update has time to propagate before the URL sync effect re-runs.
- Skip the cross-page sync and broadcast entirely when the component draft was not actually edited. New `componentDraftDirty` flag on `useComponentsStore` is set in `updateComponentDraft` and cleared in `loadComponentDraft` / after a successful save.
- `updateComponentOnLayers` now skips pages that don't contain the component (new `containsComponent` helper) and the recursive `updateLayersWithComponent` preserves referential identity for unchanged subtrees, so React reconciliation can skip whole branches in `LayersTree` and `CenterCanvas`.
- `generateAndSaveCSS` runs in `requestIdleCallback` (with `setTimeout` fallback) instead of awaited. Layer collection is also scoped to pages that actually contain instances of the component.

### Page switching
- Remove the duplicate `loadDraft` effect in `CenterCanvas`. `LeftSidebar` already owns it (and uses `startTransition`).
- Add a module-level in-flight dedupe map in `usePagesStore.loadDraft` so concurrent calls for the same page reuse one promise.
- Stop flipping the global `isLoading` flag inside `loadDraft` — it was a global signal for a per-page fetch and re-rendered every consumer mid-switch.
- Replace `JSON.stringify(currentDraft.layers)` autosave change-detection with reference equality on the layers array. Functionally equivalent (Zustand mutators always produce a new array on actual changes), but O(1) instead of O(tree size).

### UX: canvas double-click to edit component
- Double-click a component instance on the canvas to open its editor — same flow as the "Edit component" sidebar button. Works on the component root and on any layer inside the instance.
- Extracted the open-component flow into a reusable `useEditComponent` hook so the sidebar button and canvas double-click share one implementation.

## Test plan

- [ ] Edit a component, click "Back to page" — exit is near-instant, no longer feels like it pauses
- [ ] Open a component, exit without editing — confirm no PUT request fires (no-op save) and no broadcast
- [ ] Edit a component used on Page A, exit — Page A reflects the update
- [ ] Edit a component used on no pages, exit — exit is instant and no other pages re-render
- [ ] Switch rapidly between two large pages — no double `loadDraft` request in DevTools Network, no jank
- [ ] Switch between pages with no autosave-pending changes — no spurious autosave fires
- [ ] Double-click a component instance on the canvas — opens it for editing
- [ ] Double-click any layer inside a component instance — opens the parent component
- [ ] Verify the existing "Edit component" sidebar button still works
- [ ] Click "Back to homepage" from a deeply nested component — returns to the correct page

Made with [Cursor](https://cursor.com)