### PR TITLE
feat: edit translations directly on the builder canvas

### DIFF
--- a/app/(builder)/ycode/components/Canvas.tsx
+++ b/app/(builder)/ycode/components/Canvas.tsx
@@ -27,7 +27,9 @@ import { useEditorStore } from '@/stores/useEditorStore';
 import { useFontsStore } from '@/stores/useFontsStore';
 import { useColorVariablesStore } from '@/stores/useColorVariablesStore';
 
-import type { Layer, Component, CollectionItemWithValues, CollectionField, Breakpoint, Asset, ComponentVariable } from '@/types';
+import { injectTranslatedText } from '@/lib/localisation-utils';
+
+import type { Layer, Component, CollectionItemWithValues, CollectionField, Breakpoint, Asset, ComponentVariable, Locale, Translation } from '@/types';
 import type { UseLiveLayerUpdatesReturn } from '@/hooks/use-live-layer-updates';
 import type { UseLiveComponentUpdatesReturn } from '@/hooks/use-live-component-updates';
 
@@ -108,6 +110,12 @@ interface CanvasProps {
   zoom?: number;
   /** Fixed viewport height for stable measurement of content using vh/svh/dvh units */
   referenceViewportHeight?: number;
+  /** Currently selected locale (controls translation injection on the canvas) */
+  currentLocale?: Locale | null;
+  /** All available locales (forwarded to LocaleSelector layers) */
+  availableLocales?: Locale[];
+  /** Translation map for the current locale (keyed by translatable key) */
+  translations?: Record<string, Translation> | null;
 }
 
 /**
@@ -131,6 +139,9 @@ interface CanvasContentProps {
   editorBreakpoint?: Breakpoint;
   zoom?: number;
   onComponentEdit?: (componentId: string, instanceLayerId: string) => void;
+  currentLocale?: Locale | null;
+  availableLocales?: Locale[];
+  translations?: Record<string, Translation> | null;
 }
 
 function CanvasContent({
@@ -151,6 +162,9 @@ function CanvasContent({
   editorBreakpoint,
   zoom = 100,
   onComponentEdit,
+  currentLocale,
+  availableLocales,
+  translations,
 }: CanvasContentProps) {
   const bodyRef = useRef<HTMLDivElement>(null);
   const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null);
@@ -251,6 +265,9 @@ function CanvasContent({
           editorBreakpoint={editorBreakpoint}
           ancestorComponentIds={initialAncestorIds}
           onComponentEdit={onComponentEdit}
+          currentLocale={currentLocale}
+          availableLocales={availableLocales}
+          translations={translations}
         />
       </div>
     </CanvasPortalProvider>
@@ -300,6 +317,9 @@ export default function Canvas({
   disableEditorHiddenLayers = false,
   zoom = 100,
   referenceViewportHeight,
+  currentLocale,
+  availableLocales,
+  translations,
 }: CanvasProps) {
   // Refs
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -315,6 +335,22 @@ export default function Canvas({
   const { layers: resolvedLayers, componentMap } = useMemo(() => {
     return serializeLayers(layers, components, editingComponentVariables);
   }, [layers, components, editingComponentVariables]);
+
+  // When a non-default locale is active, swap layer text and translatable
+  // asset references with their translations so the canvas mirrors what the
+  // server-rendered preview / published page would output. The injection runs
+  // AFTER serializeLayers so component instance child IDs are already resolved
+  // (injectTranslatedText reads _originalLayerId / _masterComponentId to look
+  // up component-scoped translations).
+  const localizedLayers = useMemo(() => {
+    if (!currentLocale || currentLocale.is_default || !translations || !pageId) {
+      return resolvedLayers;
+    }
+    // Builder canvas mirrors what the editor has saved, including in-progress
+    // translations that are not yet marked complete. Production rendering
+    // (page-fetcher) keeps the default behaviour and only ships completed ones.
+    return injectTranslatedText(resolvedLayers, pageId, translations, { includeIncomplete: true });
+  }, [resolvedLayers, currentLocale, translations, pageId]);
 
   // Enrich page collection item data with reference field dotted keys
   // so variables like "refFieldId.targetFieldId" resolve on canvas
@@ -498,7 +534,7 @@ export default function Canvas({
 
     rootRef.current.render(
       <CanvasContent
-        layers={resolvedLayers}
+        layers={localizedLayers}
         selectedLayerId={selectedLayerId}
         hoveredLayerId={effectiveHoveredLayerId}
         pageId={pageId}
@@ -515,6 +551,9 @@ export default function Canvas({
         editorBreakpoint={breakpoint}
         zoom={zoom}
         onComponentEdit={onComponentEdit}
+        currentLocale={currentLocale}
+        availableLocales={availableLocales}
+        translations={translations}
       />
     );
   // selectedLayerId and hoveredLayerId are intentionally excluded from deps:
@@ -523,7 +562,7 @@ export default function Canvas({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     iframeReady,
-    resolvedLayers,
+    localizedLayers,
     editingComponentId,
     editingComponentVariables,
     pageId,
@@ -538,6 +577,9 @@ export default function Canvas({
     breakpoint,
     zoom,
     onComponentEdit,
+    currentLocale,
+    availableLocales,
+    translations,
   ]);
 
   // Handle keyboard events from iframe
@@ -771,7 +813,7 @@ export default function Canvas({
       clearTimeout(observerTimer);
       observer.disconnect();
     };
-  }, [iframeReady, onContentHeightChange, onContentWidthChange, resolvedLayers, referenceViewportHeight, breakpoint]);
+  }, [iframeReady, onContentHeightChange, onContentWidthChange, localizedLayers, referenceViewportHeight, breakpoint]);
 
   // Handle zoom gestures from iframe (Ctrl+wheel, trackpad pinch)
   useEffect(() => {

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -58,7 +58,7 @@ import RichTextEditorSheet from './RichTextEditorSheet';
 
 // 6. Utils
 import { buildLocalizedSlugPath, buildLocalizedDynamicPageUrl } from '@/lib/page-utils';
-import { getTranslationValue, applyCmsTranslations } from '@/lib/localisation-utils';
+import { getTranslationValue, applyCmsTranslations, extractLayerTranslatableItemsShallow } from '@/lib/localisation-utils';
 import { cn } from '@/lib/utils';
 import { getCollectionVariable, canDeleteLayer, findLayerById, findParentCollectionLayer, canLayerHaveLink, updateLayerProps, removeRichTextSublayer, isRichTextLayer, getLayerCmsFieldBinding } from '@/lib/layer-utils';
 import { CANVAS_BORDER, CANVAS_PADDING, updateViewportOverrides } from '@/lib/canvas-utils';
@@ -645,6 +645,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
   const activeInteractionTriggerLayerId = useEditorStore((state) => state.activeInteractionTriggerLayerId);
   const richTextSheetLayerId = useEditorStore((state) => state.richTextSheetLayerId);
   const closeRichTextSheet = useEditorStore((state) => state.closeRichTextSheet);
+  const openRichTextSheet = useEditorStore((state) => state.openRichTextSheet);
   const activeSublayerIndex = useEditorStore((state) => state.activeSublayerIndex);
   const setActiveSublayerIndex = useEditorStore((state) => state.setActiveSublayerIndex);
   const activeListItemIndex = useEditorStore((state) => state.activeListItemIndex);
@@ -682,9 +683,15 @@ const CenterCanvas = React.memo(function CenterCanvas({
     }
   }, [isTextEditing, editingLayerId, selectedLayerId, requestFinishEditing]);
 
-  // Close rich text sheet if a different layer is selected
+  // Close rich text sheet if a different layer is selected. Flushing the
+  // pending translation save first ensures the last keystroke is persisted
+  // when the user changes selection mid-edit. The flush function is defined
+  // later in this component, so we go through a ref to keep effect ordering
+  // and avoid a "use-before-declaration" cycle.
+  const flushRichTextTranslationSaveRef = useRef<() => void>(() => { });
   useEffect(() => {
     if (richTextSheetLayerId && selectedLayerId !== richTextSheetLayerId) {
+      flushRichTextTranslationSaveRef.current();
       closeRichTextSheet();
     }
   }, [richTextSheetLayerId, selectedLayerId, closeRichTextSheet]);
@@ -1482,24 +1489,130 @@ const CenterCanvas = React.memo(function CenterCanvas({
   // when other deps (fields, allFields) change.
   const [richTextSheetValue, setRichTextSheetValue] = useState<any>(null);
 
+  // Translation context for the rich-text sheet. When the user is browsing the
+  // canvas in a non-default locale and a rich-text layer is the sheet target,
+  // we redirect read/write through the translations table instead of mutating
+  // the source layer. This is what makes the rich-text editor act as the
+  // translation surface for rich text (no plain-textarea fallback in the sidebar).
+  const richTextTranslationContext = useMemo(() => {
+    if (!richTextSheetLayerId || !selectedLocale || selectedLocale.is_default) return null;
+    const sourceLayers: Layer[] = editingComponentId
+      ? (componentDrafts[editingComponentId] || [])
+      : (currentDraft?.layers || []);
+    const layer = findLayerById(sourceLayers, richTextSheetLayerId);
+    if (!layer || !isRichTextLayer(layer)) return null;
+    const sourceType: 'page' | 'component' = editingComponentId ? 'component' : 'page';
+    const sourceId = editingComponentId || currentPageId;
+    if (!sourceId) return null;
+    const items = extractLayerTranslatableItemsShallow(layer, sourceType, sourceId);
+    const item = items.find((i) => i.content_type === 'richtext');
+    if (!item) return null;
+    return { item };
+  }, [richTextSheetLayerId, selectedLocale, editingComponentId, componentDrafts, currentDraft, currentPageId]);
+
   useEffect(() => {
     if (!richTextSheetLayerId) {
       setRichTextSheetValue(null);
       return;
     }
+
+    // Localization mode: only show the saved translation. Per spec we don't
+    // surface the default-locale source inside the editor — the user types the
+    // translation from scratch (the source is visible on the canvas).
+    if (richTextTranslationContext && selectedLocaleId) {
+      const stored = useLocalisationStore
+        .getState()
+        .getTranslationByKey(selectedLocaleId, richTextTranslationContext.item.key)?.content_value;
+      if (stored && stored.trim()) {
+        try {
+          setRichTextSheetValue(JSON.parse(stored));
+          return;
+        } catch {
+          // fall through to empty doc
+        }
+      }
+      setRichTextSheetValue({ type: 'doc', content: [{ type: 'paragraph' }] });
+      return;
+    }
+
     const source = editingComponentId
       ? componentDrafts[editingComponentId]
       : currentDraft?.layers ?? null;
     const layer = source ? findLayerById(source as Layer[], richTextSheetLayerId) : null;
     setRichTextSheetValue(getRichTextValue(layer?.variables));
-  // Only re-derive when the sheet target layer changes, not on every draft update
+  // Only re-derive when the sheet target layer (or translation context) changes,
+  // not on every draft update.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [richTextSheetLayerId]);
+  }, [richTextSheetLayerId, richTextTranslationContext, selectedLocaleId]);
+
+  // Debounced save for translation writes — the rich-text editor fires onChange
+  // on every keystroke, so we coalesce writes to avoid spamming the API and
+  // racing the optimistic create with concurrent updates.
+  const richTextTranslationSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const richTextTranslationPendingValueRef = useRef<{ key: string; value: string; localeId: string } | null>(null);
+
+  const flushRichTextTranslationSave = useCallback(() => {
+    if (richTextTranslationSaveTimerRef.current) {
+      clearTimeout(richTextTranslationSaveTimerRef.current);
+      richTextTranslationSaveTimerRef.current = null;
+    }
+    const pending = richTextTranslationPendingValueRef.current;
+    if (!pending) return;
+    // Drop the pending save if the user switched locale or selection while
+    // typing — we only want to persist edits authored against the locale they
+    // were typed for.
+    if (!richTextTranslationContext || !selectedLocaleId) return;
+    if (pending.key !== richTextTranslationContext.item.key) return;
+    if (pending.localeId !== selectedLocaleId) return;
+    const item = richTextTranslationContext.item;
+    const store = useLocalisationStore.getState();
+    const latest = store.getTranslationByKey(selectedLocaleId, item.key);
+    const previousValue = latest?.content_value || '';
+    if (pending.value === previousValue) {
+      richTextTranslationPendingValueRef.current = null;
+      return;
+    }
+    richTextTranslationPendingValueRef.current = null;
+    const savePromise = latest
+      ? store.updateTranslation(latest, { content_value: pending.value, is_completed: true })
+      : store.createTranslation({
+        locale_id: selectedLocaleId,
+        source_type: item.source_type as 'page' | 'component',
+        source_id: item.source_id,
+        content_key: item.content_key,
+        content_type: 'richtext',
+        content_value: pending.value,
+        is_completed: true,
+      });
+    savePromise.catch((error) => console.error('Failed to save rich text translation:', error));
+  }, [richTextTranslationContext, selectedLocaleId]);
+
+  // Keep the flush ref pointing at the latest closure so the early
+  // close-on-different-selection effect can flush without a forward reference.
+  useEffect(() => {
+    flushRichTextTranslationSaveRef.current = flushRichTextTranslationSave;
+  }, [flushRichTextTranslationSave]);
 
   const handleRichTextSheetChange = useCallback((value: any) => {
     if (!richTextSheetLayerId) return;
-    // Keep local state in sync so the value prop matches the editor's content
     setRichTextSheetValue(value);
+
+    if (richTextTranslationContext && selectedLocaleId) {
+      const finalValue = value ? JSON.stringify(value) : '';
+      richTextTranslationPendingValueRef.current = {
+        key: richTextTranslationContext.item.key,
+        value: finalValue,
+        localeId: selectedLocaleId,
+      };
+      if (richTextTranslationSaveTimerRef.current) {
+        clearTimeout(richTextTranslationSaveTimerRef.current);
+      }
+      richTextTranslationSaveTimerRef.current = setTimeout(() => {
+        flushRichTextTranslationSave();
+      }, 400);
+      return;
+    }
+
     const textVariable = value && (typeof value === 'object' || (typeof value === 'string' && value.trim())) ? {
       type: 'dynamic_rich_text' as const,
       data: {
@@ -1528,7 +1641,33 @@ const CenterCanvas = React.memo(function CenterCanvas({
         variables: { ...layer?.variables, text: textVariable },
       });
     }
-  }, [richTextSheetLayerId, updateLayer]);
+  }, [richTextSheetLayerId, updateLayer, richTextTranslationContext, selectedLocaleId, flushRichTextTranslationSave]);
+
+  // Auto-open the rich-text editor sheet when a rich-text layer is selected
+  // while localizing — the sheet is the translation surface for rich text, so
+  // it replaces the regular sidebar editor for these layers. We only fire on
+  // selection transitions so the user is free to close the sheet without it
+  // immediately re-opening for the same selection.
+  const lastAutoOpenedRichTextLayerRef = useRef<string | null>(null);
+  useEffect(() => {
+    const isLocalizing = !!(selectedLocale && !selectedLocale.is_default);
+    if (!isLocalizing || !selectedLayerId) {
+      lastAutoOpenedRichTextLayerRef.current = null;
+      return;
+    }
+    if (lastAutoOpenedRichTextLayerRef.current === selectedLayerId) return;
+
+    const sourceLayers: Layer[] = editingComponentId
+      ? (componentDrafts[editingComponentId] || [])
+      : (currentDraft?.layers || []);
+    const layer = findLayerById(sourceLayers, selectedLayerId);
+    if (layer && isRichTextLayer(layer)) {
+      lastAutoOpenedRichTextLayerRef.current = selectedLayerId;
+      openRichTextSheet(selectedLayerId);
+    } else {
+      lastAutoOpenedRichTextLayerRef.current = null;
+    }
+  }, [selectedLocale, selectedLayerId, editingComponentId, componentDrafts, currentDraft, openRichTextSheet]);
 
   // Handle iframe ready callback (for SelectionOverlay)
   const handleIframeReady = useCallback((iframeElement: HTMLIFrameElement) => {
@@ -2808,9 +2947,14 @@ const CenterCanvas = React.memo(function CenterCanvas({
       {richTextSheetValue && (
         <RichTextEditorSheet
           open={!!richTextSheetLayerId}
-          onOpenChange={(open) => { if (!open) closeRichTextSheet(); }}
-          title="Content editor"
-          description="Element content"
+          onOpenChange={(open) => {
+            if (!open) {
+              flushRichTextTranslationSave();
+              closeRichTextSheet();
+            }
+          }}
+          title={richTextTranslationContext ? 'Translate rich text' : 'Content editor'}
+          description={richTextTranslationContext ? selectedLocale?.label : 'Element content'}
           value={richTextSheetValue}
           onChange={handleRichTextSheetChange}
           fieldGroups={richTextSheetFieldGroups}

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -2926,8 +2926,10 @@ const CenterCanvas = React.memo(function CenterCanvas({
               closeRichTextSheet();
             }
           }}
-          title={richTextTranslationContext ? 'Translate rich text' : 'Content editor'}
-          description={richTextTranslationContext ? selectedLocale?.label : 'Element content'}
+          title="Content editor"
+          description={richTextTranslationContext && selectedLocale
+            ? `Translate to ${selectedLocale.label}`
+            : 'Element content'}
           value={richTextSheetValue}
           onChange={handleRichTextSheetChange}
           fieldGroups={richTextSheetFieldGroups}

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -645,7 +645,6 @@ const CenterCanvas = React.memo(function CenterCanvas({
   const activeInteractionTriggerLayerId = useEditorStore((state) => state.activeInteractionTriggerLayerId);
   const richTextSheetLayerId = useEditorStore((state) => state.richTextSheetLayerId);
   const closeRichTextSheet = useEditorStore((state) => state.closeRichTextSheet);
-  const openRichTextSheet = useEditorStore((state) => state.openRichTextSheet);
   const activeSublayerIndex = useEditorStore((state) => state.activeSublayerIndex);
   const setActiveSublayerIndex = useEditorStore((state) => state.setActiveSublayerIndex);
   const activeListItemIndex = useEditorStore((state) => state.activeListItemIndex);
@@ -1642,32 +1641,6 @@ const CenterCanvas = React.memo(function CenterCanvas({
       });
     }
   }, [richTextSheetLayerId, updateLayer, richTextTranslationContext, selectedLocaleId, flushRichTextTranslationSave]);
-
-  // Auto-open the rich-text editor sheet when a rich-text layer is selected
-  // while localizing — the sheet is the translation surface for rich text, so
-  // it replaces the regular sidebar editor for these layers. We only fire on
-  // selection transitions so the user is free to close the sheet without it
-  // immediately re-opening for the same selection.
-  const lastAutoOpenedRichTextLayerRef = useRef<string | null>(null);
-  useEffect(() => {
-    const isLocalizing = !!(selectedLocale && !selectedLocale.is_default);
-    if (!isLocalizing || !selectedLayerId) {
-      lastAutoOpenedRichTextLayerRef.current = null;
-      return;
-    }
-    if (lastAutoOpenedRichTextLayerRef.current === selectedLayerId) return;
-
-    const sourceLayers: Layer[] = editingComponentId
-      ? (componentDrafts[editingComponentId] || [])
-      : (currentDraft?.layers || []);
-    const layer = findLayerById(sourceLayers, selectedLayerId);
-    if (layer && isRichTextLayer(layer)) {
-      lastAutoOpenedRichTextLayerRef.current = selectedLayerId;
-      openRichTextSheet(selectedLayerId);
-    } else {
-      lastAutoOpenedRichTextLayerRef.current = null;
-    }
-  }, [selectedLocale, selectedLayerId, editingComponentId, componentDrafts, currentDraft, openRichTextSheet]);
 
   // Handle iframe ready callback (for SelectionOverlay)
   const handleIframeReady = useCallback((iframeElement: HTMLIFrameElement) => {

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -58,7 +58,7 @@ import RichTextEditorSheet from './RichTextEditorSheet';
 
 // 6. Utils
 import { buildLocalizedSlugPath, buildLocalizedDynamicPageUrl } from '@/lib/page-utils';
-import { getTranslationValue } from '@/lib/localisation-utils';
+import { getTranslationValue, applyCmsTranslations } from '@/lib/localisation-utils';
 import { cn } from '@/lib/utils';
 import { getCollectionVariable, canDeleteLayer, findLayerById, findParentCollectionLayer, canLayerHaveLink, updateLayerProps, removeRichTextSublayer, isRichTextLayer, getLayerCmsFieldBinding } from '@/lib/layer-utils';
 import { CANVAS_BORDER, CANVAS_PADDING, updateViewportOverrides } from '@/lib/canvas-utils';
@@ -623,8 +623,15 @@ const CenterCanvas = React.memo(function CenterCanvas({
   const selectLayerWithSublayer = useEditorStore((state) => state.selectLayerWithSublayer);
 
   const selectedLocaleId = useLocalisationStore((state) => state.selectedLocaleId);
-  const getSelectedLocale = useLocalisationStore((state) => state.getSelectedLocale);
   const translations = useLocalisationStore((state) => state.translations);
+  const locales = useLocalisationStore((state) => state.locales);
+  // Derive the selected locale here (instead of via getSelectedLocale()) so it
+  // is in scope for callbacks defined below — non-default locales gate every
+  // canvas mutation handler into a no-op (read-only translation mode).
+  const selectedLocale = useMemo(
+    () => (selectedLocaleId ? locales.find((l) => l.id === selectedLocaleId) ?? null : null),
+    [selectedLocaleId, locales]
+  );
   const activeUIState = useEditorStore((state) => state.activeUIState);
   const editingComponentId = useEditorStore((state) => state.editingComponentId);
   const setCurrentPageId = useEditorStore((state) => state.setCurrentPageId);
@@ -1375,6 +1382,11 @@ const CenterCanvas = React.memo(function CenterCanvas({
   }, [isPreviewMode, setActiveSidebarTab, selectLayerWithSublayer, editingComponentId, componentDrafts, currentDraft]);
 
   const handleCanvasLayerUpdate = useCallback((layerId: string, updates: Partial<Layer>) => {
+    // Block all source-layer mutations from the canvas while in a non-default
+    // locale. The Translate panel writes through the translations table instead
+    // of mutating the layer tree.
+    if (selectedLocale && !selectedLocale.is_default) return;
+
     if (editingComponentId) {
       const { updateComponentDraft } = useComponentsStore.getState();
       const currentDraft = componentDrafts[editingComponentId] || [];
@@ -1382,10 +1394,12 @@ const CenterCanvas = React.memo(function CenterCanvas({
     } else if (currentPageId) {
       updateLayer(currentPageId, layerId, updates);
     }
-  }, [editingComponentId, componentDrafts, currentPageId, updateLayer]);
+  }, [editingComponentId, componentDrafts, currentPageId, updateLayer, selectedLocale]);
 
   const handleCanvasDeleteLayer = useCallback(() => {
     if (!selectedLayerId || !currentPageId) return;
+    // Block layer deletion in non-default locales (read-only canvas).
+    if (selectedLocale && !selectedLocale.is_default) return;
 
     // Handle sublayer deletion (remove TipTap block, not the whole layer)
     if (activeSublayerIndex !== null) {
@@ -1422,10 +1436,11 @@ const CenterCanvas = React.memo(function CenterCanvas({
         setSelectedLayerId(null);
       }
     }
-  }, [selectedLayerId, currentPageId, selectedLayerIds, currentDraft, deleteLayers, clearSelection, deleteLayer, setSelectedLayerId, activeSublayerIndex, setActiveSublayerIndex, updateLayer]);
+  }, [selectedLayerId, currentPageId, selectedLayerIds, currentDraft, deleteLayers, clearSelection, deleteLayer, setSelectedLayerId, activeSublayerIndex, setActiveSublayerIndex, updateLayer, selectedLocale]);
 
   const handleCanvasGapUpdate = useCallback((layerId: string, gapValue: string) => {
     if (!currentPageId) return;
+    if (selectedLocale && !selectedLocale.is_default) return;
 
     // Find the layer and update its gap class
     if (!currentDraft) return;
@@ -1444,7 +1459,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
 
     // Update the layer
     updateLayer(currentPageId, layerId, { classes: newClasses });
-  }, [currentPageId, currentDraft, updateLayer]);
+  }, [currentPageId, currentDraft, updateLayer, selectedLocale]);
 
   // Rich text sheet for canvas double-click (layers with components/variables)
   // Build field groups using the sheet target layer (not the canvas text editor layer)
@@ -1552,6 +1567,8 @@ const CenterCanvas = React.memo(function CenterCanvas({
     dropTarget: { layerId: string; position: 'above' | 'below' | 'inside'; parentId: string | null }
   ) => {
     if (!currentPageId) return;
+    // Block element insertion in non-default locales (read-only canvas).
+    if (selectedLocale && !selectedLocale.is_default) return;
 
     if (source === 'elements') {
       // Determine insert position based on drop target
@@ -1597,7 +1614,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
     } else if (source === 'components') {
       // TODO: Add component using similar logic
     }
-  }, [currentPageId, addLayerFromTemplate, setSelectedLayerId, liveLayerUpdates]);
+  }, [currentPageId, addLayerFromTemplate, setSelectedLayerId, liveLayerUpdates, selectedLocale]);
 
   // Use the canvas drop detection hook for throttled hit-testing
   useCanvasDropDetection({
@@ -1682,11 +1699,36 @@ const CenterCanvas = React.memo(function CenterCanvas({
     return layer?.name || null;
   }, [selectedLayerId, layers]);
 
-  // Get selected locale and translations
-  const selectedLocale = getSelectedLocale();
+  // Translations map for the active locale (used to inject into the canvas)
   const localeTranslations = useMemo(() => {
     return selectedLocaleId ? translations[selectedLocaleId] : undefined;
   }, [selectedLocaleId, translations]);
+
+  // True when the user is browsing the canvas in a non-default locale.
+  // The canvas becomes a read-only translation view in this state.
+  const isLocalizing = !!(selectedLocale && !selectedLocale.is_default);
+
+  // Subscribe to translation loading state so we can show a spinner overlay
+  // while translations for the active locale are being fetched.
+  const isLoadingTranslations = useLocalisationStore((state) => state.isLoading.loadTranslations);
+
+  // Translate the dynamic page's CMS item values when localizing so layers
+  // bound to CMS fields render the translated values.
+  const translatedPageCollectionItem = useMemo(() => {
+    if (!pageCollectionItem || !isLocalizing || !localeTranslations) {
+      return pageCollectionItem;
+    }
+    return {
+      ...pageCollectionItem,
+      values: applyCmsTranslations(
+        pageCollectionItem.id,
+        pageCollectionItem.values || {},
+        pageCollectionFields,
+        localeTranslations,
+        { includeIncomplete: true }
+      ),
+    };
+  }, [pageCollectionItem, pageCollectionFields, isLocalizing, localeTranslations]);
 
   // Build preview URL for preview mode
   const previewUrl = useMemo(() => {
@@ -2338,6 +2380,15 @@ const CenterCanvas = React.memo(function CenterCanvas({
         {/* Element picker SVG connector overlay */}
         <ElementPickerOverlay iframeElement={canvasIframeElement} zoom={zoom} />
 
