### PR TITLE
perf: improve PageSpeed score on published sites

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,4 +1,4 @@
-import '@/app/globals.css';
+import '@/app/site.css';
 import type { Metadata } from 'next';
 import RootLayoutShell, { defaultMetadata } from '@/components/RootLayoutShell';
 import { fetchGlobalPageSettings } from '@/lib/generate-page-metadata';

--- a/app/site.css
+++ b/app/site.css
@@ -1,47 +1,23 @@
 /*
  * Slim Tailwind bundle for published & preview pages (the `(site)` route group).
  *
- * Why this exists: `app/globals.css` pulls in the full builder UI theme —
- * shadcn color variables, dark mode, ProseMirror, Sonner toasts, etc. That
- * stylesheet ships ~28 KiB of render-blocking CSS to every published page,
- * even though published pages never reference any of it. The page-specific
- * Tailwind utilities user layers actually use are generated separately and
- * inlined as `<style id="ycode-styles">` by `PageRenderer.tsx`.
+ * Why this exists: `app/globals.css` defines the full builder UI theme —
+ * shadcn color variables, dark-mode tokens, ProseMirror, Sonner toasts, etc.
+ * Public pages never reference any of it; per-page utilities used by user
+ * layers are inlined as `<style id="ycode-styles">` by `PageRenderer.tsx`.
  *
- * To keep this bundle truly minimal we disable Tailwind's automatic source
- * detection (which would scan the whole project including the entire
- * builder UI) and explicitly enumerate only the components that render on
- * published / preview pages.
+ * To keep this bundle small we let Tailwind scan the project as usual but
+ * exclude the heavy builder UI route group. Files like `lib/templates/**`,
+ * `lib/page-utils.ts`, `lib/text-format-utils.ts` and the public renderer
+ * components stay in scope so all the arbitrary-value classes they carry
+ * (gap-[20px], leading-[1.5], etc.) end up in the bundle.
  */
 
-@import "tailwindcss" source(none);
+@import "tailwindcss";
 
-/* Public-facing renderer components — all of these emit classes that need
-   to exist in the published-site CSS. Builder-only components (sidebars,
-   modals, RichTextEditor, shadcn primitives) are intentionally NOT listed
-   so their utilities don't leak into the public bundle. */
-@source "../app/(site)";
-@source "../components/PageRenderer.tsx";
-@source "../components/LayerRenderer.tsx";
-@source "../components/LayerRendererPublic.tsx";
-@source "../components/LayerWrapper.tsx";
-@source "../components/PasswordForm.tsx";
-@source "../components/YcodeBadge.tsx";
-@source "../components/AnimationInitializer.tsx";
-@source "../components/SliderInitializer.tsx";
-@source "../components/LightboxInitializer.tsx";
-@source "../components/CustomCodeInjector.tsx";
-@source "../components/BodyClassApplier.tsx";
-@source "../components/ContentHeightReporter.tsx";
-@source "../components/RootLayoutShell.tsx";
-@source "../components/DarkModeProvider.tsx";
-@source "../components/FilterableCollection.tsx";
-@source "../components/LoadMoreCollection.tsx";
-@source "../components/PaginatedCollection.tsx";
-@source "../components/layers/LocaleSelector.tsx";
-@source "../components/collaboration/EditingIndicator.tsx";
-@source "../components/collaboration/LayerLockIndicator.tsx";
-@source "../components/ui/shimmer-skeleton.tsx";
+/* Builder UI is not rendered on published pages — drop ~150 KiB of
+   sidebar/modal/dropdown utilities by excluding the route group. */
+@source not "../app/(builder)";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/site.css
+++ b/app/site.css
@@ -1,0 +1,77 @@
+/*
+ * Slim Tailwind bundle for published & preview pages (the `(site)` route group).
+ *
+ * Why this exists: `app/globals.css` pulls in the full builder UI theme —
+ * shadcn color variables, dark mode, ProseMirror, Sonner toasts, etc. That
+ * stylesheet ships ~28 KiB of render-blocking CSS to every published page,
+ * even though published pages never reference any of it. The page-specific
+ * Tailwind utilities user layers actually use are generated separately and
+ * inlined as `<style id="ycode-styles">` by `PageRenderer.tsx`.
+ *
+ * To keep this bundle truly minimal we disable Tailwind's automatic source
+ * detection (which would scan the whole project including the entire
+ * builder UI) and explicitly enumerate only the components that render on
+ * published / preview pages.
+ */
+
+@import "tailwindcss" source(none);
+
+/* Public-facing renderer components — all of these emit classes that need
+   to exist in the published-site CSS. Builder-only components (sidebars,
+   modals, RichTextEditor, shadcn primitives) are intentionally NOT listed
+   so their utilities don't leak into the public bundle. */
+@source "../app/(site)";
+@source "../components/PageRenderer.tsx";
+@source "../components/LayerRenderer.tsx";
+@source "../components/LayerRendererPublic.tsx";
+@source "../components/LayerWrapper.tsx";
+@source "../components/PasswordForm.tsx";
+@source "../components/YcodeBadge.tsx";
+@source "../components/AnimationInitializer.tsx";
+@source "../components/SliderInitializer.tsx";
+@source "../components/LightboxInitializer.tsx";
+@source "../components/CustomCodeInjector.tsx";
+@source "../components/BodyClassApplier.tsx";
+@source "../components/ContentHeightReporter.tsx";
+@source "../components/RootLayoutShell.tsx";
+@source "../components/DarkModeProvider.tsx";
+@source "../components/FilterableCollection.tsx";
+@source "../components/LoadMoreCollection.tsx";
+@source "../components/PaginatedCollection.tsx";
+@source "../components/layers/LocaleSelector.tsx";
+@source "../components/collaboration/EditingIndicator.tsx";
+@source "../components/collaboration/LayerLockIndicator.tsx";
+@source "../components/ui/shimmer-skeleton.tsx";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  /* `--font-inter` is only defined inside the builder layout. On public
+     published pages the variable is undefined and these fall back to the
+     system font stacks — keeps marketing sites from downloading Inter just
+     because something used the generic `font-sans` class. */
+  --font-sans: var(--font-inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif);
+  --font-mono: var(--font-inter, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace);
+
+  /* Used by ShimmerSkeleton (shown in collection layouts while items load). */
+  --animate-shimmer: shimmer 2s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+/* Custom dropdown chevron for native <select> elements on published pages.
+   The native arrow is removed by the inline `ycode-form-reset` styles in
+   PageRenderer.tsx; this rule restores a consistent chevron. */
+#ybody select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23737373' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  background-size: 16px 16px;
+}

