### PR TITLE
fix: resolve cross-collection link field URLs

### DIFF
--- a/app/(builder)/ycode/components/CMS.tsx
+++ b/app/(builder)/ycode/components/CMS.tsx
@@ -462,6 +462,23 @@ const CMS = React.memo(function CMS() {
   );
   const totalItems = selectedCollectionId ? (itemsTotalCount[selectedCollectionId] || 0) : 0;
 
+  // Build slug map across ALL loaded collections for cross-collection link resolution
+  const allCollectionItemSlugs = useMemo(() => {
+    const slugs: Record<string, string> = {};
+    for (const collectionId of Object.keys(items)) {
+      const colFields = fields[collectionId] || [];
+      const slugField = colFields.find(f => f.key === 'slug');
+      if (!slugField) continue;
+      for (const item of items[collectionId]) {
+        const slugValue = item.values[slugField.id];
+        if (slugValue) {
+          slugs[item.id] = slugValue;
+        }
+      }
+    }
+    return slugs;
+  }, [items, fields]);
+
   // Drag and drop sensors
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -1848,19 +1865,10 @@ const CMS = React.memo(function CMS() {
                                 displayValue = asset?.filename || linkValue.asset.id;
                                 isAssetLink = true;
                               } else {
-                                // Build collectionItemSlugs map for dynamic page resolution
-                                const collectionItemSlugs: Record<string, string> = {};
-                                collectionItems.forEach(item => {
-                                  const slugField = collectionFields.find(f => f.key === 'slug');
-                                  if (slugField && item.values[slugField.id]) {
-                                    collectionItemSlugs[item.id] = item.values[slugField.id];
-                                  }
-                                });
-
                                 const resolvedUrl = resolveCollectionLinkValue(linkValue, {
                                   pages,
                                   folders,
-                                  collectionItemSlugs,
+                                  collectionItemSlugs: allCollectionItemSlugs,
                                   isPreview: false,
                                   locale: undefined,
                                 });

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -67,6 +67,16 @@ function collectLayerPageLinks(layers: Layer[]): PageLinkRef[] {
       const { collection_item_id, id: page_id } = layer.variables.link.page ?? {};
       if (collection_item_id && page_id) results.push({ collection_item_id, page_id });
     }
+    // Field-bound links: extract page refs from pre-resolved link values
+    if (layer.variables?.link?.type === 'field') {
+      const resolvedValue = layer.variables.link.field?.data?._resolvedValue;
+      if (resolvedValue) {
+        const linkValue = parseCollectionLinkValue(resolvedValue);
+        if (linkValue?.type === 'page' && linkValue.page?.collection_item_id && linkValue.page?.id) {
+          results.push({ collection_item_id: linkValue.page.collection_item_id, page_id: linkValue.page.id });
+        }
+      }
+    }
     const textVar = layer.variables?.text as any;
     if (textVar?.type === 'dynamic_rich_text' && textVar.data?.content) {
       results.push(...collectTiptapPageLinks(textVar.data.content));

--- a/lib/link-utils.ts
+++ b/lib/link-utils.ts
@@ -318,6 +318,32 @@ export interface ResolveFieldLinkOptions {
 }
 
 /**
+ * Extract collection_item_ids referenced by link field values that point to
+ * dynamic pages. Used to pre-fetch slugs for cross-collection link resolution.
+ */
+export function extractCrossCollectionItemIds(
+  items: { values: Record<string, string> }[],
+  linkFieldIds: string[],
+  existingSlugs?: Record<string, string>,
+): string[] {
+  const itemIds = new Set<string>();
+  for (const item of items) {
+    for (const fieldId of linkFieldIds) {
+      const rawValue = item.values[fieldId];
+      if (!rawValue) continue;
+      const linkValue = parseCollectionLinkValue(rawValue);
+      if (linkValue?.type === 'page' && linkValue.page?.collection_item_id) {
+        const refItemId = linkValue.page.collection_item_id;
+        if (!existingSlugs?.[refItemId]) {
+          itemIds.add(refItemId);
+        }
+      }
+    }
+  }
+  return Array.from(itemIds);
+}
+
+/**
  * Resolve a raw field value to a link href.
  * Handles CollectionLinkValue JSON, email, phone, virtual asset fields, and regular asset fields.
  */

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -24,7 +24,7 @@ export interface PaginationContext {
   defaultPage?: number;
 }
 
-import { resolveFieldLinkValue, resolveRefCollectionItemId, generateLinkHref, isLinkAtCollectionBoundary, parseCollectionLinkValue } from '@/lib/link-utils';
+import { resolveFieldLinkValue, resolveRefCollectionItemId, generateLinkHref, isLinkAtCollectionBoundary, parseCollectionLinkValue, extractCrossCollectionItemIds } from '@/lib/link-utils';
 import type { LinkResolutionContext } from '@/lib/link-utils';
 import { getLinkSettingsFromMark } from '@/lib/tiptap-extensions/rich-text-link';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
@@ -3114,6 +3114,42 @@ export function generatePaginationWrapper(
 }
 
 /**
+ * Fetch slugs for collection items referenced by link field values in other collections.
+ * Enriches the provided slugs map in-place.
+ */
+async function enrichSlugsFromLinkFields(
+  items: CollectionItemWithValues[],
+  collectionFields: CollectionField[],
+  existingSlugs: Record<string, string>,
+  isPublished: boolean,
+): Promise<void> {
+  const linkFieldIds = collectionFields.filter(f => f.type === 'link').map(f => f.id);
+  if (linkFieldIds.length === 0) return;
+
+  const missingItemIds = extractCrossCollectionItemIds(items, linkFieldIds, existingSlugs);
+  if (missingItemIds.length === 0) return;
+
+  const refItems = await getItemsWithValuesByIds(missingItemIds, isPublished);
+  const refCollectionIds = new Set(Object.values(refItems).map(i => i.collection_id));
+
+  const fieldsByCollection = new Map<string, CollectionField[]>();
+  await Promise.all(
+    Array.from(refCollectionIds).map(async (collId) => {
+      const fields = await getFieldsByCollectionId(collId, isPublished);
+      fieldsByCollection.set(collId, fields);
+    })
+  );
+
+  for (const refItem of Object.values(refItems)) {
+    const fields = fieldsByCollection.get(refItem.collection_id);
+    const slugField = fields?.find(f => f.key === 'slug');
+    if (slugField && refItem.values[slugField.id]) {
+      existingSlugs[refItem.id] = refItem.values[slugField.id];
+    }
+  }
+}
+
+/**
  * Render collection items to HTML string for "Load More" pagination
  * Takes the original layer template and renders each item with injected data
  * @param items - Collection items with values
@@ -3147,6 +3183,10 @@ export async function renderCollectionItemsToHtml(
     ensureMapTokens(),
   ]);
   const htmlTimezone = (timezoneRaw as string | null) || 'UTC';
+
+  // Enrich slugs with cross-collection link field references
+  const enrichedSlugs = { ...collectionItemSlugs };
+  await enrichSlugsFromLinkFields(items, collectionFields, enrichedSlugs, isPublished);
 
   // Pre-process: translations + date formatting (pure computation)
   const preprocessed = items.map(item => {
@@ -3247,7 +3287,7 @@ export async function renderCollectionItemsToHtml(
       // Convert layers to HTML (handles fragments from resolved collections)
       const itemHtml = resolvedLayers
         .map((layer) =>
-          layerToHtml(layer, item.id, pages, folders, collectionItemSlugs, locale, translations, anchorMap, item.values, undefined, assetMap, undefined, undefined)
+          layerToHtml(layer, item.id, pages, folders, enrichedSlugs, locale, translations, anchorMap, item.values, undefined, assetMap, undefined, undefined)
         )
         .join('');
 


### PR DESCRIPTION
## Summary

Fix link fields pointing to dynamic pages in other collections showing `/{slug}` instead of the actual resolved URL. The slug map was only built from the current collection's items, missing cross-collection references.

## Changes

- Build CMS table slug map from all loaded collections instead of just the current one
- Extend `collectLayerPageLinks` in `PageRenderer` to extract page refs from pre-resolved field-bound link values (`_resolvedValue`)
- Add `enrichSlugsFromLinkFields` in `renderCollectionItemsToHtml` to fetch slugs for items referenced by link fields in other collections
- Add `extractCrossCollectionItemIds` utility in `link-utils.ts` for shared cross-collection ref extraction

## Test plan

- [x] Create two collections: Collection A (with a link field) and Collection B (dynamic page bound)
- [x] In Collection A, set a link field value pointing to a dynamic page with a specific Collection B item
- [x] Verify the CMS table row shows the resolved URL (e.g. `/blog/my-post`) instead of `/{slug}`
- [ ] Preview the page and verify layers bound to that link field render the correct href
- [ ] Publish and verify the generated page has the correct href
- [ ] Test load-more pagination on a collection list with cross-collection link fields