### PR TITLE
feat: improve redirects with regex and homepage support

### DIFF
--- a/app/(builder)/ycode/settings/redirects/page.tsx
+++ b/app/(builder)/ycode/settings/redirects/page.tsx
@@ -258,7 +258,7 @@ export default function RedirectsSettingsPage() {
           if (!open) resetForm();
         }}
       >
-        <DialogContent>
+        <DialogContent aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Add redirect</DialogTitle>
           </DialogHeader>
@@ -322,7 +322,7 @@ export default function RedirectsSettingsPage() {
           if (!open) resetForm();
         }}
       >
-        <DialogContent>
+        <DialogContent aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Edit redirect</DialogTitle>
           </DialogHeader>

--- a/app/(site)/[...slug]/page.tsx
+++ b/app/(site)/[...slug]/page.tsx
@@ -10,6 +10,7 @@ import PasswordForm from '@/components/PasswordForm';
 import { getSettingByKey } from '@/lib/repositories/settingsRepository';
 import { parseAuthCookie, getPasswordProtection, fetchFoldersForAuth } from '@/lib/page-auth';
 import { getSiteBaseUrl } from '@/lib/url-utils';
+import { matchRedirect } from '@/lib/redirect-utils';
 import type { Page, PageFolder, Translation, Redirect as RedirectType } from '@/types';
 
 // Static by default for performance, dynamic only when pagination is requested
