### PR TITLE
feat: add resizable sidebar and horizontal layer scrolling

### DIFF
--- a/app/(builder)/ycode/components/ElementLibrary.tsx
+++ b/app/(builder)/ycode/components/ElementLibrary.tsx
@@ -148,6 +148,7 @@ interface ElementLibraryProps {
   isOpen: boolean;
   onClose: () => void;
   liveLayerUpdates?: UseLiveLayerUpdatesReturn | null;
+  sidebarWidth?: number;
 }
 
 // Category definitions
@@ -275,7 +276,7 @@ async function restoreInlinedComponents(
   return newLayer;
 }
 
-export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: ElementLibraryProps) {
+export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates, sidebarWidth = 256 }: ElementLibraryProps) {
   const { addLayerFromTemplate, updateLayer, setDraftLayers, draftsByPageId, pages } = usePagesStore();
   const { currentPageId, selectedLayerId, setSelectedLayerId, editingComponentId, activeBreakpoint, pushComponentNavigation, startCanvasDrag, endCanvasDrag } = useEditorStore();
   const { components, componentDrafts, updateComponentDraft, deleteComponent, getDeletePreview, loadComponentDraft, getComponentById, loadComponents } = useComponentsStore();
@@ -1390,9 +1391,10 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
   return (
     <div
       className={cn(
-        'fixed left-64 top-14 bottom-0 w-64 bg-background border-r z-50 flex flex-col',
+        'fixed top-14 bottom-0 w-64 bg-background border-r z-50 flex flex-col',
         !isOpen && 'hidden'
       )}
+      style={{ left: `${sidebarWidth}px` }}
     >
         {/* Tabs */}
         <Tabs

--- a/app/(builder)/ycode/components/ElementLibrary.tsx
+++ b/app/(builder)/ycode/components/ElementLibrary.tsx
@@ -148,7 +148,6 @@ interface ElementLibraryProps {
   isOpen: boolean;
   onClose: () => void;
   liveLayerUpdates?: UseLiveLayerUpdatesReturn | null;
-  sidebarWidth?: number;
 }
 
 // Category definitions
@@ -276,9 +275,10 @@ async function restoreInlinedComponents(
   return newLayer;
 }
 
-export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates, sidebarWidth = 256 }: ElementLibraryProps) {
+export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: ElementLibraryProps) {
   const { addLayerFromTemplate, updateLayer, setDraftLayers, draftsByPageId, pages } = usePagesStore();
   const { currentPageId, selectedLayerId, setSelectedLayerId, editingComponentId, activeBreakpoint, pushComponentNavigation, startCanvasDrag, endCanvasDrag } = useEditorStore();
+  const leftSidebarWidth = useEditorStore((state) => state.leftSidebarWidth);
   const { components, componentDrafts, updateComponentDraft, deleteComponent, getDeletePreview, loadComponentDraft, getComponentById, loadComponents } = useComponentsStore();
   const { openComponent } = useEditorActions();
 
@@ -1394,7 +1394,7 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates, side
         'fixed top-14 bottom-0 w-64 bg-background border-r z-50 flex flex-col',
         !isOpen && 'hidden'
       )}
-      style={{ left: `${sidebarWidth}px` }}
+      style={{ left: `${leftSidebarWidth}px` }}
     >
         {/* Tabs */}
         <Tabs

--- a/app/(builder)/ycode/components/FolderSettingsPanel.tsx
+++ b/app/(builder)/ycode/components/FolderSettingsPanel.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Spinner } from '@/components/ui/spinner';
 import { usePagesStore } from '@/stores/usePagesStore';
