### PR TITLE
feat: support default value for sort order select

### DIFF
--- a/app/(builder)/ycode/components/SelectOptionsSettings.tsx
+++ b/app/(builder)/ycode/components/SelectOptionsSettings.tsx
@@ -584,6 +584,14 @@ export default function SelectOptionsSettings({
     patchOptionsSource({ sortOrder: value as 'asc' | 'desc' });
   }, [patchOptionsSource]);
 
+  const handleSortOrderDefaultChange = useCallback((value: string) => {
+    if (!layer) return;
+    const { value: _omit, ...restAttrs } = layer.attributes || {};
+    onLayerUpdate(layer.id, {
+      attributes: value === 'none' ? restAttrs : { ...restAttrs, value },
+    });
+  }, [layer, onLayerUpdate]);
+
   // Fetch collection items for the Default picker (paged)
   const [sourceItems, setSourceItems] = useState<CollectionItemWithValues[]>([]);
   const [sourceItemsOffset, setSourceItemsOffset] = useState(0);
@@ -1227,6 +1235,28 @@ export default function SelectOptionsSettings({
           <>
             {isSortOrderMode ? (
               <div className="flex flex-col gap-2">
+                <div className="grid grid-cols-3 items-center">
+                  <Label variant="muted">Default</Label>
+                  <div className="col-span-2">
+                    <Select
+                      value={(layer?.attributes?.value as string) || 'none'}
+                      onValueChange={handleSortOrderDefaultChange}
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="None" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">None</SelectItem>
+                        <SelectItem value="asc">
+                          {options.find((opt) => opt.value === 'asc')?.label || 'Ascending'}
+                        </SelectItem>
+                        <SelectItem value="desc">
+                          {options.find((opt) => opt.value === 'desc')?.label || 'Descending'}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
                 <div className="grid grid-cols-3 items-center">
                   <Label variant="muted">Ascending</Label>
                   <div className="col-span-2 *:w-full">

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -11,7 +11,7 @@ import { useLocalisationStore } from '@/stores/useLocalisationStore';
 import type { Layer, Locale, ComponentVariable, FormSettings, LinkSettings, Breakpoint, CollectionItemWithValues, Component } from '@/types';
 import type { UseLiveLayerUpdatesReturn } from '@/hooks/use-live-layer-updates';
 import type { UseLiveComponentUpdatesReturn } from '@/hooks/use-live-component-updates';
-import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEditable, isTextContentLayer, isRichTextLayer, getCollectionVariable, evaluateVisibility, findAncestorByName, filterDisabledSliderLayers, getLayerCmsFieldBinding } from '@/lib/layer-utils';
+import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEditable, isTextContentLayer, isRichTextLayer, getCollectionVariable, evaluateVisibility, findAncestorByName, filterDisabledSliderLayers, getLayerCmsFieldBinding, findLayerById } from '@/lib/layer-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/templates/utilities';
 import { useCanvasSlider } from '@/hooks/use-canvas-slider';
@@ -1301,6 +1301,33 @@ const LayerItem: React.FC<{
   }, [collectionId, allCollectionItems, sourceFieldId, sourceFieldType, sourceFieldSource, collectionLayerData, pageCollectionItemData, collectionLayerItemId, pageCollectionItemId, getAsset, collectionVariable?.filters, isEditMode]);
 
   const optionsSourceSort = layer.settings?.optionsSource;
+
+  // Subscribe to the linked sort-by/sort-order input layers' default `value`
+  // attribute so the canvas re-fetches when the user changes the default in the
+  // SelectOptionsSettings panel. On the canvas there is no live `<select>`
+  // value, so the layer attribute drives the effective sort.
+  const sortByInputDefaultValue = usePagesStore((state) => {
+    const inputLayerId = collectionVariable?.sort_by_inputLayerId;
+    if (!inputLayerId) return undefined;
+    for (const draft of Object.values(state.draftsByPageId)) {
+      if (!draft) continue;
+      const found = findLayerById(draft.layers, inputLayerId);
+      if (found) return found.attributes?.value;
+    }
+    return undefined;
+  });
+
+  const sortOrderInputDefaultValue = usePagesStore((state) => {
+    const inputLayerId = collectionVariable?.sort_order_inputLayerId;
+    if (!inputLayerId) return undefined;
+    for (const draft of Object.values(state.draftsByPageId)) {
+      if (!draft) continue;
+      const found = findLayerById(draft.layers, inputLayerId);
+      if (found) return found.attributes?.value;
+    }
+    return undefined;
+  });
+
   useEffect(() => {
     if (!isEditMode) return;
     if (!collectionVariable?.id) return;
@@ -1310,8 +1337,20 @@ const LayerItem: React.FC<{
     if (isLoadingLayerData) return;
 
     // Checkbox wrappers store sort config in settings.optionsSource, not in the collection variable
-    const sortBy = optionsSourceSort?.sortFieldId || collectionVariable.sort_by;
-    const sortOrder = optionsSourceSort?.sortOrder || collectionVariable.sort_order;
+    let sortBy = optionsSourceSort?.sortFieldId || collectionVariable.sort_by;
+    let sortOrder = optionsSourceSort?.sortOrder || collectionVariable.sort_order;
+
+    // Mirror runtime behavior on the canvas: when the sort is bound to an
+    // input layer, use that layer's default `value` as the effective sort.
+    if (collectionVariable.sort_by_inputLayerId && typeof sortByInputDefaultValue === 'string' && sortByInputDefaultValue.trim() && sortByInputDefaultValue.trim().toLowerCase() !== 'none') {
+      sortBy = sortByInputDefaultValue.trim();
+    }
+    if (collectionVariable.sort_order_inputLayerId) {
+      const normalized = (sortOrderInputDefaultValue || '').toString().trim().toLowerCase();
+      if (normalized === 'asc' || normalized === 'desc') {
+        sortOrder = normalized;
+      }
+    }
 
     fetchLayerData(
       layer.id,
@@ -1327,10 +1366,14 @@ const LayerItem: React.FC<{
     collectionVariable?.source_field_type,
     collectionVariable?.sort_by,
     collectionVariable?.sort_order,
+    collectionVariable?.sort_by_inputLayerId,
+    collectionVariable?.sort_order_inputLayerId,
     collectionVariable?.limit,
     collectionVariable?.offset,
     optionsSourceSort?.sortFieldId,
     optionsSourceSort?.sortOrder,
+    sortByInputDefaultValue,
+    sortOrderInputDefaultValue,
     isLoadingLayerData,
     fetchLayerData,
     layer.id,
@@ -2150,11 +2193,17 @@ const LayerItem: React.FC<{
         elementProps.name = layer.settings?.id || layer.id;
       }
 
-      // Keep select uncontrolled while still supporting default selection
-      // from layer attributes (e.g. collection-sourced default option).
+      // In edit mode, keep value controlled (canvas selects aren't interactive)
+      // so the rendered selection reflects default changes in real time.
+      // In preview/published, convert to defaultValue so the field is uncontrolled
+      // and users can pick a different option.
       if ('value' in elementProps) {
-        elementProps.defaultValue = elementProps.value;
-        delete elementProps.value;
+        if (isEditMode) {
+          elementProps.onChange = () => {};
+        } else {
+          elementProps.defaultValue = elementProps.value;
+          delete elementProps.value;
+        }
       }
 
       if (isEditMode && layer.settings?.optionsSource?.collectionId) {


### PR DESCRIPTION
## Summary

Adds the ability to choose a default `Ascending` / `Descending` value for a
select layer that is acting as a CMS sort-order input, and makes the canvas
respect that default in real time so editors can preview the effect without
running preview/publish.

## Changes

- Add a "Default" select (None / Ascending / Descending) above the option
  labels in `SelectOptionsSettings` when in sort-order mode; persists the
  choice on the layer's `value` attribute
- Render `<select>` as a controlled element on the canvas (edit mode) so the
  chosen default is reflected immediately; keep it uncontrolled
  (`defaultValue`) on preview/published so end users can still interact
- Subscribe to the linked sort-by / sort-order input layers' `value`
  attribute via `usePagesStore` and use it as the effective sort when the
  collection's sort is bound to an input, mirroring the runtime behavior

## Test plan

- [ ] Bind a collection's "Sort order" to an "Input value" pointing at a
      sort-order select layer
- [ ] Open the select layer's settings and pick `Ascending` / `Descending`
      as the default — the canvas select should update visually and the
      collection items should re-order in place
- [ ] Switching the default to `None` falls back to the static
      `sort_order` configured on the collection
- [ ] Same flow for "Sort by" bound to an input layer with a custom default
      value
- [ ] On preview / published, the select stays interactive (uncontrolled)
      and the chosen default is preselected
