### PR TITLE
fix: apply translations to component content on pages

### DIFF
--- a/app/(builder)/ycode/components/Canvas.tsx
+++ b/app/(builder)/ycode/components/Canvas.tsx
@@ -342,15 +342,27 @@ export default function Canvas({
   // AFTER serializeLayers so component instance child IDs are already resolved
   // (injectTranslatedText reads _originalLayerId / _masterComponentId to look
   // up component-scoped translations).
+  //
+  // When the user is editing a component definition (editingComponentId set),
+  // the rendered layers are the component's raw layers (not a resolved
+  // instance), so they carry no _masterComponentId. Pass editingComponentId
+  // as the default so translations stored under `component:{id}:...` apply.
   const localizedLayers = useMemo(() => {
-    if (!currentLocale || currentLocale.is_default || !translations || !pageId) {
+    if (!currentLocale || currentLocale.is_default || !translations) {
       return resolvedLayers;
     }
+    // pageId may be empty when editing a component without a page selected.
+    // injectTranslatedText still needs a non-empty value to perform lookups.
+    const lookupPageId = pageId || (editingComponentId ?? '');
+    if (!lookupPageId) return resolvedLayers;
     // Builder canvas mirrors what the editor has saved, including in-progress
     // translations that are not yet marked complete. Production rendering
     // (page-fetcher) keeps the default behaviour and only ships completed ones.
-    return injectTranslatedText(resolvedLayers, pageId, translations, { includeIncomplete: true });
-  }, [resolvedLayers, currentLocale, translations, pageId]);
+    return injectTranslatedText(resolvedLayers, lookupPageId, translations, {
+      includeIncomplete: true,
+      defaultMasterComponentId: editingComponentId ?? undefined,
+    });
+  }, [resolvedLayers, currentLocale, translations, pageId, editingComponentId]);
 
   // Enrich page collection item data with reference field dotted keys
   // so variables like "refFieldId.targetFieldId" resolve on canvas

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -16,7 +16,7 @@ import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/templates/utilitie
 import { useCanvasSlider } from '@/hooks/use-canvas-slider';
 import { resolveFieldFromSources } from '@/lib/cms-variables-utils';
 import { getDynamicTextContent, getImageUrlFromVariable, getVideoUrlFromVariable, getIframeUrlFromVariable, isFieldVariable, isAssetVariable, isStaticTextVariable, isDynamicTextVariable, getAssetId, getStaticTextContent, createAssetVariable, createDynamicTextVariable, resolveDesignStyles } from '@/lib/variable-utils';
-import { getTranslatedAssetId, getTranslatedText, applyCmsTranslations } from '@/lib/localisation-utils';
+import { getTranslatedAssetId, getTranslatedText, applyCmsTranslations, injectTranslatedText } from '@/lib/localisation-utils';
 import { isValidLinkSettings } from '@/lib/link-utils';
 import { DEFAULT_ASSETS, ASSET_CATEGORIES, isAssetOfType } from '@/lib/asset-utils';
 import { parseMultiAssetFieldValue, buildAssetVirtualValues } from '@/lib/multi-asset-utils';
@@ -1156,13 +1156,24 @@ const LayerItem: React.FC<{
   const component = (isEditMode && layer.componentId) ? getComponentById(layer.componentId) : null;
 
   // Transform component layers for this instance to ensure unique IDs per instance
-  // This enables animations to target the correct elements when multiple instances exist
+  // This enables animations to target the correct elements when multiple instances exist.
+  //
+  // Also inject translations for the active locale: in edit mode the component
+  // is re-resolved here from the store, bypassing the canvas-level
+  // injectTranslatedText pass on the serialized page layers. Without injecting
+  // here, component content would always render in the default language even
+  // when the user previews a non-default locale on a page.
   const transformedComponentLayers = useMemo(() => {
-    if (isEditMode && component && component.layers && component.layers.length > 0) {
-      return transformLayerIdsForInstance(component.layers, layer.id);
+    if (!isEditMode || !component?.layers?.length) return null;
+    const transformed = transformLayerIdsForInstance(component.layers, layer.id);
+    if (!currentLocale || currentLocale.is_default || !translations) {
+      return transformed;
     }
-    return null;
-  }, [isEditMode, component, layer.id]);
+    return injectTranslatedText(transformed, pageId || component.id, translations, {
+      includeIncomplete: true,
+      defaultMasterComponentId: component.id,
+    });
+  }, [isEditMode, component, layer.id, currentLocale, translations, pageId]);
 
   // Collect hidden layer IDs from the component's transformed layers
   // Needed because Canvas computes editorHiddenLayerIds from serializeLayers (different ID transform)

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -2348,6 +2348,21 @@ function remapInteractionLayerIds(
 }
 
 /**
+ * Recursively tag a layer subtree with `_masterComponentId` so translation
+ * lookups in `injectTranslatedText` resolve to component-scoped keys.
+ * Mirrors `tagLayersWithComponentId` in `lib/resolve-components.ts`.
+ */
+function tagLayerSubtreeWithComponentId(layer: Layer, componentId: string): Layer {
+  return {
+    ...layer,
+    _masterComponentId: componentId,
+    children: layer.children
+      ? layer.children.map(child => tagLayerSubtreeWithComponentId(child, componentId))
+      : layer.children,
+  };
+}
+
+/**
  * Transform component layers with instance-specific IDs
  * This ensures each component instance has unique layer IDs for proper targeting
  */
@@ -2377,6 +2392,9 @@ function transformLayersForInstance(
     const transformedLayer: Layer = {
       ...layer,
       id: newId,
+      // Preserve the original layer ID so injectTranslatedText can resolve
+      // component-scoped translation keys (which use the template layer ID).
+      _originalLayerId: layer._originalLayerId || layer.id,
     };
 
     // Remap interaction IDs and tween layer_id references
@@ -2483,8 +2501,20 @@ function resolveComponentsInLayers(
           component.variables,
         );
 
+        // Tag children with the master component ID so injectTranslatedText
+        // resolves component-scoped translation keys (component:{componentId}:...)
+        // instead of falling back to page scope. Mirrors the server-side
+        // resolveComponents pipeline so the canvas matches what the published
+        // page renders.
+        const taggedChildren = overriddenChildren.map(child =>
+          tagLayerSubtreeWithComponentId(child, component.id)
+        );
+
         // Return the wrapper with the component's content merged in
         // IMPORTANT: Keep componentId so LayerRenderer knows this is a component instance
+        // _originalLayerId is the component's root template ID — translations on the
+        // root wrapper itself are stored under that ID, while the runtime ID is the
+        // page-instance ID.
         const resolved = {
           ...layer,
           ...componentContent, // Merge the component's properties (classes, design, etc.)
@@ -2492,7 +2522,9 @@ function resolveComponentsInLayers(
           componentId: layer.componentId, // Keep the original componentId for selection
           componentOverrides: layer.componentOverrides, // Keep instance overrides
           interactions: remappedInteractions, // Use remapped interactions
-          children: overriddenChildren,
+          children: taggedChildren,
+          _masterComponentId: component.id,
+          _originalLayerId: componentContent.id,
         };
 
         return resolved;

--- a/lib/localisation-utils.ts
+++ b/lib/localisation-utils.ts
@@ -1,6 +1,6 @@
 import type { Layer, Page, Translation, Locale, LocaleOption, CollectionField } from '@/types';
 import { getLayerIcon, getLayerName } from '@/lib/layer-utils';
-import { createDynamicTextVariable, createDynamicRichTextVariable, createAssetVariable } from '@/lib/variable-utils';
+import { createDynamicTextVariable, createDynamicRichTextVariable, createDynamicRichTextVariableFromPlainText, createAssetVariable } from '@/lib/variable-utils';
 import { castValue } from '@/lib/collection-utils';
 import { tiptapDocHasFormatting, tiptapDocToCanonicalString, hasVariableNode, hasAnyTextOrVariable } from '@/lib/tiptap-utils';
 import { looksLikeFormattedHtml } from '@/lib/translation-classification';
@@ -837,12 +837,18 @@ export function getTranslatedText(
  *
  * Shared between the server-side page fetcher (preview / published) and the
  * builder canvas so both paths produce identical output.
+ *
+ * @param defaultMasterComponentId - When provided, any layer that doesn't carry
+ *   `_masterComponentId` is treated as belonging to this component. Used by the
+ *   builder canvas while editing a component definition (where the rendered
+ *   layers are the component's raw layers, not a resolved instance), so
+ *   translations stored under `component:{componentId}:...` apply.
  */
 export function injectTranslatedText(
   layers: Layer[],
   pageId: string,
   translations: Record<string, Translation>,
-  options?: { includeIncomplete?: boolean }
+  options?: { includeIncomplete?: boolean; defaultMasterComponentId?: string }
 ): Layer[] {
   const valueOptions = options?.includeIncomplete ? { includeIncomplete: true } : undefined;
   return layers.map(layer => {
@@ -853,7 +859,8 @@ export function injectTranslatedText(
     // child layer IDs are transformed to instance-specific IDs (e.g., "instanceId-childId")
     // but translations are stored with the original component layer IDs.
     const translationLayerId = (layer as any)._originalLayerId || layer.id;
-    const masterComponentId = (layer as any)._masterComponentId as string | undefined;
+    const masterComponentId =
+      ((layer as any)._masterComponentId as string | undefined) ?? options?.defaultMasterComponentId;
 
     // 1. Inject text translation
     const textTranslationKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:text`, masterComponentId);
@@ -861,9 +868,17 @@ export function injectTranslatedText(
 
     const textValue = getTranslationValue(textTranslation, valueOptions);
     if (textValue) {
-      // Preserve the original variable type (dynamic_text or dynamic_rich_text)
+      // Preserve the original variable type (dynamic_text or dynamic_rich_text).
+      // Use the translation's stored content_type to decide whether the value is
+      // a JSON-serialized Tiptap doc or plain text — when a rich-text source has
+      // no formatting, it's stored as plain text (see classifyLayerTextForTranslation),
+      // so blindly JSON.parse-ing it would log noisy errors on every render.
       if (layer.variables?.text?.type === 'dynamic_rich_text') {
-        (variableUpdates as any).text = createDynamicRichTextVariable(textValue);
+        if (textTranslation?.content_type === 'richtext') {
+          (variableUpdates as any).text = createDynamicRichTextVariable(textValue);
+        } else {
+          (variableUpdates as any).text = createDynamicRichTextVariableFromPlainText(textValue);
+        }
       } else {
         (variableUpdates as any).text = createDynamicTextVariable(textValue);
       }

--- a/lib/resolve-components.ts
+++ b/lib/resolve-components.ts
@@ -613,12 +613,16 @@ export function resolveComponents(
 
         // Merge component content with instance layer, keeping instance ID
         // IMPORTANT: Keep componentId so LayerRenderer knows this is a component instance
+        // _originalLayerId is the component's root template ID — translations on the
+        // component's root wrapper (text/media) are stored under this ID, while the
+        // runtime ID becomes the page-instance ID.
         return {
           ...layer,
           ...overriddenRoot,
           id: layer.id,
           componentId: layer.componentId, // Keep the original componentId
           _masterComponentId: component.id,
+          _originalLayerId: componentContent.id,
           children: resolvedChildren,
           interactions: resolvedInteractions,
         };

--- a/lib/variable-utils.ts
+++ b/lib/variable-utils.ts
@@ -65,6 +65,22 @@ export function createDynamicRichTextVariable(content: string): DynamicRichTextV
 }
 
 /**
+ * Create a DynamicRichTextVariable directly from plain text, without attempting
+ * JSON parsing. Use this when the source value is known to be plain text
+ * (e.g. a translation whose stored content_type is `text` even though the
+ * target variable is `dynamic_rich_text`), to avoid the noisy JSON.parse
+ * fallback in `createDynamicRichTextVariable`.
+ */
+export function createDynamicRichTextVariableFromPlainText(content: string): DynamicRichTextVariable {
+  return {
+    type: 'dynamic_rich_text',
+    data: {
+      content: stringToTiptapContent(content),
+    },
+  };
+}
+
+/**
  * Create an AssetVariable from an asset ID
  */
 export function createAssetVariable(assetId: string): AssetVariable {


### PR DESCRIPTION
## Summary

Component instances rendered in the default language regardless of the active locale, both in the builder canvas and on the published site, so translations stored against the component never appeared. This restores the expected behaviour by aligning the three component-resolution paths (server/page-fetcher, builder canvas serializer, and the LayerRenderer's edit-mode re-resolution) on the same set of translation-lookup hints.

Closes #205

## Changes

- Tag merged component instance roots with `_originalLayerId` (server and canvas paths) so root-level translations on the wrapper resolve.
- Make the canvas serializer (`resolveComponentsInLayers` / `transformLayersForInstance`) tag instance children with `_masterComponentId` and `_originalLayerId`, mirroring the server pipeline.
- Inject translations on the LayerRenderer's edit-mode `transformedComponentLayers`, since the renderer re-resolves component instances from the store and would otherwise bypass the canvas-level translation pass.
- Pass `editingComponentId` as `defaultMasterComponentId` to `injectTranslatedText` so translations apply when previewing a non-default locale inside the component editor itself.
- Use the translation row's stored `content_type` to wrap plain-text values destined for `dynamic_rich_text` variables, avoiding a noisy `JSON.parse` console error on every render.

## Test plan

- [ ] On a page that uses a component, switch the locale picker to a non-default locale — component text/media translations should appear in the canvas.
- [ ] Open the component editor, switch locale — translations on the component's own layers should appear.
- [ ] Visit the published page at a localized URL (`/{locale}/...`) — component content should render translated.
- [ ] Translate a regular page-level text layer (e.g. heading not inside any component) — translation should still apply on locale switch.
- [ ] Verify no `Failed to parse rich text JSON` errors in the browser console while previewing translations.

Made with [Cursor](https://cursor.com)