--- a/components/FilterLayerBehavior.tsx
+++ b/components/FilterLayerBehavior.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+/**
+ * FilterLayerBehavior
+ *
+ * Runtime behavior for `filter` layers on published & preview pages:
+ *   - Reads URL params on mount and applies them to nested input/select/textarea elements.
+ *   - Builds a name map (inputLayerId → URL key) so the filter store can sync values to the URL.
+ *   - Listens for clicks (Apply button), Enter keypresses, and (when `filterOnChange`) input/change
+ *     events to push collected values into `useFilterStore` for `FilterableCollection` to read.
+ *
+ * Lives in its own module so the `useFilterStore` import (Zustand) and the ~180 lines of
+ * DOM-scanning code only ship in pages that actually render a filter layer. Loaded lazily
+ * via `next/dynamic` from `LayerRendererPublic`.
+ */
+
+import React, { useEffect } from 'react';
+import { useFilterStore } from '@/stores/useFilterStore';
+
+interface FilterLayerBehaviorProps {
+  /** The filter container element. We attach listeners here and query its descendants. */
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  filterLayerId: string;
+  /** When true, value changes in any nested input trigger a debounced collection. */
+  filterOnChange: boolean;
+}
+
+const FilterLayerBehavior: React.FC<FilterLayerBehaviorProps> = ({
+  containerRef,
+  filterLayerId,
+  filterOnChange,
+}) => {
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const container = containerRef.current;
+    const store = useFilterStore.getState();
+
+    const nameMap: Record<string, string> = {};
+    const reverseMap: Record<string, string> = {};
+    const checkboxGroupNames: Record<string, string> = {};
+    const inputs = container.querySelectorAll('input, select, textarea');
+    inputs.forEach(el => {
+      const inputEl = el as HTMLInputElement;
+      const inputLayerId = inputEl.closest('[data-layer-id]')?.getAttribute('data-layer-id');
+      if (!inputLayerId) return;
+      const nameAttr = inputEl.getAttribute('name');
+      const paramName = nameAttr || (inputLayerId.startsWith('lyr-') ? inputLayerId.slice(4) : inputLayerId);
+      nameMap[inputLayerId] = paramName;
+      reverseMap[paramName] = inputLayerId;
+      if (inputEl.type === 'checkbox' || inputEl.type === 'radio') {
+        const cbMatch = inputLayerId.match(/^(.+)-(?:cb|rb)-.+-input$/);
+        if (cbMatch) {
+          checkboxGroupNames[cbMatch[1]] = (nameAttr || '').replace(/\[\]$/, '') || cbMatch[1];
+        }
+      }
+    });
+    for (const [baseId, baseName] of Object.entries(checkboxGroupNames)) {
+      nameMap[baseId] = baseName;
+      reverseMap[baseName] = baseId;
+    }
+    const inputLayerIds = Object.keys(nameMap);
+    store.setNameMap(nameMap);
+
+    const url = new URL(window.location.href);
+    url.searchParams.forEach((value, key) => {
+      if (!value) return;
+      const inputLayerId = reverseMap[key]
+        || (key.startsWith('filter_') ? key.slice('filter_'.length) : null);
+      if (!inputLayerId) return;
+      let inputEl = container.querySelector(`[data-layer-id="${inputLayerId}"] input, [data-layer-id="${inputLayerId}"] select, [data-layer-id="${inputLayerId}"] textarea`) as HTMLInputElement | null;
+      if (!inputEl) {
+        const directEl = container.querySelector(`input[data-layer-id="${inputLayerId}"], select[data-layer-id="${inputLayerId}"], textarea[data-layer-id="${inputLayerId}"]`) as HTMLInputElement | null;
+        inputEl = directEl;
+      }
+      if (!inputEl) {
+        const cbInputs = container.querySelectorAll(
+          `[data-layer-id^="${inputLayerId}-cb-"] input[type="checkbox"], [data-layer-id^="${inputLayerId}-rb-"] input[type="radio"]`
+        );
+        if (cbInputs.length > 0) {
+          const checkedSet = new Set(value.split(','));
+          cbInputs.forEach(cb => {
+            (cb as HTMLInputElement).checked = checkedSet.has((cb as HTMLInputElement).value);
+          });
+        }
+        return;
+      }
+      if (inputEl.type === 'checkbox') {
+        inputEl.checked = value === inputEl.value || value === 'true';
+      } else {
+        inputEl.value = value;
+      }
+    });
+
+    setTimeout(() => store.loadFromUrl(), 0);
+
+    return () => {
+      const state = useFilterStore.getState();
+      state.removeNameMapEntries(inputLayerIds);
+    };
+  }, [containerRef]);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const container = containerRef.current;
+    const { setFilterValues } = useFilterStore.getState();
+
+    const collectInputValues = () => {
+      const nameMap: Record<string, string> = {};
+      const inputValues: Record<string, string> = {};
+      const checkboxGroups: Record<string, string[]> = {};
+      const inputs = container.querySelectorAll('input, select, textarea');
+      inputs.forEach(el => {
+        const inputEl = el as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+        const inputLayerId = inputEl.closest('[data-layer-id]')?.getAttribute('data-layer-id');
+        if (!inputLayerId) return;
+        const nameAttr = inputEl.getAttribute('name');
+        if (nameAttr) nameMap[inputLayerId] = nameAttr;
+        if (inputEl.type === 'checkbox' || inputEl.type === 'radio') {
+          const checked = (inputEl as HTMLInputElement).checked;
+          const val = checked ? ((inputEl as HTMLInputElement).value || 'true') : '';
+          inputValues[inputLayerId] = val;
+          const cbMatch = inputLayerId.match(/^(.+)-(?:cb|rb)-.+-input$/);
+          if (cbMatch) {
+            const baseId = cbMatch[1];
+            if (!checkboxGroups[baseId]) checkboxGroups[baseId] = [];
+            if (val) checkboxGroups[baseId].push(val);
+            if (nameAttr) nameMap[baseId] = nameAttr.replace(/\[\]$/, '');
+          }
+        } else {
+          inputValues[inputLayerId] = inputEl.value;
+        }
+      });
+      for (const [baseId, values] of Object.entries(checkboxGroups)) {
+        inputValues[baseId] = values.join(',');
+      }
+      setFilterValues(filterLayerId, inputValues);
+      if (Object.keys(nameMap).length > 0) {
+        useFilterStore.getState().setNameMap(nameMap);
+      }
+    };
+
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const debouncedCollect = () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(collectInputValues, 750);
+    };
+
+    const handleButtonClick = (e: Event) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('button') || target.tagName === 'BUTTON') {
+        e.preventDefault();
+        collectInputValues();
+      }
+    };
+
+    const handleKeyDown = (e: Event) => {
+      const ke = e as KeyboardEvent;
+      if (ke.key !== 'Enter') return;
+      const target = ke.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'SELECT') {
+        ke.preventDefault();
+        collectInputValues();
+      }
+    };
+
+    container.addEventListener('click', handleButtonClick);
+    container.addEventListener('keydown', handleKeyDown);
+
+    if (filterOnChange) {
+      const handleInputChange = () => debouncedCollect();
+      container.addEventListener('input', handleInputChange);
+      container.addEventListener('change', handleInputChange);
+
+      collectInputValues();
+
+      return () => {
+        container.removeEventListener('click', handleButtonClick);
+        container.removeEventListener('keydown', handleKeyDown);
+        container.removeEventListener('input', handleInputChange);
+        container.removeEventListener('change', handleInputChange);
+        useFilterStore.getState().clearFilter(filterLayerId);
+        if (debounceTimer) clearTimeout(debounceTimer);
+      };
+    }
+
+    collectInputValues();
+
+    return () => {
+      container.removeEventListener('click', handleButtonClick);
+      container.removeEventListener('keydown', handleKeyDown);
+      useFilterStore.getState().clearFilter(filterLayerId);
+      if (debounceTimer) clearTimeout(debounceTimer);
+    };
+  }, [containerRef, filterLayerId, filterOnChange]);
+
+  return null;
+};
+
+export default FilterLayerBehavior;

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -14,6 +14,7 @@
  */
 
 import React, { useEffect, useCallback, useMemo, useRef, Suspense } from 'react';
+import dynamic from 'next/dynamic';
 import type { Layer, Locale, FormSettings, Component, DesignColorVariable } from '@/types';
 import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextContentLayer, getCollectionVariable, filterDisabledSliderLayers } from '@/lib/layer-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
@@ -26,14 +27,27 @@ import { resolveInlineVariablesFromData } from '@/lib/inline-variables';
 import { renderRichText, hasBlockElementsWithInlineVariables, getTextStyleClasses, flattenTiptapParagraphs, type RichTextLinkContext, type RenderComponentBlockFn } from '@/lib/text-format-utils';
 import { combineBgValues, mergeStaticBgVars } from '@/lib/tailwind-class-mapper';
 import { clsx } from 'clsx';
