### PR TITLE
fix: bump virtual updated_at field on CMS item edits

### DIFF
--- a/lib/repositories/collectionItemValueRepository.ts
+++ b/lib/repositories/collectionItemValueRepository.ts
@@ -509,6 +509,17 @@ export async function setValuesByFieldName(
     valuesToSet[fieldId] = valueToString(value, type);
   }
 
+  // Auto-bump the virtual `updated_at` field whenever values are being set,
+  // unless the caller explicitly provided one. The DB column on
+  // `collection_items` is bumped via updateContentHash below, but the
+  // user-facing "Updated Date" column in the CMS table reads this virtual
+  // field — without this, edits would never appear to refresh.
+  const updatedAtFieldId = Object.keys(fieldKeyMap).find(id => fieldKeyMap[id] === 'updated_at');
+  const autoBumpedUpdatedAt = updatedAtFieldId && !(updatedAtFieldId in valuesToSet);
+  if (autoBumpedUpdatedAt) {
+    valuesToSet[updatedAtFieldId!] = new Date().toISOString();
+  }
+
   // Detect changes and removals for translation management (only for draft)
   if (!is_published) {
     const changedKeys: string[] = [];
@@ -516,6 +527,9 @@ export async function setValuesByFieldName(
 
     // Check for changed values
     for (const [fieldId, newValue] of Object.entries(valuesToSet)) {
+      // An auto-bumped `updated_at` shouldn't mark translations as incomplete
+      if (autoBumpedUpdatedAt && fieldId === updatedAtFieldId) continue;
+
       const oldValue = currentValuesMap[fieldId];
 
       // Generate content key based on field key (if exists) or field id

--- a/stores/useCollectionsStore.ts
+++ b/stores/useCollectionsStore.ts
@@ -737,7 +737,8 @@ export const useCollectionsStore = create<CollectionsStore>((set, get) => ({
     const previousItem = previousItems.find(item => item.id === itemId);
 
     // Optimistically set status to "Published · Edited" if the item is currently published
-    const statusFieldId = findStatusFieldId(get().fields[collectionId] || []);
+    const collectionFields = get().fields[collectionId] || [];
+    const statusFieldId = findStatusFieldId(collectionFields);
     const optimisticStatus: Record<string, string> = {};
     if (statusFieldId && previousItem) {
       try {
@@ -748,12 +749,25 @@ export const useCollectionsStore = create<CollectionsStore>((set, get) => ({
       } catch { /* non-JSON status value, skip */ }
     }
 
+    // Optimistically bump the virtual `updated_at` field to mirror the
+    // server-side auto-bump in setValuesByFieldName.
+    const now = new Date().toISOString();
+    const updatedAtFieldId = collectionFields.find(f => f.key === 'updated_at')?.id;
+    const optimisticTimestamps: Record<string, string> = {};
+    if (updatedAtFieldId && !(updatedAtFieldId in values)) {
+      optimisticTimestamps[updatedAtFieldId] = now;
+    }
+
     set(state => ({
       items: {
         ...state.items,
         [collectionId]: (state.items[collectionId] || []).map(item =>
           item.id === itemId
-            ? { ...item, values: { ...item.values, ...values, ...optimisticStatus }, updated_at: new Date().toISOString() }
+            ? {
+              ...item,
+              values: { ...item.values, ...values, ...optimisticStatus, ...optimisticTimestamps },
+              updated_at: now,
+            }
             : item
         ),
       },


### PR DESCRIPTION
## Summary

Each CMS item carries timestamps in two places — the DB columns on `collection_items` (used for sorting/metadata) and the virtual `created_at`/`updated_at` fields stored in `collection_item_values`. The CMS table UI reads the virtual fields. The internal builder routes only bumped the DB column, so the user-facing "Updated Date" column stayed stale after every in-builder edit.

## Changes

- Auto-bump the virtual `updated_at` field inside `setValuesByFieldName` so every internal write path (PUT `/items/[item_id]`, PUT `/items/[item_id]/values`, and the MCP `update_item` tool) keeps the value fresh
- Skip the auto-bumped field in the translation change-detection loop so it doesn't mark translations as incomplete
- Mirror the bump optimistically in `useCollectionsStore.updateItem` so the row updates instantly in the UI
- Honor an explicit `updated_at` from the caller (import flows, duplication, v1 API still control their own value)

## Test plan

- [ ] Edit any field on a CMS item in the builder — the "Updated Date" column reflects the change immediately
- [ ] Refresh the page — the persisted value matches what the UI showed
- [ ] Edit a translated field — the translation status updates correctly (not stuck on "incomplete" from the timestamp bump)
- [ ] Update a published item via the public v1 API — `updated_at` still reflects request time (no regression)
- [ ] Duplicate an item — the duplicate uses its own creation timestamp, not `now` from the edit path

Made with [Cursor](https://cursor.com)