@@ -258,13 +259,12 @@ export default async function Page({ params }: PageProps) {
   const currentPath = `/${slugPath}`;
   const redirects = await fetchCachedRedirects();
   if (redirects && Array.isArray(redirects)) {
-    const matchedRedirect = redirects.find((r) => r.oldUrl === currentPath);
-    if (matchedRedirect) {
-      // Use permanentRedirect for 301 (default), redirect for 302
-      if (matchedRedirect.type === '302') {
-        redirect(matchedRedirect.newUrl);
+    const matched = matchRedirect(currentPath, redirects);
+    if (matched) {
+      if (matched.type === '302') {
+        redirect(matched.newUrl);
       } else {
-        permanentRedirect(matchedRedirect.newUrl);
+        permanentRedirect(matched.newUrl);
       }
     }
   }

--- a/app/(site)/_dynamic/[...slug]/page.tsx
+++ b/app/(site)/_dynamic/[...slug]/page.tsx
@@ -6,6 +6,7 @@ import PasswordForm from '@/components/PasswordForm';
 import { fetchGlobalPageSettings } from '@/lib/generate-page-metadata';
 import { getSettingByKey } from '@/lib/repositories/settingsRepository';
 import { parseAuthCookie, getPasswordProtection, fetchFoldersForAuth } from '@/lib/page-auth';
+import { matchRedirect } from '@/lib/redirect-utils';
 import type { Redirect as RedirectType } from '@/types';
 
 // Internal pagination path: always dynamic/no-store.
@@ -26,12 +27,12 @@ export default async function DynamicSlugPage({ params, searchParams }: DynamicS
 
   const redirects = await getSettingByKey('redirects') as RedirectType[] | null;
   if (redirects && Array.isArray(redirects)) {
-    const matchedRedirect = redirects.find((r) => r.oldUrl === currentPath);
-    if (matchedRedirect) {
-      if (matchedRedirect.type === '302') {
-        redirect(matchedRedirect.newUrl);
+    const matched = matchRedirect(currentPath, redirects);
+    if (matched) {
+      if (matched.type === '302') {
+        redirect(matched.newUrl);
       } else {
-        permanentRedirect(matchedRedirect.newUrl);
+        permanentRedirect(matched.newUrl);
       }
     }
   }

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,3 +1,4 @@
+import { redirect, permanentRedirect } from 'next/navigation';
 import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import { fetchHomepage, fetchErrorPage, splitPageData, reassemblePageData, slimPageData } from '@/lib/page-fetcher';
@@ -5,8 +6,11 @@ import type { PageData } from '@/lib/page-fetcher';
 import PageRenderer from '@/components/PageRenderer';
 import PasswordForm from '@/components/PasswordForm';
 import { generatePageMetadata, fetchGlobalPageSettings } from '@/lib/generate-page-metadata';
+import { getSettingByKey } from '@/lib/repositories/settingsRepository';
+import { matchRedirect } from '@/lib/redirect-utils';
 import { parseAuthCookie, getPasswordProtection, fetchFoldersForAuth } from '@/lib/page-auth';
 import { getSiteBaseUrl } from '@/lib/url-utils';
+import type { Redirect as RedirectType } from '@/types';
 import type { Metadata } from 'next';
 
 // Static by default for performance, dynamic only when pagination is requested
@@ -68,6 +72,18 @@ async function fetchCachedGlobalSettings() {
   }
 }
 
+async function fetchCachedRedirects(): Promise<RedirectType[] | null> {
+  try {
+    return await unstable_cache(
+      async () => getSettingByKey('redirects') as Promise<RedirectType[] | null>,
+      ['data-for-redirects'],
+      { tags: ['all-pages'], revalidate: false }
+    )();
+  } catch {
+    return null;
+  }
+}
+
 async function fetchCachedFoldersForAuth() {
   try {
     return await unstable_cache(
@@ -92,6 +108,19 @@ async function fetchCachedErrorPage(errorCode: 401) {
 }
 
 export default async function Home() {
+  // Check for redirects targeting the homepage
+  const redirects = await fetchCachedRedirects();
+  if (redirects && Array.isArray(redirects)) {
+    const matched = matchRedirect('/', redirects);
+    if (matched) {
+      if (matched.type === '302') {
+        redirect(matched.newUrl);
+      } else {
+        permanentRedirect(matched.newUrl);
+      }
+    }
+  }
+
   // Cache-first homepage path; pagination is served through internal dynamic routes.
   const data = await fetchPublishedHomepage();
 

--- a/lib/redirect-utils.ts
+++ b/lib/redirect-utils.ts
@@ -1,0 +1,52 @@
+import type { Redirect } from '@/types';
+
+/**
+ * Match a request path against configured redirects.
+ * Exact string matches take priority, then regex patterns (`.+`, `.*`).
+ * Ported from legacy CustomDomain::getRedirectedUrl behavior.
+ */
+export function matchRedirect(
+  currentPath: string,
+  redirects: Redirect[],
+): Redirect | null {
+  const exactMatches: Redirect[] = [];
+  const regexMatches: Redirect[] = [];
+
+  for (const r of redirects) {
+    let oldUrl = r.oldUrl;
+
+    if (!oldUrl.startsWith('/')) {
+      oldUrl = '/' + oldUrl;
+    }
+
+    const isRegex = oldUrl.includes('.+') || oldUrl.includes('.*');
+
+    if (isRegex) {
+      regexMatches.push({ ...r, oldUrl });
+    } else {
+      exactMatches.push({ ...r, oldUrl });
+    }
+  }
+
+  for (const r of exactMatches) {
+    if (r.oldUrl === currentPath) {
+      return r;
+    }
+  }
+
+  for (const r of regexMatches) {
+    try {
+      const escapedPattern = r.oldUrl.replace(/\?/g, '\\?');
+      const regex = new RegExp(`^${escapedPattern}$`);
+
+      if (regex.test(currentPath)) {
+        const newUrl = currentPath.replace(regex, r.newUrl);
+        return { ...r, newUrl };
+      }
+    } catch {
+      // Invalid regex pattern — skip
+    }
+  }
+
+  return null;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -28,6 +28,7 @@ if (process.env.SUPABASE_URL) {
 }
 
 const nextConfig: NextConfig = {
+  trailingSlash: false,
   staticPageGenerationTimeout: 120,
   experimental: {
     proxyClientMaxBodySize: '500mb',


### PR DESCRIPTION
## Summary

Bring redirect behavior to parity with legacy by adding regex pattern matching, homepage redirect support, centralized matching logic, and trailing slash canonicalization.

## Changes

- Add `lib/redirect-utils.ts` with `matchRedirect()` supporting exact and regex (`.+`, `.*`) patterns, with exact matches taking priority
- Add redirect checking to homepage `app/(site)/page.tsx` so `/` can be redirected
- Update `[...slug]/page.tsx` and `_dynamic/[...slug]/page.tsx` to use shared `matchRedirect()` instead of inline exact-match `find()`
- Add `trailingSlash: false` to `next.config.ts` for trailing slash canonicalization
- Add `aria-describedby={undefined}` to redirect dialog components

## Test plan

**Note**: You can test in incognito mode to prevent browser from caching redirections.

- [ ] Add an exact redirect `/old-page` -> `/about` and verify 301
- [ ] Add a homepage redirect `/` -> `/about` and verify 301
- [ ] Add a regex redirect `/old-blog/.*` -> `/blog` and verify `/old-blog/any-post` redirects
- [ ] Add a regex redirect `/articles/.+` -> `/posts` and verify it requires at least one char after `/articles/`
- [ ] Add both `/special/page` -> `/exact` and `/special/.*` -> `/regex`, verify exact match wins
- [ ] Visit `/about/` (trailing slash) and verify 308 redirect to `/about`
- [ ] Add an external redirect `/external` -> `https://google.com` and verify