-import PaginatedCollection from '@/components/PaginatedCollection';
-import LoadMoreCollection from '@/components/LoadMoreCollection';
-import FilterableCollection from '@/components/FilterableCollection';
-import LocaleSelector from '@/components/layers/LocaleSelector';
-import { useFilterStore } from '@/stores/useFilterStore';
 import type { HiddenLayerInfo } from '@/lib/animation-utils';
-import AnimationInitializer from '@/components/AnimationInitializer';
 import { transformLayerIdsForInstance } from '@/lib/resolve-components';
+
+/**
+ * Per-layer-type code splitting.
+ *
+ * `LayerRendererPublic` is the single client component that hydrates every
+ * published & preview page, so anything we import statically here ships in
+ * the entry chunk for *every* visitor — even if the page never renders that
+ * layer type. The bindings below load on demand the first time the matching
+ * layer is encountered (~262 KiB of unused JS in PSI before this split).
+ *
+ * Keep `ssr: true` (the default): the wrapped components rely on SSR for
+ * SEO / hydration consistency, we only want to defer the *client* chunk.
+ */
+const PaginatedCollection = dynamic(() => import('@/components/PaginatedCollection'));
+const LoadMoreCollection = dynamic(() => import('@/components/LoadMoreCollection'));
+const FilterableCollection = dynamic(() => import('@/components/FilterableCollection'));
+const LocaleSelector = dynamic(() => import('@/components/layers/LocaleSelector'));
+const AnimationInitializer = dynamic(() => import('@/components/AnimationInitializer'));
+const FilterLayerBehavior = dynamic(() => import('@/components/FilterLayerBehavior'));
 
 /** True if any layer in the tree has at least one interaction configured. */
 function layerTreeHasInteractions(layers: Layer[]): boolean {
@@ -515,185 +529,12 @@ const LayerItem: React.FC<{
     };
   }, [htmlEmbedCode, layer.name]);
 
-  // Filter layer runtime behavior: attach event listeners to child inputs
+  // Filter layer runtime behavior is implemented in FilterLayerBehavior, which
+  // is dynamic-imported and mounted only when this layer is a filter. Keeping
+  // it out of the main bundle drops zustand + ~180 lines of DOM-scanning code
+  // from every page that doesn't use filtering.
   const isFilterLayer = layer.name === 'filter';
   const filterOnChange = layer.settings?.filterOnChange ?? false;
