### PR TITLE
fix: coerce image dimensions and preserve custom script load order

### DIFF
--- a/components/CustomCodeInjector.tsx
+++ b/components/CustomCodeInjector.tsx
@@ -12,6 +12,7 @@ interface CustomCodeInjectorProps {
  * Injects custom HTML/script code after React hydration.
  * Renders an empty container on SSR to avoid hydration mismatches,
  * then injects and executes scripts via useEffect on the client.
+ * External scripts are loaded sequentially to preserve dependency order.
  */
 export default function CustomCodeInjector({ html }: CustomCodeInjectorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -22,10 +23,32 @@ export default function CustomCodeInjector({ html }: CustomCodeInjectorProps) {
 
     container.innerHTML = html;
 
-    const scripts = container.querySelectorAll('script');
-    scripts.forEach((original) => {
-      original.replaceWith(recreateScript(original));
-    });
+    const scripts = Array.from(container.querySelectorAll('script'));
+    let cancelled = false;
+
+    // Execute sequentially — dynamically created scripts with `src` are
+    // async by default, which breaks dependencies between external libs
+    // and inline scripts that use them.
+    async function executeScripts() {
+      for (const original of scripts) {
+        if (cancelled) return;
+        const script = recreateScript(original);
+
+        if (script.src) {
+          await new Promise<void>((resolve) => {
+            script.addEventListener('load', () => resolve());
+            script.addEventListener('error', () => resolve());
+            original.replaceWith(script);
+          });
+        } else {
+          original.replaceWith(script);
+        }
+      }
+    }
+
+    executeScripts();
+
+    return () => { cancelled = true; };
   }, [html]);
 
   return <div ref={containerRef} />;

--- a/components/HeadCodeInjector.tsx
+++ b/components/HeadCodeInjector.tsx
@@ -14,32 +14,50 @@ interface HeadCodeInjectorProps {
  * Next.js streaming SSR prevents React 19 hoisting from working for
  * page-level content, so we programmatically append all elements
  * (meta, link, style, script, noscript) to document.head client-side.
- * Scripts are recreated to ensure execution.
+ * External scripts are loaded sequentially to preserve dependency order.
  */
 export default function HeadCodeInjector({ html, id }: HeadCodeInjectorProps) {
   useEffect(() => {
     const temp = document.createElement('div');
     temp.innerHTML = html;
 
+    const elements = Array.from(temp.children);
     const injected: Element[] = [];
+    let cancelled = false;
 
-    Array.from(temp.children).forEach((original, i) => {
-      const tag = `${id}-${i}`;
+    async function injectElements() {
+      for (let i = 0; i < elements.length; i++) {
+        if (cancelled) return;
+        const original = elements[i];
+        const tag = `${id}-${i}`;
 
-      if (original.tagName === 'SCRIPT') {
-        const script = recreateScript(original as HTMLScriptElement);
-        script.dataset.meta = tag;
-        document.head.appendChild(script);
-        injected.push(script);
-      } else {
-        const clone = original.cloneNode(true) as Element;
-        clone.setAttribute('data-meta', tag);
-        document.head.appendChild(clone);
-        injected.push(clone);
+        if (original.tagName === 'SCRIPT') {
+          const script = recreateScript(original as HTMLScriptElement);
+          script.dataset.meta = tag;
+          injected.push(script);
+
+          if (script.src) {
+            await new Promise<void>((resolve) => {
+              script.addEventListener('load', () => resolve());
+              script.addEventListener('error', () => resolve());
+              document.head.appendChild(script);
+            });
+          } else {
+            document.head.appendChild(script);
+          }
+        } else {
+          const clone = original.cloneNode(true) as Element;
+          clone.setAttribute('data-meta', tag);
+          document.head.appendChild(clone);
+          injected.push(clone);
+        }
       }
-    });
+    }
+
+    injectElements();
 
     return () => {
+      cancelled = true;
       injected.forEach((el) => el.remove());
     };
   }, [html, id]);

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -2119,8 +2119,8 @@ const LayerItem: React.FC<{
       const finalImageUrl = imageUrl && imageUrl.trim() !== '' ? imageUrl : DEFAULT_ASSETS.IMAGE;
 
       // Resolve intrinsic dimensions: explicit attributes > asset record > URL reverse-lookup
-      let imgWidth = layer.attributes?.width as string | undefined;
-      let imgHeight = layer.attributes?.height as string | undefined;
+      let imgWidth = layer.attributes?.width != null ? String(layer.attributes.width) : undefined;
+      let imgHeight = layer.attributes?.height != null ? String(layer.attributes.height) : undefined;
 
       if (!imgWidth || !imgHeight) {
         const assetId = isAssetVariable(imageVariable) ? getAssetId(imageVariable) : undefined;

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -1093,8 +1093,8 @@ const LayerItem: React.FC<{
       const finalImageUrl = imageUrl && imageUrl.trim() !== '' ? imageUrl : DEFAULT_ASSETS.IMAGE;
 
       // Resolve intrinsic dimensions: explicit attributes > asset record > URL reverse-lookup
-      let imgWidth = layer.attributes?.width as string | undefined;
-      let imgHeight = layer.attributes?.height as string | undefined;
+      let imgWidth = layer.attributes?.width != null ? String(layer.attributes.width) : undefined;
+      let imgHeight = layer.attributes?.height != null ? String(layer.attributes.height) : undefined;
 
       if (!imgWidth || !imgHeight) {
         const assetId = isAssetVariable(imageVariable) ? getAssetId(imageVariable) : undefined;


### PR DESCRIPTION
## Summary

Fix two runtime errors: image `width`/`height` attributes stored as numbers causing `TypeError: imgWidth.replace is not a function`, and custom code external scripts loading asynchronously which breaks inline scripts that depend on them.

## Changes

- Coerce `layer.attributes.width/height` to `String()` in `LayerRenderer` and `LayerRendererPublic` instead of unsafe `as string` cast
- Execute scripts sequentially in `CustomCodeInjector` — wait for external scripts to load before running the next script
- Apply the same sequential loading fix to `HeadCodeInjector`

## Test plan

- [ ] Add an image layer with numeric width/height attributes — verify no `.replace` TypeError in builder or preview
- [ ] Add global body custom code with an external library script followed by an inline script that uses it — verify no ReferenceError on preview or published page
- [ ] Verify page-specific head custom code with external + inline scripts also loads in order
- [ ] Confirm existing custom code (analytics, tracking pixels) still executes correctly

Made with [Cursor](https://cursor.com)