### PR TITLE
fix: center component canvas inside scroll area

### DIFF
--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -2529,6 +2529,11 @@ const CenterCanvas = React.memo(function CenterCanvas({
               position: 'relative',
               minWidth: '100%',
               minHeight: '100%',
+              // When editing a component, center the canvas inside the scroll area.
+              // Page editing keeps default block flow so absolute overlays anchor at the top.
+              ...(editingComponentId
+                ? { display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }
+                : null),
             }}
           >
               <div


### PR DESCRIPTION
## Summary

When editing a component, the canvas iframe is sized to the component itself (e.g. a button is just a few dozen pixels tall). Previously the scaled-canvas wrapper was anchored to the top of the scroll container, so small components stuck awkwardly to the top instead of being centered.

## Changes

- In `CenterCanvas`, when `editingComponentId` is set, make the outer scaled-canvas wrapper a flex container with `height: 100%` so the inner content-sized canvas is vertically and horizontally centered inside the scroll area.
- Page editing keeps its existing top-anchored layout — the new flex styles only apply in component-editing mode.

## Test plan

- [ ] Open a component containing a small element (e.g. a button) in the component editor — the canvas is centered both vertically and horizontally.
- [ ] Open a component with tall content that exceeds the viewport — content scrolls naturally and isn't clipped.
- [ ] Open a normal page in the editor — layout is unchanged (canvas still anchors at the top with the usual padding).
- [ ] Switch between page and component editing several times — no layout flicker, overlays still align correctly.