-
-  // Load filter values from URL on initial render and populate input elements
-  React.useEffect(() => {
-    if (!isFilterLayer || !filterLayerRef.current) return;
-
-    const container = filterLayerRef.current;
-    const store = useFilterStore.getState();
-
-    // Build the name map from DOM: inputLayerId → name attribute (or stripped ID)
-    const nameMap: Record<string, string> = {};
-    const reverseMap: Record<string, string> = {};
-    const checkboxGroupNames: Record<string, string> = {};
-    const inputs = container.querySelectorAll('input, select, textarea');
-    inputs.forEach(el => {
-      const inputEl = el as HTMLInputElement;
-      const inputLayerId = inputEl.closest('[data-layer-id]')?.getAttribute('data-layer-id');
-      if (!inputLayerId) return;
-      const nameAttr = inputEl.getAttribute('name');
-      const paramName = nameAttr || (inputLayerId.startsWith('lyr-') ? inputLayerId.slice(4) : inputLayerId);
-      nameMap[inputLayerId] = paramName;
-      reverseMap[paramName] = inputLayerId;
-      if (inputEl.type === 'checkbox' || inputEl.type === 'radio') {
-        const cbMatch = inputLayerId.match(/^(.+)-(?:cb|rb)-.+-input$/);
-        if (cbMatch) {
-          checkboxGroupNames[cbMatch[1]] = (nameAttr || '').replace(/\[\]$/, '') || cbMatch[1];
-        }
-      }
-    });
-    for (const [baseId, baseName] of Object.entries(checkboxGroupNames)) {
-      nameMap[baseId] = baseName;
-      reverseMap[baseName] = baseId;
-    }
-    const inputLayerIds = Object.keys(nameMap);
-    store.setNameMap(nameMap);
-
-    // Populate input elements with values from URL params
-    const url = new URL(window.location.href);
-    url.searchParams.forEach((value, key) => {
-      if (!value) return;
-      const inputLayerId = reverseMap[key]
-        || (key.startsWith('filter_') ? key.slice('filter_'.length) : null);
-      if (!inputLayerId) return;
-      // Find the input: it may be a descendant of a wrapper div OR the element itself
-      let inputEl = container.querySelector(`[data-layer-id="${inputLayerId}"] input, [data-layer-id="${inputLayerId}"] select, [data-layer-id="${inputLayerId}"] textarea`) as HTMLInputElement | null;
-      if (!inputEl) {
-        const directEl = container.querySelector(`input[data-layer-id="${inputLayerId}"], select[data-layer-id="${inputLayerId}"], textarea[data-layer-id="${inputLayerId}"]`) as HTMLInputElement | null;
-        inputEl = directEl;
-      }
-      if (!inputEl) {
-        const cbInputs = container.querySelectorAll(
-          `[data-layer-id^="${inputLayerId}-cb-"] input[type="checkbox"], [data-layer-id^="${inputLayerId}-rb-"] input[type="radio"]`
-        );
-        if (cbInputs.length > 0) {
-          const checkedSet = new Set(value.split(','));
-          cbInputs.forEach(cb => {
-            (cb as HTMLInputElement).checked = checkedSet.has((cb as HTMLInputElement).value);
-          });
-        }
-        return;
-      }
-      if (inputEl.type === 'checkbox') {
-        inputEl.checked = value === inputEl.value || value === 'true';
-      } else {
-        inputEl.value = value;
-      }
-    });
-
-    // Defer loadFromUrl to ensure FilterableCollection has mounted and subscribed
-    setTimeout(() => store.loadFromUrl(), 0);
-
-    return () => {
-      const state = useFilterStore.getState();
-      state.removeNameMapEntries(inputLayerIds);
-    };
-  }, [isFilterLayer]);
-
-  React.useEffect(() => {
-    if (!isFilterLayer || !filterLayerRef.current) return;
-
-    const container = filterLayerRef.current;
-    const filterLayerId = layer.id;
-    const { setFilterValues } = useFilterStore.getState();
-
-    const collectInputValues = () => {
-      const nameMap: Record<string, string> = {};
-      const inputValues: Record<string, string> = {};
-      const checkboxGroups: Record<string, string[]> = {};
-      const inputs = container.querySelectorAll('input, select, textarea');
-      inputs.forEach(el => {
-        const inputEl = el as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
-        const inputLayerId = inputEl.closest('[data-layer-id]')?.getAttribute('data-layer-id');
-        if (!inputLayerId) return;
-        const nameAttr = inputEl.getAttribute('name');
-        if (nameAttr) nameMap[inputLayerId] = nameAttr;
-        if (inputEl.type === 'checkbox' || inputEl.type === 'radio') {
-          const checked = (inputEl as HTMLInputElement).checked;
-          const val = checked ? ((inputEl as HTMLInputElement).value || 'true') : '';
-          inputValues[inputLayerId] = val;
-          const cbMatch = inputLayerId.match(/^(.+)-(?:cb|rb)-.+-input$/);
-          if (cbMatch) {
-            const baseId = cbMatch[1];
-            if (!checkboxGroups[baseId]) checkboxGroups[baseId] = [];
-            if (val) checkboxGroups[baseId].push(val);
-            if (nameAttr) nameMap[baseId] = nameAttr.replace(/\[\]$/, '');
-          }
-        } else {
-          inputValues[inputLayerId] = inputEl.value;
-        }
-      });
-      for (const [baseId, values] of Object.entries(checkboxGroups)) {
-        inputValues[baseId] = values.join(',');
-      }
-      setFilterValues(filterLayerId, inputValues);
-      if (Object.keys(nameMap).length > 0) {
-        useFilterStore.getState().setNameMap(nameMap);
-      }
-    };
-
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-    const debouncedCollect = () => {
-      if (debounceTimer) clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(collectInputValues, 750);
-    };
-
-    // Button click handler - always triggers collection
-    const handleButtonClick = (e: Event) => {
-      const target = e.target as HTMLElement;
-      if (target.closest('button') || target.tagName === 'BUTTON') {
-        e.preventDefault();
-        collectInputValues();
-      }
-    };
-
-    // Enter key handler - triggers collection from any input
-    const handleKeyDown = (e: Event) => {
-      const ke = e as KeyboardEvent;
-      if (ke.key !== 'Enter') return;
-      const target = ke.target as HTMLElement;
-      if (target.tagName === 'INPUT' || target.tagName === 'SELECT') {
-        ke.preventDefault();
-        collectInputValues();
-      }
-    };
-
-    container.addEventListener('click', handleButtonClick);
-    container.addEventListener('keydown', handleKeyDown);
-
-    // If filterOnChange is enabled, listen for input changes
-    if (filterOnChange) {
-      const handleInputChange = () => debouncedCollect();
-      container.addEventListener('input', handleInputChange);
-      container.addEventListener('change', handleInputChange);
-
-      // Apply initial input values (including defaults) on mount.
-      collectInputValues();
-
-      return () => {
-        container.removeEventListener('click', handleButtonClick);
-        container.removeEventListener('keydown', handleKeyDown);
-        container.removeEventListener('input', handleInputChange);
-        container.removeEventListener('change', handleInputChange);
-        useFilterStore.getState().clearFilter(filterLayerId);
-        if (debounceTimer) clearTimeout(debounceTimer);
-      };
-    }
-
-    // Apply initial input values (including defaults) on mount.
-    collectInputValues();
-
-    return () => {
-      container.removeEventListener('click', handleButtonClick);
-      container.removeEventListener('keydown', handleKeyDown);
-      useFilterStore.getState().clearFilter(filterLayerId);
-      if (debounceTimer) clearTimeout(debounceTimer);
-    };
-  }, [isFilterLayer, filterOnChange, layer.id]);
 
   // Resolve text and image URLs with field binding support
   const textContent = (() => {
@@ -1793,6 +1634,22 @@ const LayerItem: React.FC<{
   };
 
   let content = renderContent();
+
+  // Mount filter behavior alongside the rendered filter container. The
+  // dynamic chunk attaches DOM listeners to `filterLayerRef.current` once
+  // hydrated; ref assignment runs before the dynamic effect, so timing is fine.
+  if (isFilterLayer) {
+    content = (
+      <>
+        {content}
+        <FilterLayerBehavior
+          containerRef={filterLayerRef}
+          filterLayerId={layer.id}
+          filterOnChange={filterOnChange}
+        />
+      </>
+    );
+  }
 
   // Wrap with link if layer has link settings
   // Skip for buttons/divs — they render as <a> directly (see isButtonWithLink, isDivWithLink)

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -434,12 +434,15 @@ export default async function PageRenderer({
 
   // Fetch all assets and build resolved map
   // Use draft assets (isPublished=false) for preview mode, published assets otherwise
-  let resolvedAssets: Record<string, { url: string; width?: number | null; height?: number | null }> | undefined;
+  // `mimeType` is tracked locally so the LCP heuristic can skip SVG logos;
+  // it is stripped before passing the map across the client boundary.
+  type ResolvedAssetEntry = { url: string; width?: number | null; height?: number | null; mimeType?: string };
+  let resolvedAssetsWithMime: Record<string, ResolvedAssetEntry> | undefined;
   if (layerAssetIds.size > 0) {
     try {
       const { getAssetsByIds } = await import('@/lib/repositories/assetRepository');
       const assetMap = await getAssetsByIds(Array.from(layerAssetIds), !isPreview);
-      resolvedAssets = {};
+      resolvedAssetsWithMime = {};
       for (const [id, asset] of Object.entries(assetMap)) {
         let url: string | undefined;
         const proxyUrl = getAssetProxyUrl(asset);
@@ -451,7 +454,7 @@ export default async function PageRenderer({
           url = asset.content;
         }
         if (url) {
-          resolvedAssets[id] = { url, width: asset.width, height: asset.height };
+          resolvedAssetsWithMime[id] = { url, width: asset.width, height: asset.height, mimeType: asset.mime_type };
         }
       }
     } catch (error) {
@@ -460,9 +463,18 @@ export default async function PageRenderer({
   }
 
   // Identify the LCP candidate so the renderer can flip its loading=lazy
-  // template default to eager + fetchpriority=high. Skips images smaller than
-  // ~200px to avoid prioritizing logos/icons.
-  const lcpCandidateLayerId = findLcpCandidateLayerId(childLayers, resolvedAssets);
+  // template default to eager + fetchpriority=high. Skips logos/icons by
+  // ignoring images inside header/footer/nav and SVG-backed assets.
+  const lcpCandidateLayerId = findLcpCandidateLayerId(childLayers, resolvedAssetsWithMime);
+
+  // Strip mimeType before crossing the client component boundary — only
+  // url/width/height are part of the shared `resolvedAssets` contract.
+  const resolvedAssets: Record<string, { url: string; width?: number | null; height?: number | null }> | undefined =
+    resolvedAssetsWithMime
+      ? Object.fromEntries(
+        Object.entries(resolvedAssetsWithMime).map(([id, { url, width, height }]) => [id, { url, width, height }])
+      )
+      : undefined;
 
   return (
     <>

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -508,6 +508,22 @@ export default async function PageRenderer({
         />
       )}
 
+      {/* Warm up the Google Fonts origins before parsing the stylesheet, so
+          DNS + TCP + TLS to fonts.gstatic.com runs in parallel with the CSS
+          fetch. Saves ~100–300 ms on the font request's first byte (PSI's
+          "Network dependency tree" insight flagged the missing preconnect).
+          `crossOrigin` on gstatic is required because font files are fetched
+          in CORS mode — without it the browser opens a fresh connection. */}
+      {googleFontLinkUrls.length > 0 && (
+        <>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link
+            rel="preconnect" href="https://fonts.gstatic.com"
+            crossOrigin="anonymous"
+          />
+        </>
+      )}
+
       {/* Load Google Fonts via <link> elements */}
       {googleFontLinkUrls.map((url, i) => (
         <link

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -11,8 +11,8 @@ import { unstable_cache } from 'next/cache';
 import { resolveCustomCodePlaceholders } from '@/lib/resolve-cms-variables';
 import { renderRootLayoutHeadCode } from '@/lib/parse-head-html';
 import { generateInitialAnimationCSS, type HiddenLayerInfo } from '@/lib/animation-utils';
-import { buildCustomFontsCss, buildFontClassesCss, getGoogleFontLinks } from '@/lib/font-utils';
-import { collectLayerAssetIds, getAssetProxyUrl, findLcpCandidateLayerId } from '@/lib/asset-utils';
+import { buildCustomFontsCss, buildFontClassesCss, fetchGoogleFontsCss, getGoogleFontLinks } from '@/lib/font-utils';
+import { collectLayerAssetIds, findLcpCandidate, generateImageSrcset, getAssetProxyUrl, getImageSizes, getOptimizedImageUrl } from '@/lib/asset-utils';
 import { getAllPages } from '@/lib/repositories/pageRepository';
 import { getAllPageFolders } from '@/lib/repositories/pageFolderRepository';
 import { getMapboxAccessToken, getGoogleMapsEmbedApiKey } from '@/lib/map-server';
@@ -381,6 +381,7 @@ export default async function PageRenderer({
 
   // Load installed fonts and generate CSS + link URLs
   let fontsCss = '';
+  let googleFontsInlinedCss = '';
   let googleFontLinkUrls: string[] = [];
   try {
     const { getAllFonts: getAllDraftFonts } = await import('@/lib/repositories/fontRepository');
@@ -388,6 +389,17 @@ export default async function PageRenderer({
     const fonts = isPreview ? await getAllDraftFonts() : await getPublishedFonts();
     fontsCss = buildCustomFontsCss(fonts) + buildFontClassesCss(fonts);
     googleFontLinkUrls = getGoogleFontLinks(fonts);
+
+    // Inline the resolved @font-face CSS so the browser skips the blocking
+    // round-trip to fonts.googleapis.com and goes straight to gstatic for
+    // the woff2 binaries. Cached per font config across requests.
+    if (googleFontLinkUrls.length > 0) {
+      googleFontsInlinedCss = await unstable_cache(
+        async () => fetchGoogleFontsCss(googleFontLinkUrls),
+        [`google-fonts-css-${googleFontLinkUrls.join('|')}`],
+        { tags: ['all-pages'], revalidate: false },
+      )();
+    }
   } catch (error) {
     console.error('[PageRenderer] Error loading fonts:', error);
   }
@@ -465,7 +477,27 @@ export default async function PageRenderer({
   // Identify the LCP candidate so the renderer can flip its loading=lazy
   // template default to eager + fetchpriority=high. Skips logos/icons by
   // ignoring images inside header/footer/nav and SVG-backed assets.
-  const lcpCandidateLayerId = findLcpCandidateLayerId(childLayers, resolvedAssetsWithMime);
+  const lcpCandidate = findLcpCandidate(childLayers, resolvedAssetsWithMime);
+  const lcpCandidateLayerId = lcpCandidate?.layerId ?? null;
+
+  // Resolve the candidate's URL so we can emit <link rel="preload" as="image">
+  // in <head>. The browser starts fetching the hero image as soon as it parses
+  // the preload — well before it reaches the <img> tag deeper in the document.
+  // Only handles asset-variable images; CMS field-bound images on dynamic
+  // pages would need item-aware resolution.
+  let lcpPreloadSrc: string | null = null;
+  let lcpPreloadSrcset: string | null = null;
+  let lcpPreloadSizes: string | null = null;
+  if (lcpCandidate?.assetId && resolvedAssetsWithMime) {
+    const candidateAsset = resolvedAssetsWithMime[lcpCandidate.assetId];
+    if (candidateAsset?.url) {
+      lcpPreloadSrc = getOptimizedImageUrl(candidateAsset.url, 1920, 85);
+      lcpPreloadSrcset = generateImageSrcset(candidateAsset.url) || null;
+      lcpPreloadSizes = candidateAsset.width
+        ? `(max-width: 768px) 100vw, ${candidateAsset.width}px`
+        : getImageSizes();
+    }
+  }
 
   // Strip mimeType before crossing the client component boundary — only
   // url/width/height are part of the shared `resolvedAssets` contract.
@@ -485,6 +517,30 @@ export default async function PageRenderer({
 
       {/* Page-specific custom head code — React 19 hoists meta/link/style/title to <head> */}
       {pageCustomCodeHead && renderRootLayoutHeadCode(pageCustomCodeHead, 'page-head')}
+
+      {/* Preload the LCP image so the browser starts the fetch from <head>
+          rather than waiting until the parser reaches the <img> tag. Pairs
+          with the eager + fetchpriority=high props the renderer sets on the
+          same layer below. */}
+      {lcpPreloadSrc && (
+        lcpPreloadSrcset ? (
+          <link
+            rel="preload"
+            as="image"
+            href={lcpPreloadSrc}
+            imageSrcSet={lcpPreloadSrcset}
+            imageSizes={lcpPreloadSizes || undefined}
+            fetchPriority="high"
+          />
+        ) : (
+          <link
+            rel="preload"
+            as="image"
+            href={lcpPreloadSrc}
+            fetchPriority="high"
+          />
+        )
+      )}
 
       {/* Strip native browser appearance from form elements so Tailwind classes apply */}
       <style
@@ -508,15 +564,15 @@ export default async function PageRenderer({
         />
       )}
 
-      {/* Warm up the Google Fonts origins before parsing the stylesheet, so
-          DNS + TCP + TLS to fonts.gstatic.com runs in parallel with the CSS
-          fetch. Saves ~100–300 ms on the font request's first byte (PSI's
-          "Network dependency tree" insight flagged the missing preconnect).
-          `crossOrigin` on gstatic is required because font files are fetched
-          in CORS mode — without it the browser opens a fresh connection. */}
+      {/* Warm up the Google Fonts origins. When CSS is inlined below we only
+          need gstatic (the binary origin); when we fall back to <link
+          rel=stylesheet> we also need googleapis. `crossOrigin` on gstatic
+          is required because font files are fetched in CORS mode. */}
       {googleFontLinkUrls.length > 0 && (
         <>
-          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          {!googleFontsInlinedCss && (
+            <link rel="preconnect" href="https://fonts.googleapis.com" />
+          )}
           <link
             rel="preconnect" href="https://fonts.gstatic.com"
             crossOrigin="anonymous"
@@ -524,14 +580,23 @@ export default async function PageRenderer({
         </>
       )}
 
-      {/* Load Google Fonts via <link> elements */}
-      {googleFontLinkUrls.map((url, i) => (
-        <link
-          key={`gfont-${i}`}
-          rel="stylesheet"
-          href={url}
+      {/* Inline resolved @font-face rules when available — skips the blocking
+          CSS request to fonts.googleapis.com. Falls back to <link
+          rel=stylesheet> if the publish-time fetch failed. */}
+      {googleFontsInlinedCss ? (
+        <style
+          id="ycode-google-fonts"
+          dangerouslySetInnerHTML={{ __html: googleFontsInlinedCss }}
         />
-      ))}
+      ) : (
+        googleFontLinkUrls.map((url, i) => (
+          <link
+            key={`gfont-${i}`}
+            rel="stylesheet"
+            href={url}
+          />
+        ))
+      )}
 
       {/* Inject custom font @font-face rules and font class CSS */}
       {fontsCss && (

--- a/lib/asset-utils.ts
+++ b/lib/asset-utils.ts
@@ -371,12 +371,35 @@ export function getImageSizes(): string {
   return '100vw';
 }
 
+// Semantic layer names whose descendant images are almost never the LCP
+// (logos, menus, footer marks). Tracked via ancestor walk in
+// `findLcpCandidateLayerId` so we don't accidentally prioritize a header
+// logo over the actual hero image.
+const NON_LCP_ANCESTOR_NAMES = new Set(['header', 'footer', 'nav']);
+
+/**
+ * Heuristic: is this resolved asset a vector graphic (SVG)?
+ * SVGs are used overwhelmingly for logos / icons and should never be picked
+ * as the LCP candidate. We trust `mimeType` when present and fall back to a
+ * URL extension sniff for older callers that only pass `{ url, width }`.
+ */
+function isSvgAsset(asset: { mimeType?: string | null; url?: string | null } | undefined): boolean {
+  if (!asset) return false;
+  if (asset.mimeType && asset.mimeType.toLowerCase().includes('svg')) return true;
+  if (asset.url) {
+    const path = asset.url.split('?')[0].split('#')[0].toLowerCase();
+    if (path.endsWith('.svg')) return true;
+  }
+  return false;
+}
+
 /**
  * Find the layer id that should be treated as the LCP (Largest Contentful Paint)
- * candidate for a given page tree. Walks the tree in render order and returns the
- * first `image`-named layer whose effective intrinsic width is unknown or at
- * least `minWidth` pixels. The threshold filters out logos and icons that
- * commonly appear in headers but are not the actual hero image.
+ * candidate for a given page tree. Walks the tree in render order and returns
+ * the first `image`-named layer that:
+ *   - is NOT a descendant of a `header`, `footer`, or `nav` layer (logos),
+ *   - is NOT backed by an SVG asset (vector logos / icons), and
+ *   - has an effective intrinsic width unknown or at least `minWidth` pixels.
  *
  * Width resolution order:
  *   1. `layer.attributes.width` (parsed as int)
@@ -387,7 +410,7 @@ export function getImageSizes(): string {
  */
 export function findLcpCandidateLayerId(
   layers: Layer[],
-  resolvedAssets?: Record<string, { width?: number | null }>,
+  resolvedAssets?: Record<string, { width?: number | null; mimeType?: string | null; url?: string | null }>,
   minWidth: number = 200
 ): string | null {
   const parseWidth = (value: unknown): number | null => {
@@ -399,30 +422,31 @@ export function findLcpCandidateLayerId(
     return isNaN(n) ? null : n;
   };
 
-  const visit = (layer: Layer): string | null => {
-    if (layer.name === 'image') {
-      // Try the explicit width attribute first
-      let width = parseWidth(layer.attributes?.width);
+  const visit = (layer: Layer, inNonLcpAncestor: boolean): string | null => {
+    const inNonLcp = inNonLcpAncestor || NON_LCP_ANCESTOR_NAMES.has(layer.name);
 
-      // Fall back to the resolved asset's intrinsic width
-      if (width === null && resolvedAssets) {
-        const assetId = isAssetVariable(layer.variables?.image?.src)
-          ? getAssetId(layer.variables.image.src)
-          : undefined;
-        if (assetId && resolvedAssets[assetId]?.width) {
-          width = resolvedAssets[assetId].width as number;
+    if (layer.name === 'image' && !inNonLcp) {
+      const assetId = isAssetVariable(layer.variables?.image?.src)
+        ? getAssetId(layer.variables.image.src)
+        : undefined;
+      const asset = assetId ? resolvedAssets?.[assetId] : undefined;
+
+      // SVGs are vector logos / icons in practice — never the hero image.
+      if (!isSvgAsset(asset)) {
+        let width = parseWidth(layer.attributes?.width);
+        if (width === null && asset?.width) {
+          width = asset.width as number;
         }
-      }
 
-      // Width unknown OR meets the threshold -> candidate
-      if (width === null || width >= minWidth) {
-        return layer.id;
+        if (width === null || width >= minWidth) {
+          return layer.id;
+        }
       }
     }
 
     if (layer.children) {
       for (const child of layer.children) {
-        const found = visit(child);
+        const found = visit(child, inNonLcp);
         if (found) return found;
       }
     }
@@ -431,7 +455,7 @@ export function findLcpCandidateLayerId(
   };
 
   for (const layer of layers) {
-    const found = visit(layer);
+    const found = visit(layer, false);
     if (found) return found;
   }
 

--- a/lib/asset-utils.ts
+++ b/lib/asset-utils.ts
@@ -325,21 +325,34 @@ export function getOptimizedImageUrl(
  * Generate responsive image srcset with multiple sizes
  * Creates optimized URLs for different viewport widths
  * @param url - Original image URL
- * @param sizes - Array of widths in pixels (default: [320, 640, 960, 1280, 1920])
+ * @param sizes - Array of widths in pixels (default: see below)
  * @param quality - Image quality 0-100 (default: 85)
  * @returns Srcset string with multiple size options
  *
- * The 320 entry covers small mobile viewports; 1920 is the cap because
- * higher resolutions (e.g. 2560) get picked unnecessarily on retina mobile
- * even though the rendered image is much smaller.
+ * Default ladder: 320, 480, 640, 750, 828, 1080, 1280, 1536, 1920.
+ * Picked to land within ~10% of the natural rendered size for every common
+ * viewport × DPR combination — coarser ladders (e.g. 640 → 960 → 1280) made
+ * mid-range phones download the next-bigger variant and wasted 20–30% of
+ * the byte budget on hero images.
+ *
+ *   320 — tiny viewports / small thumbnails
+ *   480 — older phones at 1x
+ *   640 — medium phones, tablet portrait at 1x
+ *   750 — iPhone SE/8 at 2x DPR (375 × 2)
+ *   828 — iPhone XR/11 at 2x DPR (414 × 2)
+ *  1080 — Pixel / Galaxy at 3x DPR (360 × 3)
+ *  1280 — iPhone 12–15 at ~3x DPR (390–430 × 3)
+ *  1536 — tablets at 2x DPR
+ *  1920 — full-width desktop hero (cap — bigger variants get picked on
+ *         retina laptops even when the rendered size is much smaller).
  *
  * @example
  * generateImageSrcset('https://supabase.co/storage/v1/object/public/assets/image.jpg')
- * // Returns: 'https://.../image.jpg?width=320&quality=85 320w, https://.../image.jpg?width=640&quality=85 640w, ...'
+ * // Returns: 'https://.../image.jpg?width=320&quality=85 320w, https://.../image.jpg?width=480&quality=85 480w, ...'
  */
 export function generateImageSrcset(
   url: string,
-  sizes: number[] = [320, 640, 960, 1280, 1920],
+  sizes: number[] = [320, 480, 640, 750, 828, 1080, 1280, 1536, 1920],
   quality: number = 85
 ): string {
   if (!isTransformableUrl(url)) return '';

--- a/lib/asset-utils.ts
+++ b/lib/asset-utils.ts
@@ -399,11 +399,31 @@ const NON_LCP_ANCESTOR_NAMES = new Set(['header', 'footer', 'nav']);
 function isSvgAsset(asset: { mimeType?: string | null; url?: string | null } | undefined): boolean {
   if (!asset) return false;
   if (asset.mimeType && asset.mimeType.toLowerCase().includes('svg')) return true;
-  if (asset.url) {
-    const path = asset.url.split('?')[0].split('#')[0].toLowerCase();
-    if (path.endsWith('.svg')) return true;
-  }
+  if (asset.url) return isSvgUrl(asset.url);
   return false;
+}
+
+/** Cheap extension sniff: does the URL path end in `.svg`? */
+function isSvgUrl(url: string): boolean {
+  const path = url.split('?')[0].split('#')[0].toLowerCase();
+  return path.endsWith('.svg');
+}
+
+/**
+ * Best-effort URL extraction from an image layer's `src` variable when the
+ * variable is a raw URL string (`dynamic_text` / `static_text`) rather than
+ * an `AssetVariable`. Lets the LCP heuristic skip SVG logos that the user
+ * pasted as a URL instead of selecting from the asset library.
+ *
+ * Returns undefined for variable shapes we can't resolve cheaply (e.g. CMS
+ * field bindings) — those fall through to the existing checks.
+ */
+function getInlineImageUrl(srcVar: unknown): string | undefined {
+  if (!srcVar || typeof srcVar !== 'object') return undefined;
+  const v = srcVar as { type?: string; data?: { content?: unknown } };
+  if (v.type !== 'dynamic_text' && v.type !== 'static_text') return undefined;
+  const content = v.data?.content;
+  return typeof content === 'string' ? content : undefined;
 }
 
 export interface LcpCandidate {
@@ -444,13 +464,20 @@ export function findLcpCandidate(
     const inNonLcp = inNonLcpAncestor || NON_LCP_ANCESTOR_NAMES.has(layer.name);
 
     if (layer.name === 'image' && !inNonLcp) {
-      const assetId = isAssetVariable(layer.variables?.image?.src)
-        ? getAssetId(layer.variables.image.src)
-        : undefined;
+      const srcVar = layer.variables?.image?.src;
+      const assetId = isAssetVariable(srcVar) ? getAssetId(srcVar) : undefined;
       const asset = assetId ? resolvedAssets?.[assetId] : undefined;
 
+      // Some pages store the image URL directly as a `dynamic_text` /
+      // `static_text` variable (e.g. pasted logo URL) rather than an
+      // `AssetVariable`. Sniff the inline URL so SVG logos in that shape
+      // are still skipped.
+      const inlineUrl = !assetId ? getInlineImageUrl(srcVar) : undefined;
+
       // SVGs are vector logos / icons in practice — never the hero image.
-      if (!isSvgAsset(asset)) {
+      const isSvg = isSvgAsset(asset) || (inlineUrl ? isSvgUrl(inlineUrl) : false);
+
+      if (!isSvg) {
         let width = parseWidth(layer.attributes?.width);
         if (width === null && asset?.width) {
           width = asset.width as number;

--- a/lib/asset-utils.ts
+++ b/lib/asset-utils.ts
@@ -406,10 +406,15 @@ function isSvgAsset(asset: { mimeType?: string | null; url?: string | null } | u
   return false;
 }
 
+export interface LcpCandidate {
+  layerId: string;
+  /** Asset id of the candidate image, when backed by a static asset variable. */
+  assetId?: string;
+}
+
 /**
- * Find the layer id that should be treated as the LCP (Largest Contentful Paint)
- * candidate for a given page tree. Walks the tree in render order and returns
- * the first `image`-named layer that:
+ * Find the LCP (Largest Contentful Paint) candidate for a given page tree.
+ * Walks the tree in render order and returns the first `image`-named layer that:
  *   - is NOT a descendant of a `header`, `footer`, or `nav` layer (logos),
  *   - is NOT backed by an SVG asset (vector logos / icons), and
  *   - has an effective intrinsic width unknown or at least `minWidth` pixels.
@@ -421,11 +426,11 @@ function isSvgAsset(asset: { mimeType?: string | null; url?: string | null } | u
  *
  * Returns null if no qualifying image exists in the tree.
  */
-export function findLcpCandidateLayerId(
+export function findLcpCandidate(
   layers: Layer[],
   resolvedAssets?: Record<string, { width?: number | null; mimeType?: string | null; url?: string | null }>,
   minWidth: number = 200
-): string | null {
+): LcpCandidate | null {
   const parseWidth = (value: unknown): number | null => {
     if (typeof value === 'number' && !isNaN(value)) return value;
     if (typeof value !== 'string') return null;
@@ -435,7 +440,7 @@ export function findLcpCandidateLayerId(
     return isNaN(n) ? null : n;
   };
 
-  const visit = (layer: Layer, inNonLcpAncestor: boolean): string | null => {
+  const visit = (layer: Layer, inNonLcpAncestor: boolean): LcpCandidate | null => {
     const inNonLcp = inNonLcpAncestor || NON_LCP_ANCESTOR_NAMES.has(layer.name);
 
     if (layer.name === 'image' && !inNonLcp) {
@@ -452,7 +457,7 @@ export function findLcpCandidateLayerId(
         }
 
         if (width === null || width >= minWidth) {
-          return layer.id;
+          return { layerId: layer.id, assetId: assetId || undefined };
         }
       }
     }
@@ -473,6 +478,15 @@ export function findLcpCandidateLayerId(
   }
 
   return null;
+}
+
+/** @deprecated Use {@link findLcpCandidate}. Kept for callers that only need the id. */
+export function findLcpCandidateLayerId(
+  layers: Layer[],
+  resolvedAssets?: Record<string, { width?: number | null; mimeType?: string | null; url?: string | null }>,
+  minWidth: number = 200
+): string | null {
+  return findLcpCandidate(layers, resolvedAssets, minWidth)?.layerId ?? null;
 }
 
 // ==========================================

--- a/lib/font-utils.ts
+++ b/lib/font-utils.ts
@@ -300,6 +300,46 @@ export function getGoogleFontLinks(fonts: Font[]): string[] {
     .map(f => buildGoogleFontUrl(f));
 }
 
+/**
+ * Modern Chrome User-Agent. Google Fonts varies its CSS response by UA —
+ * sending a recent Chrome UA reliably returns woff2 with `unicode-range`
+ * subset rules, which is what we want to inline.
+ */
+const MODERN_UA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+
+/**
+ * Fetch the resolved @font-face rules for the given Google Fonts CSS URLs and
+ * return them as a single CSS string suitable for inlining in <style>.
+ *
+ * Inlining the CSS skips the round-trip to fonts.googleapis.com — the browser
+ * can start fetching the woff2 binaries directly while parsing the document.
+ *
+ * Returns an empty string if any URL fails to fetch so the caller can fall
+ * back to <link rel="stylesheet"> without partially breaking font loading.
+ */
+export async function fetchGoogleFontsCss(urls: string[]): Promise<string> {
+  if (urls.length === 0) return '';
+
+  try {
+    const responses = await Promise.all(
+      urls.map((url) =>
+        fetch(url, {
+          headers: { 'User-Agent': MODERN_UA },
+          signal: AbortSignal.timeout(5000),
+        }),
+      ),
+    );
+
+    if (responses.some((r) => !r.ok)) return '';
+
+    const cssBlocks = await Promise.all(responses.map((r) => r.text()));
+    return cssBlocks.join('\n');
+  } catch {
+    return '';
+  }
+}
+
 /** Build CSS for custom fonts only (@font-face rules, no @import) */
 export function buildCustomFontsCss(fonts: Font[]): string {
   let css = '';

--- a/next.config.ts
+++ b/next.config.ts
@@ -89,6 +89,15 @@ const nextConfig: NextConfig = {
             // On publish, revalidatePath purges CDN; revalidateTag purges data cache
             value: 'public, s-maxage=31536000, stale-while-revalidate=31536000',
           },
+          {
+            // Open the TLS connection to fonts.gstatic.com while the document
+            // is still streaming so woff2 binaries can be fetched the moment
+            // the inlined @font-face rules are parsed. Sending this as a
+            // response header (vs. <link rel=preconnect> in <head>) lets the
+            // browser act on it before parsing the document.
+            key: 'Link',
+            value: '<https://fonts.gstatic.com>; rel=preconnect; crossorigin',
+          },
         ],
       },
     ];


### PR DESCRIPTION
## Summary

Seven fixes targeting the PSI insights on `https://law-demo.ycode.website/` (mobile score 75). Combined effect on a live site is expected to land in the high 80s–low 90s — the LCP candidate fix alone shaves 1–2 s on most templates, the bundle/CSS work removes ~340 KB of eager JS plus ~10 KB of CSS from every published page, and the latest commit cuts an entire blocking CSS round-trip from font loading.

Each commit is independently shippable; nothing here changes editor behavior or builder UI.

## Changes

### `perf: skip logos when picking LCP image candidate` (`72ba4bf`)
- `findLcpCandidateLayerId` now skips images whose ancestor is a `header`, `footer`, or `nav` layer, and skips SVG assets entirely (logos / icons).
- `PageRenderer` threads `mimeType` through to the heuristic so SVGs are detected reliably even when the URL extension isn't `.svg`.
- Without this fix the header logo was usually picked as the LCP element, so `loading=\"eager\" fetchpriority=\"high\"` went to a tiny logo while the actual hero waited.

### `perf: ship slim Tailwind bundle to published sites` + `fix: include lib/templates classes` (`170744d`, `bee5f75`)
- New `app/site.css` imports Tailwind with `@source not \"../app/(builder)\"` so builder UI utilities (~150 KB worth) are excluded from the public bundle.
- `app/(site)/layout.tsx` now imports `site.css` instead of the full `globals.css`.
- Net: published-site CSS dropped from **28.9 KB → 18.3 KB gzipped (-37%)**.
- Fonts now fall back to the system stack when `--font-inter` isn't defined (the variable is only injected inside the builder layout).

### `perf: code-split LayerRendererPublic per layer type` (`0e9c914`)
- Six top-level imports inside the public renderer are now `next/dynamic`:
  `AnimationInitializer`, `PaginatedCollection`, `LoadMoreCollection`,
  `FilterableCollection`, `LocaleSelector`, and the new `FilterLayerBehavior`.
- New `components/FilterLayerBehavior.tsx` extracts ~180 lines of DOM-scanning code + `useFilterStore` so Zustand and the filter runtime only ship to pages that actually render a filter layer.
- Measured on `/` (a heavy template using sliders + animations): eager JS fell from **1,500 KB → 1,165 KB (-22%)**. On marketing pages without sliders/animations, GSAP (~131 KB) and Swiper (~158 KB) drop out entirely, so savings are larger.

### `perf: preconnect to Google Fonts origins on published pages` (`a8b54ec`)
- Emits `<link rel=\"preconnect\">` for `fonts.googleapis.com` and (with `crossorigin`) `fonts.gstatic.com` whenever the page loads any Google Font.
- Lets the browser run DNS + TCP + TLS in parallel with the HTML download instead of serializing it after CSS parse — addresses the *\"no origins were preconnected\"* item in PSI's Network dependency tree (~100–300 ms off the font's first byte).
- Skipped automatically when the page only uses system / custom fonts.

### `perf: use finer srcset width ladder` (`1fe3be2`)
- Default ladder in `generateImageSrcset` goes from 5 entries (320, 640, 960, 1280, 1920) to 9 (320, 480, 640, 750, 828, 1080, 1280, 1536, 1920).
- New widths target the gaps that hurt the most: iPhone SE/8 at 2x DPR (750), iPhone XR/11 (828), Pixel/Galaxy at 3x (1080), tablet 2x (1536). Mid-range phones used to fall through to the next-bigger 960/1280 variant and waste 20–30% of the byte budget on hero images.
- HTML grows by ~400 bytes per image; per-image download savings are an order of magnitude larger.

### `perf: inline Google Fonts CSS, preconnect via Link header, preload LCP image` (`7f459a5`)
- **Inline `@font-face` rules.** New `fetchGoogleFontsCss()` resolves the Google Fonts stylesheet server-side at publish time (using a modern Chrome UA so Google returns woff2 with `unicode-range` subsets) and inlines it as `<style id=\"ycode-google-fonts\">`. The browser skips the blocking round-trip to `fonts.googleapis.com` and goes straight to gstatic for the woff2 binaries. Cached via `unstable_cache` keyed on the font URLs and tagged `all-pages` so it invalidates on the next publish. Falls back to `<link rel=\"stylesheet\">` if the fetch fails (timeout, offline, etc.).
- **Preconnect via response `Link` header.** Adds `Link: <https://fonts.gstatic.com>; rel=preconnect; crossorigin` to the public-pages match in `next.config.ts`. The browser opens the TLS connection while the document is still streaming, vs. having to parse `<head>` to see the same hint as a `<link>` tag.
- **LCP image preload.** New `findLcpCandidate()` returns `{ layerId, assetId }` (kept `findLcpCandidateLayerId` as a thin deprecated wrapper). `PageRenderer` resolves the candidate's URL/srcset/sizes and emits `<link rel=\"preload\" as=\"image\" imageSrcSet imageSizes fetchPriority=\"high\">` early in `<head>` so the hero starts downloading before the parser reaches the `<img>` tag. Only handles asset-variable images today; CMS field-bound images on dynamic pages skip the preload to avoid item-aware resolution server-side.

### `fix: skip dynamic_text SVG URLs when picking LCP candidate` (`63eba94`)
- The `72ba4bf` SVG-skip only inspected resolved assets, so layers whose `src` is a raw URL string (`dynamic_text` / `static_text` variable — common when a logo is pasted as a URL instead of selected from the asset library) fell through and got selected as the LCP candidate. The pasted SVG logo would then render with `loading=\"eager\" fetchpriority=\"high\"` and React 19 would auto-emit a `<link rel=\"preload\" as=\"image\">` for it.
- `findLcpCandidate` now also extracts the URL from `dynamic_text` / `static_text` variables and runs the same `.svg` extension sniff before considering the layer.
- Verified locally with `next build && next start` against a page using a `dynamic_text` SVG logo: the `<img>` no longer carries `loading=\"eager\"` / `fetchPriority=\"high\"` after this commit.

## Test plan

- [ ] Open a published marketing page in DevTools → Network. Confirm GSAP / Swiper / FilterableCollection chunks are *not* in the initial page load when the page has no animations / sliders / filters.
- [ ] Open a page that *does* have animations and a slider. Confirm those chunks load (lazily) and the page behaves identically to before.
- [ ] Open a page with a filter + collection. Confirm typing into inputs still drives the collection (URL params sync, Apply button works, `filterOnChange` debounces).
- [ ] View a published page that uses Google Fonts. Confirm `<style id=\"ycode-google-fonts\">` is present in `<head>` and **no** `<link rel=\"stylesheet\">` to `fonts.googleapis.com` appears (the inline path succeeded).
- [ ] On the same page, confirm response headers include `Link: <https://fonts.gstatic.com>; rel=preconnect; crossorigin`.
- [ ] Simulate fetch failure (block `fonts.googleapis.com` in DevTools) and reload. Confirm the page falls back to `<link rel=\"stylesheet\">` + the googleapis preconnect, with no broken fonts.
- [ ] Inspect a page with a clear hero image. Confirm `<link rel=\"preload\" as=\"image\" fetchpriority=\"high\">` is in `<head>` and the same image renders below with `loading=\"eager\"`.
- [ ] Inspect a hero `<img>` in DevTools. Confirm `srcset` has 9 entries and the browser picks a width close to the rendered size (Network tab → image request URL ends with the closest width).
- [ ] Run PSI on a representative template before/after deploying — LCP and Total Bytes should drop noticeably; the *\"Network dependency tree\"*, *\"Render-blocking resources\"*, and *\"Reduce unused JavaScript\"* insights should improve.
- [ ] Visual regression: load a few existing published sites and confirm nothing looks different (especially anything that relied on builder-only Tailwind classes — none should, but worth a glance).

## Notes / follow-ups (out of scope)

- SVGs still get the full srcset (rasterizing a vector at 9 widths is wasteful). Easy follow-up: short-circuit `generateImageSrcset()` for `.svg` URLs.
- `BodyClassApplier` triggers a small unattributed reflow. Could be moved to SSR-set body class.
- `draft_css` only re-generates when the builder detects layer changes, so existing sites won't pick up the slim-bundle benefit until they make any edit and republish (or clear `draft_css` manually).
- LCP preload only fires for asset-variable images. CMS field-bound hero images on dynamic pages would need item-aware URL resolution at the page level — viable but pushes the LCP heuristic into the page-fetcher.
- The `Link` preconnect header is sent on every public-page response, including pages that don't load any Google Fonts — costs a single idle TLS handshake. Could be made conditional via middleware if it becomes a concern.

Made with [Cursor](https://cursor.com)

