### PR TITLE
fix: resolve field-based links on published pages

### DIFF
--- a/lib/link-utils.ts
+++ b/lib/link-utils.ts
@@ -540,46 +540,50 @@ export function generateLinkHref(
       }
       break;
     case 'field': {
-      // For field-based links, use source to select correct data (page vs collection)
-      const source = linkSettings.field?.data?.source;
-      const collectionLayerId = linkSettings.field?.data?.collection_layer_id;
-      const { layerDataMap } = context;
+      const fieldId = linkSettings.field?.data?.field_id;
+      if (!fieldId) break;
 
-      let fieldData: Record<string, string> | undefined;
+      // Use pre-resolved value from injectCollectionData when available
+      // (published pages strip _collectionItemValues, but _resolvedValue survives)
+      let rawValue: string | undefined = linkSettings.field?.data?._resolvedValue;
 
-      // If collection_layer_id is specified, use layer-specific data from layerDataMap
-      if (collectionLayerId && layerDataMap?.[collectionLayerId]) {
-        fieldData = layerDataMap[collectionLayerId];
-      } else if (source === 'page') {
-        fieldData = pageCollectionItemData;
-      } else if (source === 'collection') {
-        fieldData = collectionItemData;
-      } else {
-        // No source specified - prefer collection layer data, fall back to page data (backwards compatibility)
-        fieldData = collectionItemData || pageCollectionItemData;
+      if (!rawValue) {
+        // Fall back to runtime field data lookup
+        const source = linkSettings.field?.data?.source;
+        const collectionLayerId = linkSettings.field?.data?.collection_layer_id;
+        const { layerDataMap } = context;
+
+        let fieldData: Record<string, string> | undefined;
+
+        if (collectionLayerId && layerDataMap?.[collectionLayerId]) {
+          fieldData = layerDataMap[collectionLayerId];
+        } else if (source === 'page') {
+          fieldData = pageCollectionItemData;
+        } else if (source === 'collection') {
+          fieldData = collectionItemData;
+        } else {
+          fieldData = collectionItemData || pageCollectionItemData;
+        }
+
+        if (fieldData) {
+          const relationships = linkSettings.field?.data?.relationships || [];
+          if (relationships.length > 0) {
+            const fullPath = [fieldId, ...relationships].join('.');
+            rawValue = fieldData[fullPath];
+          } else {
+            rawValue = fieldData[fieldId];
+          }
+        }
       }
 
-      if (linkSettings.field?.data?.field_id && fieldData) {
-        const fieldId = linkSettings.field.data.field_id;
-        const relationships = linkSettings.field.data.relationships || [];
-
-        let rawValue: string | undefined;
-        if (relationships.length > 0) {
-          const fullPath = [fieldId, ...relationships].join('.');
-          rawValue = fieldData[fullPath];
-        } else {
-          rawValue = fieldData[fieldId];
-        }
-
-        if (rawValue) {
-          const fieldType = linkSettings.field?.data?.field_type;
-          href = resolveFieldLinkValue({
-            fieldId,
-            rawValue,
-            fieldType,
-            context,
-          });
-        }
+      if (rawValue) {
+        const fieldType = linkSettings.field?.data?.field_type;
+        href = resolveFieldLinkValue({
+          fieldId,
+          rawValue,
+          fieldType,
+          context,
+        });
       }
       break;
     }

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -1223,6 +1223,24 @@ async function injectCollectionData(
     }
   }
 
+  // Link field binding — pre-resolve raw value so it survives stripSSROnlyData
+  const linkVar = layer.variables?.link;
+  if (linkVar?.type === 'field' && linkVar.field?.data?.field_id) {
+    const resolvedValue = resolveFieldValueWithRelationships(linkVar.field, enhancedValues, layerDataMap);
+    if (resolvedValue) {
+      resolvedVars.link = {
+        ...linkVar,
+        field: {
+          ...linkVar.field,
+          data: {
+            ...linkVar.field.data,
+            _resolvedValue: resolvedValue,
+          },
+        },
+      };
+    }
+  }
+
   // Design color field bindings → inline styles (supports solid + gradient)
   const designBindings = layer.variables?.design as Record<string, DesignColorVariable> | undefined;
   if (designBindings) {

--- a/types/index.ts
+++ b/types/index.ts
@@ -1136,6 +1136,8 @@ export interface FieldVariable extends VariableType {
     source?: 'page' | 'collection';
     /** ID of the collection layer this field belongs to (for nested collections) */
     collection_layer_id?: string;
+    /** Pre-resolved raw value from injectCollectionData (survives stripSSROnlyData) */
+    _resolvedValue?: string;
   };
 }
 


### PR DESCRIPTION
## Summary

Fix field-based links (e.g. collection link fields bound to buttons) rendering as `<span>` instead of `<a>` on published pages. Links worked in preview but broke on published pages because `stripSSROnlyData` removed the `_collectionItemValues` needed by `generateLinkHref` to resolve field references.

## Changes

- Pre-resolve link field values in `injectCollectionData` and store as `_resolvedValue` on the field variable, so the value survives `stripSSROnlyData`
- Update `generateLinkHref` to use `_resolvedValue` when available, falling back to runtime lookup for preview/draft
- Add `_resolvedValue` to `FieldVariable` type definition

## Test plan

- [ ] Create a collection with a Link field and a few CMS items, create a component on a page
- [ ] in the component: add a button inside a collection with a link bound to the collection field (type: link)
- [ ] Verify the button renders as `<a>` with correct `href` in **preview**
- [ ] Publish the page and verify the button also renders as `<a>` with correct `href` on the published site
- [ ] Verify non-field links (URL, page, email) still work on **published pages**