+        {/* Translation loading overlay — shown while translations for the
+            active locale are being fetched. Mirrors the preview-mode overlay
+            below for visual consistency. */}
+        {isLocalizing && isLoadingTranslations && (
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-4 bg-background/80">
+            <Spinner />
+          </div>
+        )}
+
         {/* Scrollable container with hidden scrollbars (editor canvas) */}
         <div
           ref={scrollContainerRef}
@@ -2420,8 +2471,11 @@ const CenterCanvas = React.memo(function CenterCanvas({
                         editingComponentId={editingComponentId || null}
                         collectionItems={{ ...collectionItemsFromStore, ...referencedItems }}
                         collectionFields={collectionFieldsFromStore}
-                        pageCollectionItem={pageCollectionItem}
+                        pageCollectionItem={translatedPageCollectionItem}
                         pageCollectionFields={pageCollectionFields}
+                        currentLocale={selectedLocale}
+                        availableLocales={locales}
+                        translations={localeTranslations}
                         assets={assetsMap}
                         collectionLayerData={collectionLayerData}
                         pageId={currentPageId || ''}
@@ -2512,6 +2566,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
                             onClick={() => setShowAddBlockPanel(!showAddBlockPanel)}
                             size="lg"
                             className="gap-2"
+                            disabled={!!(selectedLocale && !selectedLocale.is_default)}
                           >
                             <Icon name="plus" className="w-5 h-5" />
                             Add Block

--- a/app/(builder)/ycode/components/CollectionItemSheet.tsx
+++ b/app/(builder)/ycode/components/CollectionItemSheet.tsx
@@ -48,6 +48,8 @@ import { useCollectionLayerStore } from '@/stores/useCollectionLayerStore';
 import { usePagesStore } from '@/stores/usePagesStore';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { useAssetsStore } from '@/stores/useAssetsStore';
+import { useLocalisationStore } from '@/stores/useLocalisationStore';
+import { useLocalizationMode } from '@/hooks/use-localization-mode';
 import { useLiveCollectionUpdates } from '@/hooks/use-live-collection-updates';
 import { useResourceLock } from '@/hooks/use-resource-lock';
 import { slugify, normalizeBooleanValue, parseMultiReferenceValue } from '@/lib/collection-utils';
@@ -65,7 +67,7 @@ import AssetFieldCard, { SortableAssetFieldCard } from './AssetFieldCard';
 import { DndContext, closestCenter, useSensor, useSensors, PointerSensor } from '@dnd-kit/core';
 import type { DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, rectSortingStrategy, arrayMove } from '@dnd-kit/sortable';
-import type { Asset, CollectionItemWithValues } from '@/types';
+import type { Asset, CollectionField, CollectionItemWithValues, CreateTranslationData } from '@/types';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -92,6 +94,16 @@ export default function CollectionItemSheet({
   const { currentPageId, openFileManager } = useEditorStore();
   const getAsset = useAssetsStore((state) => state.getAsset);
   const timezone = useSettingsStore((state) => state.settingsByKey.timezone as string | null) ?? 'UTC';
+
+  // Localization: when the user is browsing the canvas in a non-default
+  // locale, this sheet edits CMS *translations* rather than the canonical
+  // collection item values. Reads/writes go through the translations table
+  // so canvas + preview pick up the new copy via applyCmsTranslations.
+  const { isLocalizing, currentLocale } = useLocalizationMode();
+  const selectedLocaleId = useLocalisationStore((state) => state.selectedLocaleId);
+  const createTranslation = useLocalisationStore((state) => state.createTranslation);
+  const updateTranslation = useLocalisationStore((state) => state.updateTranslation);
+  const deleteTranslation = useLocalisationStore((state) => state.deleteTranslation);
 
   // Collection collaboration sync
   const liveCollectionUpdates = useLiveCollectionUpdates();
@@ -238,18 +250,55 @@ export default function CollectionItemSheet({
     };
   }, [open, itemId]);
 
-  // Reset form when editing item changes
+  // Translatable CMS field types — must match extractCmsTranslatableItems /
+  // applyCmsTranslations so the read + write paths agree on which fields are
+  // localised vs canonical.
+  const isTranslatableField = useCallback((field: CollectionField) => {
+    return field.type === 'text' || field.type === 'rich_text';
+  }, []);
+
+  const buildCmsContentKey = useCallback((field: CollectionField) => {
+    return field.key ? `field:key:${field.key}` : `field:id:${field.id}`;
+  }, []);
+
+  // Reset form when editing item changes. In localizing mode, translatable
+  // fields seed from the saved translation (parsed for rich text); other
+  // fields keep their canonical values for read-only context. We deliberately
+  // snapshot translations once on mount/locale switch so a background refresh
+  // doesn't clobber the user's in-flight edits.
   useEffect(() => {
-    // Only include fillable/visible fields in form state to avoid
-    // sending computed fields (status, ID, timestamps) to the API
     const editableFields = collectionFields.filter(f => f.fillable);
 
     if (editingItem) {
+      const localeTranslations = isLocalizing && selectedLocaleId
+        ? useLocalisationStore.getState().translations[selectedLocaleId]
+        : undefined;
+
       const values: Record<string, any> = {};
       editableFields.forEach(field => {
-        let value = editingItem.values[field.id] ?? '';
-        if (field.type === 'boolean') {
-          value = normalizeBooleanValue(value);
+        let value: any;
+        if (isLocalizing && localeTranslations && isTranslatableField(field)) {
+          const tKey = `cms:${editingItem.id}:${buildCmsContentKey(field)}`;
+          const translation = localeTranslations[tKey];
+          const stored = translation?.content_value || '';
+          if (field.type === 'rich_text') {
+            if (stored) {
+              try {
+                value = JSON.parse(stored);
+              } catch {
+                value = '';
+              }
+            } else {
+              value = '';
+            }
+          } else {
+            value = stored;
+          }
+        } else {
+          value = editingItem.values[field.id] ?? '';
+          if (field.type === 'boolean') {
+            value = normalizeBooleanValue(value);
+          }
         }
         values[field.id] = value;
       });
@@ -265,7 +314,7 @@ export default function CollectionItemSheet({
       });
       form.reset(defaultValues);
     }
-  }, [editingItem, collectionFields, form]);
+  }, [editingItem, collectionFields, form, isLocalizing, selectedLocaleId, isTranslatableField, buildCmsContentKey]);
 
   // Handle auto-focus on sheet open
   const handleOpenAutoFocus = useCallback((e: Event) => {
@@ -313,8 +362,106 @@ export default function CollectionItemSheet({
     }
   }, [form, editingItem, collectionFields]);
 
+  // Save flow for non-default locales. Each translatable text/rich_text
+  // field is created/updated/deleted in the translations table; everything
+  // else is left untouched. Canvas + preview re-read translations from the
+  // store via applyCmsTranslations, so no extra optimistic patching of the
+  // canonical item is needed.
+  const handleLocalizedSubmit = (values: Record<string, any>) => {
+    if (!editingItem || !selectedLocaleId) {
+      toast.error('Cannot save translation', {
+        description: !editingItem
+          ? 'Translations can only be added to existing items.'
+          : 'No locale selected.',
+      });
+      return;
+    }
+
+    const localeTranslations = useLocalisationStore.getState().translations[selectedLocaleId] || {};
+    const itemId = editingItem.id;
+    const promises: Promise<unknown>[] = [];
+
+    for (const field of collectionFields) {
+      if (!field.fillable || !isTranslatableField(field)) continue;
+      const contentKey = buildCmsContentKey(field);
+      const tKey = `cms:${itemId}:${contentKey}`;
+      const existing = localeTranslations[tKey];
+
+      const raw = values[field.id];
+      let serialized: string;
+      if (field.type === 'rich_text') {
+        if (raw && typeof raw === 'object') {
+          serialized = JSON.stringify(raw);
+        } else if (typeof raw === 'string') {
+          serialized = raw.trim();
+        } else {
+          serialized = '';
+        }
+      } else {
+        serialized = typeof raw === 'string' ? raw.trim() : '';
+      }
+
+      const previous = existing?.content_value || '';
+      if (serialized === previous) continue;
+
+      if (!serialized) {
+        if (existing) {
+          promises.push(deleteTranslation(existing));
+        }
+        continue;
+      }
+
+      if (existing) {
+        promises.push(updateTranslation(existing, { content_value: serialized, is_completed: true }));
+      } else {
+        const data: CreateTranslationData = {
+          locale_id: selectedLocaleId,
+          source_type: 'cms',
+          source_id: itemId,
+          content_key: contentKey,
+          content_type: field.type === 'rich_text' ? 'richtext' : 'text',
+          content_value: serialized,
+          is_completed: true,
+        };
+        promises.push(createTranslation(data));
+      }
+    }
+
+    setEditingItem(null);
+    form.reset();
+    if (onSuccess) {
+      onSuccess();
+    } else {
+      onOpenChange(false);
+    }
+
+    if (promises.length === 0) return;
+
+    Promise.all(promises)
+      .then(() => {
+        if (isPageLevelItem && currentPageId) {
+          refetchPageCollectionItem(currentPageId);
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to save translations:', error);
+        toast.error('Failed to save translations', {
+          description: 'Please try again.',
+        });
+      });
+  };
+
   const handleSubmit = (values: Record<string, any>) => {
     if (!collectionId) return;
+
+    // Localising flow runs entirely against the translations table — see
+    // the dedicated branch further down. Skip canonical-field validation
+    // (required name / unique slug) since the translation may be empty
+    // (= fall back to source) and slug uniqueness is per-locale anyway.
+    if (isLocalizing) {
+      handleLocalizedSubmit(values);
+      return;
+    }
 
     // Normalize boolean values to strings before submitting
     collectionFields.forEach(field => {
@@ -488,14 +635,22 @@ export default function CollectionItemSheet({
       <SheetContent onOpenAutoFocus={handleOpenAutoFocus} aria-describedby={undefined}>
         <SheetHeader>
           <SheetTitle className="flex items-center gap-2 flex-wrap">
-            {editingItem ? 'Edit' : 'Create'} {collection?.name} Item
-            {!isNewItem && statusValue && (
+            {isLocalizing && currentLocale
+              ? `Translate ${collection?.name} Item`
+              : `${editingItem ? 'Edit' : 'Create'} ${collection?.name} Item`}
+            {!isNewItem && statusValue && !isLocalizing && (
               <CollectionStatusPill statusValue={statusValue} />
+            )}
+            {isLocalizing && currentLocale && (
+              <span className="text-xs text-muted-foreground font-normal">
+                Translate to {currentLocale.label}
+              </span>
             )}
           </SheetTitle>
           <SheetActions>
-            {/* More options dropdown */}
-            {editingItem && !isTempId(editingItem.id) && (
+            {/* More options dropdown — hidden while translating, the only
+                action there is Delete which doesn't apply to translations. */}
+            {editingItem && !isTempId(editingItem.id) && !isLocalizing && (
               <DropdownMenu modal={false}>
                 <DropdownMenuTrigger asChild>
                   <Button size="sm" variant="secondary">
@@ -515,58 +670,66 @@ export default function CollectionItemSheet({
               </DropdownMenu>
             )}
 
-            {/* Save button with dropdown for alternate actions */}
+            {/* Save button. The status-action dropdown (draft / publish) is
+                hidden when translating since those operate at the canonical
+                item level — translations are saved as a single unit. */}
             <div className="flex">
               <Button
                 size="sm"
                 type="submit"
                 form="collection-item-form"
-                disabled={isTempId(editingItem?.id)}
-                className="rounded-r-none"
+                disabled={isTempId(editingItem?.id) || (isLocalizing && !editingItem)}
+                className={isLocalizing ? '' : 'rounded-r-none'}
               >
-                {editingItem ? (isTempId(editingItem.id) ? 'Saving...' : 'Save') : 'Create'}
+                {isLocalizing
+                  ? 'Save translation'
+                  : editingItem
+                    ? (isTempId(editingItem.id) ? 'Saving...' : 'Save')
+                    : 'Create'}
               </Button>
-              <DropdownMenu modal={false}>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    size="sm"
-                    variant="default"
-                    className="rounded-l-none border-l border-primary-foreground/20 px-1.5"
-                    disabled={isTempId(editingItem?.id)}
-                  >
-                    <Icon name="triangle-down" className="w-3 h-3" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  {!isNewItem && (
+              {!isLocalizing && (
+                <DropdownMenu modal={false}>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      size="sm"
+                      variant="default"
+                      className="rounded-l-none border-l border-primary-foreground/20 px-1.5"
+                      disabled={isTempId(editingItem?.id)}
+                    >
+                      <Icon name="triangle-down" className="w-3 h-3" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {!isNewItem && (
+                      <DropdownMenuItem
+                        onClick={() => {
+                          pendingStatusActionRef.current = 'stage';
+                          form.handleSubmit(handleSubmit)();
+                        }}
+                      >
+                        Save as staged for publish
+                      </DropdownMenuItem>
+                    )}
                     <DropdownMenuItem
                       onClick={() => {
-                        pendingStatusActionRef.current = 'stage';
+                        pendingStatusActionRef.current = 'draft';
                         form.handleSubmit(handleSubmit)();
                       }}
                     >
-                      Save as staged for publish
+                      {isNewItem ? 'Create' : 'Save'} as draft
                     </DropdownMenuItem>
-                  )}
-                  <DropdownMenuItem
-                    onClick={() => {
-                      pendingStatusActionRef.current = 'draft';
-                      form.handleSubmit(handleSubmit)();
-                    }}
-                  >
-                    {isNewItem ? 'Create' : 'Save'} as draft
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    disabled={!collection?.has_published_version}
-                    onClick={() => {
-                      pendingStatusActionRef.current = 'publish';
-                      form.handleSubmit(handleSubmit)();
-                    }}
-                  >
-                    {isNewItem ? 'Create' : 'Save'} and publish
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+                    <DropdownMenuItem
+                      disabled={!collection?.has_published_version}
+                      onClick={() => {
+                        pendingStatusActionRef.current = 'publish';
+                        form.handleSubmit(handleSubmit)();
+                      }}
+                    >
+                      {isNewItem ? 'Create' : 'Save'} and publish
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
           </SheetActions>
         </SheetHeader>
@@ -582,6 +745,12 @@ export default function CollectionItemSheet({
                 .filter(f => f.fillable)
                 .map((field) => {
                   const isSynced = syncedFieldIds.has(field.id);
+                  // While translating, lock everything that isn't a
+                  // translatable text/rich_text field — the canonical value
+                  // is shown read-only so the user has context, but only
+                  // translatable fields can be edited per locale.
+                  const isLockedForLocale = isLocalizing && !isTranslatableField(field);
+                  const isFieldDisabled = isSynced || isLockedForLocale;
 
                   return (
                   <FormField
@@ -605,9 +774,14 @@ export default function CollectionItemSheet({
                               Synced from Airtable
                             </span>
                           )}
+                          {isLockedForLocale && (
+                            <span className="text-[10px] text-muted-foreground leading-none">
+                              Not translatable
+                            </span>
+                          )}
                         </div>
                         <FormControl>
-                          <div className={cn('min-w-0', isSynced && 'opacity-50 pointer-events-none')}>
+                          <div className={cn('min-w-0', isFieldDisabled && 'opacity-50 pointer-events-none')}>
                           {field.type === 'rich_text' ? (
                             <div>
                               <RichTextEditor

--- a/app/(builder)/ycode/components/ElementLibrary.tsx
+++ b/app/(builder)/ycode/components/ElementLibrary.tsx
@@ -45,6 +45,7 @@ import { usePagesStore } from '@/stores/usePagesStore';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { useComponentsStore } from '@/stores/useComponentsStore';
 import { useEditorActions } from '@/hooks/use-editor-url';
+import { useLocalizationMode } from '@/hooks/use-localization-mode';
 import type { UseLiveLayerUpdatesReturn } from '@/hooks/use-live-layer-updates';
 
 /**
@@ -278,6 +279,7 @@ async function restoreInlinedComponents(
 export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: ElementLibraryProps) {
   const { addLayerFromTemplate, updateLayer, setDraftLayers, draftsByPageId, pages } = usePagesStore();
   const { currentPageId, selectedLayerId, setSelectedLayerId, editingComponentId, activeBreakpoint, pushComponentNavigation, startCanvasDrag, endCanvasDrag } = useEditorStore();
+  const { isLocalizing } = useLocalizationMode();
   const { components, componentDrafts, updateComponentDraft, deleteComponent, getDeletePreview, loadComponentDraft, getComponentById, loadComponents } = useComponentsStore();
   const { openComponent } = useEditorActions();
 
@@ -1386,6 +1388,29 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
   }
 
   const deleteConfirmDescription = `Are you sure you want to delete "${componentName}"? ${usageSuffix}`;
+
+  // Read-only translation mode: hide the library entirely so the user knows
+  // they can't add or modify structural elements while in a non-default locale.
+  if (isLocalizing) {
+    return (
+      <div
+        className={cn(
+          'fixed left-64 top-14 bottom-0 w-64 bg-background border-r z-50 flex flex-col items-center justify-center p-6 text-center',
+          !isOpen && 'hidden'
+        )}
+      >
+        <Empty>
+          <EmptyMedia variant="icon">
+            <Icon name="globe" />
+          </EmptyMedia>
+          <EmptyTitle>Translating</EmptyTitle>
+          <EmptyDescription>
+            Switch to the default locale to add elements.
+          </EmptyDescription>
+        </Empty>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/app/(builder)/ycode/components/HeaderBar.tsx
+++ b/app/(builder)/ycode/components/HeaderBar.tsx
@@ -492,14 +492,6 @@ export default function HeaderBar({
       </div>
 
       <div className="flex gap-1.5 items-center justify-center">
-        {/* Subtle 'Translating' badge so the user always knows the canvas is
-            in read-only translation mode (canvas mutations are disabled,
-            sidebar shows the per-layer Translate panel instead of Design). */}
-        {selectedLocale && !selectedLocale.is_default && (
-          <Badge variant="secondary" className="text-[10px] uppercase">
-            Translating
-          </Badge>
-        )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button size="xs" variant="ghost">

--- a/app/(builder)/ycode/components/HeaderBar.tsx
+++ b/app/(builder)/ycode/components/HeaderBar.tsx
@@ -85,7 +85,7 @@ export default function HeaderBar({
   const { currentPageCollectionItemId, currentPageId: storeCurrentPageId, isPreviewMode, setPreviewMode, openFileManager, setKeyboardShortcutsOpen, setActiveSidebarTab, lastDesignUrl, setLastDesignUrl, previewReturnUrl, previewReturnTab, setPreviewReturn } = useEditorStore();
   const { folders, pages: storePages } = usePagesStore();
   const { items, fields, collections, selectedCollectionId: storeSelectedCollectionId, setSelectedCollectionId } = useCollectionsStore();
-  const { locales, selectedLocaleId, setSelectedLocaleId, translations } = useLocalisationStore();
+  const { locales, selectedLocaleId, setSelectedLocaleId, translations, loadTranslations } = useLocalisationStore();
   const { navigateToLayers, navigateToCollection, navigateToCollections, updateQueryParams, routeType } = useEditorUrl();
 
   // Optimistic nav button state - set immediately on click, cleared when URL catches up
@@ -492,6 +492,14 @@ export default function HeaderBar({
       </div>
 
       <div className="flex gap-1.5 items-center justify-center">
+        {/* Subtle 'Translating' badge so the user always knows the canvas is
+            in read-only translation mode (canvas mutations are disabled,
+            sidebar shows the per-layer Translate panel instead of Design). */}
+        {selectedLocale && !selectedLocale.is_default && (
+          <Badge variant="secondary" className="text-[10px] uppercase">
+            Translating
+          </Badge>
+        )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button size="xs" variant="ghost">
@@ -502,7 +510,13 @@ export default function HeaderBar({
           <DropdownMenuContent align="end">
             <DropdownMenuRadioGroup
               value={selectedLocaleId || ''}
-              onValueChange={(value) => setSelectedLocaleId(value)}
+              onValueChange={(value) => {
+                setSelectedLocaleId(value);
+                // Eager-load translations so the canvas reflects the new locale
+                // without waiting for component-level effects to run. The store
+                // short-circuits for the default locale and for cached locales.
+                loadTranslations(value);
+              }}
             >
               {locales.map((locale) => (
                 <DropdownMenuRadioItem key={locale.id} value={locale.id}>

--- a/app/(builder)/ycode/components/LayersTree.tsx
+++ b/app/(builder)/ycode/components/LayersTree.tsx
@@ -28,6 +28,7 @@ import { useEditorStore } from '@/stores/useEditorStore';
 import { useLayerStylesStore } from '@/stores/useLayerStylesStore';
 import { useComponentsStore } from '@/stores/useComponentsStore';
 import { useCollectionsStore } from '@/stores/useCollectionsStore';
+import { useLocalisationStore } from '@/stores/useLocalisationStore';
 import { usePagesStore } from '@/stores/usePagesStore';
 import { useCollaborationPresenceStore, getResourceLockKey, RESOURCE_TYPES } from '@/stores/useCollaborationPresenceStore';
 import { useAuthStore } from '@/stores/useAuthStore';
@@ -196,13 +197,23 @@ const LayerRow = React.memo(function LayerRow({
   const setHoveredLayerId = useEditorStore((state) => state.setHoveredLayerId);
   const activeUIState = useEditorStore((state) => state.activeUIState);
   const isStateActive = activeUIState !== 'neutral';
+
+  // Disable layer drag/drop and add buttons in non-default locales — the tree
+  // becomes a read-only map of the page while translating.
+  const isLocalizing = useLocalisationStore((state) => {
+    const id = state.selectedLocaleId;
+    if (!id) return false;
+    const locale = state.locales.find((l) => l.id === id);
+    return !!(locale && !locale.is_default);
+  });
+
   const { setNodeRef: setDropRef } = useDroppable({
     id: node.id,
   });
 
   const { attributes, listeners, setNodeRef: setDragRef } = useDraggable({
     id: node.id,
-    disabled: isRenaming,
+    disabled: isRenaming || isLocalizing,
   });
 
   const renameInputRef = React.useRef<HTMLInputElement>(null);

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -1831,31 +1831,22 @@ const RightSidebar = React.memo(function RightSidebar({
   return (
     <div className="w-64 shrink-0 bg-background border-l flex flex-col p-4 pb-0 h-full overflow-hidden">
       {/* Tabs.
-          When the user is translating (non-default locale active) we hide
-          the Design + Interactions tabs entirely and force the Settings tab,
-          which is where the per-layer Translate panel renders. */}
+          When the user is translating (non-default locale active) we keep the
+          tab list visible but disable Design + Interactions and force the
+          Settings tab, which is where the per-layer Translate panel renders.
+          Mirrors the disabled-tabs pattern used for component instances. */}
       <Tabs
         value={isLocalizing ? 'settings' : activeTab}
-        onValueChange={isLocalizing ? () => {} : handleTabChange}
+        onValueChange={isLocalizing ? () => { } : handleTabChange}
         className="flex flex-col flex-1 min-h-0 gap-0"
       >
-        {!isLocalizing && (
-          <div className="">
-            <TabsList className="w-full">
-              <TabsTrigger value="design">Design</TabsTrigger>
-              <TabsTrigger value="settings">Settings</TabsTrigger>
-              <TabsTrigger value="interactions">Interactions</TabsTrigger>
-            </TabsList>
-          </div>
-        )}
-        {isLocalizing && currentLocale && (
-          <div className="flex items-center gap-2 px-1 pb-2">
-            <Icon name="globe" className="size-3 opacity-60" />
-            <span className="text-xs font-medium">
-              Translating to {currentLocale.label}
-            </span>
-          </div>
-        )}
+        <div className="">
+          <TabsList className="w-full">
+            <TabsTrigger value="design" disabled={isLocalizing}>Design</TabsTrigger>
+            <TabsTrigger value="settings">Settings</TabsTrigger>
+            <TabsTrigger value="interactions" disabled={isLocalizing}>Interactions</TabsTrigger>
+          </TabsList>
+        </div>
 
         <hr className="mt-4" />
 

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -233,6 +233,7 @@ const RightSidebar = React.memo(function RightSidebar({
   const startElementPicker = useEditorStore((state) => state.startElementPicker);
   const stopElementPicker = useEditorStore((state) => state.stopElementPicker);
   const isElementPickerActive = useEditorStore((state) => !!state.elementPicker?.active);
+  const openRichTextSheet = useEditorStore((state) => state.openRichTextSheet);
 
   // Check if text is being edited on canvas
   const isTextEditingOnCanvas = useCanvasTextEditorStore((state) => state.isEditing);
@@ -2053,19 +2054,37 @@ const RightSidebar = React.memo(function RightSidebar({
             {isLocalizing && selectedLayer && currentLocale && (
               <div className="flex flex-col gap-6 py-5">
                 {translatableItemsForSelectedLayer.length === 0 ? (
-                  <Empty>
-                    <EmptyMedia variant="icon">
-                      <Icon name={isRichTextLayer(selectedLayer) ? 'type' : 'globe'} />
-                    </EmptyMedia>
-                    <EmptyTitle>
-                      {isRichTextLayer(selectedLayer) ? 'Translate in the editor' : 'Nothing to translate'}
-                    </EmptyTitle>
-                    <EmptyDescription>
-                      {isRichTextLayer(selectedLayer)
-                        ? 'Rich text is translated in the editor panel that opens on the right.'
-                        : 'This layer has no translatable content. Select a text or media element.'}
-                    </EmptyDescription>
-                  </Empty>
+                  // Rich text translations are routed through the
+                  // RichTextEditorSheet overlay. Mirror the regular Element →
+                  // Content row used for non-localizing rich text editing so
+                  // the user can re-open the editor after closing it.
+                  isRichTextLayer(selectedLayer) ? (
+                    <div className="grid grid-cols-3 items-center">
+                      <Label variant="muted">Content</Label>
+                      <div className="col-span-2 *:w-full">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="secondary"
+                          className="gap-2.5"
+                          onClick={() => selectedLayerId && openRichTextSheet(selectedLayerId)}
+                        >
+                          Expand
+                          <span><Icon name="expand" className="size-2.5" /></span>
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <Empty>
+                      <EmptyMedia variant="icon">
+                        <Icon name="globe" />
+                      </EmptyMedia>
+                      <EmptyTitle>Nothing to translate</EmptyTitle>
+                      <EmptyDescription>
+                        This layer has no translatable content. Select a text or media element.
+                      </EmptyDescription>
+                    </Empty>
+                  )
                 ) : (
                   translatableItemsForSelectedLayer.map((item) => (
                     <SidebarTranslationRow

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -297,11 +297,14 @@ const RightSidebar = React.memo(function RightSidebar({
 
   const translatableItemsForSelectedLayer = useMemo(() => {
     if (!selectedLayer || !translationSource) return [];
+    // Rich text translations are edited in the dedicated RichTextEditorSheet
+    // overlay (auto-opened by CenterCanvas), so we hide them from the sidebar
+    // to avoid a duplicate, less-capable plain-text editor for the same field.
     return extractLayerTranslatableItemsShallow(
       selectedLayer,
       translationSource.sourceType,
       translationSource.sourceId,
-    );
+    ).filter((item) => item.content_type !== 'richtext');
   }, [selectedLayer, translationSource]);
 
   const hasCustomAttributes = !!(selectedLayer?.settings?.customAttributes &&
@@ -2046,11 +2049,15 @@ const RightSidebar = React.memo(function RightSidebar({
                 {translatableItemsForSelectedLayer.length === 0 ? (
                   <Empty>
                     <EmptyMedia variant="icon">
-                      <Icon name="globe" />
+                      <Icon name={isRichTextLayer(selectedLayer) ? 'type' : 'globe'} />
                     </EmptyMedia>
-                    <EmptyTitle>Nothing to translate</EmptyTitle>
+                    <EmptyTitle>
+                      {isRichTextLayer(selectedLayer) ? 'Translate in the editor' : 'Nothing to translate'}
+                    </EmptyTitle>
                     <EmptyDescription>
-                      This layer has no translatable content. Select a text or media element.
+                      {isRichTextLayer(selectedLayer)
+                        ? 'Rich text is translated in the editor panel that opens on the right.'
+                        : 'This layer has no translatable content. Select a text or media element.'}
                     </EmptyDescription>
                   </Empty>
                 ) : (

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -2046,31 +2046,44 @@ const RightSidebar = React.memo(function RightSidebar({
                     </EmptyDescription>
                   </Empty>
                 ) : (
-                  translatableItemsForSelectedLayer.map((item) => {
-                    // Rich-text element layers are previewed read-only here
-                    // and edited in the dedicated RichTextEditorSheet overlay,
-                    // launched via the per-row "Expand to edit" button.
-                    const isRichTextElementContent = isRichTextLayer(selectedLayer) && item.content_type === 'richtext';
-                    return (
-                      <SidebarTranslationRow
-                        key={item.key}
-                        item={item}
-                        selectedLocaleId={selectedLocaleId}
-                        defaultLocaleLabel={defaultLocale?.label || 'Default'}
-                        currentLocaleLabel={currentLocale.label}
-                        localInputValues={translationLocalInputValues}
-                        onLocalValueChange={handleTranslationLocalValueChange}
-                        onLocalValueClear={handleTranslationLocalValueClear}
-                        getTranslationByKey={getTranslationByKey}
-                        createTranslation={createTranslation}
-                        updateTranslation={updateTranslation}
-                        previewOnly={isRichTextElementContent}
-                        onExpand={isRichTextElementContent && selectedLayerId
-                          ? () => openRichTextSheet(selectedLayerId)
-                          : undefined}
-                      />
-                    );
-                  })
+                  // Group rows under language headers: all source values for
+                  // the default locale first, then the editable translations
+                  // for the active locale. Easier to scan when a layer has
+                  // multiple translatable properties (e.g. image src + alt).
+                  (['source', 'translation'] as const).map((side) => (
+                    <div key={side} className="flex flex-col gap-4">
+                      <Label className="text-xs font-medium">
+                        {side === 'source'
+                          ? defaultLocale?.label || 'Default'
+                          : currentLocale.label}
+                      </Label>
+                      {translatableItemsForSelectedLayer.map((item) => {
+                        // Rich-text element layers are previewed read-only and
+                        // edited in the dedicated RichTextEditorSheet overlay,
+                        // launched via the per-row "Expand to edit" button.
+                        const isRichTextElementContent =
+                          isRichTextLayer(selectedLayer) && item.content_type === 'richtext';
+                        return (
+                          <SidebarTranslationRow
+                            key={`${side}:${item.key}`}
+                            item={item}
+                            side={side}
+                            selectedLocaleId={selectedLocaleId}
+                            localInputValues={translationLocalInputValues}
+                            onLocalValueChange={handleTranslationLocalValueChange}
+                            onLocalValueClear={handleTranslationLocalValueClear}
+                            getTranslationByKey={getTranslationByKey}
+                            createTranslation={createTranslation}
+                            updateTranslation={updateTranslation}
+                            previewOnly={isRichTextElementContent}
+                            onExpand={isRichTextElementContent && selectedLayerId
+                              ? () => openRichTextSheet(selectedLayerId)
+                              : undefined}
+                          />
+                        );
+                      })}
+                    </div>
+                  ))
                 )}
               </div>
             )}

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -298,20 +298,11 @@ const RightSidebar = React.memo(function RightSidebar({
 
   const translatableItemsForSelectedLayer = useMemo(() => {
     if (!selectedLayer || !translationSource) return [];
-    const items = extractLayerTranslatableItemsShallow(
+    return extractLayerTranslatableItemsShallow(
       selectedLayer,
       translationSource.sourceType,
       translationSource.sourceId,
     );
-    // For the dedicated richText element we route translations through the
-    // RichTextEditorSheet overlay (auto-opened by CenterCanvas), so suppress
-    // its sidebar entry to avoid a duplicate plain-text editor. Headings,
-    // paragraphs, etc. that happen to use the rich-text variable type keep
-    // their textarea editor here — only the `richText` element is special.
-    if (isRichTextLayer(selectedLayer)) {
-      return items.filter((item) => item.content_type !== 'richtext');
-    }
-    return items;
   }, [selectedLayer, translationSource]);
 
   const hasCustomAttributes = !!(selectedLayer?.settings?.customAttributes &&
@@ -2054,53 +2045,41 @@ const RightSidebar = React.memo(function RightSidebar({
             {isLocalizing && selectedLayer && currentLocale && (
               <div className="flex flex-col gap-6 py-5">
                 {translatableItemsForSelectedLayer.length === 0 ? (
-                  // Rich text translations are routed through the
-                  // RichTextEditorSheet overlay. Mirror the regular Element →
-                  // Content row used for non-localizing rich text editing so
-                  // the user can re-open the editor after closing it.
-                  isRichTextLayer(selectedLayer) ? (
-                    <div className="grid grid-cols-3 items-center">
-                      <Label variant="muted">Content</Label>
-                      <div className="col-span-2 *:w-full">
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="secondary"
-                          className="gap-2.5"
-                          onClick={() => selectedLayerId && openRichTextSheet(selectedLayerId)}
-                        >
-                          Expand
-                          <span><Icon name="expand" className="size-2.5" /></span>
-                        </Button>
-                      </div>
-                    </div>
-                  ) : (
-                    <Empty>
-                      <EmptyMedia variant="icon">
-                        <Icon name="globe" />
-                      </EmptyMedia>
-                      <EmptyTitle>Nothing to translate</EmptyTitle>
-                      <EmptyDescription>
-                        This layer has no translatable content. Select a text or media element.
-                      </EmptyDescription>
-                    </Empty>
-                  )
+                  <Empty>
+                    <EmptyMedia variant="icon">
+                      <Icon name="globe" />
+                    </EmptyMedia>
+                    <EmptyTitle>Nothing to translate</EmptyTitle>
+                    <EmptyDescription>
+                      This layer has no translatable content. Select a text or media element.
+                    </EmptyDescription>
+                  </Empty>
                 ) : (
-                  translatableItemsForSelectedLayer.map((item) => (
-                    <SidebarTranslationRow
-                      key={item.key}
-                      item={item}
-                      selectedLocaleId={selectedLocaleId}
-                      defaultLocaleLabel={defaultLocale?.label || 'Default'}
-                      currentLocaleLabel={currentLocale.label}
-                      localInputValues={translationLocalInputValues}
-                      onLocalValueChange={handleTranslationLocalValueChange}
-                      onLocalValueClear={handleTranslationLocalValueClear}
-                      getTranslationByKey={getTranslationByKey}
-                      createTranslation={createTranslation}
-                      updateTranslation={updateTranslation}
-                    />
-                  ))
+                  translatableItemsForSelectedLayer.map((item) => {
+                    // Rich-text element layers are previewed read-only here
+                    // and edited in the dedicated RichTextEditorSheet overlay,
+                    // launched via the per-row "Expand to edit" button.
+                    const isRichTextElementContent = isRichTextLayer(selectedLayer) && item.content_type === 'richtext';
+                    return (
+                      <SidebarTranslationRow
+                        key={item.key}
+                        item={item}
+                        selectedLocaleId={selectedLocaleId}
+                        defaultLocaleLabel={defaultLocale?.label || 'Default'}
+                        currentLocaleLabel={currentLocale.label}
+                        localInputValues={translationLocalInputValues}
+                        onLocalValueChange={handleTranslationLocalValueChange}
+                        onLocalValueClear={handleTranslationLocalValueClear}
+                        getTranslationByKey={getTranslationByKey}
+                        createTranslation={createTranslation}
+                        updateTranslation={updateTranslation}
+                        previewOnly={isRichTextElementContent}
+                        onExpand={isRichTextElementContent && selectedLayerId
+                          ? () => openRichTextSheet(selectedLayerId)
+                          : undefined}
+                      />
+                    );
+                  })
                 )}
               </div>
             )}

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -297,14 +297,20 @@ const RightSidebar = React.memo(function RightSidebar({
 
   const translatableItemsForSelectedLayer = useMemo(() => {
     if (!selectedLayer || !translationSource) return [];
-    // Rich text translations are edited in the dedicated RichTextEditorSheet
-    // overlay (auto-opened by CenterCanvas), so we hide them from the sidebar
-    // to avoid a duplicate, less-capable plain-text editor for the same field.
-    return extractLayerTranslatableItemsShallow(
+    const items = extractLayerTranslatableItemsShallow(
       selectedLayer,
       translationSource.sourceType,
       translationSource.sourceId,
-    ).filter((item) => item.content_type !== 'richtext');
+    );
+    // For the dedicated richText element we route translations through the
+    // RichTextEditorSheet overlay (auto-opened by CenterCanvas), so suppress
+    // its sidebar entry to avoid a duplicate plain-text editor. Headings,
+    // paragraphs, etc. that happen to use the rich-text variable type keep
+    // their textarea editor here — only the `richText` element is special.
+    if (isRichTextLayer(selectedLayer)) {
+      return items.filter((item) => item.content_type !== 'richtext');
+    }
+    return items;
   }, [selectedLayer, translationSource]);
 
   const hasCustomAttributes = !!(selectedLayer?.settings?.customAttributes &&

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -100,7 +100,7 @@ import { isFieldVariable, getCollectionVariable, findParentCollectionLayer, find
 import { detachSpecificLayerFromComponent } from '@/lib/component-utils';
 import { convertContentToValue, parseValueToContent } from '@/lib/cms-variables-utils';
 import { createTextComponentVariableValue } from '@/lib/variable-utils';
-import { getRichTextValue, extractPlainTextFromTiptap } from '@/lib/tiptap-utils';
+import { getRichTextValue, extractPlainTextFromTiptap, getSoleCmsFieldBinding } from '@/lib/tiptap-utils';
 import { DEFAULT_TEXT_STYLES, getTextStyle, getTiptapTextContent } from '@/lib/text-format-utils';
 import { buildFieldGroupsForLayer, getFieldIcon, isMultipleAssetField, MULTI_ASSET_COLLECTION_ID, SIMPLE_TEXT_FIELD_TYPES } from '@/lib/collection-field-utils';
 import { getInverseReferenceFields } from '@/lib/collection-utils';
@@ -304,6 +304,24 @@ const RightSidebar = React.memo(function RightSidebar({
       translationSource.sourceId,
     );
   }, [selectedLayer, translationSource]);
+
+  // When the selected layer's text is a single CMS-bound variable (e.g. a
+  // heading whose only content is a `[Content]` field reference), the textarea
+  // editor in the sidebar would just show "[Content]" — the actual translation
+  // happens against the bound CMS item, not against the layer. Detect this so
+  // the panel can render a read-only "Content → variable" row instead, and
+  // hide the unhelpful textarea pair.
+  const layerCmsTextBinding = useMemo(() => {
+    if (!selectedLayer || !isLocalizing) return null;
+    if (selectedLayer.variables?.text?.type !== 'dynamic_rich_text') return null;
+    const richValue = getRichTextValue(selectedLayer.variables);
+    return getSoleCmsFieldBinding(richValue);
+  }, [selectedLayer, isLocalizing]);
+
+  const translatableItemsExcludingCmsText = useMemo(() => {
+    if (!layerCmsTextBinding) return translatableItemsForSelectedLayer;
+    return translatableItemsForSelectedLayer.filter((item) => !item.content_key.endsWith(':text'));
+  }, [translatableItemsForSelectedLayer, layerCmsTextBinding]);
 
   const hasCustomAttributes = !!(selectedLayer?.settings?.customAttributes &&
     Object.keys(selectedLayer.settings.customAttributes).length > 0);
@@ -2035,7 +2053,33 @@ const RightSidebar = React.memo(function RightSidebar({
                 the selected layer. */}
             {isLocalizing && selectedLayer && currentLocale && (
               <div className="flex flex-col gap-6 py-5">
-                {translatableItemsForSelectedLayer.length === 0 ? (
+                {/* CMS-bound text indicator — shown when the layer's text is a
+                    single CMS variable. The translation happens on the bound
+                    CMS item (via the collection item sheet), not here, so the
+                    sidebar just surfaces the connected variable for context.
+                    No clear/X button — the binding can't be removed in
+                    translation mode. */}
+                {layerCmsTextBinding && (
+                  <div className="grid grid-cols-3 items-center">
+                    <Label variant="muted">Content</Label>
+                    <div className="col-span-2 *:w-full">
+                      <Button
+                        asChild
+                        variant="data"
+                        className="justify-between! cursor-default"
+                      >
+                        <div>
+                          <span className="flex items-center gap-1.5 truncate">
+                            <Icon name="database" className="size-3 opacity-60 shrink-0" />
+                            <span className="truncate">{layerCmsTextBinding.label || 'CMS Field'}</span>
+                          </span>
+                        </div>
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {translatableItemsExcludingCmsText.length === 0 && !layerCmsTextBinding ? (
                   <Empty>
                     <EmptyMedia variant="icon">
                       <Icon name="globe" />
@@ -2045,7 +2089,7 @@ const RightSidebar = React.memo(function RightSidebar({
                       This layer has no translatable content. Select a text or media element.
                     </EmptyDescription>
                   </Empty>
-                ) : (
+                ) : translatableItemsExcludingCmsText.length > 0 ? (
                   // Group rows under language headers: all source values for
                   // the default locale first, then the editable translations
                   // for the active locale. Easier to scan when a layer has
@@ -2057,7 +2101,7 @@ const RightSidebar = React.memo(function RightSidebar({
                           ? defaultLocale?.label || 'Default'
                           : currentLocale.label}
                       </Label>
-                      {translatableItemsForSelectedLayer.map((item) => {
+                      {translatableItemsExcludingCmsText.map((item) => {
                         // Rich-text element layers are previewed read-only and
                         // edited in the dedicated RichTextEditorSheet overlay,
                         // launched via the per-row "Expand to edit" button.
@@ -2084,7 +2128,7 @@ const RightSidebar = React.memo(function RightSidebar({
                       })}
                     </div>
                   ))
-                )}
+                ) : null}
               </div>
             )}
 

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -81,6 +81,10 @@ import { useCollectionsStore } from '@/stores/useCollectionsStore';
 import { useLayerStylesStore } from '@/stores/useLayerStylesStore';
 import { useCanvasTextEditorStore } from '@/stores/useCanvasTextEditorStore';
 import { useEditorActions, useEditorUrl } from '@/hooks/use-editor-url';
+import { useLocalizationMode } from '@/hooks/use-localization-mode';
+import SidebarTranslationRow from './SidebarTranslationRow';
+import { extractLayerTranslatableItemsShallow } from '@/lib/localisation-utils';
+import { useLocalisationStore } from '@/stores/useLocalisationStore';
 
 // 5.5 Hooks
 import { useLayerLocks } from '@/hooks/use-layer-locks';
@@ -136,6 +140,25 @@ const RightSidebar = React.memo(function RightSidebar({
 }: RightSidebarProps) {
   const { openComponent, urlState, updateQueryParams } = useEditorActions();
   const { routeType } = useEditorUrl();
+  const { isLocalizing, currentLocale, defaultLocale } = useLocalizationMode();
+
+  // Translation editor state + store actions used by the per-layer Translate
+  // panel rendered inside the Settings tab when a non-default locale is active.
+  const selectedLocaleId = useLocalisationStore((state) => state.selectedLocaleId);
+  const getTranslationByKey = useLocalisationStore((state) => state.getTranslationByKey);
+  const createTranslation = useLocalisationStore((state) => state.createTranslation);
+  const updateTranslation = useLocalisationStore((state) => state.updateTranslation);
+  const [translationLocalInputValues, setTranslationLocalInputValues] = useState<Record<string, string>>({});
+  const handleTranslationLocalValueChange = useCallback((key: string, value: string) => {
+    setTranslationLocalInputValues((prev) => ({ ...prev, [key]: value }));
+  }, []);
+  const handleTranslationLocalValueClear = useCallback((key: string) => {
+    setTranslationLocalInputValues((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  }, []);
 
   // Local state for immediate UI feedback
   const [activeTab, setActiveTab] = useState<'design' | 'settings' | 'interactions' | undefined>(
@@ -255,6 +278,31 @@ const RightSidebar = React.memo(function RightSidebar({
 
   const selectedLayerRef = useRef(selectedLayer);
   selectedLayerRef.current = selectedLayer;
+
+  // Translatable items for the selected layer, computed only when actually
+  // localizing. The source resolution mirrors the server: layers inside a
+  // component are scoped to that component (via _masterComponentId on the
+  // server / editingComponentId here) so a single translation propagates to
+  // all instances of the component on the site.
+  const translationSource = useMemo(() => {
+    if (!selectedLayer || !isLocalizing) return null;
+    if (editingComponentId) {
+      return { sourceType: 'component' as const, sourceId: editingComponentId };
+    }
+    if (currentPageId) {
+      return { sourceType: 'page' as const, sourceId: currentPageId };
+    }
+    return null;
+  }, [selectedLayer, isLocalizing, editingComponentId, currentPageId]);
+
+  const translatableItemsForSelectedLayer = useMemo(() => {
+    if (!selectedLayer || !translationSource) return [];
+    return extractLayerTranslatableItemsShallow(
+      selectedLayer,
+      translationSource.sourceType,
+      translationSource.sourceId,
+    );
+  }, [selectedLayer, translationSource]);
 
   const hasCustomAttributes = !!(selectedLayer?.settings?.customAttributes &&
     Object.keys(selectedLayer.settings.customAttributes).length > 0);
@@ -1781,19 +1829,32 @@ const RightSidebar = React.memo(function RightSidebar({
 
   return (
     <div className="w-64 shrink-0 bg-background border-l flex flex-col p-4 pb-0 h-full overflow-hidden">
-      {/* Tabs */}
+      {/* Tabs.
+          When the user is translating (non-default locale active) we hide
+          the Design + Interactions tabs entirely and force the Settings tab,
+          which is where the per-layer Translate panel renders. */}
       <Tabs
-        value={activeTab}
-        onValueChange={handleTabChange}
+        value={isLocalizing ? 'settings' : activeTab}
+        onValueChange={isLocalizing ? () => {} : handleTabChange}
         className="flex flex-col flex-1 min-h-0 gap-0"
       >
-        <div className="">
-          <TabsList className="w-full">
-            <TabsTrigger value="design">Design</TabsTrigger>
-            <TabsTrigger value="settings">Settings</TabsTrigger>
-            <TabsTrigger value="interactions">Interactions</TabsTrigger>
-          </TabsList>
-        </div>
+        {!isLocalizing && (
+          <div className="">
+            <TabsList className="w-full">
+              <TabsTrigger value="design">Design</TabsTrigger>
+              <TabsTrigger value="settings">Settings</TabsTrigger>
+              <TabsTrigger value="interactions">Interactions</TabsTrigger>
+            </TabsList>
+          </div>
+        )}
+        {isLocalizing && currentLocale && (
+          <div className="flex items-center gap-2 px-1 pb-2">
+            <Icon name="globe" className="size-3 opacity-60" />
+            <span className="text-xs font-medium">
+              Translating to {currentLocale.label}
+            </span>
+          </div>
+        )}
 
         <hr className="mt-4" />
 
@@ -1976,7 +2037,43 @@ const RightSidebar = React.memo(function RightSidebar({
 
         <TabsContent value="settings" className="flex-1 overflow-y-auto no-scrollbar mt-0 data-[state=inactive]:hidden">
           <div className="flex flex-col divide-y">
-            {selectedLayerId !== 'body' && (<>
+            {/* Translate panel — replaces all design/settings controls when a
+                non-default locale is active. Stacked Framer-style layout: one
+                source + translation Textarea pair per translatable property of
+                the selected layer. */}
+            {isLocalizing && selectedLayer && currentLocale && (
+              <div className="flex flex-col gap-6 py-5">
+                {translatableItemsForSelectedLayer.length === 0 ? (
+                  <Empty>
+                    <EmptyMedia variant="icon">
+                      <Icon name="globe" />
+                    </EmptyMedia>
+                    <EmptyTitle>Nothing to translate</EmptyTitle>
+                    <EmptyDescription>
+                      This layer has no translatable content. Select a text or media element.
+                    </EmptyDescription>
+                  </Empty>
+                ) : (
+                  translatableItemsForSelectedLayer.map((item) => (
+                    <SidebarTranslationRow
+                      key={item.key}
+                      item={item}
+                      selectedLocaleId={selectedLocaleId}
+                      defaultLocaleLabel={defaultLocale?.label || 'Default'}
+                      currentLocaleLabel={currentLocale.label}
+                      localInputValues={translationLocalInputValues}
+                      onLocalValueChange={handleTranslationLocalValueChange}
+                      onLocalValueClear={handleTranslationLocalValueClear}
+                      getTranslationByKey={getTranslationByKey}
+                      createTranslation={createTranslation}
+                      updateTranslation={updateTranslation}
+                    />
+                  ))
+                )}
+              </div>
+            )}
+
+            {!isLocalizing && selectedLayerId !== 'body' && (<>
             {/* Attributes */}
             <div className="flex flex-col gap-2 pb-5 pt-5">
               <div className="grid grid-cols-3">
@@ -2754,7 +2851,8 @@ const RightSidebar = React.memo(function RightSidebar({
             />
             </>)}
 
-            {/* Custom Attributes Panel */}
+            {/* Custom Attributes Panel — hide while translating */}
+            {!isLocalizing && (
             <SettingsPanel
               title="Custom attributes"
               isOpen={hasCustomAttributes}
@@ -2838,6 +2936,7 @@ const RightSidebar = React.memo(function RightSidebar({
                 </div>
               )}
             </SettingsPanel>
+            )}
           </div>
         </TabsContent>
 

--- a/app/(builder)/ycode/components/SidebarTranslationRow.tsx
+++ b/app/(builder)/ycode/components/SidebarTranslationRow.tsx
@@ -69,6 +69,23 @@ export default function SidebarTranslationRow({
   const isRichText = item.content_type === 'richtext';
   const isAsset = item.content_type === 'asset_id';
 
+  // Sub-label shown beneath each language name when a layer has more than
+  // one translatable property (e.g. an image has both source + alt text).
+  // Plain text content stays unlabelled — the language name plus the textarea
+  // already make it obvious what's being translated.
+  const propertyLabel = (() => {
+    const suffix = item.content_key.split(':').pop();
+    switch (suffix) {
+      case 'image_alt': return 'Image ALT';
+      case 'image_src': return 'Image';
+      case 'video_src': return 'Video';
+      case 'video_poster': return 'Video poster';
+      case 'audio_src': return 'Audio';
+      case 'icon_src': return 'Icon';
+      default: return null;
+    }
+  })();
+
   const translation = selectedLocaleId
     ? getTranslationByKey(selectedLocaleId, item.key)
     : null;
@@ -250,7 +267,14 @@ export default function SidebarTranslationRow({
     <div className="flex flex-col gap-4">
       {/* Source (default locale, read-only) */}
       <div className="flex flex-col gap-1.5">
-        <Label className="text-xs font-medium">{defaultLocaleLabel}</Label>
+        <div className="flex flex-col gap-0.5">
+          <Label className="text-xs font-medium">{defaultLocaleLabel}</Label>
+          {propertyLabel && (
+            <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
+              {propertyLabel}
+            </span>
+          )}
+        </div>
         {isAsset ? (
           <div className="flex items-center gap-2 p-2 border border-border/50 rounded-md bg-secondary/20 opacity-80">
             {sourceAsset && renderAssetPreview(sourceAsset)}
@@ -273,7 +297,14 @@ export default function SidebarTranslationRow({
           read-only preview + Expand button when caller opted into previewOnly
           mode (rich-text layers, which edit in the dedicated overlay). */}
       <div className="flex flex-col gap-1.5">
-        <Label className="text-xs font-medium">{currentLocaleLabel}</Label>
+        <div className="flex flex-col gap-0.5">
+          <Label className="text-xs font-medium">{currentLocaleLabel}</Label>
+          {propertyLabel && (
+            <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
+              {propertyLabel}
+            </span>
+          )}
+        </div>
         {isAsset ? (
           <div
             className="flex items-center gap-2 p-2 border border-border/50 rounded-md bg-secondary/20 cursor-pointer hover:bg-secondary/35 transition-colors"

--- a/app/(builder)/ycode/components/SidebarTranslationRow.tsx
+++ b/app/(builder)/ycode/components/SidebarTranslationRow.tsx
@@ -19,9 +19,14 @@ import type { IconProps } from '@/components/ui/icon';
 
 interface SidebarTranslationRowProps {
   item: TranslatableItem;
+  /**
+   * Which half of the translation pair to render. The right sidebar groups
+   * rows under language sections (Default → Active), so each item is rendered
+   * twice — once as the read-only source, once as the (usually editable)
+   * translation for the selected locale.
+   */
+  side: 'source' | 'translation';
   selectedLocaleId: string | null;
-  defaultLocaleLabel: string;
-  currentLocaleLabel: string;
   localInputValues: Record<string, string>;
   onLocalValueChange: (key: string, value: string) => void;
   onLocalValueClear: (key: string) => void;
@@ -29,9 +34,9 @@ interface SidebarTranslationRowProps {
   createTranslation: (data: CreateTranslationData) => Promise<Translation | null>;
   updateTranslation: (translation: Translation, data: UpdateTranslationData) => Promise<void>;
   /**
-   * When true, both source and translation textareas are read-only previews.
-   * Used for rich-text layers where editing happens in a dedicated overlay
-   * (the RichTextEditorSheet) opened via `onExpand`.
+   * When true, the translation side renders a read-only preview with an
+   * "Expand to edit" button instead of an editable surface. Used for the
+   * rich-text element layer, which edits in the dedicated RichTextEditorSheet.
    */
   previewOnly?: boolean;
   /** Click handler for the "Expand to edit" button shown in preview-only mode. */
@@ -39,12 +44,11 @@ interface SidebarTranslationRowProps {
 }
 
 /**
- * Right-sidebar translation editor.
+ * Right-sidebar translation editor for a single (item, side) pair.
  *
- * A deliberately simpler take on `TranslationRow`: stacked plain `Textarea`s
- * for source + translation, no rich-text editor, no completion toggle, no slug
- * validation. Used while the user is browsing the canvas in a non-default
- * locale — quick inline translation flow next to the layer being edited.
+ * A deliberately simpler take on `TranslationRow`: stacked plain `Textarea`s,
+ * no rich-text editor, no completion toggle, no slug validation. Used while
+ * the user is browsing the canvas in a non-default locale.
  *
  * Rich-text values (Tiptap JSON) are flattened to plain text for display and
  * re-wrapped into a Tiptap doc on save so the rendering pipeline keeps getting
@@ -52,9 +56,8 @@ interface SidebarTranslationRowProps {
  */
 export default function SidebarTranslationRow({
   item,
+  side,
   selectedLocaleId,
-  defaultLocaleLabel,
-  currentLocaleLabel,
   localInputValues,
   onLocalValueChange,
   onLocalValueClear,
@@ -263,19 +266,21 @@ export default function SidebarTranslationRow({
     );
   };
 
+  // Cap height so long translations scroll inside the field instead of
+  // pushing the rest of the inspector down (Textarea uses field-sizing-content
+  // by default, which auto-grows).
+  const textareaClass = 'resize-none max-h-32 overflow-y-auto';
+
   return (
-    <div className="flex flex-col gap-4">
-      {/* Source (default locale, read-only) */}
-      <div className="flex flex-col gap-1.5">
-        <div className="flex flex-col gap-0.5">
-          <Label className="text-xs font-medium">{defaultLocaleLabel}</Label>
-          {propertyLabel && (
-            <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
-              {propertyLabel}
-            </span>
-          )}
-        </div>
-        {isAsset ? (
+    <div className="flex flex-col gap-1.5">
+      {propertyLabel && (
+        <Label className="text-[10px] text-muted-foreground uppercase tracking-wide font-medium">
+          {propertyLabel}
+        </Label>
+      )}
+
+      {side === 'source' ? (
+        isAsset ? (
           <div className="flex items-center gap-2 p-2 border border-border/50 rounded-md bg-secondary/20 opacity-80">
             {sourceAsset && renderAssetPreview(sourceAsset)}
           </div>
@@ -284,68 +289,54 @@ export default function SidebarTranslationRow({
             value={sourceDisplayValue}
             readOnly
             tabIndex={-1}
-            // Cap height so long translations scroll inside the field instead
-            // of pushing the rest of the inspector down (textarea uses
-            // field-sizing-content by default, which auto-grows).
-            className="resize-none text-muted-foreground max-h-32 overflow-y-auto"
+            className={`${textareaClass} text-muted-foreground`}
             rows={3}
           />
-        )}
-      </div>
-
-      {/* Translation (current locale). Editable for plain text/asset rows;
-          read-only preview + Expand button when caller opted into previewOnly
-          mode (rich-text layers, which edit in the dedicated overlay). */}
-      <div className="flex flex-col gap-1.5">
-        <div className="flex flex-col gap-0.5">
-          <Label className="text-xs font-medium">{currentLocaleLabel}</Label>
-          {propertyLabel && (
-            <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
-              {propertyLabel}
-            </span>
+        )
+      ) : (
+        <>
+          {isAsset ? (
+            <div
+              className="flex items-center gap-2 p-2 border border-border/50 rounded-md bg-secondary/20 cursor-pointer hover:bg-secondary/35 transition-colors"
+              onClick={() => setIsAssetPickerOpen(true)}
+            >
+              {displayedAsset && renderAssetPreview(displayedAsset)}
+            </div>
+          ) : previewOnly ? (
+            <Textarea
+              value={translationDisplayValue}
+              readOnly
+              tabIndex={-1}
+              placeholder={sourceDisplayValue || 'No translation yet'}
+              className={`${textareaClass} text-muted-foreground`}
+              rows={3}
+            />
+          ) : (
+            <Textarea
+              value={translationDisplayValue}
+              onChange={(e) => handleTextChange(e.target.value)}
+              onBlur={(e) => handleTextBlur(e.target.value)}
+              placeholder={sourceDisplayValue || 'Enter translation...'}
+              className={textareaClass}
+              rows={3}
+            />
           )}
-        </div>
-        {isAsset ? (
-          <div
-            className="flex items-center gap-2 p-2 border border-border/50 rounded-md bg-secondary/20 cursor-pointer hover:bg-secondary/35 transition-colors"
-            onClick={() => setIsAssetPickerOpen(true)}
-          >
-            {displayedAsset && renderAssetPreview(displayedAsset)}
-          </div>
-        ) : previewOnly ? (
-          <Textarea
-            value={translationDisplayValue}
-            readOnly
-            tabIndex={-1}
-            placeholder={sourceDisplayValue || 'No translation yet'}
-            className="resize-none text-muted-foreground max-h-32 overflow-y-auto"
-            rows={3}
-          />
-        ) : (
-          <Textarea
-            value={translationDisplayValue}
-            onChange={(e) => handleTextChange(e.target.value)}
-            onBlur={(e) => handleTextBlur(e.target.value)}
-            placeholder={sourceDisplayValue || 'Enter translation...'}
-            className="resize-none max-h-32 overflow-y-auto"
-            rows={3}
-          />
-        )}
-        {previewOnly && onExpand && (
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            className="gap-2.5 mt-1"
-            onClick={onExpand}
-          >
-            Expand to edit
-            <span><Icon name="expand" className="size-2.5" /></span>
-          </Button>
-        )}
-      </div>
+          {previewOnly && onExpand && (
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              className="gap-2.5 mt-1"
+              onClick={onExpand}
+            >
+              Expand to edit
+              <span><Icon name="expand" className="size-2.5" /></span>
+            </Button>
+          )}
+        </>
+      )}
 
-      {isAsset && (
+      {side === 'translation' && isAsset && (
         <FileManagerDialog
           open={isAssetPickerOpen}
           onOpenChange={setIsAssetPickerOpen}

--- a/app/(builder)/ycode/components/SidebarTranslationRow.tsx
+++ b/app/(builder)/ycode/components/SidebarTranslationRow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import Icon from '@/components/ui/icon';
@@ -27,6 +28,14 @@ interface SidebarTranslationRowProps {
   getTranslationByKey: (localeId: string, key: string) => Translation | undefined;
   createTranslation: (data: CreateTranslationData) => Promise<Translation | null>;
   updateTranslation: (translation: Translation, data: UpdateTranslationData) => Promise<void>;
+  /**
+   * When true, both source and translation textareas are read-only previews.
+   * Used for rich-text layers where editing happens in a dedicated overlay
+   * (the RichTextEditorSheet) opened via `onExpand`.
+   */
+  previewOnly?: boolean;
+  /** Click handler for the "Expand to edit" button shown in preview-only mode. */
+  onExpand?: () => void;
 }
 
 /**
@@ -52,6 +61,8 @@ export default function SidebarTranslationRow({
   getTranslationByKey,
   createTranslation,
   updateTranslation,
+  previewOnly = false,
+  onExpand,
 }: SidebarTranslationRowProps) {
   const [isAssetPickerOpen, setIsAssetPickerOpen] = useState(false);
 
@@ -247,7 +258,9 @@ export default function SidebarTranslationRow({
         )}
       </div>
 
-      {/* Translation (current locale, editable) */}
+      {/* Translation (current locale). Editable for plain text/asset rows;
+          read-only preview + Expand button when caller opted into previewOnly
+          mode (rich-text layers, which edit in the dedicated overlay). */}
       <div className="flex flex-col gap-1.5">
         <Label className="text-xs font-medium">{currentLocaleLabel}</Label>
         {isAsset ? (
@@ -257,6 +270,15 @@ export default function SidebarTranslationRow({
           >
             {displayedAsset && renderAssetPreview(displayedAsset)}
           </div>
+        ) : previewOnly ? (
+          <Textarea
+            value={translationDisplayValue}
+            readOnly
+            tabIndex={-1}
+            placeholder={sourceDisplayValue || 'No translation yet'}
+            className="resize-none text-muted-foreground"
+            rows={3}
+          />
         ) : (
           <Textarea
             value={translationDisplayValue}
@@ -266,6 +288,18 @@ export default function SidebarTranslationRow({
             className="resize-none"
             rows={3}
           />
+        )}
+        {previewOnly && onExpand && (
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            className="gap-2.5 mt-1"
+            onClick={onExpand}
+          >
+            Expand to edit
+            <span><Icon name="expand" className="size-2.5" /></span>
+          </Button>
         )}
       </div>
 

--- a/app/(builder)/ycode/components/SidebarTranslationRow.tsx
+++ b/app/(builder)/ycode/components/SidebarTranslationRow.tsx
@@ -6,7 +6,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import Icon from '@/components/ui/icon';
 import FileManagerDialog from './FileManagerDialog';
-import { extractPlainTextFromTiptap } from '@/lib/tiptap-utils';
+import { extractPlainTextFromTiptap, extractMultilinePlainTextFromTiptap } from '@/lib/tiptap-utils';
 import { stringToTiptapContent } from '@/lib/text-format-utils';
 import { useAsset } from '@/hooks/use-asset';
 import { useAssetsStore } from '@/stores/useAssetsStore';
@@ -76,11 +76,17 @@ export default function SidebarTranslationRow({
 
   // Display value for the source textarea: convert Tiptap JSON → plain text so
   // the user sees readable content instead of raw JSON for rich-text fields.
+  // In preview-only mode (rich-text element layers) we keep block-level
+  // structure as newlines so headings/paragraphs render the way they do on
+  // the canvas; the editable textarea path stays single-line so it round-trips
+  // cleanly through stringToTiptapContent on save.
   const sourceDisplayValue = (() => {
     if (!isRichText || !item.content_value) return item.content_value || '';
     try {
       const parsed = JSON.parse(item.content_value);
-      return extractPlainTextFromTiptap(parsed);
+      return previewOnly
+        ? extractMultilinePlainTextFromTiptap(parsed)
+        : extractPlainTextFromTiptap(parsed);
     } catch {
       return item.content_value;
     }
@@ -95,7 +101,9 @@ export default function SidebarTranslationRow({
     if (!isRichText || !storeValue) return storeValue || '';
     try {
       const parsed = JSON.parse(storeValue);
-      return extractPlainTextFromTiptap(parsed);
+      return previewOnly
+        ? extractMultilinePlainTextFromTiptap(parsed)
+        : extractPlainTextFromTiptap(parsed);
     } catch {
       return storeValue;
     }

--- a/app/(builder)/ycode/components/SidebarTranslationRow.tsx
+++ b/app/(builder)/ycode/components/SidebarTranslationRow.tsx
@@ -1,0 +1,283 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import Icon from '@/components/ui/icon';
+import FileManagerDialog from './FileManagerDialog';
+import { extractPlainTextFromTiptap } from '@/lib/tiptap-utils';
+import { stringToTiptapContent } from '@/lib/text-format-utils';
+import { useAsset } from '@/hooks/use-asset';
+import { useAssetsStore } from '@/stores/useAssetsStore';
+import { getAssetIcon, isAssetOfType, getAssetCategoryFromMimeType, ASSET_CATEGORIES } from '@/lib/asset-utils';
+import { buildAssetFolderPath } from '@/lib/asset-folder-utils';
+import { toast } from 'sonner';
+import type { TranslatableItem } from '@/lib/localisation-utils';
+import type { Translation, CreateTranslationData, UpdateTranslationData, Asset, AssetCategory } from '@/types';
+import type { IconProps } from '@/components/ui/icon';
+
+interface SidebarTranslationRowProps {
+  item: TranslatableItem;
+  selectedLocaleId: string | null;
+  defaultLocaleLabel: string;
+  currentLocaleLabel: string;
+  localInputValues: Record<string, string>;
+  onLocalValueChange: (key: string, value: string) => void;
+  onLocalValueClear: (key: string) => void;
+  getTranslationByKey: (localeId: string, key: string) => Translation | undefined;
+  createTranslation: (data: CreateTranslationData) => Promise<Translation | null>;
+  updateTranslation: (translation: Translation, data: UpdateTranslationData) => Promise<void>;
+}
+
+/**
+ * Right-sidebar translation editor.
+ *
+ * A deliberately simpler take on `TranslationRow`: stacked plain `Textarea`s
+ * for source + translation, no rich-text editor, no completion toggle, no slug
+ * validation. Used while the user is browsing the canvas in a non-default
+ * locale — quick inline translation flow next to the layer being edited.
+ *
+ * Rich-text values (Tiptap JSON) are flattened to plain text for display and
+ * re-wrapped into a Tiptap doc on save so the rendering pipeline keeps getting
+ * a valid rich_text content shape.
+ */
+export default function SidebarTranslationRow({
+  item,
+  selectedLocaleId,
+  defaultLocaleLabel,
+  currentLocaleLabel,
+  localInputValues,
+  onLocalValueChange,
+  onLocalValueClear,
+  getTranslationByKey,
+  createTranslation,
+  updateTranslation,
+}: SidebarTranslationRowProps) {
+  const [isAssetPickerOpen, setIsAssetPickerOpen] = useState(false);
+
+  const isRichText = item.content_type === 'richtext';
+  const isAsset = item.content_type === 'asset_id';
+
+  const translation = selectedLocaleId
+    ? getTranslationByKey(selectedLocaleId, item.key)
+    : null;
+  const storeValue = translation?.content_value || '';
+
+  // Display value for the source textarea: convert Tiptap JSON → plain text so
+  // the user sees readable content instead of raw JSON for rich-text fields.
+  const sourceDisplayValue = (() => {
+    if (!isRichText || !item.content_value) return item.content_value || '';
+    try {
+      const parsed = JSON.parse(item.content_value);
+      return extractPlainTextFromTiptap(parsed);
+    } catch {
+      return item.content_value;
+    }
+  })();
+
+  // Same plain-text projection for the translation: prefer in-flight local
+  // input, fall back to whatever is stored on the server.
+  const translationDisplayValue = (() => {
+    if (localInputValues[item.key] !== undefined) {
+      return localInputValues[item.key];
+    }
+    if (!isRichText || !storeValue) return storeValue || '';
+    try {
+      const parsed = JSON.parse(storeValue);
+      return extractPlainTextFromTiptap(parsed);
+    } catch {
+      return storeValue;
+    }
+  })();
+
+  const sourceAsset = useAsset(isAsset ? item.content_value : null);
+  const translatedAsset = useAsset(isAsset ? storeValue : null);
+  const displayedAsset = translatedAsset || sourceAsset;
+  const assetCategory: AssetCategory | null = sourceAsset
+    ? getAssetCategoryFromMimeType(sourceAsset.mime_type)
+    : null;
+  const assetFolders = useAssetsStore((state) => state.folders);
+
+  const handleTextChange = (value: string) => {
+    onLocalValueChange(item.key, value);
+  };
+
+  const handleTextBlur = (value: string) => {
+    if (!selectedLocaleId) return;
+
+    // Re-wrap plain text into Tiptap JSON for rich_text fields so the
+    // rendering pipeline still receives a valid rich_text payload.
+    const finalValue = isRichText
+      ? JSON.stringify(stringToTiptapContent(value))
+      : value;
+
+    onLocalValueClear(item.key);
+
+    // Skip the round-trip when nothing actually changed (handles the case
+    // where the user focuses then blurs without editing).
+    const previousValue = storeValue;
+    if (finalValue === previousValue) return;
+    if (!finalValue && !previousValue) return;
+
+    // The simplified sidebar flow has no explicit "complete" toggle — saving
+    // any value here means the user committed it, so we mark it completed so
+    // injectTranslatedText / runtime rendering picks it up. Partial translations
+    // that were created elsewhere also flip to completed on first save here.
+    const savePromise = translation
+      ? updateTranslation(translation, { content_value: finalValue, is_completed: true })
+      : createTranslation({
+        locale_id: selectedLocaleId,
+        source_type: item.source_type as CreateTranslationData['source_type'],
+        source_id: item.source_id,
+        content_key: item.content_key,
+        content_type: item.content_type as CreateTranslationData['content_type'],
+        content_value: finalValue,
+        is_completed: true,
+      });
+
+    savePromise.catch((error) => console.error('Failed to save translation:', error));
+  };
+
+  const handleAssetSelect = (asset: Asset): void | false => {
+    if (!selectedLocaleId) return false;
+
+    if (assetCategory && asset.mime_type && !isAssetOfType(asset.mime_type, assetCategory)) {
+      const categoryLabels: Record<AssetCategory, string> = {
+        images: 'an image',
+        videos: 'a video',
+        audio: 'an audio file',
+        icons: 'an icon',
+        documents: 'a document',
+      };
+      toast.error('Invalid asset type', {
+        description: `Please select ${categoryLabels[assetCategory] || 'a file with the correct type'}.`,
+      });
+      return false;
+    }
+
+    onLocalValueChange(item.key, asset.id);
+
+    const savePromise = translation
+      ? updateTranslation(translation, { content_value: asset.id, is_completed: true })
+      : createTranslation({
+        locale_id: selectedLocaleId,
+        source_type: item.source_type as CreateTranslationData['source_type'],
+        source_id: item.source_id,
+        content_key: item.content_key,
+        content_type: item.content_type as CreateTranslationData['content_type'],
+        content_value: asset.id,
+        is_completed: true,
+      });
+
+    savePromise
+      .catch((error) => console.error('Failed to save asset translation:', error))
+      .finally(() => setIsAssetPickerOpen(false));
+  };
+
+  const getAssetFolderPath = (asset: Asset | null): string | null => {
+    if (!asset) return null;
+    if (!asset.asset_folder_id) return 'All files';
+    const folder = assetFolders.find((f) => f.id === asset.asset_folder_id);
+    if (!folder) return 'All files';
+    const folderPath = buildAssetFolderPath(folder, assetFolders) as string;
+    return `All files / ${folderPath}`;
+  };
+
+  const renderAssetPreview = (asset: Asset) => {
+    const isIcon = !!asset.content && isAssetOfType(asset.mime_type, ASSET_CATEGORIES.ICONS);
+    const isVideo = isAssetOfType(asset.mime_type, ASSET_CATEGORIES.VIDEOS);
+    const isAudio = isAssetOfType(asset.mime_type, ASSET_CATEGORIES.AUDIO);
+    const isImage = isAssetOfType(asset.mime_type, ASSET_CATEGORIES.IMAGES) && !isIcon;
+    const folderPath = getAssetFolderPath(asset);
+    const showCheckerboard = isIcon || isImage;
+
+    return (
+      <>
+        <div className="size-8 rounded overflow-hidden flex-shrink-0 flex items-center justify-center relative">
+          {showCheckerboard
+            ? <div className="absolute inset-0 opacity-10 bg-checkerboard" />
+            : <div className="absolute inset-0 bg-secondary" />
+          }
+          {isIcon && asset.content ? (
+            <div
+              data-icon="true"
+              className="relative w-full h-full flex items-center justify-center text-foreground p-1 z-10"
+              dangerouslySetInnerHTML={{ __html: asset.content }}
+            />
+          ) : isVideo || isAudio ? (
+            <Icon name={getAssetIcon(asset.mime_type) as IconProps['name']} className="size-4 opacity-50 relative z-10" />
+          ) : isImage && asset.public_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={asset.public_url}
+              alt={asset.filename}
+              className="relative w-full h-full object-cover z-10"
+            />
+          ) : (
+            <Icon name={getAssetIcon(asset.mime_type) as IconProps['name']} className="size-4 opacity-50 relative z-10" />
+          )}
+        </div>
+        <div className="flex flex-col min-w-0 flex-1">
+          <span className="text-xs truncate text-foreground/80">{asset.filename}</span>
+          {folderPath && (
+            <span className="text-[11px] text-muted-foreground/70 truncate">{folderPath}</span>
+          )}
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Source (default locale, read-only) */}
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-xs font-medium">{defaultLocaleLabel}</Label>
+        {isAsset ? (
+          <div className="flex items-center gap-2 p-2 border border-border/50 rounded-md bg-secondary/20 opacity-80">
+            {sourceAsset && renderAssetPreview(sourceAsset)}
+          </div>
+        ) : (
+          <Textarea
+            value={sourceDisplayValue}
+            readOnly
+            tabIndex={-1}
+            className="resize-none text-muted-foreground"
+            rows={3}
+          />
+        )}
+      </div>
+
+      {/* Translation (current locale, editable) */}
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-xs font-medium">{currentLocaleLabel}</Label>
+        {isAsset ? (
+          <div
+            className="flex items-center gap-2 p-2 border border-border/50 rounded-md bg-secondary/20 cursor-pointer hover:bg-secondary/35 transition-colors"
+            onClick={() => setIsAssetPickerOpen(true)}
+          >
+            {displayedAsset && renderAssetPreview(displayedAsset)}
+          </div>
+        ) : (
+          <Textarea
+            value={translationDisplayValue}
+            onChange={(e) => handleTextChange(e.target.value)}
+            onBlur={(e) => handleTextBlur(e.target.value)}
+            placeholder={sourceDisplayValue || 'Enter translation...'}
+            className="resize-none"
+            rows={3}
+          />
+        )}
+      </div>
+
+      {isAsset && (
+        <FileManagerDialog
+          open={isAssetPickerOpen}
+          onOpenChange={setIsAssetPickerOpen}
+          onAssetSelect={handleAssetSelect}
+          assetId={storeValue || item.content_value || null}
+          category={assetCategory || undefined}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/(builder)/ycode/components/SidebarTranslationRow.tsx
+++ b/app/(builder)/ycode/components/SidebarTranslationRow.tsx
@@ -252,7 +252,10 @@ export default function SidebarTranslationRow({
             value={sourceDisplayValue}
             readOnly
             tabIndex={-1}
-            className="resize-none text-muted-foreground"
+            // Cap height so long translations scroll inside the field instead
+            // of pushing the rest of the inspector down (textarea uses
+            // field-sizing-content by default, which auto-grows).
+            className="resize-none text-muted-foreground max-h-32 overflow-y-auto"
             rows={3}
           />
         )}
@@ -276,7 +279,7 @@ export default function SidebarTranslationRow({
             readOnly
             tabIndex={-1}
             placeholder={sourceDisplayValue || 'No translation yet'}
-            className="resize-none text-muted-foreground"
+            className="resize-none text-muted-foreground max-h-32 overflow-y-auto"
             rows={3}
           />
         ) : (
@@ -285,7 +288,7 @@ export default function SidebarTranslationRow({
             onChange={(e) => handleTextChange(e.target.value)}
             onBlur={(e) => handleTextBlur(e.target.value)}
             placeholder={sourceDisplayValue || 'Enter translation...'}
-            className="resize-none"
+            className="resize-none max-h-32 overflow-y-auto"
             rows={3}
           />
         )}

--- a/app/(builder)/ycode/components/TranslationRow.tsx
+++ b/app/(builder)/ycode/components/TranslationRow.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { Icon } from '@/components/ui/icon';
 import { Spinner } from '@/components/ui/spinner';
 import { Separator } from '@/components/ui/separator';
 import RichTextEditor from './RichTextEditor';
+import RichTextEditorSheet from './RichTextEditorSheet';
 import type { FieldGroup } from './CollectionFieldSelector';
 import FileManagerDialog from './FileManagerDialog';
 import { sanitizeSlug, checkDuplicatePageSlug, checkDuplicateFolderSlug, type ValidationResult } from '@/lib/page-utils';
+import { parseValueToContent } from '@/lib/cms-variables-utils';
+import { flattenFieldGroups, SIMPLE_TEXT_FIELD_TYPES } from '@/lib/collection-field-utils';
 import type { TranslatableItem } from '@/lib/localisation-utils';
 import type { Translation, CollectionField, Collection, CreateTranslationData, UpdateTranslationData, Page, PageFolder, Asset } from '@/types';
 import { useAsset } from '@/hooks/use-asset';
@@ -67,6 +70,8 @@ export default function TranslationRow({
   const [isSaving, setIsSaving] = useState(false);
   const [isSavingStatus, setIsSavingStatus] = useState(false);
   const [isAssetPickerOpen, setIsAssetPickerOpen] = useState(false);
+  const [isRichTextSheetOpen, setIsRichTextSheetOpen] = useState(false);
+  const richTextValueRef = useRef<string | null>(null);
   const [pendingCompletions, setPendingCompletions] = useState<Record<string, boolean | null>>({});
   const [isUpdatingCompletion, setIsUpdatingCompletion] = useState(false);
 
@@ -78,21 +83,33 @@ export default function TranslationRow({
 
   // Check if this is rich text content (stored as JSON string)
   const isRichText = item.content_type === 'richtext';
+  const openInSheet = isRichText && item.open_in_sheet === true;
+
+  // Flatten field groups for parseValueToContent fallback
+  const flatFields = React.useMemo(() => flattenFieldGroups(fieldGroups), [fieldGroups]);
+
+  const emptyDoc = { type: 'doc', content: [{ type: 'paragraph' }] };
+
+  // Parse a richtext value (always Tiptap JSON after migration).
+  // Falls back to parseValueToContent for legacy inline-variable strings.
+  const parseRichTextValue = (val: string): any => {
+    const trimmed = val.trim();
+    if (trimmed.startsWith('{')) {
+      try {
+        const parsed = JSON.parse(val);
+        if (parsed?.type === 'doc') return parsed;
+      } catch { /* not valid JSON */ }
+    }
+    return parseValueToContent(val, flatFields, undefined, allFields);
+  };
 
   // Parse original value if it's rich text (JSON string → Tiptap JSON)
   let originalValueForEditor: string | any = item.content_value;
   if (isRichText) {
     if (item.content_value && typeof item.content_value === 'string') {
-      try {
-        originalValueForEditor = JSON.parse(item.content_value);
-      } catch (error) {
-        // If parsing fails, use empty Tiptap document
-        console.error('Failed to parse original value JSON:', error, item.content_value);
-        originalValueForEditor = { type: 'doc', content: [{ type: 'paragraph' }] };
-      }
+      originalValueForEditor = parseRichTextValue(item.content_value);
     } else if (!item.content_value) {
-      // Empty original value - use empty Tiptap document
-      originalValueForEditor = { type: 'doc', content: [{ type: 'paragraph' }] };
+      originalValueForEditor = emptyDoc;
     }
   }
 
@@ -105,18 +122,48 @@ export default function TranslationRow({
   let translationValueForEditor: string | any = translationValue;
   if (isRichText) {
     if (translationValue && typeof translationValue === 'string') {
-      try {
-        translationValueForEditor = JSON.parse(translationValue);
-      } catch (error) {
-        // If parsing fails, use empty Tiptap document
-        console.error('Failed to parse translation JSON:', error, translationValue);
-        translationValueForEditor = { type: 'doc', content: [{ type: 'paragraph' }] };
-      }
+      translationValueForEditor = parseRichTextValue(translationValue);
     } else if (!translationValue) {
-      // Empty translation - use empty Tiptap document structure
-      translationValueForEditor = { type: 'doc', content: [{ type: 'paragraph' }] };
+      translationValueForEditor = emptyDoc;
     }
   }
+
+  // Check if the rich text translation is empty (no real text content) — only relevant for sheet items
+  const isRichTextTranslationEmpty = openInSheet && (
+    !translationValue ||
+    translationValue === '' ||
+    (() => {
+      if (typeof translationValueForEditor === 'object' && translationValueForEditor?.content) {
+        return !translationValueForEditor.content.some((block: any) =>
+          block.content?.some((node: any) =>
+            (node.type === 'text' && node.text?.trim()) || node.type === 'dynamicVariable'
+          )
+        );
+      }
+      return true;
+    })()
+  );
+
+  // Build a preview string from the original value for use as the right-side placeholder.
+  // Variable references are rendered as `[Label]` so they're clearly distinguished from
+  // user-translatable text (mirrors the old localization UI).
+  const originalPreviewText = (() => {
+    const tiptapDoc = isRichText && typeof originalValueForEditor === 'object'
+      ? originalValueForEditor
+      : (item.content_value ? parseValueToContent(item.content_value, flatFields, undefined, allFields) : null);
+    if (!tiptapDoc?.content) return '';
+    const walk = (nodes: any[]): string =>
+      nodes.map((n: any) => {
+        if (n.type === 'text') return n.text || '';
+        if (n.type === 'dynamicVariable') {
+          const label = n.attrs?.label || n.attrs?.variable?.label || 'variable';
+          return `[${label}]`;
+        }
+        if (n.content) return walk(n.content);
+        return '';
+      }).join('');
+    return walk(tiptapDoc.content).trim();
+  })();
 
   // Check if this is an asset
   const isAsset = item.content_type === 'asset_id';
@@ -159,6 +206,13 @@ export default function TranslationRow({
       setValidationError(null);
     }
   };
+
+  // Dedicated handler for the rich text sheet — writes to ref so close handler always reads latest
+  const handleRichTextSheetChange = useCallback((value: any) => {
+    const stringified = typeof value === 'object' ? JSON.stringify(value) : value;
+    richTextValueRef.current = stringified;
+    onLocalValueChange(item.key, stringified);
+  }, [item.key, onLocalValueChange]);
 
   // Save to store/API on blur (optimistic update + API call)
   const handleTranslationBlur = (value: string | any) => {
@@ -537,13 +591,14 @@ export default function TranslationRow({
             <div className="text-sm opacity-50">
               <RichTextEditor
                 value={originalValueForEditor}
-                onChange={() => {}} // Read-only on left side
+                onChange={() => {}}
                 placeholder=""
                 fieldGroups={fieldGroups}
                 allFields={allFields}
                 collections={collections}
                 disabled={true}
                 withFormatting={isRichText}
+                showFormattingToolbar={false}
               />
             </div>
           )}
@@ -561,6 +616,51 @@ export default function TranslationRow({
                   </>
                 )}
               </div>
+            ) : openInSheet ? (
+              <div
+                className="cursor-pointer"
+                onClick={() => setIsRichTextSheetOpen(true)}
+              >
+                {isRichTextTranslationEmpty ? (
+                  <div className="min-h-[28px] px-2.5 py-1 flex items-center">
+                    <span className="text-muted-foreground/50 text-xs">
+                      {translation?.is_completed === true ? '(Using original)' : 'Click to edit...'}
+                    </span>
+                  </div>
+                ) : (
+                  <div className="pointer-events-none">
+                    <RichTextEditor
+                      value={translationValueForEditor}
+                      onChange={() => {}}
+                      placeholder=""
+                      fieldGroups={fieldGroups}
+                      allFields={allFields}
+                      collections={collections}
+                      withFormatting={true}
+                      showFormattingToolbar={false}
+                      disabled={true}
+                    />
+                  </div>
+                )}
+              </div>
+            ) : isRichText ? (
+              <RichTextEditor
+                value={translationValueForEditor}
+                onChange={handleTranslationChange}
+                onBlur={handleTranslationBlur}
+                placeholder={
+                  translation?.is_completed === true
+                    ? '(Using original)'
+                    : (originalPreviewText || 'Enter translation...')
+                }
+                className={`min-h-[28px] [&_.ProseMirror]:py-1 [&_.ProseMirror]:px-2.5 [&_.ProseMirror]:!bg-transparent`}
+                fieldGroups={fieldGroups}
+                allFields={allFields}
+                collections={collections}
+                withFormatting={true}
+                showFormattingToolbar={false}
+                allowedFieldTypes={SIMPLE_TEXT_FIELD_TYPES}
+              />
             ) : (
               <RichTextEditor
                 value={translationValueForEditor}
@@ -569,7 +669,7 @@ export default function TranslationRow({
                 placeholder={
                   translation?.is_completed === true
                     ? '(Using original)'
-                    : (isRichText ? 'Enter translation...' : (item.content_value || 'Enter translation...'))
+                    : (originalPreviewText || 'Enter translation...')
                 }
                 className={`min-h-[28px] [&_.ProseMirror]:py-1 [&_.ProseMirror]:px-2.5 [&_.ProseMirror]:!bg-transparent ${
                   validationError ? '[&_.ProseMirror]:!border-destructive' : ''
@@ -577,7 +677,7 @@ export default function TranslationRow({
                 fieldGroups={fieldGroups}
                 allFields={allFields}
                 collections={collections}
-                withFormatting={isRichText}
+                allowedFieldTypes={SIMPLE_TEXT_FIELD_TYPES}
               />
             )}
             {validationError && (
@@ -595,6 +695,47 @@ export default function TranslationRow({
           onAssetSelect={handleAssetSelect}
           assetId={translationValue || item.content_value || null}
           category={assetCategory || undefined}
+        />
+      )}
+
+      {/* Rich Text Editor Sheet */}
+      {openInSheet && (
+        <RichTextEditorSheet
+          open={isRichTextSheetOpen}
+          onOpenChange={(open) => {
+            if (!open && selectedLocaleId) {
+              const latestValue = richTextValueRef.current;
+              if (latestValue !== null && latestValue !== storeValue) {
+                const translationData: CreateTranslationData = {
+                  locale_id: selectedLocaleId,
+                  source_type: item.source_type as CreateTranslationData['source_type'],
+                  source_id: item.source_id,
+                  content_key: item.content_key,
+                  content_type: item.content_type as CreateTranslationData['content_type'],
+                  content_value: latestValue,
+                };
+
+                const existingTranslation = getTranslationByKey(selectedLocaleId, item.key);
+                const savePromise = existingTranslation
+                  ? updateTranslationValue(existingTranslation, latestValue)
+                  : createTranslation(translationData);
+
+                savePromise
+                  .then(() => onLocalValueClear(item.key))
+                  .catch((error) => console.error('Failed to save rich text translation:', error));
+              }
+              richTextValueRef.current = null;
+            }
+            setIsRichTextSheetOpen(open);
+          }}
+          title={item.info.label}
+          description={item.info.description || undefined}
+          value={translationValueForEditor}
+          onChange={handleRichTextSheetChange}
+          placeholder="Enter translation..."
+          fieldGroups={fieldGroups}
+          allFields={allFields}
+          collections={collections}
         />
       )}
     </li>

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -502,6 +502,17 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
             setStyles(response.data.styles);
             setSettings(response.data.settings);
             setLocales(response.data.locales || []);
+
+            // Eager-load translations if the persisted selected locale is non-default
+            // so the canvas reflects the locale on first paint instead of source content.
+            const localisationState = useLocalisationStore.getState();
+            const persistedLocaleId = localisationState.selectedLocaleId;
+            if (persistedLocaleId) {
+              const persistedLocale = localisationState.locales.find(l => l.id === persistedLocaleId);
+              if (persistedLocale && !persistedLocale.is_default) {
+                localisationState.loadTranslations(persistedLocaleId);
+              }
+            }
             setAssets(response.data.assets || []);
             setAssetFolders(response.data.assetFolders || []);
             setFonts(response.data.fonts || []);

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -7,7 +7,6 @@ import LayerLockIndicator from '@/components/collaboration/LayerLockIndicator';
 import EditingIndicator from '@/components/collaboration/EditingIndicator';
 import { useCollaborationPresenceStore, getResourceLockKey, RESOURCE_TYPES } from '@/stores/useCollaborationPresenceStore';
 import { useAuthStore } from '@/stores/useAuthStore';
-import { useLocalisationStore } from '@/stores/useLocalisationStore';
 import type { Layer, Locale, ComponentVariable, FormSettings, LinkSettings, Breakpoint, CollectionItemWithValues, Component } from '@/types';
 import type { UseLiveLayerUpdatesReturn } from '@/hooks/use-live-layer-updates';
 import type { UseLiveComponentUpdatesReturn } from '@/hooks/use-live-component-updates';
@@ -17,7 +16,7 @@ import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/templates/utilitie
 import { useCanvasSlider } from '@/hooks/use-canvas-slider';
 import { resolveFieldFromSources } from '@/lib/cms-variables-utils';
 import { getDynamicTextContent, getImageUrlFromVariable, getVideoUrlFromVariable, getIframeUrlFromVariable, isFieldVariable, isAssetVariable, isStaticTextVariable, isDynamicTextVariable, getAssetId, getStaticTextContent, createAssetVariable, createDynamicTextVariable, resolveDesignStyles } from '@/lib/variable-utils';
-import { getTranslatedAssetId, getTranslatedText } from '@/lib/localisation-utils';
+import { getTranslatedAssetId, getTranslatedText, applyCmsTranslations } from '@/lib/localisation-utils';
 import { isValidLinkSettings } from '@/lib/link-utils';
 import { DEFAULT_ASSETS, ASSET_CATEGORIES, isAssetOfType } from '@/lib/asset-utils';
 import { parseMultiAssetFieldValue, buildAssetVirtualValues } from '@/lib/multi-asset-utils';
@@ -500,8 +499,6 @@ const LayerItem: React.FC<{
     return getAssetFromStore(id);
   }, [resolvedAssets, getAssetFromStore]);
   const openFileManager = useEditorStore((state) => state.openFileManager);
-  const allTranslations = useLocalisationStore((state) => state.translations);
-  const editModeTranslations = isEditMode && currentLocale ? allTranslations[currentLocale.id] : null;
   const storeComponents = useComponentsStore((state) => state.components);
   const allComponents = storeComponents.length > 0 ? storeComponents : (componentsProp ?? []);
 
@@ -917,8 +914,11 @@ const LayerItem: React.FC<{
 
   // Resolve text and image URLs with field binding support
   const textContent = (() => {
-    // Special handling for locale selector label
-    if (layer.key === 'localeSelectorLabel' && !isEditMode) {
+    // Special handling for locale selector label.
+    // Runs in both edit and runtime modes so the builder canvas reflects the
+    // active locale chosen via the header dropdown — otherwise the label
+    // would show stale placeholder text while the rest of the canvas updates.
+    if (layer.key === 'localeSelectorLabel') {
       // Get default locale if no locale is detected
       const defaultLocale = availableLocales?.find(l => l.is_default) || availableLocales?.[0];
       const displayLocale = currentLocale || defaultLocale;
@@ -1400,7 +1400,7 @@ const LayerItem: React.FC<{
     transition,
   } = useSortable({
     id: layer.id,
-    disabled: !enableDragDrop || isEditing || isLockedByOther,
+    disabled: !enableDragDrop || isEditing || isLockedByOther || !!(currentLocale && !currentLocale.is_default),
     data: {
       layer,
     },
@@ -1410,9 +1410,14 @@ const LayerItem: React.FC<{
   const sliderRef = useRef<HTMLElement | null>(null);
   useCanvasSlider(sliderRef, layer, isEditMode);
 
+  // Block inline canvas editing while in a non-default locale: source layer
+  // text must only be edited via the default locale. Translations are saved
+  // through the right-sidebar Translate panel instead.
+  const isLocalizingLayer = !!(currentLocale && !currentLocale.is_default);
+
   const startEditing = (clickX?: number, clickY?: number) => {
     // Enable inline editing for text layers (both rich text and plain text)
-    if (textEditable && isEditMode && !isLockedByOther) {
+    if (textEditable && isEditMode && !isLockedByOther && !isLocalizingLayer) {
       setEditingLayerId(layer.id);
       // Clear sublayer selection when entering edit mode
       useEditorStore.getState().setActiveSublayerIndex(null);
@@ -2716,7 +2721,7 @@ const LayerItem: React.FC<{
               editorBreakpoint={editorBreakpoint}
               currentLocale={currentLocale}
               availableLocales={availableLocales}
-              localeSelectorFormat={localeSelectorFormat}
+              localeSelectorFormat={layer.name === 'localeSelector' ? (layer.settings?.locale?.format || 'locale') : localeSelectorFormat}
               liveLayerUpdates={liveLayerUpdates}
               isInsideForm={isInsideForm}
               isInsideLink={isInsideLink}
@@ -2819,15 +2824,24 @@ const LayerItem: React.FC<{
             // Get collection fields for reference resolution
             const collectionFields = collectionId ? fieldsByCollectionId[collectionId] || [] : [];
 
+            // Apply CMS translations to this item's values when localizing so
+            // repeater children render translated text/rich-text values. Mirrors
+            // what the server-side page fetcher does on /preview and published
+            // routes via applyCmsTranslations.
+            const baseItemValues = item.values || {};
+            const translatedItemValues = (currentLocale && !currentLocale.is_default && translations)
+              ? applyCmsTranslations(item.id, baseItemValues, collectionFields, translations, isEditMode ? { includeIncomplete: true } : undefined)
+              : baseItemValues;
+
             // Resolve reference fields to add relationship paths (e.g., "refFieldId.targetFieldId")
             const enhancedItemValues = collectionFields.length > 0
               ? resolveReferenceFieldsSync(
-                item.values || {},
+                translatedItemValues,
                 collectionFields,
                 itemsByCollectionId,
                 fieldsByCollectionId
               )
-              : (item.values || {});
+              : translatedItemValues;
 
             // Merge parent collection data with enhanced item values
             // Parent data provides access to fields from outer collection layers

--- a/hooks/use-localization-mode.ts
+++ b/hooks/use-localization-mode.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useLocalisationStore } from '@/stores/useLocalisationStore';
+import type { Locale } from '@/types';
+
+/**
+ * Returns the active locale state used to gate canvas + sidebar editing.
+ *
+ * `isLocalizing` is true when a non-default locale is selected. In that mode
+ * the canvas becomes a read-only translation view: layer styles, structure,
+ * and source content can't be edited; the right sidebar swaps to a per-layer
+ * translation editor instead.
+ */
+export interface LocalizationModeState {
+  currentLocale: Locale | null;
+  defaultLocale: Locale | null;
+  isLocalizing: boolean;
+}
+
+export function useLocalizationMode(): LocalizationModeState {
+  const selectedLocaleId = useLocalisationStore((state) => state.selectedLocaleId);
+  const locales = useLocalisationStore((state) => state.locales);
+  const defaultLocale = useLocalisationStore((state) => state.defaultLocale);
+
+  return useMemo(() => {
+    const currentLocale = selectedLocaleId
+      ? locales.find((l) => l.id === selectedLocaleId) ?? null
+      : null;
+
+    const isLocalizing = !!(currentLocale && !currentLocale.is_default);
+
+    return { currentLocale, defaultLocale, isLocalizing };
+  }, [selectedLocaleId, locales, defaultLocale]);
+}

--- a/lib/cms-variables-utils.ts
+++ b/lib/cms-variables-utils.ts
@@ -167,52 +167,6 @@ function looksLikeUuid(id: string): boolean {
 }
 
 /**
- * Determine whether a string contains any actual translatable text after
- * stripping all known inline variable markup formats. Used to detect legacy
- * translation values that consist solely of variable references (which carry
- * no real translation — the value comes from the bound field at render time).
- */
-export function hasTranslatableTextInValue(value: string): boolean {
-  if (!value) return false;
-  const stripped = value
-    // canonical inline variable tags
-    .replace(/<ycode-inline-variable\b[^>]*>[\s\S]*?<\/ycode-inline-variable>/gi, '')
-    .replace(/<ycode-inline-variable\b[^>]*\/>/gi, '')
-    // legacy span-based variable markup (any attribute order, single or double quotes)
-    .replace(/<span\b[^>]*\b(y_variable|y_dynamic_variable|data-variable)\s*=\s*["'][^"']*["'][^>]*>[\s\S]*?<\/span>/gi, '')
-    .replace(/<span\b[^>]*\b(y_variable|y_dynamic_variable|data-variable)\s*=\s*["'][^"']*["'][^>]*\/?>/gi, '')
-    // raw JSON variable objects sometimes embedded directly in the value
-    .replace(/\{"type":"[^"]+","data":\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}[^{}]*\}/g, '')
-    // residual empty wrapping spans
-    .replace(/<span\b[^>]*>\s*<\/span>/gi, '')
-    // strip any other lingering tags
-    .replace(/<[^>]+>/g, '');
-  return stripped.replace(/\s+/g, '').length > 0;
-}
-
-/**
- * Variant of {@link hasTranslatableTextInValue} that also understands Tiptap
- * JSON documents. A Tiptap doc is considered translatable when it contains at
- * least one non-empty text node (dynamicVariable nodes alone don't count).
- */
-export function hasTranslatableTextInRichValue(value: string | unknown): boolean {
-  // Try Tiptap JSON first
-  const doc = typeof value === 'object' ? value as any : (() => {
-    if (typeof value !== 'string' || !value.trim().startsWith('{')) return null;
-    try { return JSON.parse(value); } catch { return null; }
-  })();
-  if (doc?.type === 'doc' && Array.isArray(doc.content)) {
-    const walk = (nodes: any[]): boolean => nodes.some((n: any) => {
-      if (n.type === 'text' && typeof n.text === 'string' && n.text.trim().length > 0) return true;
-      if (Array.isArray(n.content)) return walk(n.content);
-      return false;
-    });
-    return walk(doc.content);
-  }
-  return typeof value === 'string' ? hasTranslatableTextInValue(value) : false;
-}
-
-/**
  * Build the canonical <ycode-inline-variable> tag from a field id and label.
  * Embeds an explicit label so the pill renders even when the field can't be looked up.
  */

--- a/lib/cms-variables-utils.ts
+++ b/lib/cms-variables-utils.ts
@@ -153,6 +153,232 @@ export function getVariableLabel(
 }
 
 /**
+ * Extract a single attribute value from a span attribute string.
+ * Supports both " and ' quoted values.
+ */
+function getAttr(attrs: string, name: string): string | null {
+  const m = attrs.match(new RegExp(`${name}=["']([^"']*)["']`));
+  return m ? m[1] : null;
+}
+
+/** Loose check for a CMS field UUID-like identifier. */
+function looksLikeUuid(id: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+}
+
+/**
+ * Determine whether a string contains any actual translatable text after
+ * stripping all known inline variable markup formats. Used to detect legacy
+ * translation values that consist solely of variable references (which carry
+ * no real translation — the value comes from the bound field at render time).
+ */
+export function hasTranslatableTextInValue(value: string): boolean {
+  if (!value) return false;
+  const stripped = value
+    // canonical inline variable tags
+    .replace(/<ycode-inline-variable\b[^>]*>[\s\S]*?<\/ycode-inline-variable>/gi, '')
+    .replace(/<ycode-inline-variable\b[^>]*\/>/gi, '')
+    // legacy span-based variable markup (any attribute order, single or double quotes)
+    .replace(/<span\b[^>]*\b(y_variable|y_dynamic_variable|data-variable)\s*=\s*["'][^"']*["'][^>]*>[\s\S]*?<\/span>/gi, '')
+    .replace(/<span\b[^>]*\b(y_variable|y_dynamic_variable|data-variable)\s*=\s*["'][^"']*["'][^>]*\/?>/gi, '')
+    // raw JSON variable objects sometimes embedded directly in the value
+    .replace(/\{"type":"[^"]+","data":\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}[^{}]*\}/g, '')
+    // residual empty wrapping spans
+    .replace(/<span\b[^>]*>\s*<\/span>/gi, '')
+    // strip any other lingering tags
+    .replace(/<[^>]+>/g, '');
+  return stripped.replace(/\s+/g, '').length > 0;
+}
+
+/**
+ * Variant of {@link hasTranslatableTextInValue} that also understands Tiptap
+ * JSON documents. A Tiptap doc is considered translatable when it contains at
+ * least one non-empty text node (dynamicVariable nodes alone don't count).
+ */
+export function hasTranslatableTextInRichValue(value: string | unknown): boolean {
+  // Try Tiptap JSON first
+  const doc = typeof value === 'object' ? value as any : (() => {
+    if (typeof value !== 'string' || !value.trim().startsWith('{')) return null;
+    try { return JSON.parse(value); } catch { return null; }
+  })();
+  if (doc?.type === 'doc' && Array.isArray(doc.content)) {
+    const walk = (nodes: any[]): boolean => nodes.some((n: any) => {
+      if (n.type === 'text' && typeof n.text === 'string' && n.text.trim().length > 0) return true;
+      if (Array.isArray(n.content)) return walk(n.content);
+      return false;
+    });
+    return walk(doc.content);
+  }
+  return typeof value === 'string' ? hasTranslatableTextInValue(value) : false;
+}
+
+/**
+ * Build the canonical <ycode-inline-variable> tag from a field id and label.
+ * Embeds an explicit label so the pill renders even when the field can't be looked up.
+ */
+function buildCanonicalVariable(fieldId: string, label: string, fieldType: string = 'text'): string {
+  const variable = {
+    type: 'field',
+    data: { field_id: fieldId, field_type: fieldType },
+    label,
+  };
+  return `<ycode-inline-variable>${JSON.stringify(variable)}</ycode-inline-variable>`;
+}
+
+/**
+ * Replace all matches of `regex` only outside of existing <ycode-inline-variable>...</ycode-inline-variable> tags.
+ * This prevents re-wrapping already-normalized content.
+ */
+function replaceOutsideCanonical(text: string, regex: RegExp, replacer: (match: string, ...groups: string[]) => string): string {
+  const canonical = /<ycode-inline-variable[^>]*>[\s\S]*?<\/ycode-inline-variable>/g;
+  const segments: { text: string; isCanonical: boolean }[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = canonical.exec(text)) !== null) {
+    if (m.index > last) segments.push({ text: text.slice(last, m.index), isCanonical: false });
+    segments.push({ text: m[0], isCanonical: true });
+    last = canonical.lastIndex;
+  }
+  if (last < text.length) segments.push({ text: text.slice(last), isCanonical: false });
+
+  return segments
+    .map((seg) => (seg.isCanonical ? seg.text : seg.text.replace(regex, replacer as any)))
+    .join('');
+}
+
+/**
+ * Normalize all known legacy inline variable formats to the canonical
+ * <ycode-inline-variable>JSON</ycode-inline-variable> format.
+ *
+ * Handles:
+ * - <span y_dynamic_variable="true" y_fieldtype="..." y_fieldname="..." y_name="...">...</span>
+ * - <span y_variable="ID" y_name="Label" ...>...</span> (any attr order)
+ * - <span y_variable="ID">...</span> (no label)
+ * - <span data-variable="JSON">label</span>
+ * - Raw JSON variable objects embedded in text: {"type":"field","data":{...}}
+ *
+ * Important: each pass operates only on text outside existing canonical tags,
+ * so already-normalized content is never re-wrapped.
+ */
+function normalizeInlineVariableFormats(text: string): string {
+  // 0. Convert self-closing <ycode-inline-variable .../> to open/close form
+  text = text.replace(
+    /<ycode-inline-variable\b([^>]*?)\/>/g,
+    '<ycode-inline-variable$1></ycode-inline-variable>'
+  );
+
+  // 1. <span ...y_dynamic_variable="true" ...>...</span>
+  text = replaceOutsideCanonical(
+    text,
+    /<span\b([^>]*\by_dynamic_variable=["']true["'][^>]*)>([\s\S]*?)<\/span>/g,
+    (_full: string, attrs: string) => {
+      const fieldId = getAttr(attrs, 'y_fieldname') || getAttr(attrs, 'y_variable') || '';
+      const fieldType = getAttr(attrs, 'y_fieldtype') || 'text';
+      const label = getAttr(attrs, 'y_name') || fieldId || 'variable';
+      return buildCanonicalVariable(fieldId, label, fieldType);
+    }
+  );
+
+  // 2. <span ...y_variable="ID" ...>...</span> (and any reordered attrs with y_name)
+  text = replaceOutsideCanonical(
+    text,
+    /<span\b([^>]*\by_variable=["']([^"']+)["'][^>]*)>([\s\S]*?)<\/span>/g,
+    (_full: string, attrs: string, fieldId: string) => {
+      const explicitLabel = getAttr(attrs, 'y_name') || getAttr(attrs, 'y_fieldname');
+      // y_variable is a layer-local short ID (not a CMS field UUID). When no explicit
+      // label is available, fall back to a generic name rather than the cryptic id.
+      const label = explicitLabel || (looksLikeUuid(fieldId) ? fieldId : 'Variable');
+      const fieldType = getAttr(attrs, 'y_fieldtype') || 'text';
+      return buildCanonicalVariable(fieldId, label, fieldType);
+    }
+  );
+
+  // 3. <span data-variable="JSON">label</span> (TipTap HTML serialization)
+  text = replaceOutsideCanonical(
+    text,
+    /<span\b[^>]*\bdata-variable=["']([^"']*)["'][^>]*>([\s\S]*?)<\/span>/g,
+    (full: string, encoded: string, label: string) => {
+      const decoded = encoded.replace(/&quot;/g, '"').replace(/&amp;/g, '&');
+      try {
+        const parsed = JSON.parse(decoded);
+        if (parsed?.type && parsed?.data) {
+          if (!parsed.label && label) parsed.label = label.trim();
+          return `<ycode-inline-variable>${JSON.stringify(parsed)}</ycode-inline-variable>`;
+        }
+      } catch { /* not valid JSON */ }
+      return full;
+    }
+  );
+
+  // 4. Raw JSON variable objects embedded in text (only outside canonical tags)
+  text = transformOutsideCanonical(text, transformRawJsonVariables);
+
+  return text;
+}
+
+/**
+ * Walk the text and convert any embedded `{"type":"...","data":{"field_id":"..."},...}`
+ * JSON object into the canonical <ycode-inline-variable> form, leaving other text intact.
+ */
+function transformRawJsonVariables(segment: string): string {
+  if (!segment.includes('{"type":"')) return segment;
+  let result = '';
+  let i = 0;
+  while (i < segment.length) {
+    if (segment[i] === '{' && segment.startsWith('{"type":"', i)) {
+      let depth = 0;
+      let consumed = false;
+      for (let j = i; j < segment.length; j++) {
+        if (segment[j] === '{') depth++;
+        else if (segment[j] === '}') {
+          depth--;
+          if (depth === 0) {
+            const jsonStr = segment.slice(i, j + 1);
+            try {
+              const parsed = JSON.parse(jsonStr);
+              if (parsed?.type && parsed?.data && (parsed.data.field_id || parsed.data.fieldId)) {
+                const fieldId = parsed.data.field_id || parsed.data.fieldId;
+                const fieldType = parsed.data.field_type || parsed.data.fieldType || 'text';
+                const label = parsed.label || fieldId || 'variable';
+                result += buildCanonicalVariable(fieldId, label, fieldType);
+                i = j + 1;
+                consumed = true;
+              }
+            } catch { /* not valid JSON */ }
+            break;
+          }
+        }
+      }
+      if (!consumed) {
+        result += segment[i];
+        i++;
+      }
+    } else {
+      result += segment[i];
+      i++;
+    }
+  }
+  return result;
+}
+
+/**
+ * Apply a transform function to each text segment outside of canonical tags.
+ */
+function transformOutsideCanonical(text: string, transform: (segment: string) => string): string {
+  const canonical = /<ycode-inline-variable[^>]*>[\s\S]*?<\/ycode-inline-variable>/g;
+  const parts: string[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = canonical.exec(text)) !== null) {
+    if (m.index > last) parts.push(transform(text.slice(last, m.index)));
+    parts.push(m[0]);
+    last = canonical.lastIndex;
+  }
+  if (last < text.length) parts.push(transform(text.slice(last)));
+  return parts.join('');
+}
+
+/**
  * Converts string with variables to Tiptap JSON content
  * Supports both ID-based format and legacy embedded JSON format
  * ID-based: <ycode-inline-variable id="uuid"></ycode-inline-variable>
@@ -170,6 +396,9 @@ export function parseValueToContent(
     content?: any[];
   }>;
 } {
+  // Normalize all known variable formats before parsing
+  text = normalizeInlineVariableFormats(text);
+
   const content: any[] = [];
   const regex = /<ycode-inline-variable(?:\s+id="([^"]+)")?>([\s\S]*?)<\/ycode-inline-variable>/g;
   let lastIndex = 0;
@@ -203,7 +432,14 @@ export function parseValueToContent(
         const parsed = JSON.parse(variableContent);
         if (parsed.type && parsed.data) {
           variable = parsed;
-          label = getVariableLabel(parsed, fields, allFields);
+          const resolvedLabel = getVariableLabel(parsed, fields, allFields);
+          // Prefer an explicit embedded label when field lookup couldn't resolve a real name
+          // (returns 'field' for unknown types or '[Deleted Field]' when field id missing)
+          if (parsed.label && (resolvedLabel === 'field' || resolvedLabel === '[Deleted Field]')) {
+            label = parsed.label;
+          } else {
+            label = resolvedLabel;
+          }
         }
       } catch {
         // Invalid JSON, skip this variable

--- a/lib/localisation-utils.ts
+++ b/lib/localisation-utils.ts
@@ -1,5 +1,7 @@
 import type { Layer, Page, Translation, Locale, LocaleOption } from '@/types';
 import { getLayerIcon, getLayerName } from '@/lib/layer-utils';
+import { tiptapDocHasFormatting, tiptapDocToCanonicalString } from '@/lib/tiptap-utils';
+import { looksLikeFormattedHtml } from '@/lib/translation-classification';
 import type { IconProps } from '@/components/ui/icon';
 
 /**
@@ -253,6 +255,7 @@ export interface TranslatableItem {
   content_key: string; // Source key (e.g., 'layer:{layerId}:text', 'seo:title', 'slug')
   content_type: 'text' | 'richtext' | 'asset_id'; // Content type (text, richtext, asset)
   content_value: string; // Current text value (may contain inline variables)
+  open_in_sheet?: boolean; // If true, editing opens in a right-side sheet panel (for block-level rich text)
   info: {
     icon: IconProps['name']; // Icon name for the item
     label: string; // Item label (e.g., "SEO Title", "Heading")
@@ -320,6 +323,80 @@ export function extractImageAltText(layer: Layer): string | null {
 }
 
 /**
+ * Decide how a layer's text content should be surfaced in the localization UI.
+ *
+ * Classification follows the *current* content, not the source layer type:
+ * - A `richText` layer whose content currently has formatting (bold, lists,
+ *   headings, etc.) gets the full sheet editor.
+ * - A `richText` layer whose content is currently flat plain text falls back
+ *   to a simple inline input — there's nothing to format anyway.
+ * - All other layers (heading, paragraph, span, etc.) are always flattened
+ *   to plain text. Their on-canvas widget doesn't expose formatting
+ *   controls, so offering them in translation would be misleading.
+ *
+ * The returned `value` always uses the canonical inline-variable string
+ * format for `text` content, and the JSON-stringified Tiptap doc for
+ * `richtext` content, so downstream rendering is unambiguous.
+ */
+function classifyLayerTextForTranslation(
+  layer: Layer
+): { contentType: 'text' | 'richtext'; value: string; openInSheet: boolean } | null {
+  const textVariable = layer.variables?.text;
+  if (!textVariable) return null;
+
+  if (textVariable.type === 'dynamic_text') {
+    const text = textVariable.data.content;
+    if (!text || typeof text !== 'string' || !text.trim()) return null;
+    if (looksLikeFormattedHtml(text)) {
+      return { contentType: 'richtext', value: text.trim(), openInSheet: true };
+    }
+    return { contentType: 'text', value: text.trim(), openInSheet: false };
+  }
+
+  if (textVariable.type === 'dynamic_rich_text') {
+    const doc = textVariable.data.content;
+    if (!doc || typeof doc !== 'object') return null;
+
+    if (tiptapDocHasFormatting(doc) || hasVariableNode(doc)) {
+      const json = JSON.stringify(doc);
+      if (!hasAnyTextOrVariable(doc)) return null;
+      return { contentType: 'richtext', value: json, openInSheet: true };
+    }
+
+    const canonical = tiptapDocToCanonicalString(doc).trim();
+    if (!canonical) return null;
+    return { contentType: 'text', value: canonical, openInSheet: false };
+  }
+
+  return null;
+}
+
+/** True if a Tiptap doc contains at least one dynamicVariable node. */
+function hasVariableNode(doc: any): boolean {
+  if (!doc?.content || !Array.isArray(doc.content)) return false;
+  const walk = (nodes: any[]): boolean => nodes.some((n: any) => {
+    if (!n || typeof n !== 'object') return false;
+    if (n.type === 'dynamicVariable') return true;
+    if (Array.isArray(n.content)) return walk(n.content);
+    return false;
+  });
+  return walk(doc.content);
+}
+
+/** True if a Tiptap doc contains at least one text or dynamicVariable node. */
+function hasAnyTextOrVariable(doc: any): boolean {
+  if (!doc?.content || !Array.isArray(doc.content)) return false;
+  const walk = (nodes: any[]): boolean => nodes.some((n: any) => {
+    if (!n || typeof n !== 'object') return false;
+    if (n.type === 'text' && typeof n.text === 'string' && n.text.length > 0) return true;
+    if (n.type === 'dynamicVariable') return true;
+    if (Array.isArray(n.content)) return walk(n.content);
+    return false;
+  });
+  return walk(doc.content);
+}
+
+/**
  * Recursively extract all translatable text items from layers
  */
 function extractLayerTranslatableItems(
@@ -332,21 +409,17 @@ function extractLayerTranslatableItems(
     // Skip locale selector label as it is dynamically generated based on locale
     if (layer.key === 'localeSelectorLabel') continue;
 
-    // Extract text from this layer (including inline variables)
-    const text = extractLayerText(layer);
+    const classification = classifyLayerTextForTranslation(layer);
 
-    if (text) {
-      // Determine content type based on the variable type
-      // If the layer uses DynamicRichTextVariable, mark it as 'richtext'
-      const contentType = layer.variables?.text?.type === 'dynamic_rich_text' ? 'richtext' : 'text';
-
+    if (classification) {
       items.push({
         key: `${sourceType}:${sourceId}:layer:${layer.id}:text`,
         source_type: sourceType,
         source_id: sourceId,
         content_key: `layer:${layer.id}:text`,
-        content_type: contentType,
-        content_value: text,
+        content_type: classification.contentType,
+        content_value: classification.value,
+        open_in_sheet: classification.openInSheet,
         info: {
           icon: getLayerIcon(layer),
           label: getLayerName(layer),
@@ -446,24 +519,8 @@ function extractLayerTranslatableItems(
       }
     }
 
-    // Icon layer - extract src asset
-    if (layer.name === 'icon' && layer.variables?.icon?.src) {
-      const iconSrc = layer.variables.icon.src;
-      if (iconSrc.type === 'asset' && iconSrc.data?.asset_id) {
-        items.push({
-          key: `${sourceType}:${sourceId}:layer:${layer.id}:icon_src`,
-          source_type: sourceType,
-          source_id: sourceId,
-          content_key: `layer:${layer.id}:icon_src`,
-          content_type: 'asset_id',
-          content_value: iconSrc.data.asset_id,
-          info: {
-            icon: 'icon',
-            label: `${getLayerName(layer)} (source)`,
-          },
-        });
-      }
-    }
+    // Icons are intentionally not exposed for translation: they are typically
+    // identical across locales and translating them adds noise to the UI.
 
     // Recursively process children
     if (layer.children && Array.isArray(layer.children) && layer.children.length > 0) {
@@ -475,6 +532,13 @@ function extractLayerTranslatableItems(
 /**
  * Extract SEO translatable items from page settings
  */
+function classifySeoValue(value: string): { contentType: 'text' | 'richtext'; openInSheet: boolean } {
+  if (looksLikeFormattedHtml(value) || value.includes('<ycode-inline-variable>')) {
+    return { contentType: 'richtext', openInSheet: true };
+  }
+  return { contentType: 'text', openInSheet: false };
+}
+
 function extractSeoItems(
   pageId: string,
   seo: { title?: string; description?: string } | undefined,
@@ -483,13 +547,15 @@ function extractSeoItems(
   if (!seo) return;
 
   if (seo.title && typeof seo.title === 'string' && seo.title.trim()) {
+    const classification = classifySeoValue(seo.title);
     items.push({
       key: `page:${pageId}:seo:title`,
       source_type: 'page',
       source_id: pageId,
       content_key: 'seo:title',
-      content_type: 'text',
+      content_type: classification.contentType,
       content_value: seo.title.trim(),
+      open_in_sheet: classification.openInSheet,
       info: {
         icon: 'search',
         label: 'SEO Title',
@@ -498,13 +564,15 @@ function extractSeoItems(
   }
 
   if (seo.description && typeof seo.description === 'string' && seo.description.trim()) {
+    const classification = classifySeoValue(seo.description);
     items.push({
       key: `page:${pageId}:seo:description`,
       source_type: 'page',
       source_id: pageId,
       content_key: 'seo:description',
-      content_type: 'text',
+      content_type: classification.contentType,
       content_value: seo.description.trim(),
+      open_in_sheet: classification.openInSheet,
       info: {
         icon: 'search',
         label: 'SEO Description',

--- a/lib/localisation-utils.ts
+++ b/lib/localisation-utils.ts
@@ -2,7 +2,7 @@ import type { Layer, Page, Translation, Locale, LocaleOption, CollectionField } 
 import { getLayerIcon, getLayerName } from '@/lib/layer-utils';
 import { createDynamicTextVariable, createDynamicRichTextVariable, createAssetVariable } from '@/lib/variable-utils';
 import { castValue } from '@/lib/collection-utils';
-import { tiptapDocHasFormatting, tiptapDocToCanonicalString } from '@/lib/tiptap-utils';
+import { tiptapDocHasFormatting, tiptapDocToCanonicalString, hasVariableNode, hasAnyTextOrVariable } from '@/lib/tiptap-utils';
 import { looksLikeFormattedHtml } from '@/lib/translation-classification';
 import type { IconProps } from '@/components/ui/icon';
 
@@ -266,45 +266,6 @@ export interface TranslatableItem {
 }
 
 /**
- * Extract text from a layer (includes text with inline variables)
- * Supports both DynamicTextVariable (plain text) and DynamicRichTextVariable (formatted text)
- */
-export function extractLayerText(layer: Layer): string | null {
-  if (!layer.variables?.text) {
-    return null;
-  }
-
-  const textVariable = layer.variables.text;
-
-  // Handle DynamicTextVariable (plain text)
-  if (textVariable.type === 'dynamic_text') {
-    const text = textVariable.data.content;
-
-    if (!text || !text.trim()) {
-      return null;
-    }
-
-    return text.trim();
-  }
-
-  // Handle DynamicRichTextVariable (Tiptap JSON with formatting)
-  if (textVariable.type === 'dynamic_rich_text') {
-    // Store Tiptap JSON as JSON string to preserve all formatting (bold, italic, custom styles, etc.)
-    const jsonContent = textVariable.data.content;
-
-    // Check if content is empty
-    if (!jsonContent || typeof jsonContent !== 'object') {
-      return null;
-    }
-
-    // Convert to JSON string for storage in translation database
-    return JSON.stringify(jsonContent);
-  }
-
-  return null;
-}
-
-/**
  * Extract alt text from an image layer
  * @param layer - Layer with image variables
  * @returns Alt text content or null if not available
@@ -373,29 +334,88 @@ function classifyLayerTextForTranslation(
   return null;
 }
 
-/** True if a Tiptap doc contains at least one dynamicVariable node. */
-function hasVariableNode(doc: any): boolean {
-  if (!doc?.content || !Array.isArray(doc.content)) return false;
-  const walk = (nodes: any[]): boolean => nodes.some((n: any) => {
-    if (!n || typeof n !== 'object') return false;
-    if (n.type === 'dynamicVariable') return true;
-    if (Array.isArray(n.content)) return walk(n.content);
-    return false;
-  });
-  return walk(doc.content);
-}
+/**
+ * Extract translatable media items (image src/alt, video src/poster, audio src)
+ * from a single layer. Shared by both the recursive and shallow extractors.
+ */
+function extractMediaTranslatableItems(
+  layer: Layer,
+  sourceType: 'page' | 'component',
+  sourceId: string,
+  items: TranslatableItem[]
+): void {
+  const layerName = getLayerName(layer);
 
-/** True if a Tiptap doc contains at least one text or dynamicVariable node. */
-function hasAnyTextOrVariable(doc: any): boolean {
-  if (!doc?.content || !Array.isArray(doc.content)) return false;
-  const walk = (nodes: any[]): boolean => nodes.some((n: any) => {
-    if (!n || typeof n !== 'object') return false;
-    if (n.type === 'text' && typeof n.text === 'string' && n.text.length > 0) return true;
-    if (n.type === 'dynamicVariable') return true;
-    if (Array.isArray(n.content)) return walk(n.content);
-    return false;
-  });
-  return walk(doc.content);
+  if (layer.name === 'image' && layer.variables?.image) {
+    const imageSrc = layer.variables.image.src;
+    if (imageSrc && imageSrc.type === 'asset' && imageSrc.data?.asset_id) {
+      items.push({
+        key: `${sourceType}:${sourceId}:layer:${layer.id}:image_src`,
+        source_type: sourceType,
+        source_id: sourceId,
+        content_key: `layer:${layer.id}:image_src`,
+        content_type: 'asset_id',
+        content_value: imageSrc.data.asset_id,
+        info: { icon: 'image', label: `${layerName} (source)` },
+      });
+    }
+
+    const imageAlt = extractImageAltText(layer);
+    if (imageAlt) {
+      items.push({
+        key: `${sourceType}:${sourceId}:layer:${layer.id}:image_alt`,
+        source_type: sourceType,
+        source_id: sourceId,
+        content_key: `layer:${layer.id}:image_alt`,
+        content_type: 'text',
+        content_value: imageAlt,
+        info: { icon: 'image', label: `${layerName} (alt text)` },
+      });
+    }
+  }
+
+  if (layer.name === 'video' && layer.variables?.video) {
+    const videoSrc = layer.variables.video.src;
+    if (videoSrc && videoSrc.type === 'asset' && videoSrc.data?.asset_id) {
+      items.push({
+        key: `${sourceType}:${sourceId}:layer:${layer.id}:video_src`,
+        source_type: sourceType,
+        source_id: sourceId,
+        content_key: `layer:${layer.id}:video_src`,
+        content_type: 'asset_id',
+        content_value: videoSrc.data.asset_id,
+        info: { icon: 'video', label: `${layerName} (source)` },
+      });
+    }
+
+    const videoPoster = layer.variables.video.poster;
+    if (videoPoster && videoPoster.type === 'asset' && videoPoster.data?.asset_id) {
+      items.push({
+        key: `${sourceType}:${sourceId}:layer:${layer.id}:video_poster`,
+        source_type: sourceType,
+        source_id: sourceId,
+        content_key: `layer:${layer.id}:video_poster`,
+        content_type: 'asset_id',
+        content_value: videoPoster.data.asset_id,
+        info: { icon: 'image', label: `${layerName} (poster)` },
+      });
+    }
+  }
+
+  if (layer.name === 'audio' && layer.variables?.audio?.src) {
+    const audioSrc = layer.variables.audio.src;
+    if (audioSrc.type === 'asset' && audioSrc.data?.asset_id) {
+      items.push({
+        key: `${sourceType}:${sourceId}:layer:${layer.id}:audio_src`,
+        source_type: sourceType,
+        source_id: sourceId,
+        content_key: `layer:${layer.id}:audio_src`,
+        content_type: 'asset_id',
+        content_value: audioSrc.data.asset_id,
+        info: { icon: 'audio', label: `${layerName} (source)` },
+      });
+    }
+  }
 }
 
 /**
@@ -408,7 +428,6 @@ function extractLayerTranslatableItems(
   items: TranslatableItem[]
 ): void {
   for (const layer of layers) {
-    // Skip locale selector label as it is dynamically generated based on locale
     if (layer.key === 'localeSelectorLabel') continue;
 
     const classification = classifyLayerTextForTranslation(layer);
@@ -429,102 +448,8 @@ function extractLayerTranslatableItems(
       });
     }
 
-    // Extract asset IDs from media layers
-    // Image layer - extract src asset and alt text
-    if (layer.name === 'image' && layer.variables?.image) {
-      // Extract image src asset
-      const imageSrc = layer.variables.image.src;
-      if (imageSrc && imageSrc.type === 'asset' && imageSrc.data?.asset_id) {
-        items.push({
-          key: `${sourceType}:${sourceId}:layer:${layer.id}:image_src`,
-          source_type: sourceType,
-          source_id: sourceId,
-          content_key: `layer:${layer.id}:image_src`,
-          content_type: 'asset_id',
-          content_value: imageSrc.data.asset_id,
-          info: {
-            icon: 'image',
-            label: `${getLayerName(layer)} (source)`,
-          },
-        });
-      }
+    extractMediaTranslatableItems(layer, sourceType, sourceId, items);
 
-      // Extract image alt text
-      const imageAlt = extractImageAltText(layer);
-      if (imageAlt) {
-        items.push({
-          key: `${sourceType}:${sourceId}:layer:${layer.id}:image_alt`,
-          source_type: sourceType,
-          source_id: sourceId,
-          content_key: `layer:${layer.id}:image_alt`,
-          content_type: 'text',
-          content_value: imageAlt,
-          info: {
-            icon: 'image',
-            label: `${getLayerName(layer)} (alt text)`,
-          },
-        });
-      }
-    }
-
-    // Video layer - extract src and poster assets
-    if (layer.name === 'video' && layer.variables?.video) {
-      const videoSrc = layer.variables.video.src;
-      if (videoSrc && videoSrc.type === 'asset' && videoSrc.data?.asset_id) {
-        items.push({
-          key: `${sourceType}:${sourceId}:layer:${layer.id}:video_src`,
-          source_type: sourceType,
-          source_id: sourceId,
-          content_key: `layer:${layer.id}:video_src`,
-          content_type: 'asset_id',
-          content_value: videoSrc.data.asset_id,
-          info: {
-            icon: 'video',
-            label: `${getLayerName(layer)} (source)`,
-          },
-        });
-      }
-
-      const videoPoster = layer.variables.video.poster;
-      if (videoPoster && videoPoster.type === 'asset' && videoPoster.data?.asset_id) {
-        items.push({
-          key: `${sourceType}:${sourceId}:layer:${layer.id}:video_poster`,
-          source_type: sourceType,
-          source_id: sourceId,
-          content_key: `layer:${layer.id}:video_poster`,
-          content_type: 'asset_id',
-          content_value: videoPoster.data.asset_id,
-          info: {
-            icon: 'image',
-            label: `${getLayerName(layer)} (poster)`,
-          },
-        });
-      }
-    }
-
-    // Audio layer - extract src asset
-    if (layer.name === 'audio' && layer.variables?.audio?.src) {
-      const audioSrc = layer.variables.audio.src;
-      if (audioSrc.type === 'asset' && audioSrc.data?.asset_id) {
-        items.push({
-          key: `${sourceType}:${sourceId}:layer:${layer.id}:audio_src`,
-          source_type: sourceType,
-          source_id: sourceId,
-          content_key: `layer:${layer.id}:audio_src`,
-          content_type: 'asset_id',
-          content_value: audioSrc.data.asset_id,
-          info: {
-            icon: 'audio',
-            label: `${getLayerName(layer)} (source)`,
-          },
-        });
-      }
-    }
-
-    // Icons are intentionally not exposed for translation: they are typically
-    // identical across locales and translating them adds noise to the UI.
-
-    // Recursively process children
     if (layer.children && Array.isArray(layer.children) && layer.children.length > 0) {
       extractLayerTranslatableItems(layer.children, sourceType, sourceId, items);
     }
@@ -712,15 +637,17 @@ export function extractCmsTranslatableItems(
       ? `field:key:${field.key}`
       : `field:id:${field.id}`;
 
+    const isRichText = field.type === 'rich_text';
     items.push({
       key: `cms:${collectionItem.id}:${contentKey}`,
       source_type: 'cms',
       source_id: collectionItem.id,
       content_key: contentKey,
-      content_type: field.type === 'rich_text' ? 'richtext' : 'text',
+      content_type: isRichText ? 'richtext' : 'text',
       content_value: contentValue,
+      open_in_sheet: isRichText,
       info: {
-        icon: field.type === 'rich_text' ? 'type' : 'text',
+        icon: isRichText ? 'type' : 'text',
         label: field.name,
         description: isSlugField ? `Affects ${localeName} URLs generated by dynamic pages using this CMS item` : undefined,
       },
@@ -1088,16 +1015,16 @@ export function extractLayerTranslatableItemsShallow(
 
   if (layer.key === 'localeSelectorLabel') return items;
 
-  const text = extractLayerText(layer);
-  if (text) {
-    const contentType = layer.variables?.text?.type === 'dynamic_rich_text' ? 'richtext' : 'text';
+  const classification = classifyLayerTextForTranslation(layer);
+  if (classification) {
     items.push({
       key: `${sourceType}:${sourceId}:layer:${layer.id}:text`,
       source_type: sourceType,
       source_id: sourceId,
       content_key: `layer:${layer.id}:text`,
-      content_type: contentType,
-      content_value: text,
+      content_type: classification.contentType,
+      content_value: classification.value,
+      open_in_sheet: classification.openInSheet,
       info: {
         icon: getLayerIcon(layer),
         label: getLayerName(layer),
@@ -1105,109 +1032,7 @@ export function extractLayerTranslatableItemsShallow(
     });
   }
 
-  if (layer.name === 'image' && layer.variables?.image) {
-    const imageSrc = layer.variables.image.src;
-    if (imageSrc && imageSrc.type === 'asset' && imageSrc.data?.asset_id) {
-      items.push({
-        key: `${sourceType}:${sourceId}:layer:${layer.id}:image_src`,
-        source_type: sourceType,
-        source_id: sourceId,
-        content_key: `layer:${layer.id}:image_src`,
-        content_type: 'asset_id',
-        content_value: imageSrc.data.asset_id,
-        info: {
-          icon: 'image',
-          label: `${getLayerName(layer)} (source)`,
-        },
-      });
-    }
-
-    const imageAlt = extractImageAltText(layer);
-    if (imageAlt) {
-      items.push({
-        key: `${sourceType}:${sourceId}:layer:${layer.id}:image_alt`,
-        source_type: sourceType,
-        source_id: sourceId,
-        content_key: `layer:${layer.id}:image_alt`,
-        content_type: 'text',
-        content_value: imageAlt,
-        info: {
-          icon: 'image',
-          label: `${getLayerName(layer)} (alt text)`,
-        },
-      });
-    }
-  }
-
-  if (layer.name === 'video' && layer.variables?.video) {
-    const videoSrc = layer.variables.video.src;
-    if (videoSrc && videoSrc.type === 'asset' && videoSrc.data?.asset_id) {
-      items.push({
-        key: `${sourceType}:${sourceId}:layer:${layer.id}:video_src`,
-        source_type: sourceType,
-        source_id: sourceId,
-        content_key: `layer:${layer.id}:video_src`,
-        content_type: 'asset_id',
-        content_value: videoSrc.data.asset_id,
-        info: {
-          icon: 'video',
-          label: `${getLayerName(layer)} (source)`,
-        },
-      });
-    }
-
-    const videoPoster = layer.variables.video.poster;
-    if (videoPoster && videoPoster.type === 'asset' && videoPoster.data?.asset_id) {
-      items.push({
-        key: `${sourceType}:${sourceId}:layer:${layer.id}:video_poster`,
-        source_type: sourceType,
-        source_id: sourceId,
-        content_key: `layer:${layer.id}:video_poster`,
-        content_type: 'asset_id',
-        content_value: videoPoster.data.asset_id,
-        info: {
-          icon: 'image',
-          label: `${getLayerName(layer)} (poster)`,
-        },
-      });
-    }
-  }
-
-  if (layer.name === 'audio' && layer.variables?.audio?.src) {
-    const audioSrc = layer.variables.audio.src;
-    if (audioSrc.type === 'asset' && audioSrc.data?.asset_id) {
-      items.push({
-        key: `${sourceType}:${sourceId}:layer:${layer.id}:audio_src`,
-        source_type: sourceType,
-        source_id: sourceId,
-        content_key: `layer:${layer.id}:audio_src`,
-        content_type: 'asset_id',
-        content_value: audioSrc.data.asset_id,
-        info: {
-          icon: 'audio',
-          label: `${getLayerName(layer)} (source)`,
-        },
-      });
-    }
-  }
-
-  if (layer.name === 'icon' && layer.variables?.icon?.src) {
-    const iconSrc = layer.variables.icon.src;
-    if (iconSrc.type === 'asset' && iconSrc.data?.asset_id) {
-      items.push({
-        key: `${sourceType}:${sourceId}:layer:${layer.id}:icon_src`,
-        source_type: sourceType,
-        source_id: sourceId,
-        content_key: `layer:${layer.id}:icon_src`,
-        content_type: 'asset_id',
-        content_value: iconSrc.data.asset_id,
-        info: {
-          icon: 'icon',
-          label: `${getLayerName(layer)} (source)`,
-        },
-      });
-    }
-  }
+  extractMediaTranslatableItems(layer, sourceType, sourceId, items);
 
   return items;
 }

--- a/lib/localisation-utils.ts
+++ b/lib/localisation-utils.ts
@@ -1,5 +1,7 @@
-import type { Layer, Page, Translation, Locale, LocaleOption } from '@/types';
+import type { Layer, Page, Translation, Locale, LocaleOption, CollectionField } from '@/types';
 import { getLayerIcon, getLayerName } from '@/lib/layer-utils';
+import { createDynamicTextVariable, createDynamicRichTextVariable, createAssetVariable } from '@/lib/variable-utils';
+import { castValue } from '@/lib/collection-utils';
 import type { IconProps } from '@/components/ui/icon';
 
 /**
@@ -728,11 +730,24 @@ export function hasValidTranslationValue(translation: Translation | undefined): 
 /**
  * Get translation value if valid, otherwise return undefined
  * @param translation - Translation object or undefined
+ * @param options - { includeIncomplete } when true, skip the `is_completed` gate
+ *   so any non-empty saved value is returned. Used by the builder canvas where
+ *   the editor wants to see whatever they have saved; production rendering
+ *   (page-fetcher / published site) keeps the default behaviour and only
+ *   surfaces completed translations.
  * @returns Content value if valid, undefined otherwise
  */
-export function getTranslationValue(translation: Translation | undefined): string | undefined {
+export function getTranslationValue(
+  translation: Translation | undefined,
+  options?: { includeIncomplete?: boolean }
+): string | undefined {
+  if (!translation) return undefined;
+  if (options?.includeIncomplete) {
+    const value = translation.content_value;
+    return value && value.trim() !== '' ? value : undefined;
+  }
   if (hasValidTranslationValue(translation)) {
-    return translation!.content_value;
+    return translation.content_value;
   }
   return undefined;
 }
@@ -818,4 +833,313 @@ export function getTranslatedText(
   }
 
   return originalText;
+}
+
+/**
+ * Inject translated text and assets into layers recursively.
+ * Replaces layer text content and asset sources with translations when available.
+ * Handles both page-level and component-level translations via _masterComponentId.
+ *
+ * Shared between the server-side page fetcher (preview / published) and the
+ * builder canvas so both paths produce identical output.
+ */
+export function injectTranslatedText(
+  layers: Layer[],
+  pageId: string,
+  translations: Record<string, Translation>,
+  options?: { includeIncomplete?: boolean }
+): Layer[] {
+  const valueOptions = options?.includeIncomplete ? { includeIncomplete: true } : undefined;
+  return layers.map(layer => {
+    const updates: Partial<Layer> = {};
+    const variableUpdates: Partial<Layer['variables']> = {};
+
+    // Use original layer ID for translation lookups — after resolveComponents,
+    // child layer IDs are transformed to instance-specific IDs (e.g., "instanceId-childId")
+    // but translations are stored with the original component layer IDs.
+    const translationLayerId = (layer as any)._originalLayerId || layer.id;
+    const masterComponentId = (layer as any)._masterComponentId as string | undefined;
+
+    // 1. Inject text translation
+    const textTranslationKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:text`, masterComponentId);
+    const textTranslation = getTranslationByKey(translations, textTranslationKey);
+
+    const textValue = getTranslationValue(textTranslation, valueOptions);
+    if (textValue) {
+      // Preserve the original variable type (dynamic_text or dynamic_rich_text)
+      if (layer.variables?.text?.type === 'dynamic_rich_text') {
+        (variableUpdates as any).text = createDynamicRichTextVariable(textValue);
+      } else {
+        (variableUpdates as any).text = createDynamicTextVariable(textValue);
+      }
+    }
+
+    // 2. Inject asset translations for media layers
+    if (layer.name === 'image') {
+      const imageSrcKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:image_src`, masterComponentId);
+      const imageSrcTranslation = getTranslationByKey(translations, imageSrcKey);
+      const imageAltKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:image_alt`, masterComponentId);
+      const imageAltTranslation = getTranslationByKey(translations, imageAltKey);
+
+      if (imageSrcTranslation || imageAltTranslation) {
+        const imageUpdates: any = { ...(layer.variables?.image as any) };
+
+        if (imageSrcTranslation && imageSrcTranslation.content_value) {
+          imageUpdates.src = createAssetVariable(imageSrcTranslation.content_value);
+        }
+
+        const imageAltValue = getTranslationValue(imageAltTranslation, valueOptions);
+        if (imageAltValue) {
+          imageUpdates.alt = createDynamicTextVariable(imageAltValue);
+        } else {
+          // Preserve original alt if no translation
+          imageUpdates.alt = layer.variables?.image?.alt || createDynamicTextVariable('');
+        }
+
+        (variableUpdates as any).image = imageUpdates;
+      }
+    }
+
+    if (layer.name === 'video') {
+      const videoSrcKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:video_src`, masterComponentId);
+      const videoSrcTranslation = getTranslationByKey(translations, videoSrcKey);
+      const videoPosterKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:video_poster`, masterComponentId);
+      const videoPosterTranslation = getTranslationByKey(translations, videoPosterKey);
+
+      if (videoSrcTranslation || videoPosterTranslation) {
+        const videoUpdates: any = { ...(layer.variables?.video as any) };
+
+        if (videoSrcTranslation && videoSrcTranslation.content_value) {
+          videoUpdates.src = createAssetVariable(videoSrcTranslation.content_value);
+        }
+
+        if (videoPosterTranslation && videoPosterTranslation.content_value) {
+          videoUpdates.poster = createAssetVariable(videoPosterTranslation.content_value);
+        }
+
+        (variableUpdates as any).video = videoUpdates;
+      }
+    }
+
+    if (layer.name === 'audio') {
+      const audioSrcKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:audio_src`, masterComponentId);
+      const audioSrcTranslation = getTranslationByKey(translations, audioSrcKey);
+
+      if (audioSrcTranslation && audioSrcTranslation.content_value) {
+        (variableUpdates as any).audio = {
+          src: createAssetVariable(audioSrcTranslation.content_value),
+        };
+      }
+    }
+
+    if (layer.name === 'icon') {
+      const iconSrcKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:icon_src`, masterComponentId);
+      const iconSrcTranslation = getTranslationByKey(translations, iconSrcKey);
+
+      if (iconSrcTranslation && iconSrcTranslation.content_value) {
+        (variableUpdates as any).icon = {
+          src: createAssetVariable(iconSrcTranslation.content_value),
+        };
+      }
+    }
+
+    if (Object.keys(variableUpdates).length > 0) {
+      updates.variables = {
+        ...layer.variables,
+        ...variableUpdates,
+      } as Layer['variables'];
+    }
+
+    if (layer.children && layer.children.length > 0) {
+      updates.children = injectTranslatedText(layer.children, pageId, translations, options);
+    }
+
+    return {
+      ...layer,
+      ...updates,
+    };
+  });
+}
+
+/**
+ * Apply CMS translations to a collection item's values map (field_id -> value).
+ * Returns a new map with translated values where available; rich-text strings are
+ * cast back into Tiptap document objects via castValue so they match the shape
+ * downstream renderers expect.
+ */
+export function applyCmsTranslations(
+  itemId: string,
+  itemValues: Record<string, any>,
+  collectionFields: CollectionField[],
+  translations?: Record<string, Translation> | null,
+  options?: { includeIncomplete?: boolean }
+): Record<string, any> {
+  if (!translations || Object.keys(translations).length === 0) {
+    return itemValues;
+  }
+
+  const valueOptions = options?.includeIncomplete ? { includeIncomplete: true } : undefined;
+  const translatedValues: Record<string, any> = { ...itemValues };
+
+  const fieldIdToKey = new Map<string, string | null>();
+  const fieldIdToType = new Map<string, string>();
+  for (const field of collectionFields) {
+    fieldIdToKey.set(field.id, field.key);
+    fieldIdToType.set(field.id, field.type);
+  }
+
+  for (const fieldId of Object.keys(itemValues)) {
+    const fieldKey = fieldIdToKey.get(fieldId);
+
+    const contentKey = fieldKey ? `field:key:${fieldKey}` : `field:id:${fieldId}`;
+    const translationKey = `cms:${itemId}:${contentKey}`;
+    const translation = translations[translationKey];
+
+    const translatedValue = getTranslationValue(translation, valueOptions);
+    if (translatedValue) {
+      const fieldType = fieldIdToType.get(fieldId);
+      translatedValues[fieldId] = fieldType
+        ? castValue(translatedValue, fieldType as any)
+        : translatedValue;
+    }
+  }
+
+  return translatedValues;
+}
+
+/**
+ * Extract the translatable items for a single layer (without recursing into children).
+ * Used by the right sidebar to build the per-layer translation editor.
+ */
+export function extractLayerTranslatableItemsShallow(
+  layer: Layer,
+  sourceType: 'page' | 'component',
+  sourceId: string
+): TranslatableItem[] {
+  const items: TranslatableItem[] = [];
+
+  if (layer.key === 'localeSelectorLabel') return items;
+
+  const text = extractLayerText(layer);
+  if (text) {
+    const contentType = layer.variables?.text?.type === 'dynamic_rich_text' ? 'richtext' : 'text';
+    items.push({
+      key: `${sourceType}:${sourceId}:layer:${layer.id}:text`,
+      source_type: sourceType,
+      source_id: sourceId,
+      content_key: `layer:${layer.id}:text`,
+      content_type: contentType,
+      content_value: text,
+      info: {
+        icon: getLayerIcon(layer),
+        label: getLayerName(layer),
+      },
+    });
+  }
+
+  if (layer.name === 'image' && layer.variables?.image) {
+    const imageSrc = layer.variables.image.src;
+    if (imageSrc && imageSrc.type === 'asset' && imageSrc.data?.asset_id) {
+      items.push({
+        key: `${sourceType}:${sourceId}:layer:${layer.id}:image_src`,
+        source_type: sourceType,
+        source_id: sourceId,
+        content_key: `layer:${layer.id}:image_src`,
+        content_type: 'asset_id',
+        content_value: imageSrc.data.asset_id,
+        info: {
+          icon: 'image',
+          label: `${getLayerName(layer)} (source)`,
+        },
+      });
+    }
+
+    const imageAlt = extractImageAltText(layer);
+    if (imageAlt) {
+      items.push({
+        key: `${sourceType}:${sourceId}:layer:${layer.id}:image_alt`,
+        source_type: sourceType,
+        source_id: sourceId,
+        content_key: `layer:${layer.id}:image_alt`,
+        content_type: 'text',
+        content_value: imageAlt,
+        info: {
+          icon: 'image',
+          label: `${getLayerName(layer)} (alt text)`,
+        },
+      });
+    }
+  }
+
+  if (layer.name === 'video' && layer.variables?.video) {
+    const videoSrc = layer.variables.video.src;
+    if (videoSrc && videoSrc.type === 'asset' && videoSrc.data?.asset_id) {
+      items.push({
+        key: `${sourceType}:${sourceId}:layer:${layer.id}:video_src`,
+        source_type: sourceType,
+        source_id: sourceId,
+        content_key: `layer:${layer.id}:video_src`,
+        content_type: 'asset_id',
+        content_value: videoSrc.data.asset_id,
+        info: {
+          icon: 'video',
+          label: `${getLayerName(layer)} (source)`,
+        },
+      });
+    }
+
+    const videoPoster = layer.variables.video.poster;
+    if (videoPoster && videoPoster.type === 'asset' && videoPoster.data?.asset_id) {
+      items.push({
+        key: `${sourceType}:${sourceId}:layer:${layer.id}:video_poster`,
+        source_type: sourceType,
+        source_id: sourceId,
+        content_key: `layer:${layer.id}:video_poster`,
+        content_type: 'asset_id',
+        content_value: videoPoster.data.asset_id,
+        info: {
+          icon: 'image',
+          label: `${getLayerName(layer)} (poster)`,
+        },
+      });
+    }
+  }
+
+  if (layer.name === 'audio' && layer.variables?.audio?.src) {
+    const audioSrc = layer.variables.audio.src;
+    if (audioSrc.type === 'asset' && audioSrc.data?.asset_id) {
+      items.push({
+        key: `${sourceType}:${sourceId}:layer:${layer.id}:audio_src`,
+        source_type: sourceType,
+        source_id: sourceId,
+        content_key: `layer:${layer.id}:audio_src`,
+        content_type: 'asset_id',
+        content_value: audioSrc.data.asset_id,
+        info: {
+          icon: 'audio',
+          label: `${getLayerName(layer)} (source)`,
+        },
+      });
+    }
+  }
+
+  if (layer.name === 'icon' && layer.variables?.icon?.src) {
+    const iconSrc = layer.variables.icon.src;
+    if (iconSrc.type === 'asset' && iconSrc.data?.asset_id) {
+      items.push({
+        key: `${sourceType}:${sourceId}:layer:${layer.id}:icon_src`,
+        source_type: sourceType,
+        source_id: sourceId,
+        content_key: `layer:${layer.id}:icon_src`,
+        content_type: 'asset_id',
+        content_value: iconSrc.data.asset_id,
+        info: {
+          icon: 'icon',
+          label: `${getLayerName(layer)} (source)`,
+        },
+      });
+    }
+  }
+
+  return items;
 }

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -29,7 +29,7 @@ import { getLinkSettingsFromMark } from '@/lib/tiptap-extensions/rich-text-link'
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/templates/utilities';
 import { resolveInlineVariables, resolveInlineVariablesFromData } from '@/lib/inline-variables';
 import { formatFieldValue } from '@/lib/cms-variables-utils';
-import { buildLayerTranslationKey, getTranslationByKey, hasValidTranslationValue, getTranslationValue } from '@/lib/localisation-utils';
+import { buildLayerTranslationKey, getTranslationByKey, hasValidTranslationValue, getTranslationValue, injectTranslatedText, applyCmsTranslations } from '@/lib/localisation-utils';
 import { formatDateFieldsInItemValues } from '@/lib/date-format-utils';
 import { getSettingByKey } from '@/lib/repositories/settingsRepository';
 import { parseMultiAssetFieldValue, buildAssetVirtualValues } from '@/lib/multi-asset-utils';
@@ -405,7 +405,7 @@ async function fetchPageByPathInternal(
         // Apply translations for the detected locale
         let processedLayers = homepageData.pageLayers.layers || [];
         if (translations && Object.keys(translations).length > 0) {
-          processedLayers = injectTranslatedText(processedLayers, homepageData.page.id, translations);
+          processedLayers = injectTranslatedText(processedLayers, homepageData.page.id, translations, { includeIncomplete: !isPublished });
         }
 
         // Resolve all AssetVariables to URLs server-side (prevents client-side API calls)
@@ -501,7 +501,7 @@ async function fetchPageByPathInternal(
                 collectionFields,
                 isPublished
               );
-              enhancedItemValues = applyCmsTranslations(collectionItem.id, enhancedItemValues, collectionFields, translations);
+              enhancedItemValues = applyCmsTranslations(collectionItem.id, enhancedItemValues, collectionFields, translations, { includeIncomplete: !isPublished });
               enhancedItemValues = formatDateFieldsInItemValues(enhancedItemValues, collectionFields, timezone);
 
               const enhancedCollectionItem = {
@@ -546,7 +546,7 @@ async function fetchPageByPathInternal(
             );
 
             // Apply CMS translations to the item values
-            enhancedItemValues = applyCmsTranslations(collectionItem.id, enhancedItemValues, collectionFields, translations);
+            enhancedItemValues = applyCmsTranslations(collectionItem.id, enhancedItemValues, collectionFields, translations, { includeIncomplete: !isPublished });
 
             const rawItemValues = { ...enhancedItemValues };
             enhancedItemValues = formatDateFieldsInItemValues(enhancedItemValues, collectionFields, timezone);
@@ -581,7 +581,7 @@ async function fetchPageByPathInternal(
 
             // Apply translations (components already resolved above)
             if (detectedLocale && translations && Object.keys(translations).length > 0) {
-              resolvedLayers = injectTranslatedText(resolvedLayers, matchingPage.id, translations);
+              resolvedLayers = injectTranslatedText(resolvedLayers, matchingPage.id, translations, { includeIncomplete: !isPublished });
             }
 
             // Resolve all AssetVariables to URLs server-side (prevents client-side API calls)
@@ -684,7 +684,7 @@ async function fetchPageByPathInternal(
 
     // Apply translations (components already resolved above)
     if (detectedLocale && translations && Object.keys(translations).length > 0) {
-      resolvedLayers = injectTranslatedText(resolvedLayers, matchingPage.id, translations);
+      resolvedLayers = injectTranslatedText(resolvedLayers, matchingPage.id, translations, { includeIncomplete: !isPublished });
     }
 
     const resolved = await resolveAllAssets(resolvedLayers, isPublished, components);
@@ -898,136 +898,6 @@ export const fetchHomepage = cache(async function fetchHomepage(
 });
 
 /**
- * Inject translated text and assets into layers recursively
- * Replaces layer text content and asset sources with translations when available
- * Handles both page-level and component-level translations
- * @param layers - Layer tree to translate
- * @param pageId - Page ID for building translation keys
- * @param translations - Translations map
- * @returns Layers with translated text and assets
- */
-function injectTranslatedText(
-  layers: Layer[],
-  pageId: string,
-  translations: Record<string, Translation>
-): Layer[] {
-  return layers.map(layer => {
-    const updates: Partial<Layer> = {};
-    const variableUpdates: Partial<Layer['variables']> = {};
-
-    // Use original layer ID for translation lookups — after resolveComponents,
-    // child layer IDs are transformed to instance-specific IDs (e.g., "instanceId-childId")
-    // but translations are stored with the original component layer IDs
-    const translationLayerId = layer._originalLayerId || layer.id;
-
-    // 1. Inject text translation
-    const textTranslationKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:text`, layer._masterComponentId);
-    const textTranslation = getTranslationByKey(translations, textTranslationKey);
-
-    const textValue = getTranslationValue(textTranslation);
-    if (textValue) {
-      // Preserve the original variable type (dynamic_text or dynamic_rich_text)
-      if (layer.variables?.text?.type === 'dynamic_rich_text') {
-        variableUpdates.text = createDynamicRichTextVariable(textValue);
-      } else {
-        variableUpdates.text = createDynamicTextVariable(textValue);
-      }
-    }
-
-    // 2. Inject asset translations for media layers
-    // Image layer - translate src and alt text
-    if (layer.name === 'image') {
-      const imageSrcKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:image_src`, layer._masterComponentId);
-      const imageSrcTranslation = getTranslationByKey(translations, imageSrcKey);
-      const imageAltKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:image_alt`, layer._masterComponentId);
-      const imageAltTranslation = getTranslationByKey(translations, imageAltKey);
-
-      if (imageSrcTranslation || imageAltTranslation) {
-        const imageUpdates: any = { ...layer.variables?.image };
-
-        if (imageSrcTranslation && imageSrcTranslation.content_value) {
-          imageUpdates.src = createAssetVariable(imageSrcTranslation.content_value);
-        }
-
-        const imageAltValue = getTranslationValue(imageAltTranslation);
-        if (imageAltValue) {
-          imageUpdates.alt = createDynamicTextVariable(imageAltValue);
-        } else {
-          // Preserve original alt if no translation
-          imageUpdates.alt = layer.variables?.image?.alt || createDynamicTextVariable('');
-        }
-
-        variableUpdates.image = imageUpdates;
-      }
-    }
-
-    // Video layer - translate src and poster
-    if (layer.name === 'video') {
-      const videoSrcKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:video_src`, layer._masterComponentId);
-      const videoSrcTranslation = getTranslationByKey(translations, videoSrcKey);
-      const videoPosterKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:video_poster`, layer._masterComponentId);
-      const videoPosterTranslation = getTranslationByKey(translations, videoPosterKey);
-
-      if (videoSrcTranslation || videoPosterTranslation) {
-        const videoUpdates: any = { ...layer.variables?.video };
-
-        if (videoSrcTranslation && videoSrcTranslation.content_value) {
-          videoUpdates.src = createAssetVariable(videoSrcTranslation.content_value);
-        }
-
-        if (videoPosterTranslation && videoPosterTranslation.content_value) {
-          videoUpdates.poster = createAssetVariable(videoPosterTranslation.content_value);
-        }
-
-        variableUpdates.video = videoUpdates;
-      }
-    }
-
-    // Audio layer - translate src
-    if (layer.name === 'audio') {
-      const audioSrcKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:audio_src`, layer._masterComponentId);
-      const audioSrcTranslation = getTranslationByKey(translations, audioSrcKey);
-
-      if (audioSrcTranslation && audioSrcTranslation.content_value) {
-        variableUpdates.audio = {
-          src: createAssetVariable(audioSrcTranslation.content_value),
-        };
-      }
-    }
-
-    // Icon layer - translate src
-    if (layer.name === 'icon') {
-      const iconSrcKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:icon_src`, layer._masterComponentId);
-      const iconSrcTranslation = getTranslationByKey(translations, iconSrcKey);
-
-      if (iconSrcTranslation && iconSrcTranslation.content_value) {
-        variableUpdates.icon = {
-          src: createAssetVariable(iconSrcTranslation.content_value),
-        };
-      }
-    }
-
-    // Apply variable updates if any
-    if (Object.keys(variableUpdates).length > 0) {
-      updates.variables = {
-        ...layer.variables,
-        ...variableUpdates,
-      };
-    }
-
-    // Recursively process children
-    if (layer.children && layer.children.length > 0) {
-      updates.children = injectTranslatedText(layer.children, pageId, translations);
-    }
-
-    return {
-      ...layer,
-      ...updates,
-    };
-  });
-}
-
-/**
  * Fetch all components from the database
  * @param supabase - Supabase client
  * @param isPublished - Whether to fetch published or draft components (defaults to false for draft)
@@ -1040,57 +910,6 @@ async function fetchComponents(supabase: any, isPublished: boolean = false): Pro
     .eq('is_published', isPublished)
     .is('deleted_at', null);
   return components || [];
-}
-
-/**
- * Apply CMS translations to collection item values
- * @param itemId - Collection item ID
- * @param itemValues - Original item values (field_id -> value)
- * @param collectionFields - Collection fields to determine field keys
- * @param translations - Translations map
- * @returns Item values with translations applied
- */
-function applyCmsTranslations(
-  itemId: string,
-  itemValues: Record<string, string>,
-  collectionFields: CollectionField[],
-  translations?: Record<string, Translation>
-): Record<string, string> {
-  if (!translations || Object.keys(translations).length === 0) {
-    return itemValues;
-  }
-
-  const translatedValues = { ...itemValues };
-
-  // Create maps for field key and field type lookup
-  const fieldIdToKey = new Map<string, string | null>();
-  const fieldIdToType = new Map<string, string>();
-  for (const field of collectionFields) {
-    fieldIdToKey.set(field.id, field.key);
-    fieldIdToType.set(field.id, field.type);
-  }
-
-  // Apply translations for each field
-  for (const fieldId of Object.keys(itemValues)) {
-    const fieldKey = fieldIdToKey.get(fieldId);
-
-    // Build translation key: field:key:{key} or field:id:{id} when key is null
-    const contentKey = fieldKey ? `field:key:${fieldKey}` : `field:id:${fieldId}`;
-    const translationKey = `cms:${itemId}:${contentKey}`;
-    const translation = translations[translationKey];
-
-    const translatedValue = getTranslationValue(translation);
-    if (translatedValue) {
-      // Cast the translated string using the field type so rich_text values
-      // are parsed back into Tiptap document objects (matching castValue behavior)
-      const fieldType = fieldIdToType.get(fieldId);
-      translatedValues[fieldId] = fieldType
-        ? castValue(translatedValue, fieldType as any)
-        : translatedValue;
-    }
-  }
-
-  return translatedValues;
 }
 
 /**
@@ -2522,7 +2341,7 @@ export async function resolveCollectionLayers(
 
           // Pre-process all items: translations + date formatting (pure computation)
           const preprocessed = sortedItems.map(item => {
-            let translatedValues = applyCmsTranslations(item.id, item.values, collectionFields, translations);
+            let translatedValues = applyCmsTranslations(item.id, item.values, collectionFields, translations, { includeIncomplete: !isPublished });
             const rawTranslatedValues = { ...translatedValues };
             translatedValues = formatDateFieldsInItemValues(translatedValues, collectionFields, timezone);
             return { item, translatedValues, rawTranslatedValues };

--- a/lib/tiptap-utils.ts
+++ b/lib/tiptap-utils.ts
@@ -256,6 +256,94 @@ export function getRichTextValue(variables?: { text?: { type: string; data: { co
 }
 
 /**
+ * Detect whether a Tiptap document carries any actual rich-text formatting.
+ * "Formatting" includes block-level structure beyond a single paragraph
+ * (headings, lists, blockquotes, code blocks, horizontal rules, images,
+ * tables, embedded components) as well as inline marks (bold, italic,
+ * underline, links, etc.) and hard breaks.
+ *
+ * Used at extraction time to decide whether translatable content should be
+ * surfaced as a rich-text sheet editor or a simple text input — the editor
+ * follows the *current* content, not the source layer's original variable type.
+ */
+export function tiptapDocHasFormatting(doc: any): boolean {
+  if (!doc || typeof doc !== 'object' || !Array.isArray(doc.content)) return false;
+
+  const blocks = doc.content;
+  // Multiple block-level nodes implies structure (paragraph break)
+  if (blocks.length > 1) return true;
+
+  const PLAIN_INLINE_MARK_TYPES: ReadonlySet<string> = new Set();
+  // Any mark counts as formatting; we don't whitelist any.
+
+  const NON_PLAIN_BLOCK_TYPES: ReadonlySet<string> = new Set([
+    'heading',
+    'bulletList',
+    'orderedList',
+    'listItem',
+    'blockquote',
+    'codeBlock',
+    'horizontalRule',
+    'image',
+    'table',
+    'tableRow',
+    'tableCell',
+    'tableHeader',
+    'iframe',
+    'youtube',
+    'richTextComponent',
+  ]);
+
+  const walk = (nodes: any[]): boolean => nodes.some((n: any) => {
+    if (!n || typeof n !== 'object') return false;
+    if (n.type && NON_PLAIN_BLOCK_TYPES.has(n.type)) return true;
+    if (n.type === 'hardBreak') return true;
+    if (n.type === 'text' && Array.isArray(n.marks) && n.marks.length > 0) {
+      // Any mark on a text node is formatting (bold, italic, link, etc.)
+      void PLAIN_INLINE_MARK_TYPES;
+      return true;
+    }
+    if (Array.isArray(n.content) && n.content.length > 0) return walk(n.content);
+    return false;
+  });
+
+  return walk(blocks);
+}
+
+/**
+ * Serialize a Tiptap document to a plain-text string with canonical inline
+ * variable tags preserved. Block-level nodes are joined by newlines so that
+ * paragraph structure round-trips through the simple text input.
+ *
+ * This is the inverse of {@link parseValueToContent} for the subset of content
+ * we accept in plain-text translation fields: text, hardBreak, and
+ * dynamicVariable nodes. Any inline marks are dropped (the surrounding caller
+ * has already decided that this content is plain).
+ */
+export function tiptapDocToCanonicalString(doc: any): string {
+  if (!doc?.content || !Array.isArray(doc.content)) return '';
+
+  const serializeNode = (node: any): string => {
+    if (!node || typeof node !== 'object') return '';
+    if (node.type === 'text') return typeof node.text === 'string' ? node.text : '';
+    if (node.type === 'hardBreak') return '\n';
+    if (node.type === 'dynamicVariable') {
+      const variable = node.attrs?.variable;
+      if (!variable) return '';
+      return `<ycode-inline-variable>${JSON.stringify(variable)}</ycode-inline-variable>`;
+    }
+    if (Array.isArray(node.content)) return node.content.map(serializeNode).join('');
+    return '';
+  };
+
+  return doc.content
+    .map(serializeNode)
+    .map((s: string) => s.replace(/[ \t]+/g, ' '))
+    .filter((s: string) => s.length > 0)
+    .join('\n');
+}
+
+/**
  * Extract plain text from Tiptap JSON content
  * Useful for previews, search indexing, or fallback display
  */

--- a/lib/tiptap-utils.ts
+++ b/lib/tiptap-utils.ts
@@ -225,6 +225,31 @@ export function getSoleCmsFieldBinding(content: any): ReturnType<typeof getCmsFi
   return getCmsFieldBinding(nodes[0]);
 }
 
+/** True if a Tiptap doc contains at least one dynamicVariable node. */
+export function hasVariableNode(doc: any): boolean {
+  if (!doc?.content || !Array.isArray(doc.content)) return false;
+  const walk = (nodes: any[]): boolean => nodes.some((n: any) => {
+    if (!n || typeof n !== 'object') return false;
+    if (n.type === 'dynamicVariable') return true;
+    if (Array.isArray(n.content)) return walk(n.content);
+    return false;
+  });
+  return walk(doc.content);
+}
+
+/** True if a Tiptap doc contains at least one text or dynamicVariable node. */
+export function hasAnyTextOrVariable(doc: any): boolean {
+  if (!doc?.content || !Array.isArray(doc.content)) return false;
+  const walk = (nodes: any[]): boolean => nodes.some((n: any) => {
+    if (!n || typeof n !== 'object') return false;
+    if (n.type === 'text' && typeof n.text === 'string' && n.text.length > 0) return true;
+    if (n.type === 'dynamicVariable') return true;
+    if (Array.isArray(n.content)) return walk(n.content);
+    return false;
+  });
+  return walk(doc.content);
+}
+
 /** Check if Tiptap JSON content contains components or inline variables (non-editable on canvas). */
 export function hasComponentOrVariable(node: any): boolean {
   if (!node || typeof node !== 'object') return false;
@@ -273,9 +298,6 @@ export function tiptapDocHasFormatting(doc: any): boolean {
   // Multiple block-level nodes implies structure (paragraph break)
   if (blocks.length > 1) return true;
 
-  const PLAIN_INLINE_MARK_TYPES: ReadonlySet<string> = new Set();
-  // Any mark counts as formatting; we don't whitelist any.
-
   const NON_PLAIN_BLOCK_TYPES: ReadonlySet<string> = new Set([
     'heading',
     'bulletList',
@@ -299,8 +321,6 @@ export function tiptapDocHasFormatting(doc: any): boolean {
     if (n.type && NON_PLAIN_BLOCK_TYPES.has(n.type)) return true;
     if (n.type === 'hardBreak') return true;
     if (n.type === 'text' && Array.isArray(n.marks) && n.marks.length > 0) {
-      // Any mark on a text node is formatting (bold, italic, link, etc.)
-      void PLAIN_INLINE_MARK_TYPES;
       return true;
     }
     if (Array.isArray(n.content) && n.content.length > 0) return walk(n.content);

--- a/lib/tiptap-utils.ts
+++ b/lib/tiptap-utils.ts
@@ -291,3 +291,89 @@ export function extractPlainTextFromTiptap(content: any): string {
 
   return result.trim();
 }
+
+/**
+ * Extract plain text from Tiptap JSON, preserving block-level boundaries as
+ * newlines. Useful for multi-line previews (e.g. read-only translation
+ * textareas) where collapsing paragraphs/headings into a single line would
+ * misrepresent the structure of the original content.
+ *
+ * Inline marks (bold, italic, links) are dropped — only the textual content
+ * and dynamic-variable labels survive.
+ */
+export function extractMultilinePlainTextFromTiptap(content: any): string {
+  if (!content || typeof content !== 'object') return '';
+
+  // Block-level nodes that should each occupy their own line in the preview.
+  const BLOCK_TYPES = new Set([
+    'paragraph',
+    'heading',
+    'blockquote',
+    'codeBlock',
+    'listItem',
+    'horizontalRule',
+    'richTextHtmlEmbed',
+    'richTextImage',
+    'richTextComponent',
+  ]);
+
+  const lines: string[] = [];
+
+  const collectInline = (node: any, into: { text: string }): void => {
+    if (!node) return;
+    if (node.type === 'text' && node.text) {
+      into.text += node.text;
+      return;
+    }
+    if (node.type === 'dynamicVariable' && node.attrs?.label) {
+      into.text += `[${node.attrs.label}]`;
+      return;
+    }
+    if (node.type === 'hardBreak') {
+      into.text += '\n';
+      return;
+    }
+    if (Array.isArray(node.content)) {
+      node.content.forEach((child: any) => collectInline(child, into));
+    }
+  };
+
+  const visit = (node: any): void => {
+    if (!node) return;
+    if (node.type === 'horizontalRule') {
+      lines.push('');
+      return;
+    }
+    if (BLOCK_TYPES.has(node.type)) {
+      const acc = { text: '' };
+      if (Array.isArray(node.content)) {
+        node.content.forEach((child: any) => {
+          // Nested block nodes (e.g. a paragraph inside a listItem) get their
+          // own line so list bullets / quotes still read naturally.
+          if (BLOCK_TYPES.has(child?.type)) {
+            visit(child);
+          } else {
+            collectInline(child, acc);
+          }
+        });
+      }
+      if (acc.text) {
+        lines.push(acc.text);
+      }
+      return;
+    }
+    if (Array.isArray(node.content)) {
+      node.content.forEach(visit);
+    }
+  };
+
+  if (content.type === 'doc' && Array.isArray(content.content)) {
+    content.content.forEach(visit);
+  } else if (Array.isArray(content)) {
+    content.forEach(visit);
+  } else {
+    visit(content);
+  }
+
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+}

--- a/lib/translation-classification.ts
+++ b/lib/translation-classification.ts
@@ -1,0 +1,32 @@
+/**
+ * Translation Content Classification
+ *
+ * Single source of truth for deciding whether a value carries rich-text
+ * formatting (and therefore must be rendered with the sheet editor) vs.
+ * being plain text suitable for a simple <input>.
+ *
+ * Used by:
+ *  - localisation-utils.ts (source-side extraction)
+ *  - management/lib/legacy-migration.ts (import-time classification)
+ */
+
+/**
+ * Returns `true` when `html` contains tags that imply rich-text formatting.
+ * Matches block-level structure (paragraphs, headings, lists, blockquotes,
+ * horizontal rules, tables) and inline marks (bold, italic, underline,
+ * links, code, etc.) as well as hard breaks (`<br>`).
+ *
+ * Does NOT match:
+ *  - `<span>` without formatting attributes (wrapper-only, no semantic meaning)
+ *  - `<ycode-inline-variable>` (variables don't imply formatting)
+ *  - `<div>` without semantic significance (wrapper-only)
+ */
+export function looksLikeFormattedHtml(html: string): boolean {
+  if (typeof html !== 'string') return false;
+  if (!html.includes('<') || !html.includes('>')) return false;
+
+  return FORMATTED_HTML_RE.test(html);
+}
+
+const FORMATTED_HTML_RE =
+  /<(?:p|h[1-6]|ul|ol|li|blockquote|pre|hr|table|thead|tbody|tfoot|tr|td|th|br|strong|b|em|i|u|s|strike|sub|sup|code|a|small|mark|kbd)\b[^>]*\/?>/i;


### PR DESCRIPTION
## Summary

Switching the locale in the builder previously had no effect on the canvas. This PR makes the builder a real translation surface: switching to a non-default locale renders the canvas with translated content, locks structural editing, and replaces the inspector with a focused translation panel for the selected layer (and CMS items via the collection item sheet).

## Changes

### Canvas rendering
- Inject translations into resolved layers and CMS item values when a non-default locale is active, including incomplete drafts so editors can see in-progress work
- Reuse the same injection in published rendering via `lib/page-fetcher.ts`, gated on `isPublished` so the public site continues to ship only completed translations
- Keep the on-canvas locale selector element in sync with the active locale
- Show the standard preloader while locale translations are loading

### Editing gates while localizing
- Disable inline text editing, drag/drop, and the element library
- Keep the Design / Settings / Interactions tabs visible but disable Design and Interactions, mirroring how component instances behave
- Drop the redundant "Translating" header badge — the locale dropdown is the source of truth

### Sidebar translation panel
- Render a Framer-style stacked layout grouped under language headers: default-locale source values first, active-locale editable values below
- Plain `<Textarea>` editors with a fixed max-height and internal scroll (no rich-text controls, no completion toggle)
- Add per-property sub-labels (e.g. `IMAGE`, `IMAGE ALT`, `VIDEO`) so multi-property layers stay scannable
- For Rich Text element layers, show a read-only multiline preview (with block-level line breaks preserved) and an "Expand to edit" button that opens the rich-text editor sheet pre-loaded with the active locale's translation
- Empty state for layers with no translatable content
- For CMS-bound text (single-variable layers like `[Content]`), hide the useless placeholder textareas and show a read-only `Content → variable` row instead — connection cannot be removed in translation mode

### Rich text editor sheet (translation mode)
- Header always reads "Content editor" with a "Translate to {locale}" subtitle when translating
- Pre-populates with the existing translation (or empty doc), never the source — translators write directly in the target language
- Debounced save with locale-awareness so a fast locale switch mid-edit can't write to the wrong row

### CMS item sheet (translation mode)
- When opened on a CMS-bound page in a non-default locale, the sheet edits *translations* of `text` and `rich_text` fields, not canonical values
- Translatable fields are seeded from existing translations; non-translatable fields are visibly disabled with a "Not translatable" hint
- Save button becomes "Save translation" and routes to `createTranslation` / `updateTranslation` / `deleteTranslation`; canonical `updateItem` is skipped
- Status pill, "more options" menu, and the staged/draft/publish save dropdown are hidden — translation saves don't have separate publish states
- Disabled when invoked without an existing item (translations require a canonical item to anchor to)

### Translation completion semantics
- `getTranslationValue` / `injectTranslatedText` / `applyCmsTranslations` accept an `includeIncomplete` option
- Builder canvas and preview pass `includeIncomplete: true` so editors and reviewers see drafts; published rendering keeps the strict default
- Sidebar and CMS sheet always save with `is_completed: true`, so the canonical "completed" flag still drives published output

### Refactors
- Extract `extractLayerTranslatableItemsShallow`, `injectTranslatedText`, and `applyCmsTranslations` into `lib/localisation-utils.ts` so the page-fetcher and the client builder share one implementation
- Add `useLocalizationMode` hook (`currentLocale` / `defaultLocale` / `isLocalizing`) and reuse it across the builder
- Add `extractMultilinePlainTextFromTiptap` for readable rich-text previews

## Test plan

- [ ] Switch the locale from default → non-default and confirm the canvas updates with translated text, images, and CMS values (including drafts)
- [ ] Confirm Design / Interactions tabs are disabled and Settings is forced active when a non-default locale is selected
- [ ] Confirm inline text editing, drag/drop, and the element library are disabled in translation mode
- [ ] Select a heading/text layer, type a translation, blur, and confirm the canvas updates immediately
- [ ] Select a Rich Text layer, click "Expand to edit", type in the sheet, close, and confirm the translation persists and appears in preview
- [ ] Select a layer with both image and image-alt, confirm `IMAGE` and `IMAGE ALT` sub-labels render and translations group under language headers
- [ ] On a CMS page, select a layer whose text is `[Content]` — sidebar should show the read-only `Content → variable` row with no X button
- [ ] On a CMS page, double-click a CMS-bound layer to open the collection item sheet, confirm only `text` / `rich_text` fields are editable, save, and confirm canvas + preview update
- [ ] Try saving the collection item sheet for a non-existent item in translation mode — Save button should be disabled
- [ ] Edit a rich-text translation, then quickly switch locale before debounce flushes — confirm the value is written to the original locale, not the new one
- [ ] Publish the page and confirm only completed translations ship; preview still shows incomplete drafts
- [ ] Confirm the on-canvas locale selector element reflects the active locale in real time

Made with [Cursor](https://cursor.com)