+import { useEditorStore } from '@/stores/useEditorStore';
 import {
   Field,
   FieldContent,
@@ -65,6 +66,7 @@ const FolderSettingsPanel = React.forwardRef<FolderSettingsPanelHandle, FolderSe
   folder,
   onSave,
 }, ref) => {
+  const leftSidebarWidth = useEditorStore((state) => state.leftSidebarWidth);
   const [name, setName] = useState('');
   const [slug, setSlug] = useState('');
   const [pageFolderId, setPageFolderId] = useState<string | null>(null);
@@ -473,12 +475,16 @@ const FolderSettingsPanel = React.forwardRef<FolderSettingsPanelHandle, FolderSe
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 left-64 z-40"
+        className="fixed inset-0 z-40"
+        style={{ left: `${leftSidebarWidth}px` }}
         onClick={handleClose}
       />
 
       {/* Panel */}
-      <div className="fixed top-14 left-64 bottom-0 w-125 bg-background border-r z-50 flex flex-col">
+      <div
+        className="fixed top-14 bottom-0 w-125 bg-background border-r z-50 flex flex-col"
+        style={{ left: `${leftSidebarWidth}px` }}
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4">
           <div className="flex items-center justify-center gap-1.5">

--- a/app/(builder)/ycode/components/LayersTree.tsx
+++ b/app/(builder)/ycode/components/LayersTree.tsx
@@ -281,6 +281,39 @@ const LayerRow = React.memo(function LayerRow({
   // Check if this is the Body layer (locked)
   const isLocked = node.layer.id === 'body';
 
+  const [isHovered, setIsHovered] = React.useState(false);
+
+  const rowBg = isSelected && !usePurpleStyle && !isStateActive
+    ? 'var(--primary)'
+    : isSelected && !usePurpleStyle && isStateActive
+      ? '#8dd92f'
+      : isSelected && usePurpleStyle
+        ? 'rgb(168 85 247)'
+        : isChildOfSelected && !usePurpleStyle && !isStateActive
+          ? isHovered
+            ? 'color-mix(in oklch, var(--primary) 20%, var(--background))'
+            : 'color-mix(in oklch, var(--primary) 15%, var(--background))'
+          : isChildOfSelected && !usePurpleStyle && isStateActive
+            ? isHovered
+              ? 'color-mix(in oklch, #8dd92f 20%, var(--background))'
+              : 'color-mix(in oklch, #8dd92f 15%, var(--background))'
+            : isChildOfSelected && usePurpleStyle
+              ? 'color-mix(in oklch, rgb(168 85 247) 10%, var(--background))'
+              : !isDragActive && !isDragging && !isLockedByOther && isHovered
+                ? 'color-mix(in oklch, var(--foreground) 8%, var(--background))'
+                : 'transparent';
+
+  const hasAlwaysVisibleIcons = !!node.layer.settings?.hidden
+    || isLockedByOther
+    || interactionTriggerLayerIds.includes(node.id)
+    || interactionTargetLayerIds.includes(node.id);
+
+  const iconBg = rowBg === 'transparent'
+    ? 'var(--background)'
+    : isSelected || isChildOfSelected || hasAlwaysVisibleIcons
+      ? rowBg
+      : 'transparent';
+
   // Sublayer rows (content blocks or text style targets)
   if (node.sublayer) {
     const handleSublayerClick = () => {
@@ -310,58 +343,84 @@ const LayerRow = React.memo(function LayerRow({
     const isSubCollapsed = node.collapsed || false;
 
     return (
-      <div className="relative">
-        {node.depth > 0 && (
-          <>
-            {Array.from({ length: node.depth }).map((_, i) => (
-              <div
-                key={i}
-                className={cn(
-                  'absolute z-10 top-0 bottom-0 w-px',
-                  (isChildOfSelected || isSelected) ? 'dark:bg-white/10 bg-neutral-900/10' : 'dark:bg-secondary bg-neutral-900/10',
-                )}
-                style={{ left: `${i * 14 + 16}px` }}
-              />
-            ))}
-          </>
-        )}
-        <div
-          className={cn(
-            'group relative flex items-center h-8 cursor-pointer',
-            isSelected && !isStateActive && 'bg-primary text-primary-foreground rounded-lg',
-            isSelected && isStateActive && 'bg-[#8dd92f] text-black rounded-lg',
-            !isSelected && isChildOfSelected && !isStateActive && 'dark:bg-primary/15 bg-primary/10 text-current/70',
-            !isSelected && isChildOfSelected && isStateActive && 'dark:bg-[#8dd92f]/15 bg-[#8dd92f]/10 text-current/70',
-            !isSelected && isChildOfSelected && isLastVisibleDescendant && 'rounded-b-lg',
-            !isSelected && isChildOfSelected && !isLastVisibleDescendant && 'rounded-none',
-            !isSelected && !isChildOfSelected && 'rounded-lg text-secondary-foreground/80 dark:text-muted-foreground',
-          )}
-          style={{ paddingLeft: `${node.depth * 14 + 8}px` }}
-          onClick={handleSublayerClick}
-        >
-          {hasExpandableChildren ? (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggle(node.id);
-              }}
-              className={cn(
-                'w-4 h-4 flex items-center justify-center shrink-0',
-                isSubCollapsed ? '' : 'rotate-90',
-              )}
-            >
-              <Icon name="chevronRight" className={cn('size-2.5 opacity-50', isSelected && 'opacity-80')} />
-            </button>
-          ) : (
-            <div className="w-4 h-4 shrink-0" />
-          )}
-          <Icon
-            name={node.sublayer.icon as any}
-            className={cn('size-3 mx-1.5 shrink-0', isSelected ? 'opacity-70' : 'opacity-40')}
+      <div className="relative flex" style={{ width: '100%', minWidth: '100%' }}>
+        {/* Background layer - stays fixed */}
+        <div className="absolute inset-0 pointer-events-none">
+          <div
+            className={cn(
+              'sticky left-0 h-full',
+              isSelected && !isStateActive && 'bg-primary rounded-lg',
+              isSelected && isStateActive && 'bg-[#8dd92f] rounded-lg',
+              !isSelected && isChildOfSelected && !isStateActive && 'dark:bg-primary/15 bg-primary/10',
+              !isSelected && isChildOfSelected && isStateActive && 'dark:bg-[#8dd92f]/15 bg-[#8dd92f]/10',
+              !isSelected && isChildOfSelected && isLastVisibleDescendant && 'rounded-b-lg',
+              !isSelected && isChildOfSelected && !isLastVisibleDescendant && 'rounded-none',
+              !isSelected && !isChildOfSelected && 'rounded-lg',
+            )}
+            style={{ width: 'var(--tree-available-width)' }}
           />
-          <span className={cn('text-2xs truncate select-none min-w-15', isSelected ? 'opacity-90' : 'opacity-60')}>
-            {node.sublayer.label}
-          </span>
+        </div>
+
+        {/* Content layer */}
+        <div className="relative flex w-full min-w-full flex-1">
+          {node.depth > 0 && (
+            <>
+              {Array.from({ length: node.depth }).map((_, i) => (
+                <div
+                  key={i}
+                  className={cn(
+                    'absolute z-10 top-0 bottom-0 w-px pointer-events-none',
+                    (isChildOfSelected || isSelected) ? 'dark:bg-white/10 bg-neutral-900/10' : 'dark:bg-secondary bg-neutral-900/10',
+                  )}
+                  style={{ left: `${i * 14 + 16}px` }}
+                />
+              ))}
+            </>
+          )}
+          <div
+            className={cn(
+              'group relative flex items-center h-8 cursor-pointer',
+              isSelected && !isStateActive && 'text-primary-foreground',
+              isSelected && isStateActive && 'text-black',
+              !isSelected && isChildOfSelected && 'text-current/70',
+              !isSelected && !isChildOfSelected && 'text-secondary-foreground/80 dark:text-muted-foreground',
+            )}
+            style={{ width: 'max-content', minWidth: '100%' }}
+            onClick={handleSublayerClick}
+          >
+            {/* Indent spacer */}
+            <div style={{ width: `${node.depth * 14 + 8}px`, flex: 'none' }} />
+
+            {/* Content area */}
+            <div
+              className="flex items-center flex-1"
+              style={{ maxWidth: 'var(--tree-available-width)' }}
+            >
+              {hasExpandableChildren ? (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggle(node.id);
+                  }}
+                  className={cn(
+                    'w-4 h-4 flex items-center justify-center shrink-0',
+                    isSubCollapsed ? '' : 'rotate-90',
+                  )}
+                >
+                  <Icon name="chevronRight" className={cn('size-2.5 opacity-50', isSelected && 'opacity-80')} />
+                </button>
+              ) : (
+                <div className="w-4 h-4 shrink-0" />
+              )}
+              <Icon
+                name={node.sublayer.icon as any}
+                className={cn('size-3 mx-1.5 shrink-0', isSelected ? 'opacity-70' : 'opacity-40')}
+              />
+              <span className={cn('flex-1 text-2xs truncate select-none min-w-0', isSelected ? 'opacity-90' : 'opacity-60')}>
+                {node.sublayer.label}
+              </span>
+            </div>
+          </div>
         </div>
       </div>
     );
@@ -378,258 +437,270 @@ const LayerRow = React.memo(function LayerRow({
       liveComponentUpdates={liveComponentUpdates}
       editingComponentId={editingComponentId}
     >
-      <div className="relative">
-        {/* Vertical connector lines - one for each depth level */}
-        {node.depth > 0 && (
-          <>
-            {Array.from({ length: node.depth }).map((_, i) => {
-              const shouldHighlight = (isSelected || isChildOfSelected) && highlightedDepths.has(i);
-              return (
-                <div
-                  key={i}
+      <div
+        className="relative flex"
+        style={{ width: '100%', minWidth: '100%' }}
+        onMouseEnter={() => { if (!isDragging) setIsHovered(true); }}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        {/* Background layer - stays fixed when scrolling horizontally */}
+        <div className="absolute inset-0 pointer-events-none">
+          <div
+            className={cn(
+              'sticky left-0 h-full',
+              isSelected && !hasVisibleChildren && 'rounded-lg',
+              isSelected && hasVisibleChildren && 'rounded-t-lg',
+              !isSelected && isChildOfSelected && !isLastVisibleDescendant && 'rounded-none',
+              !isSelected && isChildOfSelected && isLastVisibleDescendant && 'rounded-b-lg',
+              !isSelected && !isChildOfSelected && 'rounded-lg',
+            )}
+            style={{ width: 'var(--tree-available-width)', background: rowBg }}
+          />
+        </div>
+
+        {/* Content layer - scrolls horizontally */}
+        <div className="relative flex w-full min-w-full flex-1">
+          {/* Vertical connector lines */}
+          {node.depth > 0 && (
+            <>
+              {Array.from({ length: node.depth }).map((_, i) => {
+                const shouldHighlight = (isSelected || isChildOfSelected) && highlightedDepths.has(i);
+                return (
+                  <div
+                    key={i}
+                    className={cn(
+                      'absolute z-10 top-0 bottom-0 w-px pointer-events-none',
+                      shouldHighlight && 'bg-white/30',
+                      isSelected && 'bg-white/10!',
+                      isChildOfSelected && 'dark:bg-white/10 bg-neutral-900/10',
+                      !shouldHighlight && !isChildOfSelected && 'dark:bg-secondary bg-neutral-900/10',
+                    )}
+                    style={{
+                      left: `${i * 14 + 16}px`,
+                    }}
+                  />
+                );
+              })}
+            </>
+          )}
+
+          {/* Drop Indicators */}
+          {isOver && dropPosition === 'above' && (
+            <DropLineIndicator position="above" offsetLeft={node.depth * 14 + 8} />
+          )}
+          {isOver && dropPosition === 'below' && (
+            <DropLineIndicator position="below" offsetLeft={node.depth * 14 + 8} />
+          )}
+          {isOver && dropPosition === 'inside' && (
+            <DropContainerIndicator />
+          )}
+
+          {/* Main Row */}
+          <div
+            ref={setRefs}
+            {...(isRenaming ? {} : attributes)}
+            {...(isRenaming ? {} : listeners)}
+            data-drag-active={isDragActive}
+            data-layer-id={node.id}
+            className={cn(
+              'group relative flex items-center h-8 outline-none focus:outline-none',
+              isLockedByOther ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+              isSelected && 'text-primary-foreground',
+              isSelected && isStateActive && 'text-black',
+              isSelected && usePurpleStyle && 'text-white',
+              !isSelected && !isChildOfSelected && 'text-secondary-foreground/80 dark:text-muted-foreground',
+              !isSelected && isChildOfSelected && 'text-current/70',
+            )}
+            style={{ width: 'max-content', minWidth: '100%' }}
+            onMouseEnter={() => { if (!isDragging) setHoveredLayerId(node.id); }}
+            onMouseLeave={() => setHoveredLayerId(null)}
+            onClick={(e) => {
+              if (isRenaming) return;
+              if (isLockedByOther) {
+                e.stopPropagation();
+                e.preventDefault();
+                return;
+              }
+              onSelect(node.id);
+            }}
+          >
+          {/* Indent spacer */}
+          <div style={{ width: `${node.depth * 14 + 8}px`, flex: 'none' }} />
+
+          {/* Content area - fixed max-width so names truncate, scroll is for hierarchy */}
+          <div className="flex items-center flex-1" style={{ maxWidth: 'var(--tree-available-width)' }}>
+            {/* Expand/Collapse Button */}
+            {(node.canHaveChildren || hasSublayers) ? (
+              effectiveHasChildren ? (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (!shouldHideChildren) {
+                      onToggle(node.id);
+                    }
+                  }}
                   className={cn(
-                    'absolute z-10 top-0 bottom-0 w-px ',
-                    shouldHighlight && 'bg-white/30',
-                    isSelected && 'bg-white/10!',
-                    isChildOfSelected && 'dark:bg-white/10 bg-neutral-900/10',
-                    !shouldHighlight && !isChildOfSelected && 'dark:bg-secondary bg-neutral-900/10',
+                    'w-4 h-4 flex items-center justify-center shrink-0',
+                    isCollapsed ? '' : 'rotate-90',
+                    shouldHideChildren && 'opacity-30 cursor-not-allowed'
                   )}
-                  style={{
-                    left: `${i * 14 + 16}px`,
-                  }}
-                />
-              );
-            })}
-          </>
-        )}
-
-        {/* Drop Indicators - using shared components */}
-        {isOver && dropPosition === 'above' && (
-          <DropLineIndicator position="above" offsetLeft={node.depth * 14 + 8} />
-        )}
-        {isOver && dropPosition === 'below' && (
-          <DropLineIndicator position="below" offsetLeft={node.depth * 14 + 8} />
-        )}
-        {isOver && dropPosition === 'inside' && (
-          <DropContainerIndicator />
-        )}
-
-        {/* Main Row */}
-        <div
-          ref={setRefs}
-          {...(isRenaming ? {} : attributes)}
-          {...(isRenaming ? {} : listeners)}
-          data-drag-active={isDragActive}
-          data-layer-id={node.id}
-          className={cn(
-            'group relative flex items-center h-8 outline-none focus:outline-none',
-            // Locked by another user - show as non-interactive
-            isLockedByOther ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
-            // Conditional rounding based on position in selected group
-            // Selected parent: rounded top, rounded bottom ONLY if no visible children
-            isSelected && !hasVisibleChildren && 'rounded-lg', // No children: fully rounded
-            isSelected && hasVisibleChildren && 'rounded-t-lg', // Has children: only top rounded
-            // Children of selected should have NO rounding, EXCEPT last visible descendant gets bottom rounding
-            !isSelected && isChildOfSelected && !isLastVisibleDescendant && 'rounded-none',
-            !isSelected && isChildOfSelected && isLastVisibleDescendant && 'rounded-b-lg',
-            // Not in group: fully rounded
-            !isSelected && !isChildOfSelected && 'rounded-lg text-secondary-foreground/80 dark:text-muted-foreground',
-            // Background colors
-            !isDragActive && !isDragging && !isLockedByOther && 'hover:bg-secondary/50',
-            // Component instances OR component edit mode use purple, regular layers use blue
-            // When a UI state (hover/focus/active/etc.) is active, use green (#8dd92f)
-            isSelected && !usePurpleStyle && !isStateActive && 'bg-primary text-primary-foreground hover:bg-primary',
-            isSelected && !usePurpleStyle && isStateActive && 'bg-[#8dd92f] text-black hover:bg-[#8dd92f]',
-            isSelected && usePurpleStyle && 'bg-purple-500 text-white hover:bg-purple-500',
-            !isSelected && isChildOfSelected && !usePurpleStyle && !isStateActive && 'dark:bg-primary/15 bg-primary/10 text-current/70 hover:bg-primary/15 dark:hover:bg-primary/20',
-            !isSelected && isChildOfSelected && !usePurpleStyle && isStateActive && 'dark:bg-[#8dd92f]/15 bg-[#8dd92f]/10 text-current/70 hover:bg-[#8dd92f]/15 dark:hover:bg-[#8dd92f]/20',
-            !isSelected && isChildOfSelected && usePurpleStyle && 'dark:bg-purple-500/10 bg-purple-500/10 text-current/70 hover:bg-purple-500/15 dark:hover:bg-purple-500/20',
-            isSelected && !isDragActive && !isDragging && '',
-            isDragging && '',
-            !isDragActive && ''
-          )}
-          style={{ paddingLeft: `${node.depth * 14 + 8}px` }}
-          onMouseEnter={() => {
-            if (!isDragging) {
-              setHoveredLayerId(node.id);
-            }
-          }}
-          onMouseLeave={() => {
-            setHoveredLayerId(null);
-          }}
-          onClick={(e) => {
-            if (isRenaming) return;
-            // Block click if layer is locked by another user
-            if (isLockedByOther) {
-              e.stopPropagation();
-              e.preventDefault();
-              return;
-            }
-            // Normal click: Select only this layer
-            onSelect(node.id);
-          }}
-        >
-          {/* Expand/Collapse Button - show for elements that can have children or richText sublayers */}
-          {(node.canHaveChildren || hasSublayers) ? (
-            effectiveHasChildren ? (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (!shouldHideChildren) {
-                    onToggle(node.id);
-                  }
-                }}
-                className={cn(
-                  'w-4 h-4 flex items-center justify-center shrink-0',
-                  isCollapsed ? '' : 'rotate-90',
-                  shouldHideChildren && 'opacity-30 cursor-not-allowed'
-                )}
-                disabled={shouldHideChildren}
-              >
-                <Icon name="chevronRight" className={cn('size-2.5 opacity-50', isSelected && 'opacity-80')} />
-              </button>
+                  disabled={shouldHideChildren}
+                >
+                  <Icon name="chevronRight" className={cn('size-2.5 opacity-50', isSelected && 'opacity-80')} />
+                </button>
+              ) : (
+                <div className="w-4 h-4 shrink-0" />
+              )
             ) : (
-              <div className="w-4 h-4 shrink-0" />
-            )
-          ) : (
-            <div className="w-4 h-4 shrink-0 flex items-center justify-center">
-              <div className={cn('ml-px w-1.5 h-px bg-white opacity-0', isSelected && 'opacity-0')} />
-            </div>
-          )}
-
-          {/* Layer Icon */}
-          {isComponentInstance ? (
-            <Icon name="component" className="size-3 mx-1.5 shrink-0" />
-          ) : layerIcon ? (
-            <Icon
-              name={layerIcon}
-              className={cn(
-                'size-3 mx-1.5 opacity-50 shrink-0',
-                isSelected && 'opacity-100',
-              )}
-            />
-          ) : (
-            <div
-              className={cn(
-                'size-3 bg-secondary rounded mx-1.5 shrink-0',
-                isSelected && 'opacity-10 dark:bg-white'
-              )}
-            />
-          )}
-
-          {/* Label / Inline Rename Input */}
-          {isRenaming ? (
-            <Input
-              ref={renameInputRef}
-              variant="rename-selected"
-              data-renaming
-              className="grow mr-2"
-              defaultValue={node.layer.customName || ''}
-              placeholder={getLayerDisplayLabel({ ...node.layer, customName: undefined }, {
-                component_name: appliedComponent?.name,
-                collection_name: finalCollectionName,
-                source_field_name: sourceFieldName ?? undefined,
-              }, activeBreakpoint)}
-              onClick={(e) => e.stopPropagation()}
-              onMouseDown={(e) => e.stopPropagation()}
-              onPointerDown={(e) => e.stopPropagation()}
-              onBlur={(e) => {
-                if (!renameReadyRef.current) return;
-                const val = e.currentTarget.value.trim();
-                onRenameConfirm(node.id, val || null);
-              }}
-              onKeyDown={(e) => {
-                e.stopPropagation();
-                if (e.key === 'Enter') {
-                  const val = (e.target as HTMLInputElement).value.trim();
-                  onRenameConfirm(node.id, val || null);
-                } else if (e.key === 'Escape') {
-                  onRenameConfirm(node.id, node.layer.customName || null);
-                }
-              }}
-            />
-          ) : (
-            <span
-              className="grow text-xs font-medium overflow-hidden text-ellipsis whitespace-nowrap select-none min-w-15"
-              onDoubleClick={(e) => {
-                e.stopPropagation();
-                if (node.id !== 'body') {
-                  onRenameStart(node.id);
-                }
-              }}
-            >
-              {getLayerDisplayLabel(node.layer, {
-                component_name: appliedComponent?.name,
-                collection_name: finalCollectionName,
-                source_field_name: sourceFieldName ?? undefined,
-              }, activeBreakpoint)}
-            </span>
-          )}
-
-          <div className="sticky right-0 flex items-center shrink-0">
-            {isLockedByOther && (
-              <div className="mr-2 shrink-0">
-                <CollaboratorBadge
-                  collaborator={{
-                    userId: lockOwnerUser?.user_id || '',
-                    email: lockOwnerUser?.email,
-                    color: lockOwnerUser?.color,
-                  }}
-                  size="xs"
-                  tooltipPrefix="Editing by"
-                />
+              <div className="w-4 h-4 shrink-0 flex items-center justify-center">
+                <div className={cn('ml-px w-1.5 h-px bg-white opacity-0', isSelected && 'opacity-0')} />
               </div>
             )}
 
-            {interactionTriggerLayerIds.includes(node.id) && (
+            {/* Layer Icon */}
+            {isComponentInstance ? (
+              <Icon name="component" className="size-3 mx-1.5 shrink-0" />
+            ) : layerIcon ? (
               <Icon
-                name="zap"
+                name={layerIcon}
                 className={cn(
-                  'size-3 mr-2 shrink-0',
-                  activeInteractionTriggerLayerId === node.id ? 'text-white/80' : 'text-white/40'
+                  'size-3 mx-1.5 opacity-50 shrink-0',
+                  isSelected && 'opacity-100',
+                )}
+              />
+            ) : (
+              <div
+                className={cn(
+                  'size-3 bg-secondary rounded mx-1.5 shrink-0',
+                  isSelected && 'opacity-10 dark:bg-white'
                 )}
               />
             )}
 
-            {interactionTargetLayerIds.includes(node.id) && !interactionTriggerLayerIds.includes(node.id) && (
-              <Icon
-                name="zap-outline"
-                className={cn(
-                  'size-3 mr-2 shrink-0',
-                  activeInteractionTargetLayerIds.includes(node.id) ? 'text-white/70' : 'text-white/40'
-                )}
-              />
-            )}
-
-            {node.id !== 'body' && !isRenaming && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onToggleVisibility(node.id);
-                }}
+            {/* Label / Inline Rename Input */}
+            {isRenaming ? (
+              <Input
+                ref={renameInputRef}
+                variant="rename-selected"
+                data-renaming
+                className="grow mr-2"
+                defaultValue={node.layer.customName || ''}
+                placeholder={getLayerDisplayLabel({ ...node.layer, customName: undefined }, {
+                  component_name: appliedComponent?.name,
+                  collection_name: finalCollectionName,
+                  source_field_name: sourceFieldName ?? undefined,
+                }, activeBreakpoint)}
+                onClick={(e) => e.stopPropagation()}
+                onMouseDown={(e) => e.stopPropagation()}
                 onPointerDown={(e) => e.stopPropagation()}
-                className={cn(
-                  'items-center justify-center shrink-0 mr-1 rounded cursor-pointer',
-                  node.layer.settings?.hidden
-                    ? cn(
-                      'size-6 flex opacity-60',
-                      isSelected ? 'opacity-80 hover:opacity-100' : 'hover:opacity-100'
-                    )
-                    : cn(
-                      'size-0 hidden group-hover:flex group-hover:size-6 group-hover:opacity-40',
-                      isSelected ? 'group-hover:opacity-60' : '',
-                      'hover:opacity-100!'
-                    ),
-                )}
-                aria-label={node.layer.settings?.hidden ? 'Show element' : 'Hide element'}
+                onBlur={(e) => {
+                  if (!renameReadyRef.current) return;
+                  const val = e.currentTarget.value.trim();
+                  onRenameConfirm(node.id, val || null);
+                }}
+                onKeyDown={(e) => {
+                  e.stopPropagation();
+                  if (e.key === 'Enter') {
+                    const val = (e.target as HTMLInputElement).value.trim();
+                    onRenameConfirm(node.id, val || null);
+                  } else if (e.key === 'Escape') {
+                    onRenameConfirm(node.id, node.layer.customName || null);
+                  }
+                }}
+              />
+            ) : (
+              <span
+                className="flex-1 text-xs font-medium truncate select-none min-w-0"
+                onDoubleClick={(e) => {
+                  e.stopPropagation();
+                  if (node.id !== 'body') {
+                    onRenameStart(node.id);
+                  }
+                }}
               >
-                <Icon
-                  name={node.layer.settings?.hidden ? 'eye-off' : 'eye'}
-                  className="size-3"
-                />
-              </button>
+                {getLayerDisplayLabel(node.layer, {
+                  component_name: appliedComponent?.name,
+                  collection_name: finalCollectionName,
+                  source_field_name: sourceFieldName ?? undefined,
+                }, activeBreakpoint)}
+              </span>
             )}
           </div>
+
+          {/* Right icons overlay - sticky to right edge, starts after chevron+icon area */}
+          <div
+            className="absolute top-0 bottom-0 right-0 flex justify-end pointer-events-none"
+            style={{ left: `${node.depth * 14 + 8 + 36}px` }}
+          >
+            <div
+              className="sticky right-0 h-full flex items-center pointer-events-auto gap-0.5 px-1 rounded-r-lg"
+              style={{ background: iconBg }}
+            >
+              {isLockedByOther && (
+                <div className="mr-1 shrink-0">
+                  <CollaboratorBadge
+                    collaborator={{
+                      userId: lockOwnerUser?.user_id || '',
+                      email: lockOwnerUser?.email,
+                      color: lockOwnerUser?.color,
+                    }}
+                    size="xs"
+                    tooltipPrefix="Editing by"
+                  />
+                </div>
+              )}
+
+              {interactionTriggerLayerIds.includes(node.id) && (
+                <Icon
+                  name="zap"
+                  className={cn(
+                    'size-3 mr-1 shrink-0',
+                    activeInteractionTriggerLayerId === node.id ? 'text-white/80' : 'text-white/40'
+                  )}
+                />
+              )}
+
+              {interactionTargetLayerIds.includes(node.id) && !interactionTriggerLayerIds.includes(node.id) && (
+                <Icon
+                  name="zap-outline"
+                  className={cn(
+                    'size-3 mr-1 shrink-0',
+                    activeInteractionTargetLayerIds.includes(node.id) ? 'text-white/70' : 'text-white/40'
+                  )}
+                />
+              )}
+
+              {node.id !== 'body' && !isRenaming && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggleVisibility(node.id);
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  className={cn(
+                    'items-center justify-center shrink-0 mr-1 rounded cursor-pointer',
+                    node.layer.settings?.hidden
+                      ? cn(
+                        'size-6 flex opacity-60',
+                        isSelected ? 'opacity-80 hover:opacity-100' : 'hover:opacity-100'
+                      )
+                      : cn(
+                        'size-0 hidden group-hover:flex group-hover:size-6 group-hover:opacity-40',
+                        isSelected ? 'group-hover:opacity-60' : '',
+                        'hover:opacity-100!'
+                      ),
+                  )}
+                  aria-label={node.layer.settings?.hidden ? 'Show element' : 'Hide element'}
+                >
+                  <Icon
+                    name={node.layer.settings?.hidden ? 'eye-off' : 'eye'}
+                    className="size-3"
+                  />
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
         </div>
       </div>
     </LayerContextMenu>
@@ -765,7 +836,7 @@ export default function LayersTree({
   const [shouldScrollToSelected, setShouldScrollToSelected] = useState(false);
 
   // Pull multi-select state and breakpoint from editor store
-  const { selectedLayerIds: storeSelectedLayerIds, lastSelectedLayerId, toggleSelection, selectRange, editingComponentId, activeBreakpoint, activeSublayerIndex: storeActiveSublayerIndex, activeTextStyleKey: storeActiveTextStyleKey, activeListItemIndex: storeActiveListItemIndex } = useEditorStore();
+  const { selectedLayerIds: storeSelectedLayerIds, lastSelectedLayerId, toggleSelection, selectRange, editingComponentId, activeBreakpoint, activeSublayerIndex: storeActiveSublayerIndex, activeTextStyleKey: storeActiveTextStyleKey, activeListItemIndex: storeActiveListItemIndex, leftSidebarWidth } = useEditorStore();
 
   // Get component by ID function for drag overlay
   const { getComponentById } = useComponentsStore();
@@ -1190,6 +1261,7 @@ export default function LayersTree({
   }, []);
 
   const ROW_HEIGHT = 32;
+  const treeAvailableWidth = leftSidebarWidth - 32;
   const maxDepth = useMemo(() => flattenedNodes.reduce((max, n) => Math.max(max, n.depth), 0), [flattenedNodes]);
 
   const virtualizer = useVirtualizer({
@@ -1247,15 +1319,11 @@ export default function LayersTree({
         scrollEl.scrollTo({ top: Math.max(0, targetScroll), behavior: 'smooth' });
       }
 
-      // Horizontal scroll: ensure selected row content is visible
+      // Horizontal scroll: align to parent's parent layer's chevron - 2px
       const node = flattenedNodes[idx];
-      if (node) {
-        const contentLeft = node.depth * 14 + 8;
-        if (contentLeft < scrollEl.scrollLeft) {
-          scrollEl.scrollTo({ left: Math.max(0, contentLeft - 8), behavior: 'smooth' });
-        } else if (contentLeft > scrollEl.scrollLeft + scrollEl.clientWidth - 140) {
-          scrollEl.scrollTo({ left: contentLeft - 8, behavior: 'smooth' });
-        }
+      const targetLeft = node && node.depth > 0 ? (node.depth - 2) * 14 - 2 : 0;
+      if (Math.abs(scrollEl.scrollLeft - targetLeft) > 1) {
+        scrollEl.scrollTo({ left: targetLeft, behavior: 'smooth' });
       }
     }, 100);
 
@@ -1919,7 +1987,7 @@ export default function LayersTree({
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      <div ref={wrapperRef} style={{ height: virtualizer.getTotalSize(), position: 'relative', minWidth: maxDepth > 0 ? `${maxDepth * 14 + 170}px` : undefined }}>
+      <div ref={wrapperRef} style={{ height: virtualizer.getTotalSize(), position: 'relative', minWidth: maxDepth > 0 ? `${maxDepth * 14 + 8 + treeAvailableWidth}px` : undefined }}>
         {virtualizer.getVirtualItems().map((virtualRow) => {
           const node = flattenedNodes[virtualRow.index];
           const selectionData = nodeSelectionData.get(node.id)!;

--- a/app/(builder)/ycode/components/LayersTree.tsx
+++ b/app/(builder)/ycode/components/LayersTree.tsx
@@ -359,7 +359,7 @@ const LayerRow = React.memo(function LayerRow({
             name={node.sublayer.icon as any}
             className={cn('size-3 mx-1.5 shrink-0', isSelected ? 'opacity-70' : 'opacity-40')}
           />
-          <span className={cn('text-2xs truncate select-none', isSelected ? 'opacity-90' : 'opacity-60')}>
+          <span className={cn('text-2xs truncate select-none min-w-15', isSelected ? 'opacity-90' : 'opacity-60')}>
             {node.sublayer.label}
           </span>
         </div>
@@ -550,7 +550,7 @@ const LayerRow = React.memo(function LayerRow({
             />
           ) : (
             <span
-              className="grow text-xs font-medium overflow-hidden text-ellipsis whitespace-nowrap select-none"
+              className="grow text-xs font-medium overflow-hidden text-ellipsis whitespace-nowrap select-none min-w-15"
               onDoubleClick={(e) => {
                 e.stopPropagation();
                 if (node.id !== 'body') {
@@ -566,85 +566,70 @@ const LayerRow = React.memo(function LayerRow({
             </span>
           )}
 
-          {/* Lock Indicator - show when layer is locked by another user */}
-          {isLockedByOther && (
-            <div className="mr-2 shrink-0">
-              <CollaboratorBadge
-                collaborator={{
-                  userId: lockOwnerUser?.user_id || '',
-                  email: lockOwnerUser?.email,
-                  color: lockOwnerUser?.color,
-                }}
-                size="xs"
-                tooltipPrefix="Editing by"
-              />
-            </div>
-          )}
+          <div className="sticky right-0 flex items-center shrink-0">
+            {isLockedByOther && (
+              <div className="mr-2 shrink-0">
+                <CollaboratorBadge
+                  collaborator={{
+                    userId: lockOwnerUser?.user_id || '',
+                    email: lockOwnerUser?.email,
+                    color: lockOwnerUser?.color,
+                  }}
+                  size="xs"
+                  tooltipPrefix="Editing by"
+                />
+              </div>
+            )}
 
-          {/* Style Indicator - temporarily disabled */}
-          {/* {node.layer.styleId && (
-            <div className="flex items-center gap-1 mr-2 shrink-0">
-              <LayersIcon className="w-3 h-3 text-purple-400" />
-              {(() => {
-                const appliedStyle = getStyleById(node.layer.styleId);
-                return appliedStyle && hasStyleOverrides(node.layer, appliedStyle) && (
-                  <div className="w-1.5 h-1.5 rounded-full bg-orange-400" title="Style overridden" />
-                );
-              })()}
-            </div>
-          )} */}
-
-          {/* Interaction trigger indicator */}
-          {interactionTriggerLayerIds.includes(node.id) && (
-            <Icon
-              name="zap"
-              className={cn(
-                'size-3 mr-2 shrink-0',
-                activeInteractionTriggerLayerId === node.id ? 'text-white/80' : 'text-white/40'
-              )}
-            />
-          )}
-
-          {/* Interaction target indicator */}
-          {interactionTargetLayerIds.includes(node.id) && !interactionTriggerLayerIds.includes(node.id) && (
-            <Icon
-              name="zap-outline"
-              className={cn(
-                'size-3 mr-2 shrink-0',
-                activeInteractionTargetLayerIds.includes(node.id) ? 'text-white/70' : 'text-white/40'
-              )}
-            />
-          )}
-
-          {/* Visibility toggle */}
-          {node.id !== 'body' && !isRenaming && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleVisibility(node.id);
-              }}
-              onPointerDown={(e) => e.stopPropagation()}
-              className={cn(
-                'size-6 flex items-center justify-center shrink-0 mr-1 rounded cursor-pointer',
-                node.layer.settings?.hidden
-                  ? cn(
-                    'opacity-60',
-                    isSelected ? 'opacity-80 hover:opacity-100' : 'hover:opacity-100'
-                  )
-                  : cn(
-                    'opacity-0 group-hover:opacity-40',
-                    isSelected ? 'group-hover:opacity-60' : '',
-                    'hover:opacity-100!'
-                  ),
-              )}
-              aria-label={node.layer.settings?.hidden ? 'Show element' : 'Hide element'}
-            >
+            {interactionTriggerLayerIds.includes(node.id) && (
               <Icon
-                name={node.layer.settings?.hidden ? 'eye-off' : 'eye'}
-                className="size-3"
+                name="zap"
+                className={cn(
+                  'size-3 mr-2 shrink-0',
+                  activeInteractionTriggerLayerId === node.id ? 'text-white/80' : 'text-white/40'
+                )}
               />
-            </button>
-          )}
+            )}
+
+            {interactionTargetLayerIds.includes(node.id) && !interactionTriggerLayerIds.includes(node.id) && (
+              <Icon
+                name="zap-outline"
+                className={cn(
+                  'size-3 mr-2 shrink-0',
+                  activeInteractionTargetLayerIds.includes(node.id) ? 'text-white/70' : 'text-white/40'
+                )}
+              />
+            )}
+
+            {node.id !== 'body' && !isRenaming && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleVisibility(node.id);
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+                className={cn(
+                  'items-center justify-center shrink-0 mr-1 rounded cursor-pointer',
+                  node.layer.settings?.hidden
+                    ? cn(
+                      'size-6 flex opacity-60',
+                      isSelected ? 'opacity-80 hover:opacity-100' : 'hover:opacity-100'
+                    )
+                    : cn(
+                      'size-0 hidden group-hover:flex group-hover:size-6 group-hover:opacity-40',
+                      isSelected ? 'group-hover:opacity-60' : '',
+                      'hover:opacity-100!'
+                    ),
+                )}
+                aria-label={node.layer.settings?.hidden ? 'Show element' : 'Hide element'}
+              >
+                <Icon
+                  name={node.layer.settings?.hidden ? 'eye-off' : 'eye'}
+                  className="size-3"
+                />
+              </button>
+            )}
+          </div>
         </div>
       </div>
     </LayerContextMenu>
@@ -1205,6 +1190,8 @@ export default function LayersTree({
   }, []);
 
   const ROW_HEIGHT = 32;
+  const maxDepth = useMemo(() => flattenedNodes.reduce((max, n) => Math.max(max, n.depth), 0), [flattenedNodes]);
+
   const virtualizer = useVirtualizer({
     count: flattenedNodes.length,
     getScrollElement: () => scrollContainerRef.current,
@@ -1229,6 +1216,7 @@ export default function LayersTree({
     const virtualItems = virtualizer.getVirtualItems();
     const item = virtualItems.find(v => v.index === idx);
 
+    let needsVerticalScroll = true;
     if (item) {
       const wrapperTop = wrapperRef.current?.getBoundingClientRect().top ?? 0;
       const scrollTop = scrollEl.getBoundingClientRect().top;
@@ -1237,24 +1225,38 @@ export default function LayersTree({
       const viewBottom = scrollTop + scrollEl.clientHeight - SCROLL_MARGIN;
 
       if (itemScreenTop >= viewTop && itemScreenTop + ROW_HEIGHT <= viewBottom) {
-        return;
+        needsVerticalScroll = false;
       }
     }
 
-    // Jump to item first so virtualizer renders it, then center manually
-    const isAbove = idx * ROW_HEIGHT < scrollEl.scrollTop;
-    virtualizer.scrollToIndex(idx, { align: isAbove ? 'start' : 'end' });
+    if (needsVerticalScroll) {
+      const isAbove = idx * ROW_HEIGHT < scrollEl.scrollTop;
+      virtualizer.scrollToIndex(idx, { align: isAbove ? 'start' : 'end' });
+    }
 
     const timeout = setTimeout(() => {
       const wrapperEl = wrapperRef.current;
       if (!wrapperEl || !scrollEl) return;
 
-      const wrapperRect = wrapperEl.getBoundingClientRect();
-      const scrollRect = scrollEl.getBoundingClientRect();
-      const wrapperOffset = wrapperRect.top - scrollRect.top + scrollEl.scrollTop;
-      const itemTop = wrapperOffset + idx * ROW_HEIGHT;
-      const targetScroll = itemTop - (scrollEl.clientHeight / 2) + (ROW_HEIGHT / 2);
-      scrollEl.scrollTo({ top: Math.max(0, targetScroll), behavior: 'smooth' });
+      if (needsVerticalScroll) {
+        const wrapperRect = wrapperEl.getBoundingClientRect();
+        const scrollRect = scrollEl.getBoundingClientRect();
+        const wrapperOffset = wrapperRect.top - scrollRect.top + scrollEl.scrollTop;
+        const itemTop = wrapperOffset + idx * ROW_HEIGHT;
+        const targetScroll = itemTop - (scrollEl.clientHeight / 2) + (ROW_HEIGHT / 2);
+        scrollEl.scrollTo({ top: Math.max(0, targetScroll), behavior: 'smooth' });
+      }
+
+      // Horizontal scroll: ensure selected row content is visible
+      const node = flattenedNodes[idx];
+      if (node) {
+        const contentLeft = node.depth * 14 + 8;
+        if (contentLeft < scrollEl.scrollLeft) {
+          scrollEl.scrollTo({ left: Math.max(0, contentLeft - 8), behavior: 'smooth' });
+        } else if (contentLeft > scrollEl.scrollLeft + scrollEl.clientWidth - 140) {
+          scrollEl.scrollTo({ left: contentLeft - 8, behavior: 'smooth' });
+        }
+      }
     }, 100);
 
     return () => clearTimeout(timeout);
@@ -1917,7 +1919,7 @@ export default function LayersTree({
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      <div ref={wrapperRef} style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+      <div ref={wrapperRef} style={{ height: virtualizer.getTotalSize(), position: 'relative', minWidth: maxDepth > 0 ? `${maxDepth * 14 + 170}px` : undefined }}>
         {virtualizer.getVirtualItems().map((virtualRow) => {
           const node = flattenedNodes[virtualRow.index];
           const selectionData = nodeSelectionData.get(node.id)!;

--- a/app/(builder)/ycode/components/LeftSidebar.tsx
+++ b/app/(builder)/ycode/components/LeftSidebar.tsx
@@ -343,7 +343,10 @@ const LeftSidebar = React.memo(function LeftSidebar({
                 </div>
               </header>
 
-              <div className="flex flex-col flex-1 min-h-0 overflow-y-auto overflow-x-auto no-scrollbar">
+              <div
+                className="flex flex-col flex-1 min-h-0 overflow-y-auto overflow-x-auto no-scrollbar"
+                style={{ '--tree-available-width': `${sidebarWidth - 33}px` } as React.CSSProperties}
+              >
                 {!currentPageId && !editingComponentId ? (
                   <Empty>
                     <EmptyTitle>No page selected</EmptyTitle>

--- a/app/(builder)/ycode/components/LeftSidebar.tsx
+++ b/app/(builder)/ycode/components/LeftSidebar.tsx
@@ -24,6 +24,7 @@ import { resetBindingsAfterMove } from '@/lib/layer-utils';
 import { useEditorUrl } from '@/hooks/use-editor-url';
 import type { EditorTab } from '@/hooks/use-editor-url';
 import { useLayerLocks } from '@/hooks/use-layer-locks';
+import { useResizableSidebar } from '@/hooks/use-resizable-sidebar';
 
 // 6. Types
 import type { Layer } from '@/types';
@@ -53,6 +54,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
 }: LeftSidebarProps) {
   const { sidebarTab } = useEditorUrl();
   const [showElementLibrary, setShowElementLibrary] = useState(false);
+  const { width: sidebarWidth, isDragging: isResizing, handleMouseDown: handleResizeMouseDown } = useResizableSidebar({ side: 'left' });
   const [assetMessage, setAssetMessage] = useState<string | null>(null);
 
   // Optimize store subscriptions - scoped to current page only
@@ -284,7 +286,13 @@ const LeftSidebar = React.memo(function LeftSidebar({
 
   return (
     <>
-      <div className="w-64 shrink-0 bg-background border-r flex overflow-hidden p-4 pb-0">
+      <div
+        className="shrink-0 relative"
+        style={{ width: `${sidebarWidth}px` }}
+      >
+      <div
+        className="w-full h-full bg-background border-r flex overflow-hidden p-4 pb-0"
+      >
         {/* Tabs */}
         <div className="w-full">
           <Tabs
@@ -371,7 +379,22 @@ const LeftSidebar = React.memo(function LeftSidebar({
 
           </Tabs>
         </div>
+
       </div>
+
+      {/* Resize handle - wide hit area, thin visible line on hover */}
+      <div
+        onMouseDown={handleResizeMouseDown}
+        className="absolute top-0 -right-1.5 w-3 h-full cursor-col-resize z-30 flex items-center justify-center group/resize"
+      >
+        <div className="w-0.5 h-full bg-transparent group-hover/resize:bg-primary/50 group-active/resize:bg-primary/70 transition-colors" />
+      </div>
+      </div>
+
+      {/* Invisible overlay during resize to prevent iframe from capturing mouse events */}
+      {isResizing && (
+        <div className="fixed inset-0 z-50 cursor-col-resize" />
+      )}
 
       {/* Element Library Slide-Out (lazy loaded, always mounted to preserve state) */}
       <Suspense fallback={null}>
@@ -379,6 +402,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
           isOpen={showElementLibrary}
           onClose={() => setShowElementLibrary(false)}
           liveLayerUpdates={liveLayerUpdates}
+          sidebarWidth={sidebarWidth}
         />
       </Suspense>
     </>

--- a/app/(builder)/ycode/components/LeftSidebar.tsx
+++ b/app/(builder)/ycode/components/LeftSidebar.tsx
@@ -7,7 +7,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
 // 4. Internal components
 import LayersTree from './LayersTree';
-import LeftSidebarPages from './LeftSidebarPages';
+import LeftSidebarPages, { type LeftSidebarPagesHandle } from './LeftSidebarPages';
 
 // Lazy-loaded components (heavy, not needed immediately)
 const ElementLibrary = lazy(() => import('./ElementLibrary'));
@@ -55,6 +55,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
   const { sidebarTab } = useEditorUrl();
   const [showElementLibrary, setShowElementLibrary] = useState(false);
   const { width: sidebarWidth, isDragging: isResizing, handleMouseDown: handleResizeMouseDown } = useResizableSidebar({ side: 'left' });
+  const pagesRef = useRef<LeftSidebarPagesHandle>(null);
   const [assetMessage, setAssetMessage] = useState<string | null>(null);
 
   // Optimize store subscriptions - scoped to current page only
@@ -297,8 +298,13 @@ const LeftSidebar = React.memo(function LeftSidebar({
         <div className="w-full">
           <Tabs
             value={activeTab}
-            onValueChange={(value) => {
+            onValueChange={async (value) => {
               const newTab = value as EditorTab;
+
+              if (newTab === 'layers' && pagesRef.current) {
+                const canSwitch = await pagesRef.current.checkAndCloseSettings();
+                if (!canSwitch) return;
+              }
 
               setActiveSidebarTab(newTab);
               setShowElementLibrary(false);
@@ -369,6 +375,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
               forceMount
             >
               <LeftSidebarPages
+                ref={pagesRef}
                 pages={pages}
                 folders={folders}
                 currentPageId={currentPageId}
@@ -402,7 +409,6 @@ const LeftSidebar = React.memo(function LeftSidebar({
           isOpen={showElementLibrary}
           onClose={() => setShowElementLibrary(false)}
           liveLayerUpdates={liveLayerUpdates}
-          sidebarWidth={sidebarWidth}
         />
       </Suspense>
     </>

--- a/app/(builder)/ycode/components/LeftSidebar.tsx
+++ b/app/(builder)/ycode/components/LeftSidebar.tsx
@@ -322,10 +322,10 @@ const LeftSidebar = React.memo(function LeftSidebar({
 
             {/* Content - forceMount keeps all tabs mounted for instant switching */}
             <TabsContent
-              value="layers" className="flex flex-col min-h-0 overflow-y-auto no-scrollbar"
+              value="layers" className="flex flex-col min-h-0"
               forceMount
             >
-              <header className="py-5 flex justify-between shrink-0 sticky top-0 bg-linear-to-b from-background to-transparent z-20">
+              <header className="py-5 flex justify-between shrink-0 z-20">
                 <span className="font-medium">{editingComponentId ? 'Layers' : 'Layers'}</span>
                 <div className="-my-1">
                   <Button
@@ -337,7 +337,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
                 </div>
               </header>
 
-              <div className="flex flex-col flex-1 min-h-0">
+              <div className="flex flex-col flex-1 min-h-0 overflow-y-auto overflow-x-auto no-scrollbar">
                 {!currentPageId && !editingComponentId ? (
                   <Empty>
                     <EmptyTitle>No page selected</EmptyTitle>

--- a/app/(builder)/ycode/components/LeftSidebarPages.tsx
+++ b/app/(builder)/ycode/components/LeftSidebarPages.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useRef, startTransition, Suspense, lazy } from 'react';
+import React, { useState, useEffect, useRef, useImperativeHandle, startTransition, Suspense, lazy } from 'react';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import Icon from '@/components/ui/icon';
@@ -21,6 +21,10 @@ import { Separator } from '@/components/ui/separator';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { generateUniqueSlug, generateUniqueFolderSlug, getNextNumberFromNames, getParentContextFromSelection, calculateNextOrder, findNextSelection } from '@/lib/page-utils';
 
+export interface LeftSidebarPagesHandle {
+  checkAndCloseSettings: () => Promise<boolean>;
+}
+
 interface LeftSidebarPagesProps {
   pages: Page[];
   folders: PageFolder[];
@@ -29,13 +33,13 @@ interface LeftSidebarPagesProps {
   setCurrentPageId: (pageId: string | null) => void;
 }
 
-export default function LeftSidebarPages({
+const LeftSidebarPages = React.forwardRef<LeftSidebarPagesHandle, LeftSidebarPagesProps>(({
   pages,
   folders,
   currentPageId,
   onPageSelect,
   setCurrentPageId,
-}: LeftSidebarPagesProps) {
+}, ref) => {
   const { urlState } = useEditorUrl();
   const activeSidebarTab = useEditorStore((state) => state.activeSidebarTab);
   const { openPage, openPageEdit, openPageLayers, navigateToLayers, navigateToPage, navigateToPageEdit, navigateToCollections } = useEditorActions();
@@ -48,6 +52,25 @@ export default function LeftSidebarPages({
   const selectedItemIdRef = React.useRef<string | null>(currentPageId);
   const pageSettingsPanelRef = useRef<PageSettingsPanelHandle>(null);
   const folderSettingsPanelRef = useRef<FolderSettingsPanelHandle>(null);
+
+  useImperativeHandle(ref, () => ({
+    checkAndCloseSettings: async () => {
+      if (showPageSettings && pageSettingsPanelRef.current) {
+        const canProceed = await pageSettingsPanelRef.current.checkUnsavedChanges();
+        if (!canProceed) return false;
+        setShowPageSettings(false);
+        setEditingPage(null);
+      }
+      if (showFolderSettings && folderSettingsPanelRef.current) {
+        const canProceed = await folderSettingsPanelRef.current.checkUnsavedChanges();
+        if (!canProceed) return false;
+        setShowFolderSettings(false);
+        setEditingFolder(null);
+      }
+      return true;
+    },
+  }), [showPageSettings, showFolderSettings]);
+
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<{ id: string; type: 'folder' | 'page' } | null>(null);
 
@@ -895,4 +918,8 @@ export default function LeftSidebarPages({
       />
     </>
   );
-}
+});
+
+LeftSidebarPages.displayName = 'LeftSidebarPages';
+
+export default LeftSidebarPages;

--- a/app/(builder)/ycode/components/PageSettingsPanel.tsx
+++ b/app/(builder)/ycode/components/PageSettingsPanel.tsx
@@ -123,6 +123,7 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
   const [seoImage, setSeoImage] = useState<string | FieldVariable | null>(null);
   const [seoNoindex, setSeoNoindex] = useState(false);
   const { openFileManager } = useEditorStore();
+  const leftSidebarWidth = useEditorStore((state) => state.leftSidebarWidth);
 
   const nameInputRef = useRef<HTMLInputElement>(null);
 
@@ -1145,12 +1146,16 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 left-64 z-40"
+        className="fixed inset-0 z-40"
+        style={{ left: `${leftSidebarWidth}px` }}
         onClick={handleClose}
       />
 
       {/* Panel */}
-      <div className="fixed top-14 left-64 bottom-0 w-125 bg-background border-r z-50 flex flex-col">
+      <div
+        className="fixed top-14 bottom-0 w-125 bg-background border-r z-50 flex flex-col"
+        style={{ left: `${leftSidebarWidth}px` }}
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4">
           <div className="flex items-center justify-center gap-1.5">

--- a/components/SelectionOverlay.tsx
+++ b/components/SelectionOverlay.tsx
@@ -59,9 +59,10 @@ export function SelectionOverlay({
   const hoveredContainerRef = useRef<HTMLDivElement>(null);
   const parentContainerRef = useRef<HTMLDivElement>(null);
   
-  // Track drag/animation state for scroll/mutation handlers
+  // Track drag/animation/resize state for scroll/mutation handlers
   const isDraggingRef = useRef(false);
   const isSliderAnimatingRef = useRef(false);
+  const isSidebarResizingRef = useRef(false);
 
   const hideAllOutlines = useCallback(() => {
     if (selectedContainerRef.current) selectedContainerRef.current.style.display = 'none';
@@ -158,7 +159,7 @@ export function SelectionOverlay({
 
   // Update all outlines
   const updateAllOutlines = useCallback((skipSolidBorders = false) => {
-    if (isSliderAnimatingRef.current) {
+    if (isSliderAnimatingRef.current || isSidebarResizingRef.current) {
       hideAllOutlines();
       return;
     }
@@ -325,6 +326,18 @@ export function SelectionOverlay({
       updateAllOutlines();
     }
   }, [isSliderAnimating, updateAllOutlines, hideAllOutlines]);
+
+  // Hide outlines during sidebar resize
+  const isSidebarResizing = useEditorStore((state) => state.isSidebarResizing);
+
+  useEffect(() => {
+    isSidebarResizingRef.current = isSidebarResizing;
+    if (isSidebarResizing) {
+      hideAllOutlines();
+    } else {
+      updateAllOutlines();
+    }
+  }, [isSidebarResizing, hideAllOutlines, updateAllOutlines]);
 
   return (
     <div

--- a/hooks/use-resizable-sidebar.ts
+++ b/hooks/use-resizable-sidebar.ts
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+import { useEditorStore } from '@/stores/useEditorStore';
+
+const STORAGE_KEY_PREFIX = 'ycode-sidebar-width-';
+
+interface UseResizableSidebarOptions {
+  side: 'left' | 'right';
+  defaultWidth?: number;
+  minWidth?: number;
+  maxWidth?: number;
+  storageKey?: string;
+}
+
+/**
+ * Hook for making a sidebar resizable via a drag handle.
+ * Persists width to localStorage and constrains within min/max bounds.
+ * Returns isDragging so consumers can render an iframe overlay during resize.
+ */
+export function useResizableSidebar({
+  side,
+  defaultWidth = 256,
+  minWidth = 200,
+  maxWidth = 480,
+  storageKey,
+}: UseResizableSidebarOptions) {
+  const resolvedKey = storageKey ?? `${STORAGE_KEY_PREFIX}${side}`;
+  const setSidebarResizing = useEditorStore((state) => state.setSidebarResizing);
+
+  const [width, setWidth] = useState(() => {
+    if (typeof window === 'undefined') return defaultWidth;
+    const stored = localStorage.getItem(resolvedKey);
+    if (stored) {
+      const parsed = parseInt(stored, 10);
+      if (!isNaN(parsed) && parsed >= minWidth && parsed <= maxWidth) return parsed;
+    }
+    return defaultWidth;
+  });
+
+  const [isDragging, setIsDragging] = useState(false);
+  const isDraggingRef = useRef(false);
+  const startX = useRef(0);
+  const startWidth = useRef(width);
+  const latestWidth = useRef(width);
+
+  useEffect(() => {
+    latestWidth.current = width;
+  }, [width]);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+
+    if (e.detail === 2) {
+      isDraggingRef.current = false;
+      setIsDragging(false);
+      setSidebarResizing(false);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      setWidth(defaultWidth);
+      localStorage.setItem(resolvedKey, String(defaultWidth));
+      return;
+    }
+
+    isDraggingRef.current = true;
+    setIsDragging(true);
+    setSidebarResizing(true);
+    startX.current = e.clientX;
+    startWidth.current = latestWidth.current;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }, [defaultWidth, resolvedKey, setSidebarResizing]);
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDraggingRef.current) return;
+      const delta = side === 'left'
+        ? e.clientX - startX.current
+        : startX.current - e.clientX;
+      const newWidth = Math.min(maxWidth, Math.max(minWidth, startWidth.current + delta));
+      setWidth(newWidth);
+    };
+
+    const handleMouseUp = () => {
+      if (!isDraggingRef.current) return;
+      isDraggingRef.current = false;
+      setIsDragging(false);
+      setSidebarResizing(false);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      localStorage.setItem(resolvedKey, String(latestWidth.current));
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [side, minWidth, maxWidth, resolvedKey, setSidebarResizing]);
+
+  return { width, isDragging, handleMouseDown };
+}

--- a/hooks/use-resizable-sidebar.ts
+++ b/hooks/use-resizable-sidebar.ts
@@ -28,6 +28,7 @@ export function useResizableSidebar({
 }: UseResizableSidebarOptions) {
   const resolvedKey = storageKey ?? `${STORAGE_KEY_PREFIX}${side}`;
   const setSidebarResizing = useEditorStore((state) => state.setSidebarResizing);
+  const setLeftSidebarWidth = useEditorStore((state) => state.setLeftSidebarWidth);
 
   const [width, setWidth] = useState(() => {
     if (typeof window === 'undefined') return defaultWidth;
@@ -47,7 +48,8 @@ export function useResizableSidebar({
 
   useEffect(() => {
     latestWidth.current = width;
-  }, [width]);
+    if (side === 'left') setLeftSidebarWidth(width);
+  }, [width, side, setLeftSidebarWidth]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();

--- a/stores/useEditorStore.ts
+++ b/stores/useEditorStore.ts
@@ -156,6 +156,9 @@ interface EditorStoreWithHistory extends EditorState {
   // Slider transition state (hides outlines during slide animation)
   isSliderAnimating: boolean;
   setSliderAnimating: (value: boolean) => void;
+  // Sidebar resize state (hides outlines during resize drag)
+  isSidebarResizing: boolean;
+  setSidebarResizing: (value: boolean) => void;
   // Canvas context menu state (hides overlay while menu is open)
   isCanvasContextMenuOpen: boolean;
   setCanvasContextMenuOpen: (value: boolean) => void;
@@ -243,6 +246,8 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
   canvasDropTarget: null,
   isSliderAnimating: false,
   setSliderAnimating: (value) => set({ isSliderAnimating: value }),
+  isSidebarResizing: false,
+  setSidebarResizing: (value) => set({ isSidebarResizing: value }),
   isCanvasContextMenuOpen: false,
   setCanvasContextMenuOpen: (value) => set({ isCanvasContextMenuOpen: value }),
   sliderSnapCounts: {},

--- a/stores/useEditorStore.ts
+++ b/stores/useEditorStore.ts
@@ -159,6 +159,8 @@ interface EditorStoreWithHistory extends EditorState {
   // Sidebar resize state (hides outlines during resize drag)
   isSidebarResizing: boolean;
   setSidebarResizing: (value: boolean) => void;
+  leftSidebarWidth: number;
+  setLeftSidebarWidth: (value: number) => void;
   // Canvas context menu state (hides overlay while menu is open)
   isCanvasContextMenuOpen: boolean;
   setCanvasContextMenuOpen: (value: boolean) => void;
@@ -248,6 +250,8 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
   setSliderAnimating: (value) => set({ isSliderAnimating: value }),
   isSidebarResizing: false,
   setSidebarResizing: (value) => set({ isSidebarResizing: value }),
+  leftSidebarWidth: 256,
+  setLeftSidebarWidth: (value) => set({ leftSidebarWidth: value }),
   isCanvasContextMenuOpen: false,
   setCanvasContextMenuOpen: (value) => set({ isCanvasContextMenuOpen: value }),
   sliderSnapCounts: {},


### PR DESCRIPTION
## Summary

Add resizable left sidebar and horizontal scrolling to the layers tree,
improving usability with deeply nested layer structures. Closes #189

## Changes

- Add draggable resize handle to left sidebar with min/max width constraints
- Persist sidebar width to localStorage across sessions
- Add horizontal scrolling for deeply nested layers with auto-scroll on selection
- Pin action icons (eye, zap, collaborator) to the right edge with sticky positioning
- Hide visibility icon unless layer is hidden or row is hovered
- Add min-width to layer names to prevent full truncation
- Suppress canvas selection outlines during sidebar resize
- Position element library relative to dynamic sidebar width
- Double-click resize handle to reset sidebar to default width

## Test plan

- [ ] Drag the left sidebar border to resize — verify min/max constraints work
- [ ] Refresh the page — verify sidebar width persists
- [ ] Double-click the resize handle — verify it resets to default width
- [ ] Create deeply nested layers and verify horizontal scroll appears
- [ ] Select a deeply nested layer — verify it auto-scrolls into view
- [ ] Verify action icons (eye, zap) stay pinned to the right edge
- [ ] Hover a non-hidden layer — verify eye icon appears only on hover
- [ ] Verify canvas outlines are suppressed while dragging the sidebar
- [ ] Open the element library — verify it positions next to the sidebar

Made with [Cursor](https://cursor.com)