### PR TITLE
feat: add component variants

### DIFF
--- a/app/(builder)/ycode/api/components/[id]/route.ts
+++ b/app/(builder)/ycode/api/components/[id]/route.ts
@@ -44,12 +44,13 @@ export async function PUT(
   try {
     const { id } = await params;
     const body = await request.json();
-    const { name, layers, variables } = body;
+    const { name, layers, variables, variants } = body;
 
     const updates: any = {};
     if (name !== undefined) updates.name = name;
     if (layers !== undefined) updates.layers = layers;
     if (variables !== undefined) updates.variables = variables;
+    if (variants !== undefined) updates.variants = variants;
 
     const component = await updateComponent(id, updates);
 

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -1723,8 +1723,12 @@ const CenterCanvas = React.memo(function CenterCanvas({
   // Mirrors the "Edit component" sidebar button.
   const editComponent = useEditComponent();
   const handleCanvasComponentEdit = useCallback((componentId: string, instanceLayerId: string) => {
-    editComponent(componentId, { returnToLayerId: instanceLayerId });
-  }, [editComponent]);
+    const instanceLayer = findLayerById(layers, instanceLayerId);
+    editComponent(componentId, {
+      returnToLayerId: instanceLayerId,
+      variantId: instanceLayer?.componentVariantId,
+    });
+  }, [editComponent, layers]);
 
   // Undo/Redo handlers
   // Note: We don't auto-save after undo/redo to preserve the redo stack

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -634,6 +634,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
   );
   const activeUIState = useEditorStore((state) => state.activeUIState);
   const editingComponentId = useEditorStore((state) => state.editingComponentId);
+  const editingComponentVariantId = useEditorStore((state) => state.editingComponentVariantId);
   const setCurrentPageId = useEditorStore((state) => state.setCurrentPageId);
   const returnToPageId = useEditorStore((state) => state.returnToPageId);
   const currentPageCollectionItemId = useEditorStore((state) => state.currentPageCollectionItemId);
@@ -722,6 +723,16 @@ const CenterCanvas = React.memo(function CenterCanvas({
   const { urlState, navigateToLayers, navigateToPage, navigateToPageEdit, updateQueryParams } = useEditorUrl();
   const components = useComponentsStore((state) => state.components);
   const componentDrafts = useComponentsStore((state) => state.componentDrafts);
+  // Resolve the active variant id while editing a component. The editor store
+  // is the source of truth; falls back to the first persisted variant when
+  // the URL/state references a stale id.
+  const activeComponentVariantId = useMemo(() => {
+    if (!editingComponentId) return null;
+    const drafts = componentDrafts[editingComponentId];
+    if (!drafts) return editingComponentVariantId || null;
+    if (editingComponentVariantId && drafts[editingComponentVariantId]) return editingComponentVariantId;
+    return Object.keys(drafts)[0] || null;
+  }, [editingComponentId, editingComponentVariantId, componentDrafts]);
   const [collectionItems, setCollectionItems] = useState<Array<{ id: string; label: string }>>([]);
   const [collectionItemSearch, setCollectionItemSearch] = useState('');
 
@@ -1089,9 +1100,9 @@ const CenterCanvas = React.memo(function CenterCanvas({
   }, [isCanvasReady]);
 
   const layers = useMemo(() => {
-    // If editing a component, show component layers
-    if (editingComponentId) {
-      return componentDrafts[editingComponentId] || [];
+    // If editing a component, show the active variant's layers
+    if (editingComponentId && activeComponentVariantId) {
+      return componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
     }
 
     // Otherwise show page layers
@@ -1100,7 +1111,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
     }
 
     return currentDraft ? currentDraft.layers : [];
-  }, [editingComponentId, componentDrafts, currentPageId, currentDraft]);
+  }, [editingComponentId, activeComponentVariantId, componentDrafts, currentPageId, currentDraft]);
 
   // Check if we're waiting for a draft to load (page selected but no draft yet)
   const isDraftLoading = useMemo(() => {
@@ -1249,10 +1260,10 @@ const CenterCanvas = React.memo(function CenterCanvas({
   const editingLayerParentCollection = useMemo(() => {
     if (!editingLayerId || !currentPageId) return null;
 
-    // Get layers from either component draft or page draft
+    // Get layers from either the active component variant draft or page draft
     let layersToSearch: Layer[] = [];
-    if (editingComponentId) {
-      layersToSearch = componentDrafts[editingComponentId] || [];
+    if (editingComponentId && activeComponentVariantId) {
+      layersToSearch = componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
     } else {
       layersToSearch = currentDraft ? currentDraft.layers : [];
     }
@@ -1261,22 +1272,22 @@ const CenterCanvas = React.memo(function CenterCanvas({
 
     // Find parent collection layer
     return findParentCollectionLayer(layersToSearch, editingLayerId);
-  }, [editingLayerId, editingComponentId, componentDrafts, currentPageId, currentDraft]);
+  }, [editingLayerId, editingComponentId, activeComponentVariantId, componentDrafts, currentPageId, currentDraft]);
 
   // Build field groups for the canvas text editor's inline variable selection
   // Components are page-agnostic, so exclude dynamic page-collection fields when editing a component
   const fieldGroups = useMemo(() => {
     if (!editingLayerId) return undefined;
     let layers: Layer[] = [];
-    if (editingComponentId) {
-      layers = componentDrafts[editingComponentId] || [];
+    if (editingComponentId && activeComponentVariantId) {
+      layers = componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
     } else if (currentPageId) {
       layers = currentDraft ? currentDraft.layers : [];
     }
     if (!layers.length) return undefined;
     const page = editingComponentId ? null : currentPage;
     return buildFieldGroupsForLayer(editingLayerId, layers, page, collectionFieldsFromStore, collectionsFromStore);
-  }, [editingLayerId, editingComponentId, componentDrafts, currentPageId, currentDraft, currentPage, collectionFieldsFromStore, collectionsFromStore]);
+  }, [editingLayerId, editingComponentId, activeComponentVariantId, componentDrafts, currentPageId, currentDraft, currentPage, collectionFieldsFromStore, collectionsFromStore]);
 
   const textFieldGroups = useMemo(
     () => filterFieldGroupsByType(fieldGroups, SIMPLE_TEXT_FIELD_TYPES),
@@ -1369,8 +1380,8 @@ const CenterCanvas = React.memo(function CenterCanvas({
       let resolvedSublayerIndex = Number.isFinite(blockIndex) ? blockIndex : null;
       let resolvedListItemIndex = Number.isFinite(listItemIndex) ? listItemIndex : null;
       if (resolvedSublayerIndex !== null && textStyleKey) {
-        const layers = editingComponentId
-          ? (componentDrafts[editingComponentId] || [])
+        const layers = editingComponentId && activeComponentVariantId
+          ? (componentDrafts[editingComponentId]?.[activeComponentVariantId] || [])
           : (currentDraft?.layers || []);
         const layer = findLayerById(layers, layerId);
         if (layer && isRichTextLayer(layer) && !getLayerCmsFieldBinding(layer)) {
@@ -1385,7 +1396,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
         listItemIndex: resolvedListItemIndex,
       });
     }
-  }, [isPreviewMode, setActiveSidebarTab, selectLayerWithSublayer, editingComponentId, componentDrafts, currentDraft]);
+  }, [isPreviewMode, setActiveSidebarTab, selectLayerWithSublayer, editingComponentId, activeComponentVariantId, componentDrafts, currentDraft]);
 
   const handleCanvasLayerUpdate = useCallback((layerId: string, updates: Partial<Layer>) => {
     // Block all source-layer mutations from the canvas while in a non-default
@@ -1393,14 +1404,14 @@ const CenterCanvas = React.memo(function CenterCanvas({
     // of mutating the layer tree.
     if (selectedLocale && !selectedLocale.is_default) return;
 
-    if (editingComponentId) {
+    if (editingComponentId && activeComponentVariantId) {
       const { updateComponentDraft } = useComponentsStore.getState();
-      const currentDraft = componentDrafts[editingComponentId] || [];
-      updateComponentDraft(editingComponentId, updateLayerProps(currentDraft, layerId, updates));
+      const currentDraft = componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
+      updateComponentDraft(editingComponentId, activeComponentVariantId, updateLayerProps(currentDraft, layerId, updates));
     } else if (currentPageId) {
       updateLayer(currentPageId, layerId, updates);
     }
-  }, [editingComponentId, componentDrafts, currentPageId, updateLayer, selectedLocale]);
+  }, [editingComponentId, activeComponentVariantId, componentDrafts, currentPageId, updateLayer, selectedLocale]);
 
   const handleCanvasDeleteLayer = useCallback(() => {
     if (!selectedLayerId || !currentPageId) return;
@@ -1473,15 +1484,15 @@ const CenterCanvas = React.memo(function CenterCanvas({
   const richTextSheetFieldGroups = useMemo(() => {
     if (!richTextSheetLayerId || !currentPageId) return undefined;
     let layers: Layer[] = [];
-    if (editingComponentId) {
-      layers = componentDrafts[editingComponentId] || [];
+    if (editingComponentId && activeComponentVariantId) {
+      layers = componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
     } else {
       layers = currentDraft ? currentDraft.layers : [];
     }
     if (!layers.length) return undefined;
     const page = editingComponentId ? null : currentPage;
     return buildFieldGroupsForLayer(richTextSheetLayerId, layers, page, collectionFieldsFromStore, collectionsFromStore);
-  }, [richTextSheetLayerId, editingComponentId, componentDrafts, currentPageId, currentDraft, currentPage, collectionFieldsFromStore, collectionsFromStore]);
+  }, [richTextSheetLayerId, editingComponentId, activeComponentVariantId, componentDrafts, currentPageId, currentDraft, currentPage, collectionFieldsFromStore, collectionsFromStore]);
 
   // Track the current value locally so the value prop always matches the editor's
   // internal state. This prevents the editor's sync effect from resetting content
@@ -1495,8 +1506,8 @@ const CenterCanvas = React.memo(function CenterCanvas({
   // translation surface for rich text (no plain-textarea fallback in the sidebar).
   const richTextTranslationContext = useMemo(() => {
     if (!richTextSheetLayerId || !selectedLocale || selectedLocale.is_default) return null;
-    const sourceLayers: Layer[] = editingComponentId
-      ? (componentDrafts[editingComponentId] || [])
+    const sourceLayers: Layer[] = editingComponentId && activeComponentVariantId
+      ? (componentDrafts[editingComponentId]?.[activeComponentVariantId] || [])
       : (currentDraft?.layers || []);
     const layer = findLayerById(sourceLayers, richTextSheetLayerId);
     if (!layer || !isRichTextLayer(layer)) return null;
@@ -1507,7 +1518,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
     const item = items.find((i) => i.content_type === 'richtext');
     if (!item) return null;
     return { item };
-  }, [richTextSheetLayerId, selectedLocale, editingComponentId, componentDrafts, currentDraft, currentPageId]);
+  }, [richTextSheetLayerId, selectedLocale, editingComponentId, activeComponentVariantId, componentDrafts, currentDraft, currentPageId]);
 
   useEffect(() => {
     if (!richTextSheetLayerId) {
@@ -1534,8 +1545,8 @@ const CenterCanvas = React.memo(function CenterCanvas({
       return;
     }
 
-    const source = editingComponentId
-      ? componentDrafts[editingComponentId]
+    const source = editingComponentId && activeComponentVariantId
+      ? componentDrafts[editingComponentId]?.[activeComponentVariantId]
       : currentDraft?.layers ?? null;
     const layer = source ? findLayerById(source as Layer[], richTextSheetLayerId) : null;
     setRichTextSheetValue(getRichTextValue(layer?.variables));
@@ -1623,12 +1634,16 @@ const CenterCanvas = React.memo(function CenterCanvas({
     } : undefined;
 
     const compId = useEditorStore.getState().editingComponentId;
+    const variantId = useEditorStore.getState().editingComponentVariantId;
     if (compId) {
       const { componentDrafts: drafts, updateComponentDraft } = useComponentsStore.getState();
-      const currentDraft = drafts[compId];
-      if (!currentDraft) return;
+      const variantDrafts = drafts[compId];
+      if (!variantDrafts) return;
+      const targetVariantId = variantId && variantDrafts[variantId] ? variantId : Object.keys(variantDrafts)[0];
+      if (!targetVariantId) return;
+      const currentDraft = variantDrafts[targetVariantId];
       const layer = findLayerById(currentDraft, richTextSheetLayerId);
-      updateComponentDraft(compId, updateLayerProps(currentDraft, richTextSheetLayerId, {
+      updateComponentDraft(compId, targetVariantId, updateLayerProps(currentDraft, richTextSheetLayerId, {
         variables: { ...layer?.variables, text: textVariable },
       }));
     } else {
@@ -1767,10 +1782,10 @@ const CenterCanvas = React.memo(function CenterCanvas({
   const parentLayerId = useMemo(() => {
     if (!selectedLayerId || !currentPageId) return null;
 
-    // Get layers from either component draft or page draft
+    // Get layers from either the active variant draft or page draft
     let layersToSearch: Layer[] = [];
-    if (editingComponentId) {
-      layersToSearch = componentDrafts[editingComponentId] || [];
+    if (editingComponentId && activeComponentVariantId) {
+      layersToSearch = componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
     } else {
       layersToSearch = currentDraft ? currentDraft.layers : [];
     }
@@ -1801,7 +1816,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
     if (selectedLayer?.name === 'slide') return null;
 
     return result;
-  }, [selectedLayerId, currentPageId, editingComponentId, componentDrafts, currentDraft]);
+  }, [selectedLayerId, currentPageId, editingComponentId, activeComponentVariantId, componentDrafts, currentDraft]);
 
   // Get selected layer name for drag preview
   const selectedLayerName = useMemo(() => {
@@ -2252,8 +2267,8 @@ const CenterCanvas = React.memo(function CenterCanvas({
             let editingLayer: Layer | null = null;
             let layersToSearch: Layer[] = [];
             if (editingLayerId) {
-              if (editingComponentId) {
-                layersToSearch = componentDrafts[editingComponentId] || [];
+              if (editingComponentId && activeComponentVariantId) {
+                layersToSearch = componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
               } else if (currentPageId) {
                 layersToSearch = currentDraft ? currentDraft.layers : [];
               }

--- a/app/(builder)/ycode/components/ComponentInstanceSidebar.tsx
+++ b/app/(builder)/ycode/components/ComponentInstanceSidebar.tsx
@@ -97,8 +97,11 @@ export default function ComponentInstanceSidebar({
     .some(cat => Object.keys(overrides?.[cat as keyof typeof overrides] || {}).length > 0);
 
   const handleEditMasterComponent = useCallback(async () => {
-    await editComponent(component.id, { returnToLayerId: selectedLayerId });
-  }, [editComponent, component.id, selectedLayerId]);
+    await editComponent(component.id, {
+      returnToLayerId: selectedLayerId,
+      variantId: selectedLayer.componentVariantId,
+    });
+  }, [editComponent, component.id, selectedLayerId, selectedLayer.componentVariantId]);
 
   const handleOverridesChange = useCallback((newOverrides: Layer['componentOverrides']) => {
     onLayerUpdate(selectedLayerId, { componentOverrides: newOverrides });
@@ -325,7 +328,11 @@ export default function ComponentInstanceSidebar({
                       </Button>
                     ) : (
                       <Select
-                        value={selectedLayer.componentVariantId ?? component.variants[0].id}
+                        value={
+                          component.variants.some(v => v.id === selectedLayer.componentVariantId)
+                            ? selectedLayer.componentVariantId!
+                            : component.variants[0].id
+                        }
                         onValueChange={(value) => {
                           onLayerUpdate(selectedLayerId, { componentVariantId: value });
                         }}

--- a/app/(builder)/ycode/components/ComponentInstanceSidebar.tsx
+++ b/app/(builder)/ycode/components/ComponentInstanceSidebar.tsx
@@ -12,6 +12,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 import ComponentVariableOverrides from './ComponentVariableOverrides';
 import ComponentVariablesDialog from './ComponentVariablesDialog';
@@ -151,7 +158,14 @@ export default function ComponentInstanceSidebar({
     const newLayers = detachSpecificLayerFromComponent(allLayers, selectedLayerId, component);
 
     if (editingComponentId) {
-      updateComponentDraft(editingComponentId, newLayers);
+      // Detach happens against whichever variant the user is currently
+      // editing — that's what `allLayers` was sourced from upstream.
+      const variantId = useEditorStore.getState().editingComponentVariantId;
+      const variantDrafts = useComponentsStore.getState().componentDrafts[editingComponentId];
+      const targetVariantId = (variantId && variantDrafts?.[variantId]) ? variantId : (variantDrafts ? Object.keys(variantDrafts)[0] : null);
+      if (targetVariantId) {
+        updateComponentDraft(editingComponentId, targetVariantId, newLayers);
+      }
     } else if (currentPageId) {
       setDraftLayers(currentPageId, newLayers);
     }
@@ -226,6 +240,29 @@ export default function ComponentInstanceSidebar({
                 <span className="ml-auto text-[10px] italic text-orange-600 dark:text-orange-200">Overridden</span>
               )}
             </div>
+
+            {/* Variant selector — only meaningful when the component has more
+                than one variant. Variables are shared across variants, so
+                changing the variant only switches the layer tree. */}
+            {component.variants && component.variants.length > 1 && (
+              <Select
+                value={selectedLayer.componentVariantId ?? component.variants[0].id}
+                onValueChange={(value) => {
+                  onLayerUpdate(selectedLayerId, { componentVariantId: value });
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Variant" />
+                </SelectTrigger>
+                <SelectContent>
+                  {component.variants.map((variant) => (
+                    <SelectItem key={variant.id} value={variant.id}>
+                      {variant.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
 
             <Button
               size="sm"

--- a/app/(builder)/ycode/components/ComponentInstanceSidebar.tsx
+++ b/app/(builder)/ycode/components/ComponentInstanceSidebar.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 
+import ComponentVariableLabel, { VARIABLE_TYPE_ICONS } from './ComponentVariableLabel';
 import ComponentVariableOverrides from './ComponentVariableOverrides';
 import ComponentVariablesDialog from './ComponentVariablesDialog';
 import RichTextEditor from './RichTextEditor';
@@ -31,6 +32,7 @@ import { useComponentsStore } from '@/stores/useComponentsStore';
 import { usePagesStore } from '@/stores/usePagesStore';
 import { useEditComponent } from '@/hooks/use-edit-component';
 import { detachSpecificLayerFromComponent } from '@/lib/component-utils';
+import { collectVariantVariableOptions } from '@/lib/component-variant-utils';
 import { EMPTY_OVERRIDES } from '@/lib/variable-utils';
 
 import type { Layer, ComponentVariable, Component, Collection, CollectionField } from '@/types';
@@ -73,10 +75,12 @@ export default function ComponentInstanceSidebar({
   const addAudioVariable = useComponentsStore((state) => state.addAudioVariable);
   const addVideoVariable = useComponentsStore((state) => state.addVideoVariable);
   const addIconVariable = useComponentsStore((state) => state.addIconVariable);
+  const addVariantVariable = useComponentsStore((state) => state.addVariantVariable);
   const updateTextVariable = useComponentsStore((state) => state.updateTextVariable);
 
   const setDraftLayers = usePagesStore((state) => state.setDraftLayers);
   const pages = usePagesStore((state) => state.pages);
+  const allComponents = useComponentsStore((state) => state.components);
 
   const [variablesOpen, setVariablesOpen] = useState(true);
   const [variablesDialogOpen, setVariablesDialogOpen] = useState(false);
@@ -89,7 +93,7 @@ export default function ComponentInstanceSidebar({
 
   const allVariables = component.variables || [];
   const overrides = selectedLayer.componentOverrides;
-  const hasOverrides = ['text', 'rich_text', 'image', 'link', 'audio', 'video', 'icon']
+  const hasOverrides = ['text', 'rich_text', 'image', 'link', 'audio', 'video', 'icon', 'variant']
     .some(cat => Object.keys(overrides?.[cat as keyof typeof overrides] || {}).length > 0);
 
   const handleEditMasterComponent = useCallback(async () => {
@@ -112,6 +116,34 @@ export default function ComponentInstanceSidebar({
       },
     });
   }, [selectedLayerId, onLayerUpdate, overrides]);
+
+  // Variant-variable link is a top-level layer field (componentVariantVariableId)
+  // — not a `variableLinks` entry — because variant lives on the layer, not in
+  // a child variable. See plan: "linking_storage = new_field".
+  const handleLinkVariantVariable = useCallback((parentVariableId: string) => {
+    onLayerUpdate(selectedLayerId, { componentVariantVariableId: parentVariableId });
+  }, [selectedLayerId, onLayerUpdate]);
+
+  const handleUnlinkVariantVariable = useCallback(() => {
+    onLayerUpdate(selectedLayerId, { componentVariantVariableId: undefined });
+  }, [selectedLayerId, onLayerUpdate]);
+
+  const handleCreateVariantVariable = useCallback(async () => {
+    if (!editingComponentId) return;
+    const newId = await addVariantVariable(editingComponentId, 'Variant');
+    if (!newId) return;
+
+    // Seed the new variable's default with the layer's currently selected
+    // variant so reusing the parent without overriding still renders the same
+    // variant the user picked while building the parent.
+    const currentVariantId = selectedLayer.componentVariantId
+      ?? component.variants?.[0]?.id;
+    if (currentVariantId) {
+      await updateTextVariable(editingComponentId, newId, { default_value: { variant_id: currentVariantId } });
+    }
+    handleLinkVariantVariable(newId);
+    openVariablesDialog(newId);
+  }, [editingComponentId, addVariantVariable, selectedLayer.componentVariantId, component.variants, updateTextVariable, handleLinkVariantVariable, openVariablesDialog]);
 
   const handleUnlinkOverrideVariable = useCallback((childVariableId: string) => {
     const links = { ...(overrides?.variableLinks ?? {}) };
@@ -241,28 +273,80 @@ export default function ComponentInstanceSidebar({
               )}
             </div>
 
-            {/* Variant selector — only meaningful when the component has more
-                than one variant. Variables are shared across variants, so
+            {/* Variant selector. Always rendered when the component has any
+                variants so users editing a parent can link this layer's
+                variant to a parent variable even if the child only ships with
+                one variant today. Variables are shared across variants, so
                 changing the variant only switches the layer tree. */}
-            {component.variants && component.variants.length > 1 && (
-              <Select
-                value={selectedLayer.componentVariantId ?? component.variants[0].id}
-                onValueChange={(value) => {
-                  onLayerUpdate(selectedLayerId, { componentVariantId: value });
-                }}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Variant" />
-                </SelectTrigger>
-                <SelectContent>
-                  {component.variants.map((variant) => (
-                    <SelectItem key={variant.id} value={variant.id}>
-                      {variant.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
+            {component.variants && component.variants.length > 0 && (() => {
+              const linkedParentVariantVar = editingComponent?.variables?.find(
+                v => v.id === selectedLayer.componentVariantVariableId && (v.type || 'text') === 'variant'
+              );
+              const variantParentVariables = parentVariables.filter(v => (v.type || 'text') === 'variant');
+
+              return (
+                <div className="grid grid-cols-3 items-center gap-2">
+                  <div className="flex items-center gap-1">
+                    <ComponentVariableLabel
+                      label="Variant"
+                      isEditingComponent={!!editingComponentId}
+                      variables={variantParentVariables}
+                      linkedVariableId={linkedParentVariantVar?.id}
+                      onLinkVariable={handleLinkVariantVariable}
+                      onManageVariables={() => openVariablesDialog(linkedParentVariantVar?.id)}
+                      onCreateVariable={editingComponentId ? handleCreateVariantVariable : undefined}
+                    />
+                  </div>
+
+                  <div className="col-span-2 *:w-full">
+                    {linkedParentVariantVar ? (
+                      <Button
+                        asChild
+                        variant="purple"
+                        className="justify-between! w-full"
+                        onClick={() => openVariablesDialog(linkedParentVariantVar.id)}
+                      >
+                        <div>
+                          <span className="flex items-center gap-1.5">
+                            <Icon
+                              name={VARIABLE_TYPE_ICONS['variant']}
+                              className="size-3 opacity-60"
+                            />
+                            {linkedParentVariantVar.name}
+                          </span>
+                          <Button
+                            className="size-4! p-0!"
+                            variant="outline"
+                            onClick={(e) => { e.stopPropagation(); handleUnlinkVariantVariable(); }}
+                          >
+                            <Icon name="x" className="size-2" />
+                          </Button>
+                        </div>
+                      </Button>
+                    ) : (
+                      <Select
+                        value={selectedLayer.componentVariantId ?? component.variants[0].id}
+                        onValueChange={(value) => {
+                          onLayerUpdate(selectedLayerId, { componentVariantId: value });
+                        }}
+                        disabled={component.variants.length <= 1}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Variant" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {component.variants.map((variant) => (
+                            <SelectItem key={variant.id} value={variant.id}>
+                              {variant.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                  </div>
+                </div>
+              );
+            })()}
 
             <Button
               size="sm"
@@ -293,6 +377,7 @@ export default function ComponentInstanceSidebar({
               onUnlinkOverrideVariable={handleUnlinkOverrideVariable}
               onCreateOverrideVariable={handleCreateOverrideVariable}
               onManageVariables={(varId) => openVariablesDialog(varId)}
+              getVariantVariableOptions={(variableId) => collectVariantVariableOptions(component, allComponents, variableId)}
               renderTextOverride={(variable, value, onChange, onClear) =>
                 variable.type === 'rich_text' ? (
                   <ExpandableRichTextEditor

--- a/app/(builder)/ycode/components/ComponentVariableLabel.tsx
+++ b/app/(builder)/ycode/components/ComponentVariableLabel.tsx
@@ -29,6 +29,7 @@ export const VARIABLE_TYPE_ICONS: Record<string, IconProps['name']> = {
   audio: 'audio',
   video: 'video',
   icon: 'icon',
+  variant: 'component',
 };
 
 interface ComponentVariableLabelProps {

--- a/app/(builder)/ycode/components/ComponentVariableOverrides.tsx
+++ b/app/(builder)/ycode/components/ComponentVariableOverrides.tsx
@@ -18,6 +18,13 @@ import AudioSettings from './AudioSettings';
 import VideoSettings from './VideoSettings';
 import IconSettings from './IconSettings';
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
   extractTiptapFromComponentVariable,
   createTextComponentVariableValue,
   tiptapEqual,
@@ -30,11 +37,13 @@ import type {
   AudioSettingsValue,
   VideoSettingsValue,
   IconSettingsValue,
+  VariantSettingsValue,
   Layer,
   CollectionField,
   Collection,
 } from '@/types';
 import type { FieldGroup } from '@/lib/collection-field-utils';
+import type { VariantVariableOption } from '@/lib/component-variant-utils';
 
 type Overrides = Layer['componentOverrides'];
 
@@ -67,6 +76,11 @@ interface ComponentVariableOverridesProps {
   onCreateOverrideVariable?: (childVariable: ComponentVariable) => void;
   /** Called to open the variables dialog, optionally focused on a specific variable */
   onManageVariables?: (variableId?: string) => void;
+  /** Resolves the variant Select options for a given `'variant'` variable. The
+   *  caller (which has access to the parent component object) walks the tree
+   *  to produce these — see `collectVariantVariableOptions`. Required for the
+   *  variant override case to render a Select. */
+  getVariantVariableOptions?: (variableId: string) => VariantVariableOption[];
 }
 
 export default function ComponentVariableOverrides({
@@ -85,6 +99,7 @@ export default function ComponentVariableOverrides({
   onUnlinkOverrideVariable,
   onCreateOverrideVariable,
   onManageVariables,
+  getVariantVariableOptions,
 }: ComponentVariableOverridesProps) {
   const getTextOverrideCategory = useCallback(
     (variableId: string): 'text' | 'rich_text' => {
@@ -209,10 +224,15 @@ export default function ComponentVariableOverrides({
     );
   };
 
-  const renderLabel = (variable: ComponentVariable) => {
+  const renderLabel = (variable: ComponentVariable, options?: { centered?: boolean }) => {
+    // Single-line controls (e.g. the variant Select) live in `items-center`
+    // rows; the default `pt-2` / `py-1` spacing is for multi-line controls
+    // (image/text/etc.) that anchor the label to the top of the row.
+    const centered = options?.centered ?? false;
+
     if (!isEditingComponent) {
       return (
-        <Label variant="muted" className="truncate pt-2">
+        <Label variant="muted" className={cn('truncate', !centered && 'pt-2')}>
           {variable.name}
         </Label>
       );
@@ -221,7 +241,7 @@ export default function ComponentVariableOverrides({
     const linkedParentVar = getLinkedParentVar(variable.id);
 
     return (
-      <div className="flex items-start gap-1 py-1">
+      <div className={cn('flex gap-1', centered ? 'items-center' : 'items-start py-1')}>
         <ComponentVariableLabel
           label={variable.name}
           isEditingComponent
@@ -365,6 +385,44 @@ export default function ComponentVariableOverrides({
             </div>
           </div>
         );
+      case 'variant': {
+        const options = getVariantVariableOptions?.(variable.id) ?? [];
+        const currentValue = getTypedValue('variant' as 'icon', variable.id) as VariantSettingsValue | undefined;
+        const componentIds = Array.from(new Set(options.map(o => o.component_id)));
+        const showComponentName = componentIds.length > 1;
+        const variantLabel = renderLabel(variable, { centered: true });
+
+        return (
+          <div key={variable.id} className="grid grid-cols-3 gap-2 items-center">
+            {variantLabel}
+            <div className="col-span-2 *:w-full">
+              {options.length === 0 ? (
+                <p className="text-xs text-muted-foreground py-2">
+                  Link this variable from a nested component.
+                </p>
+              ) : (
+                <Select
+                  value={currentValue?.variant_id ?? ''}
+                  onValueChange={(val) => handleTypedChange('variant' as 'icon', variable.id, { variant_id: val })}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Variant" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {options.map((opt) => (
+                      <SelectItem key={`${opt.component_id}-${opt.variant_id}`} value={opt.variant_id}>
+                        {showComponentName
+                          ? `${opt.component_name} · ${opt.variant_name}`
+                          : opt.variant_name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+          </div>
+        );
+      }
       case 'rich_text':
       default:
         return (

--- a/app/(builder)/ycode/components/ComponentVariablesDialog.tsx
+++ b/app/(builder)/ycode/components/ComponentVariablesDialog.tsx
@@ -34,14 +34,22 @@ import LinkSettings, { type LinkSettingsValue } from './LinkSettings';
 import AudioSettings, { type AudioSettingsValue } from './AudioSettings';
 import VideoSettings, { type VideoSettingsValue } from './VideoSettings';
 import IconSettings, { type IconSettingsValue } from './IconSettings';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 import { useComponentsStore } from '@/stores/useComponentsStore';
 import { useCollectionsStore } from '@/stores/useCollectionsStore';
 import { createTextComponentVariableValue, extractTiptapFromComponentVariable } from '@/lib/variable-utils';
+import { collectVariantVariableOptions } from '@/lib/component-variant-utils';
 import { VARIABLE_TYPE_ICONS } from './ComponentVariableLabel';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
-import type { ComponentVariable } from '@/types';
+import type { ComponentVariable, VariantSettingsValue } from '@/types';
 
 /** Sortable variable item in the sidebar list. */
 function SortableVariableItem({
@@ -127,9 +135,11 @@ export default function ComponentVariablesDialog({
   const addAudioVariable = useComponentsStore((state) => state.addAudioVariable);
   const addVideoVariable = useComponentsStore((state) => state.addVideoVariable);
   const addIconVariable = useComponentsStore((state) => state.addIconVariable);
+  const addVariantVariable = useComponentsStore((state) => state.addVariantVariable);
   const updateTextVariable = useComponentsStore((state) => state.updateTextVariable);
   const reorderVariables = useComponentsStore((state) => state.reorderVariables);
   const deleteTextVariable = useComponentsStore((state) => state.deleteTextVariable);
+  const allComponents = useComponentsStore((state) => state.components);
   const fields = useCollectionsStore((state) => state.fields);
   const collections = useCollectionsStore((state) => state.collections);
 
@@ -262,6 +272,22 @@ export default function ComponentVariablesDialog({
       setSelectedVariableId(newId);
       setEditingName('Icon');
     }
+  };
+
+  const handleAddVariantVariable = async () => {
+    if (!componentId) return;
+
+    const newId = await addVariantVariable(componentId, 'Variant');
+    if (newId) {
+      setSelectedVariableId(newId);
+      setEditingName('Variant');
+    }
+  };
+
+  const handleVariantDefaultValueChange = (variantId: string) => {
+    if (!componentId || !selectedVariableId) return;
+    const value: VariantSettingsValue = { variant_id: variantId };
+    updateTextVariable(componentId, selectedVariableId, { default_value: value });
   };
 
   // Handle image default value change (via ImageSettings standalone mode)
@@ -413,6 +439,10 @@ export default function ComponentVariablesDialog({
                       <Icon name="video" className="size-3" />
                       Video
                     </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleAddVariantVariable}>
+                      <Icon name={VARIABLE_TYPE_ICONS['variant']} className="size-3" />
+                      Variant
+                    </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
@@ -525,7 +555,43 @@ export default function ComponentVariablesDialog({
                         value={selectedVariable.default_value as IconSettingsValue}
                         onChange={handleIconDefaultValueChange}
                       />
-                    ) : selectedVariable.type === 'rich_text' ? (
+                    ) : selectedVariable.type === 'variant' ? (() => {
+                      const options = collectVariantVariableOptions(component, allComponents, selectedVariable.id);
+                      const currentDefault = (selectedVariable.default_value as VariantSettingsValue | undefined)?.variant_id;
+                      // Group options by component for clearer labelling when
+                      // the variable is generic and links across multiple
+                      // nested components.
+                      const componentIds = Array.from(new Set(options.map(o => o.component_id)));
+                      const showComponentName = componentIds.length > 1;
+
+                      if (options.length === 0) {
+                        return (
+                          <p className="text-xs text-muted-foreground py-2">
+                            Link this variable from a nested component instance to choose a default variant.
+                          </p>
+                        );
+                      }
+
+                      return (
+                        <Select
+                          value={currentDefault ?? ''}
+                          onValueChange={handleVariantDefaultValueChange}
+                        >
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder="Select default variant" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {options.map((opt) => (
+                              <SelectItem key={`${opt.component_id}-${opt.variant_id}`} value={opt.variant_id}>
+                                {showComponentName
+                                  ? `${opt.component_name} · ${opt.variant_name}`
+                                  : opt.variant_name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      );
+                    })() : selectedVariable.type === 'rich_text' ? (
                       <ExpandableRichTextEditor
                         value={editingDefaultValue}
                         onChange={handleDefaultValueChange}

--- a/app/(builder)/ycode/components/ComponentVariantsSection.tsx
+++ b/app/(builder)/ycode/components/ComponentVariantsSection.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import Icon from '@/components/ui/icon';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+import type { Component, ComponentVariant } from '@/types';
+
+interface ComponentVariantsSectionProps {
+  component: Component;
+  /** Active variant id; falls back to the first variant if missing or stale. */
+  activeVariantId: string | null;
+  onSelectVariant: (variantId: string) => void;
+  onAddVariant: () => Promise<void> | void;
+  onRenameVariant: (variantId: string, name: string) => Promise<void> | void;
+  onDuplicateVariant: (variantId: string) => Promise<void> | void;
+  onDeleteVariant: (variantId: string) => Promise<void> | void;
+  onReorderVariants: (orderedVariantIds: string[]) => Promise<void> | void;
+}
+
+interface VariantRowProps {
+  variant: ComponentVariant;
+  isActive: boolean;
+  isOnlyVariant: boolean;
+  isMenuOpen: boolean;
+  onSelect: () => void;
+  onStartRename: () => void;
+  onMenuOpenChange: (open: boolean) => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}
+
+/**
+ * A single sortable variant row. Mirrors the CMS sidebar row layout
+ * (`SortableCollectionItem` in `CMS.tsx`) so the editor feels consistent.
+ */
+function VariantRow({
+  variant,
+  isActive,
+  isOnlyVariant,
+  isMenuOpen,
+  onSelect,
+  onStartRename,
+  onMenuOpenChange,
+  onDuplicate,
+  onDelete,
+}: VariantRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: variant.id,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          ref={setNodeRef}
+          style={style}
+          {...attributes}
+          {...listeners}
+          className={cn(
+            'px-3 h-8 rounded-lg flex gap-2 items-center justify-between text-left w-full group select-none cursor-grab active:cursor-grabbing',
+            // Active uses the same purple accent we apply to component
+            // chips elsewhere (e.g. ComponentInstanceSidebar) so the
+            // active variant visually ties back to "this is component
+            // territory".
+            isActive
+              ? 'bg-purple-500/20 text-purple-700 dark:text-purple-300'
+              : 'hover:bg-secondary/50 text-secondary-foreground/80 dark:text-muted-foreground'
+          )}
+          onClick={onSelect}
+          onDoubleClick={onStartRename}
+        >
+          <div className="flex gap-2 items-center min-w-0">
+            <Icon name="component" className="size-3 shrink-0" />
+            <span className="truncate" title={variant.name}>{variant.name}</span>
+          </div>
+
+          <div
+            className={cn(
+              'shrink-0',
+              // Keep the menu trigger visible while its menu is open so the
+              // user can mouse over without flicker.
+              isMenuOpen ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+            )}
+          >
+            <DropdownMenu open={isMenuOpen} onOpenChange={onMenuOpenChange}>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="xs"
+                  variant="ghost"
+                  // Stop both the click (selection) and the pointerdown
+                  // (drag start) — without stopping pointerdown, dnd-kit
+                  // claims the gesture and the menu never opens.
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => e.stopPropagation()}
+                  className={cn('-mr-2', isActive && 'hover:bg-purple-500/30')}
+                  aria-label="Variant actions"
+                >
+                  <Icon name="more" className="size-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-40">
+                <DropdownMenuItem onSelect={onStartRename}>
+                  Rename
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={onDuplicate}>
+                  Duplicate
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  variant="destructive"
+                  disabled={isOnlyVariant}
+                  onSelect={onDelete}
+                >
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-40">
+        <ContextMenuItem onSelect={onStartRename}>Rename</ContextMenuItem>
+        <ContextMenuItem onSelect={onDuplicate}>Duplicate</ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          variant="destructive"
+          disabled={isOnlyVariant}
+          onSelect={onDelete}
+        >
+          Delete
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+/**
+ * Variants list rendered above the layer tree while editing a component.
+ *
+ * Layout mirrors the CMS items list in the left sidebar — vertical rows with
+ * an icon, name, and a hover-revealed dropdown — but uses the purple
+ * component accent for the active row, and supports drag-to-reorder via
+ * dnd-kit (same pattern as collections).
+ */
+export default function ComponentVariantsSection({
+  component,
+  activeVariantId,
+  onSelectVariant,
+  onAddVariant,
+  onRenameVariant,
+  onDuplicateVariant,
+  onDeleteVariant,
+  onReorderVariants,
+}: ComponentVariantsSectionProps) {
+  const variants = component.variants ?? [];
+  const [renamingVariantId, setRenamingVariantId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [openMenuVariantId, setOpenMenuVariantId] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Require a small drag distance before kicking off a sort, otherwise
+  // single-clicks are stolen by the drag listener and never reach `onClick`.
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    })
+  );
+
+  // Focus & select the rename input as soon as it mounts.
+  useEffect(() => {
+    if (renamingVariantId && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [renamingVariantId]);
+
+  if (variants.length === 0) return null;
+
+  const startRename = (variantId: string, currentName: string) => {
+    setRenamingVariantId(variantId);
+    setRenameValue(currentName);
+  };
+
+  const commitRename = async () => {
+    if (!renamingVariantId) return;
+    const trimmed = renameValue.trim();
+    const original = variants.find(v => v.id === renamingVariantId)?.name ?? '';
+    if (trimmed && trimmed !== original) {
+      await onRenameVariant(renamingVariantId, trimmed);
+    }
+    setRenamingVariantId(null);
+    setRenameValue('');
+  };
+
+  const cancelRename = () => {
+    setRenamingVariantId(null);
+    setRenameValue('');
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = variants.findIndex(v => v.id === active.id);
+    const newIndex = variants.findIndex(v => v.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const next = [...variants];
+    const [moved] = next.splice(oldIndex, 1);
+    next.splice(newIndex, 0, moved);
+    onReorderVariants(next.map(v => v.id));
+  };
+
+  return (
+    <section className="border-b pb-4">
+      <header className="py-5 flex justify-between shrink-0 z-20">
+        <span className="font-medium">Variants</span>
+        <div className="-my-1">
+          <Button
+            size="xs"
+            variant="secondary"
+            onClick={() => onAddVariant()}
+            aria-label="Add variant"
+          >
+            <Icon name="plus" />
+          </Button>
+        </div>
+      </header>
+
+      <DndContext
+        sensors={sensors} collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={variants.map(v => v.id)} strategy={verticalListSortingStrategy}>
+          <div className="flex flex-col gap-0.5">
+            {variants.map((variant) => {
+              const isRenaming = renamingVariantId === variant.id;
+
+              if (isRenaming) {
+                return (
+                  <Input
+                    key={variant.id}
+                    ref={inputRef}
+                    value={renameValue}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onBlur={commitRename}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        commitRename();
+                      } else if (e.key === 'Escape') {
+                        e.preventDefault();
+                        cancelRename();
+                      }
+                    }}
+                    className="h-8"
+                  />
+                );
+              }
+
+              return (
+                <VariantRow
+                  key={variant.id}
+                  variant={variant}
+                  isActive={activeVariantId === variant.id}
+                  isOnlyVariant={variants.length <= 1}
+                  isMenuOpen={openMenuVariantId === variant.id}
+                  onSelect={() => onSelectVariant(variant.id)}
+                  onStartRename={() => startRename(variant.id, variant.name)}
+                  onMenuOpenChange={(open) => setOpenMenuVariantId(open ? variant.id : null)}
+                  onDuplicate={() => onDuplicateVariant(variant.id)}
+                  onDelete={() => onDeleteVariant(variant.id)}
+                />
+              );
+            })}
+          </div>
+        </SortableContext>
+      </DndContext>
+    </section>
+  );
+}

--- a/app/(builder)/ycode/components/ConditionalVisibilitySettings.tsx
+++ b/app/(builder)/ycode/components/ConditionalVisibilitySettings.tsx
@@ -213,6 +213,7 @@ export default function ConditionalVisibilitySettings({
   const draftsByPageId = usePagesStore((state) => state.draftsByPageId);
   const currentPageId = useEditorStore((state) => state.currentPageId);
   const editingComponentId = useEditorStore((state) => state.editingComponentId);
+  const editingComponentVariantId = useEditorStore((state) => state.editingComponentVariantId);
   const componentDrafts = useComponentsStore((state) => state.componentDrafts);
 
   // Get all collection layers on the page
@@ -221,14 +222,18 @@ export default function ConditionalVisibilitySettings({
 
     let layers: Layer[] = [];
     if (editingComponentId) {
-      layers = componentDrafts[editingComponentId] || [];
+      const variantDrafts = componentDrafts[editingComponentId];
+      const variantId = (editingComponentVariantId && variantDrafts?.[editingComponentVariantId])
+        ? editingComponentVariantId
+        : (variantDrafts ? Object.keys(variantDrafts)[0] : null);
+      layers = (variantId && variantDrafts) ? variantDrafts[variantId] || [] : [];
     } else {
       const draft = draftsByPageId[currentPageId];
       layers = draft ? draft.layers : [];
     }
 
     return findAllCollectionLayers(layers);
-  }, [currentPageId, editingComponentId, componentDrafts, draftsByPageId]);
+  }, [currentPageId, editingComponentId, editingComponentVariantId, componentDrafts, draftsByPageId]);
 
   // Initialize groups from layer data
   const groups: VisibilityConditionGroup[] = useMemo(() => {

--- a/app/(builder)/ycode/components/ElementLibrary.tsx
+++ b/app/(builder)/ycode/components/ElementLibrary.tsx
@@ -278,7 +278,7 @@ async function restoreInlinedComponents(
 
 export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: ElementLibraryProps) {
   const { addLayerFromTemplate, updateLayer, setDraftLayers, draftsByPageId, pages } = usePagesStore();
-  const { currentPageId, selectedLayerId, setSelectedLayerId, editingComponentId, activeBreakpoint, pushComponentNavigation, startCanvasDrag, endCanvasDrag } = useEditorStore();
+  const { currentPageId, selectedLayerId, setSelectedLayerId, editingComponentId, editingComponentVariantId, activeBreakpoint, pushComponentNavigation, startCanvasDrag, endCanvasDrag } = useEditorStore();
   const { isLocalizing } = useLocalizationMode();
   const leftSidebarWidth = useEditorStore((state) => state.leftSidebarWidth);
   const { components, componentDrafts, updateComponentDraft, deleteComponent, getDeletePreview, loadComponentDraft, getComponentById, loadComponents } = useComponentsStore();
@@ -309,6 +309,16 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
         .map(c => c.id)
     );
   }, [components, editingComponentId]);
+
+  // Resolve the active variant id for the component currently being edited.
+  // Newly-added elements always go into the variant the user is looking at.
+  const activeComponentVariantId = useMemo(() => {
+    if (!editingComponentId) return null;
+    const drafts = componentDrafts[editingComponentId];
+    if (!drafts) return editingComponentVariantId || null;
+    if (editingComponentVariantId && drafts[editingComponentVariantId]) return editingComponentVariantId;
+    return Object.keys(drafts)[0] || null;
+  }, [editingComponentId, editingComponentVariantId, componentDrafts]);
 
   const matchingComponentIds = useMemo(() => {
     if (!componentSearch.trim()) return null;
@@ -397,9 +407,9 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
   }, [startCanvasDrag, onClose]);
 
   const handleAddElement = (elementType: string) => {
-    // If editing component, use component draft instead
-    if (editingComponentId) {
-      const layers = componentDrafts[editingComponentId] || [];
+    // If editing component, use the active variant's draft instead
+    if (editingComponentId && activeComponentVariantId) {
+      const layers = componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
       const parentId = selectedLayerId || layers[0]?.id || 'body';
 
       // Create new layer from template
@@ -572,7 +582,9 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
           );
         }
 
-        updateComponentDraft(editingComponentId, finalLayers);
+        if (activeComponentVariantId) {
+          updateComponentDraft(editingComponentId, activeComponentVariantId, finalLayers);
+        }
         setSelectedLayerId(result.newLayerId);
         if (result.parentToExpand) {
           window.dispatchEvent(new CustomEvent('expandLayer', {
@@ -660,9 +672,9 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
   };
 
   const handleAddLayout = async (layoutKey: string) => {
-    // If editing component, use component draft instead
-    if (editingComponentId) {
-      const layers = componentDrafts[editingComponentId] || [];
+    // If editing component, use the active variant's draft instead
+    if (editingComponentId && activeComponentVariantId) {
+      const layers = componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
 
       // Get layout template first (we need it to check if it's a section)
       const layoutTemplate = getLayoutTemplate(layoutKey);
@@ -828,7 +840,9 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
           );
         }
 
-        updateComponentDraft(editingComponentId, finalLayers);
+        if (activeComponentVariantId) {
+          updateComponentDraft(editingComponentId, activeComponentVariantId, finalLayers);
+        }
         setSelectedLayerId(result.newLayerId);
         if (result.parentToExpand) {
           window.dispatchEvent(new CustomEvent('expandLayer', {
@@ -1177,8 +1191,8 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
       });
     };
 
-    // If editing a component, add to component draft
-    if (editingComponentId) {
+    // If editing a component, add to the active variant's draft
+    if (editingComponentId && activeComponentVariantId) {
       // Check for circular reference before adding
       const circularError = checkCircularReference(editingComponentId, componentInstanceLayer, components);
       if (circularError) {
@@ -1186,7 +1200,7 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
         return;
       }
 
-      const layers = componentDrafts[editingComponentId] || [];
+      const layers = componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
       const parentId = selectedLayerId || layers[0]?.id;
       if (!parentId) return;
 
@@ -1217,7 +1231,7 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
         newLayers.splice(selectedIndex + 1, 0, componentInstanceLayer);
       }
 
-      updateComponentDraft(editingComponentId, newLayers);
+      updateComponentDraft(editingComponentId, activeComponentVariantId, newLayers);
       setSelectedLayerId(componentInstanceLayer.id);
 
       if (parentToExpand) {

--- a/app/(builder)/ycode/components/FileManagerDialog.tsx
+++ b/app/(builder)/ycode/components/FileManagerDialog.tsx
@@ -1357,9 +1357,17 @@ export default function FileManagerDialog({
           )
         );
 
-        // Update component draft if it exists
-        if (componentsStore.componentDrafts[entity.componentId]) {
-          componentsStore.updateComponentDraft(entity.componentId, entity.newLayers);
+        // Update the primary variant draft if a draft exists. Cleanup
+        // currently runs against the legacy `layers` field, which mirrors
+        // variants[0] — so we replace that variant's working copy.
+        const variantDrafts = componentsStore.componentDrafts[entity.componentId];
+        if (variantDrafts) {
+          const primaryVariantId = component.variants && component.variants.length > 0
+            ? component.variants[0].id
+            : Object.keys(variantDrafts)[0];
+          if (primaryVariantId) {
+            componentsStore.updateComponentDraft(entity.componentId, primaryVariantId, entity.newLayers);
+          }
         }
       }
 

--- a/app/(builder)/ycode/components/LayerContextMenu.tsx
+++ b/app/(builder)/ycode/components/LayerContextMenu.tsx
@@ -107,6 +107,17 @@ export default function LayerContextMenu({
   const getComponentById = useComponentsStore((state) => state.getComponentById);
   const components = useComponentsStore((state) => state.components);
   const componentDrafts = useComponentsStore((state) => state.componentDrafts);
+  const editingComponentVariantId = useEditorStore((state) => state.editingComponentVariantId);
+  // Resolve the active variant id for the component being edited. When
+  // unspecified (or pointing at a missing variant) we fall back to the first
+  // variant so the editor never shows an empty tree.
+  const activeVariantId = useMemo(() => {
+    if (!editingComponentId) return null;
+    const drafts = componentDrafts[editingComponentId];
+    if (!drafts) return editingComponentVariantId || null;
+    if (editingComponentVariantId && drafts[editingComponentVariantId]) return editingComponentVariantId;
+    return Object.keys(drafts)[0] || null;
+  }, [editingComponentId, editingComponentVariantId, componentDrafts]);
   const updateComponentDraft = useComponentsStore((state) => state.updateComponentDraft);
   const createComponentFromComponentLayer = useComponentsStore((state) => state.createComponentFromLayer);
 
@@ -125,14 +136,14 @@ export default function LayerContextMenu({
   const hasStyleClipboard = copiedStyle !== null;
   const hasInteractionsClipboard = copiedInteractions !== null;
 
-  // Resolve layers: component draft when editing a component, else page draft
+  // Resolve layers: active variant draft when editing a component, else page draft
   const isComponentContext = !!editingComponentId;
   const layers = useMemo(
     () =>
-      isComponentContext
-        ? (componentDrafts[editingComponentId!] || [])
+      isComponentContext && editingComponentId && activeVariantId
+        ? (componentDrafts[editingComponentId]?.[activeVariantId] || [])
         : (draftsByPageId[pageId]?.layers || []),
-    [isComponentContext, editingComponentId, componentDrafts, draftsByPageId, pageId]
+    [isComponentContext, editingComponentId, activeVariantId, componentDrafts, draftsByPageId, pageId]
   );
   const layer = findLayerById(layers, layerId);
 
@@ -171,18 +182,20 @@ export default function LayerContextMenu({
     return canDeleteLayer(layer);
   }, [layer]);
 
-  /** Update component draft layers and broadcast to collaborators */
+  /** Update active variant draft layers and broadcast to collaborators */
   const updateComponentAndBroadcast = (newLayers: Layer[]) => {
-    if (!editingComponentId) return;
-    updateComponentDraft(editingComponentId, newLayers);
+    if (!editingComponentId || !activeVariantId) return;
+    updateComponentDraft(editingComponentId, activeVariantId, newLayers);
     if (liveComponentUpdates) {
       liveComponentUpdates.broadcastComponentLayersUpdate(editingComponentId, newLayers);
     }
   };
 
-  /** Get current component layers for the editing context */
+  /** Get current variant layers for the editing context */
   const getComponentLayers = () =>
-    editingComponentId ? (componentDrafts[editingComponentId] || []) : [];
+    editingComponentId && activeVariantId
+      ? (componentDrafts[editingComponentId]?.[activeVariantId] || [])
+      : [];
 
   const handleCopy = () => {
     if (!canCopy) return;
@@ -486,8 +499,8 @@ export default function LayerContextMenu({
     // Use the shared utility function for detaching
     const newLayers = detachSpecificLayerFromComponent(layers, layerId, component || undefined);
 
-    if (isComponentContext && editingComponentId) {
-      updateComponentDraft(editingComponentId, newLayers);
+    if (isComponentContext && editingComponentId && activeVariantId) {
+      updateComponentDraft(editingComponentId, activeVariantId, newLayers);
     } else {
       setDraftLayers(pageId, newLayers);
     }

--- a/app/(builder)/ycode/components/LayerContextMenu.tsx
+++ b/app/(builder)/ycode/components/LayerContextMenu.tsx
@@ -462,17 +462,24 @@ function LayerContextMenuInner({
   const handleEditMasterComponent = async () => {
     if (!layer?.componentId) return;
 
-    const { setEditingComponentId, setSelectedLayerId, pushComponentNavigation, editingComponentId } = useEditorStore.getState();
-    const { loadComponentDraft, getComponentById } = useComponentsStore.getState();
+    const { setEditingComponentId, setSelectedLayerId, setEditingComponentVariantId, editingComponentVariantId, pushComponentNavigation, editingComponentId } = useEditorStore.getState();
+    const { loadComponentDraft, getComponentById, getComponentDraftLayers } = useComponentsStore.getState();
     const { pages } = usePagesStore.getState();
 
+    const component = getComponentById(layer.componentId);
+    if (!component) return;
+
+    // Resolve which variant to open — use the instance's configured variant
+    const requestedVariantId = layer.componentVariantId;
+    const targetVariantId = (requestedVariantId && component.variants?.some(v => v.id === requestedVariantId))
+      ? requestedVariantId
+      : (component.variants && component.variants.length > 0 ? component.variants[0].id : null);
+
     // Capture the current layer ID BEFORE clearing selection
-    // This is the layer we'll return to when exiting component edit mode
     const componentInstanceLayerId = layer.id;
 
     // Push current context to navigation stack before entering component edit mode
     if (editingComponentId) {
-      // We're currently editing a component, push it to stack
       const currentComponent = getComponentById(editingComponentId);
       if (currentComponent) {
         pushComponentNavigation({
@@ -480,10 +487,10 @@ function LayerContextMenuInner({
           id: editingComponentId,
           name: currentComponent.name,
           layerId: layer.id,
+          variantId: editingComponentVariantId ?? null,
         });
       }
     } else if (pageId) {
-      // We're on a page, push it to stack
       const currentPage = pages.find((p) => p.id === pageId);
       if (currentPage) {
         pushComponentNavigation({
@@ -496,23 +503,22 @@ function LayerContextMenuInner({
     }
 
     // Clear selection FIRST to release lock on current page's channel
-    // before switching to component's channel
     setSelectedLayerId(null);
 
-    // Enter edit mode (changes lock channel to component)
-    // Pass the component instance layer ID so we can restore it when exiting
+    // Enter edit mode and set the target variant
     setEditingComponentId(layer.componentId, pageId, componentInstanceLayerId);
+    setEditingComponentVariantId(targetVariantId);
 
     // Load component into draft (async to ensure proper cache sync)
     await loadComponentDraft(layer.componentId);
 
-    // Select root layer only if user hasn't already selected a valid component layer during the await
-    const component = getComponentById(layer.componentId);
-    if (component && component.layers && component.layers.length > 0) {
+    // Select root layer of the target variant's tree
+    const variantLayers = getComponentDraftLayers(layer.componentId, targetVariantId);
+    if (variantLayers && variantLayers.length > 0) {
       const currentSelection = useEditorStore.getState().selectedLayerId;
-      const hasValidSelection = currentSelection && findLayerById(component.layers, currentSelection);
+      const hasValidSelection = currentSelection && findLayerById(variantLayers, currentSelection);
       if (!hasValidSelection) {
-        setSelectedLayerId(component.layers[0].id);
+        setSelectedLayerId(variantLayers[0].id);
       }
     }
   };

--- a/app/(builder)/ycode/components/LayersTree.tsx
+++ b/app/(builder)/ycode/components/LayersTree.tsx
@@ -1109,8 +1109,13 @@ export default function LayersTree({
     // Update layer first so the label shows the new name immediately
     if (editingComponentId) {
       const { componentDrafts } = useComponentsStore.getState();
-      const compLayers = componentDrafts[editingComponentId] || [];
-      updateComponentDraft(editingComponentId, updateLayerProps(compLayers, id, { customName: value }));
+      const variantId = useEditorStore.getState().editingComponentVariantId;
+      const variantDrafts = componentDrafts[editingComponentId];
+      const targetVariantId = (variantId && variantDrafts?.[variantId]) ? variantId : (variantDrafts ? Object.keys(variantDrafts)[0] : null);
+      if (targetVariantId && variantDrafts) {
+        const compLayers = variantDrafts[targetVariantId] || [];
+        updateComponentDraft(editingComponentId, targetVariantId, updateLayerProps(compLayers, id, { customName: value }));
+      }
     } else {
       updateLayer(pageId, id, { customName: value });
     }
@@ -1130,8 +1135,13 @@ export default function LayersTree({
 
     if (editingComponentId) {
       const { componentDrafts } = useComponentsStore.getState();
-      const compLayers = componentDrafts[editingComponentId] || [];
-      updateComponentDraft(editingComponentId, updateLayerProps(compLayers, id, updates));
+      const variantId = useEditorStore.getState().editingComponentVariantId;
+      const variantDrafts = componentDrafts[editingComponentId];
+      const targetVariantId = (variantId && variantDrafts?.[variantId]) ? variantId : (variantDrafts ? Object.keys(variantDrafts)[0] : null);
+      if (targetVariantId && variantDrafts) {
+        const compLayers = variantDrafts[targetVariantId] || [];
+        updateComponentDraft(editingComponentId, targetVariantId, updateLayerProps(compLayers, id, updates));
+      }
     } else {
       updateLayer(pageId, id, updates);
     }

--- a/app/(builder)/ycode/components/LeftSidebar.tsx
+++ b/app/(builder)/ycode/components/LeftSidebar.tsx
@@ -6,6 +6,7 @@ import Icon from '@/components/ui/icon';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
 // 4. Internal components
+import ComponentVariantsSection from './ComponentVariantsSection';
 import LayersTree from './LayersTree';
 import LeftSidebarPages, { type LeftSidebarPagesHandle } from './LeftSidebarPages';
 
@@ -70,6 +71,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
 
   const setCurrentPageId = useEditorStore((state) => state.setCurrentPageId);
   const editingComponentId = useEditorStore((state) => state.editingComponentId);
+  const editingComponentVariantId = useEditorStore((state) => state.editingComponentVariantId);
   const setActiveSidebarTab = useEditorStore((state) => state.setActiveSidebarTab);
 
   const storeSidebarTab = useEditorStore((state) => state.activeSidebarTab);
@@ -88,6 +90,12 @@ const LeftSidebar = React.memo(function LeftSidebar({
   const componentDrafts = useComponentsStore((state) => state.componentDrafts);
   const getComponentById = useComponentsStore((state) => state.getComponentById);
   const updateComponentDraft = useComponentsStore((state) => state.updateComponentDraft);
+  const addVariant = useComponentsStore((state) => state.addVariant);
+  const renameVariant = useComponentsStore((state) => state.renameVariant);
+  const duplicateVariant = useComponentsStore((state) => state.duplicateVariant);
+  const deleteVariant = useComponentsStore((state) => state.deleteVariant);
+  const reorderVariants = useComponentsStore((state) => state.reorderVariants);
+  const setEditingComponentVariantId = useEditorStore((state) => state.setEditingComponentVariantId);
 
   // Collaboration hooks - re-enabled
   const layerLocks = useLayerLocks();
@@ -142,16 +150,26 @@ const LeftSidebar = React.memo(function LeftSidebar({
     onLayerSelect(layerId);
   }, [onLayerSelect]);
 
+  // Resolve the active variant draft when editing a component, falling back
+  // to the first variant if the URL/state still references a stale variant id.
+  const activeComponentVariantId = useMemo(() => {
+    if (!editingComponentId) return null;
+    const drafts = componentDrafts[editingComponentId];
+    if (!drafts) return editingComponentVariantId || null;
+    if (editingComponentVariantId && drafts[editingComponentVariantId]) return editingComponentVariantId;
+    return Object.keys(drafts)[0] || null;
+  }, [editingComponentId, editingComponentVariantId, componentDrafts]);
+
   const layersForCurrentPage = useMemo(() => {
-    // If editing a component, show component layers instead
-    if (editingComponentId) {
-      return componentDrafts[editingComponentId] || [];
+    // If editing a component, show the active variant's layers.
+    if (editingComponentId && activeComponentVariantId) {
+      return componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
     }
 
     // Otherwise show page layers
     if (!currentPageId) return [];
     return currentDraft ? currentDraft.layers : [];
-  }, [editingComponentId, componentDrafts, currentPageId, currentDraft]);
+  }, [editingComponentId, activeComponentVariantId, componentDrafts, currentPageId, currentDraft]);
 
   // Handle layer reordering from drag & drop
   const handleLayersReorder = useCallback((newLayers: Layer[], movedLayerId?: string) => {
@@ -161,16 +179,16 @@ const LeftSidebar = React.memo(function LeftSidebar({
       layers = resetBindingsAfterMove(layers, movedLayerId);
     }
 
-    // If editing component, update component draft
-    if (editingComponentId) {
-      updateComponentDraft(editingComponentId, layers);
+    // If editing component, update the active variant's draft
+    if (editingComponentId && activeComponentVariantId) {
+      updateComponentDraft(editingComponentId, activeComponentVariantId, layers);
       return;
     }
 
     // Otherwise update page draft
     if (!currentPageId) return;
     setDraftLayers(currentPageId, layers);
-  }, [editingComponentId, updateComponentDraft, currentPageId, setDraftLayers]);
+  }, [editingComponentId, activeComponentVariantId, updateComponentDraft, currentPageId, setDraftLayers]);
 
   // Helper to find layer in tree
   const findLayer = useCallback((layers: Layer[], id: string): { layer: Layer; parentId: string | null } | null => {
@@ -331,6 +349,47 @@ const LeftSidebar = React.memo(function LeftSidebar({
               value="layers" className="flex flex-col min-h-0"
               forceMount
             >
+              {editingComponentId && editingComponent && (
+                <ComponentVariantsSection
+                  component={editingComponent}
+                  activeVariantId={activeComponentVariantId}
+                  onSelectVariant={(variantId) => {
+                    if (variantId === activeComponentVariantId) return;
+                    setEditingComponentVariantId(variantId);
+                    // The selected layer almost certainly belongs to the
+                    // previous variant's tree. Snap selection to the new
+                    // variant's root so the canvas + right sidebar reflect
+                    // the active variant immediately.
+                    const drafts = componentDrafts[editingComponentId];
+                    const layersForVariant = drafts?.[variantId]
+                      ?? editingComponent.variants?.find(v => v.id === variantId)?.layers
+                      ?? [];
+                    const firstLayerId = layersForVariant[0]?.id ?? null;
+                    onLayerSelect(firstLayerId);
+                  }}
+                  onAddVariant={async () => {
+                    const newId = await addVariant(editingComponentId, activeComponentVariantId);
+                    if (newId) setEditingComponentVariantId(newId);
+                  }}
+                  onRenameVariant={(variantId, name) => renameVariant(editingComponentId, variantId, name)}
+                  onDuplicateVariant={async (variantId) => {
+                    const newId = await duplicateVariant(editingComponentId, variantId);
+                    if (newId) setEditingComponentVariantId(newId);
+                  }}
+                  onReorderVariants={(orderedIds) => reorderVariants(editingComponentId, orderedIds)}
+                  onDeleteVariant={async (variantId) => {
+                    // After deletion, snap selection to the first remaining variant
+                    // so the editor is never pointed at a missing variant id.
+                    const wasActive = variantId === activeComponentVariantId;
+                    await deleteVariant(editingComponentId, variantId);
+                    if (wasActive) {
+                      const updated = useComponentsStore.getState().getComponentById(editingComponentId);
+                      const fallback = updated?.variants?.[0]?.id ?? null;
+                      setEditingComponentVariantId(fallback);
+                    }
+                  }}
+                />
+              )}
               <header className="py-5 flex justify-between shrink-0 z-20">
                 <span className="font-medium">{editingComponentId ? 'Layers' : 'Layers'}</span>
                 <div className="-my-1">

--- a/app/(builder)/ycode/components/LeftSidebar.tsx
+++ b/app/(builder)/ycode/components/LeftSidebar.tsx
@@ -382,14 +382,20 @@ const LeftSidebar = React.memo(function LeftSidebar({
                   }}
                   onReorderVariants={(orderedIds) => reorderVariants(editingComponentId, orderedIds)}
                   onDeleteVariant={async (variantId) => {
-                    // After deletion, snap selection to the first remaining variant
-                    // so the editor is never pointed at a missing variant id.
                     const wasActive = variantId === activeComponentVariantId;
                     await deleteVariant(editingComponentId, variantId);
-                    if (wasActive) {
-                      const updated = useComponentsStore.getState().getComponentById(editingComponentId);
+                    // Only switch if the variant was actually removed (API may fail silently)
+                    const updated = useComponentsStore.getState().getComponentById(editingComponentId);
+                    const stillExists = updated?.variants?.some(v => v.id === variantId);
+                    if (wasActive && !stillExists) {
                       const fallback = updated?.variants?.[0]?.id ?? null;
                       setEditingComponentVariantId(fallback);
+                      // Snap selection to first layer of the new active variant
+                      const drafts = useComponentsStore.getState().componentDrafts[editingComponentId];
+                      const fallbackLayers = fallback && drafts?.[fallback]
+                        ? drafts[fallback]
+                        : updated?.variants?.[0]?.layers ?? [];
+                      onLayerSelect(fallbackLayers[0]?.id ?? null);
                     }
                   }}
                 />

--- a/app/(builder)/ycode/components/LeftSidebar.tsx
+++ b/app/(builder)/ycode/components/LeftSidebar.tsx
@@ -89,7 +89,6 @@ const LeftSidebar = React.memo(function LeftSidebar({
   const activeTab = storeSidebarTab || sidebarTab;
 
   const componentDrafts = useComponentsStore((state) => state.componentDrafts);
-  const getComponentById = useComponentsStore((state) => state.getComponentById);
   const updateComponentDraft = useComponentsStore((state) => state.updateComponentDraft);
   const addVariant = useComponentsStore((state) => state.addVariant);
   const renameVariant = useComponentsStore((state) => state.renameVariant);
@@ -104,8 +103,11 @@ const LeftSidebar = React.memo(function LeftSidebar({
   const layerLocksRef = useRef(layerLocks);
   layerLocksRef.current = layerLocks;
 
-  // Get component layers if in edit mode
-  const editingComponent = editingComponentId ? getComponentById(editingComponentId) : null;
+  // Subscribe to the actual component object so optimistic updates (e.g.
+  // variant rename) trigger a re-render immediately.
+  const editingComponent = useComponentsStore((state) =>
+    editingComponentId ? state.components.find(c => c.id === editingComponentId) ?? null : null
+  );
 
   // Listen for keyboard shortcut to toggle ElementLibrary
   useEffect(() => {

--- a/app/(builder)/ycode/components/LocalizationContent.tsx
+++ b/app/(builder)/ycode/components/LocalizationContent.tsx
@@ -789,8 +789,17 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                       </div>
                     ) : (
                       storeComponents.map((component) => {
-                        // Get component draft or fallback to published layers
-                        const layers = componentDrafts[component.id] || component.layers || [];
+                        // Translations live on the master component's primary
+                        // variant. Pick the active draft if there is one,
+                        // otherwise fall back to the persisted variants[0]
+                        // layers (mirrored into `component.layers`).
+                        const draftVariants = componentDrafts[component.id];
+                        const primaryVariantId = component.variants && component.variants.length > 0
+                          ? component.variants[0].id
+                          : null;
+                        const layers = (primaryVariantId && draftVariants?.[primaryVariantId])
+                          || component.layers
+                          || [];
                         const translatableItems = extractComponentTranslatableItems(component, layers);
                         const filteredItems = filterTranslatableItems(translatableItems);
 

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -224,6 +224,7 @@ const RightSidebar = React.memo(function RightSidebar({
   const currentPageId = useEditorStore((state) => state.currentPageId);
   const activeBreakpoint = useEditorStore((state) => state.activeBreakpoint);
   const editingComponentId = useEditorStore((state) => state.editingComponentId);
+  const editingComponentVariantId = useEditorStore((state) => state.editingComponentVariantId);
   const setSelectedLayerId = useEditorStore((state) => state.setSelectedLayerId);
   const setInteractionHighlights = useEditorStore((state) => state.setInteractionHighlights);
   const setActiveInteraction = useEditorStore((state) => state.setActiveInteraction);
@@ -259,15 +260,25 @@ const RightSidebar = React.memo(function RightSidebar({
   const fields = useCollectionsStore((state) => state.fields);
   const loadFields = useCollectionsStore((state) => state.loadFields);
 
+  // Resolve the active variant id while editing a component, falling back to
+  // the first variant if state references a stale id.
+  const activeComponentVariantId = useMemo(() => {
+    if (!editingComponentId) return null;
+    const drafts = componentDrafts[editingComponentId];
+    if (!drafts) return editingComponentVariantId || null;
+    if (editingComponentVariantId && drafts[editingComponentVariantId]) return editingComponentVariantId;
+    return Object.keys(drafts)[0] || null;
+  }, [editingComponentId, editingComponentVariantId, componentDrafts]);
+
   // Get all layers (for interactions target selection)
   const allLayers: Layer[] = useMemo(() => {
-    if (editingComponentId) {
-      return componentDrafts[editingComponentId] || [];
+    if (editingComponentId && activeComponentVariantId) {
+      return componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
     } else if (currentPageId) {
       return currentDraft ? currentDraft.layers : [];
     }
     return [];
-  }, [editingComponentId, componentDrafts, currentPageId, currentDraft]);
+  }, [editingComponentId, activeComponentVariantId, componentDrafts, currentPageId, currentDraft]);
 
   // Cached layer index for O(1) lookups
   const layerIndexes = useMemo(() => getLayerIndexes(allLayers), [allLayers]);
@@ -1000,8 +1011,8 @@ const RightSidebar = React.memo(function RightSidebar({
   /** Reset CMS bindings on child layers after the collection source changes */
   const resetChildBindings = useCallback((layerId: string) => {
     setTimeout(() => {
-      const currentLayers = editingComponentId
-        ? useComponentsStore.getState().componentDrafts[editingComponentId]
+      const currentLayers = editingComponentId && activeComponentVariantId
+        ? useComponentsStore.getState().componentDrafts[editingComponentId]?.[activeComponentVariantId]
         : currentPageId
           ? usePagesStore.getState().draftsByPageId[currentPageId]?.layers
           : null;
@@ -1010,14 +1021,14 @@ const RightSidebar = React.memo(function RightSidebar({
 
       const cleanedLayers = resetBindingsOnCollectionSourceChange(currentLayers, layerId);
       if (cleanedLayers !== currentLayers) {
-        if (editingComponentId) {
-          useComponentsStore.getState().updateComponentDraft(editingComponentId, cleanedLayers);
+        if (editingComponentId && activeComponentVariantId) {
+          useComponentsStore.getState().updateComponentDraft(editingComponentId, activeComponentVariantId, cleanedLayers);
         } else if (currentPageId) {
           setDraftLayers(currentPageId, cleanedLayers);
         }
       }
     }, 0);
-  }, [editingComponentId, currentPageId, setDraftLayers]);
+  }, [editingComponentId, activeComponentVariantId, currentPageId, setDraftLayers]);
 
   // Handle collection binding change (also resets child bindings when source changes)
   const handleCollectionChange = (collectionId: string) => {
@@ -1496,8 +1507,8 @@ const RightSidebar = React.memo(function RightSidebar({
 
   // Helper: Get current layers from the appropriate store
   const getCurrentLayersFromStore = (): Layer[] => {
-    if (editingComponentId) {
-      return useComponentsStore.getState().componentDrafts[editingComponentId] || [];
+    if (editingComponentId && activeComponentVariantId) {
+      return useComponentsStore.getState().componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
     } else if (currentPageId) {
       const draft = usePagesStore.getState().draftsByPageId[currentPageId];
       return draft ? draft.layers : [];

--- a/app/(builder)/ycode/components/SizingControls.tsx
+++ b/app/(builder)/ycode/components/SizingControls.tsx
@@ -304,7 +304,7 @@ const SizingControls = memo(function SizingControls({ layer, onLayerUpdate }: Si
   };
 
   // Get store values
-  const { currentPageId, editingComponentId } = useEditorStore();
+  const { currentPageId, editingComponentId, editingComponentVariantId } = useEditorStore();
   const { draftsByPageId } = usePagesStore();
   const { componentDrafts } = useComponentsStore();
 
@@ -314,7 +314,11 @@ const SizingControls = memo(function SizingControls({ layer, onLayerUpdate }: Si
 
     let layers: Layer[] = [];
     if (editingComponentId) {
-      layers = componentDrafts[editingComponentId] || [];
+      const variantDrafts = componentDrafts[editingComponentId];
+      const variantId = (editingComponentVariantId && variantDrafts?.[editingComponentVariantId])
+        ? editingComponentVariantId
+        : (variantDrafts ? Object.keys(variantDrafts)[0] : null);
+      layers = (variantId && variantDrafts) ? variantDrafts[variantId] || [] : [];
     } else if (currentPageId) {
       const draft = draftsByPageId[currentPageId];
       layers = draft ? draft.layers : [];

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -1119,9 +1119,16 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
           await loadComponentDraft(returnDestination.id);
 
           // Pop the current component from the stack before transitioning
-          const { componentNavigationStack } = useEditorStore.getState();
+          const { componentNavigationStack, setEditingComponentVariantId: setVariant } = useEditorStore.getState();
           const newStack = [...componentNavigationStack];
           newStack.pop(); // Remove child component entry
+
+          // Restore the parent's variant from the navigation entry
+          const parentVariantId = returnDestination.variantId
+            ?? (parentComponent.variants && parentComponent.variants.length > 0
+              ? parentComponent.variants[0].id
+              : null);
+          setVariant(parentVariantId);
 
           // Transition directly to parent component (avoids showing page)
           // Manually update the stack to reflect the pop
@@ -1136,7 +1143,8 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
           navigateToComponent(
             returnDestination.id,
             undefined, // rightTab - use current
-            returnDestination.layerId || undefined // layerId - restore the layer
+            returnDestination.layerId || undefined, // layerId - restore the layer
+            parentVariantId // variant - restore the active variant
           );
 
           // Restore layer selection if specified

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -157,9 +157,18 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
 
   const componentIsSaving = useComponentsStore((state) => state.isSaving);
   const components = useComponentsStore((state) => state.components);
-  const componentDraftLayers = useComponentsStore((state) =>
-    editingComponentId ? state.componentDrafts[editingComponentId] ?? null : null
-  );
+  // Track the active variant draft so layer-tracking refs (selection
+  // restoration, dirty detection) react to variant edits.
+  const editingComponentVariantId = useEditorStore((state) => state.editingComponentVariantId);
+  const componentDraftLayers = useComponentsStore((state) => {
+    if (!editingComponentId) return null;
+    const drafts = state.componentDrafts[editingComponentId];
+    if (!drafts) return null;
+    const variantId = (editingComponentVariantId && drafts[editingComponentVariantId])
+      ? editingComponentVariantId
+      : Object.keys(drafts)[0];
+    return variantId ? drafts[variantId] ?? null : null;
+  });
 
   const migrationsComplete = useMigrationStore((state) => state.migrationsComplete);
   const setMigrationsComplete = useMigrationStore((state) => state.setMigrationsComplete);
@@ -206,27 +215,37 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
   // Combined saving state - either page or component
   const isCurrentlySaving = editingComponentId ? componentIsSaving : isSaving;
 
-  // Helper: Get current layers (from page or component)
+  // Helper: Get current layers (from page or active component variant)
   const getCurrentLayers = useCallback((): Layer[] => {
     if (editingComponentId) {
-      const { componentDrafts } = useComponentsStore.getState();
-      return componentDrafts[editingComponentId] || [];
+      const { componentDrafts, getComponentDraftLayers } = useComponentsStore.getState();
+      const drafts = componentDrafts[editingComponentId];
+      const variantId = (editingComponentVariantId && drafts?.[editingComponentVariantId])
+        ? editingComponentVariantId
+        : (drafts ? Object.keys(drafts)[0] : null);
+      return getComponentDraftLayers(editingComponentId, variantId);
     }
     if (currentPageId) {
       return currentDraft ? currentDraft.layers : [];
     }
     return [];
-  }, [editingComponentId, currentPageId, currentDraft]);
+  }, [editingComponentId, editingComponentVariantId, currentPageId, currentDraft]);
 
-  // Helper: Update current layers (page or component)
+  // Helper: Update current layers (page or active component variant)
   const updateCurrentLayers = useCallback((newLayers: Layer[]) => {
     if (editingComponentId) {
-      const { updateComponentDraft } = useComponentsStore.getState();
-      updateComponentDraft(editingComponentId, newLayers);
+      const { componentDrafts, updateComponentDraft } = useComponentsStore.getState();
+      const drafts = componentDrafts[editingComponentId];
+      const variantId = (editingComponentVariantId && drafts?.[editingComponentVariantId])
+        ? editingComponentVariantId
+        : (drafts ? Object.keys(drafts)[0] : null);
+      if (variantId) {
+        updateComponentDraft(editingComponentId, variantId, newLayers);
+      }
     } else if (currentPageId) {
       setDraftLayers(currentPageId, newLayers);
     }
-  }, [editingComponentId, currentPageId, setDraftLayers]);
+  }, [editingComponentId, editingComponentVariantId, currentPageId, setDraftLayers]);
 
   // Check if Supabase is configured, redirect to setup if not
   const [supabaseConfigured, setSupabaseConfigured] = useState<boolean | null>(null);
@@ -622,10 +641,20 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
       const { getComponentById, loadComponentDraft } = useComponentsStore.getState();
       const component = getComponentById(resourceId);
       if (component && editingComponentId !== resourceId) {
-        const { setEditingComponentId } = useEditorStore.getState();
+        const { setEditingComponentId, setEditingComponentVariantId } = useEditorStore.getState();
         // Use currentPageId if available, otherwise find homepage as fallback
         const returnPageId = currentPageId || (pages.length > 0 ? (findHomepage(pages)?.id || pages[0]?.id) : null);
         setEditingComponentId(resourceId, returnPageId);
+        // Restore the active variant from the URL when present so reloads land
+        // back on the same variant. Falls back to the first variant when the
+        // URL is missing/stale, matching `use-edit-component`.
+        const variantFromUrl = urlState.variantId;
+        const variantExists = variantFromUrl
+          && component.variants?.some(v => v.id === variantFromUrl);
+        const initialVariantId = variantExists
+          ? variantFromUrl!
+          : (component.variants && component.variants.length > 0 ? component.variants[0].id : null);
+        setEditingComponentVariantId(initialVariantId);
         // Load component draft (async but we don't need to await in this context)
         loadComponentDraft(resourceId);
       }
@@ -640,6 +669,14 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
       navigateToLayers(defaultPage.id);
     }
   }, [migrationsComplete, pages.length, components.length, collections.length, routeType, resourceId, currentPageId, editingComponentId, pages, components, collections, setCurrentPageId, setSelectedLayerId, navigateToLayers, navigateToCollection, navigateToCollections, urlState.layerId]);
+
+  // Mirror the active component variant id into the URL while editing a
+  // component, so reloads land back on the same variant. Uses
+  // `updateQueryParams` to avoid a router push (no history entry).
+  useEffect(() => {
+    if (routeType !== 'component') return;
+    updateQueryParams({ variant: editingComponentVariantId ?? null });
+  }, [routeType, editingComponentVariantId, updateQueryParams]);
 
   // Auto-select Body layer when switching pages (not when draft updates)
   useEffect(() => {
@@ -823,17 +860,22 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
   // Stable callback for layer updates - reads current state from stores to avoid
   // dependency on editingComponentId/currentPageId which would break React.memo
   const handleLayerUpdate = useCallback((layerId: string, updates: Partial<Layer>) => {
-    const { editingComponentId: compId } = useEditorStore.getState();
+    const { editingComponentId: compId, editingComponentVariantId: variantId } = useEditorStore.getState();
     if (compId) {
       const { componentDrafts, updateComponentDraft } = useComponentsStore.getState();
-      const layers = componentDrafts[compId] || [];
+      const variantDrafts = componentDrafts[compId];
+      const targetVariantId = (variantId && variantDrafts?.[variantId])
+        ? variantId
+        : (variantDrafts ? Object.keys(variantDrafts)[0] : null);
+      if (!targetVariantId || !variantDrafts) return;
+      const layers = variantDrafts[targetVariantId] || [];
       const updateTree = (tree: Layer[]): Layer[] =>
         tree.map(l => {
           if (l.id === layerId) return { ...l, ...updates };
           if (l.children) return { ...l, children: updateTree(l.children) };
           return l;
         });
-      updateComponentDraft(compId, updateTree(layers));
+      updateComponentDraft(compId, targetVariantId, updateTree(layers));
     } else {
       const pageId = useEditorStore.getState().currentPageId;
       if (pageId) {
@@ -1090,8 +1132,18 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
           }
         }
       } else {
-        // Returning to a page (or no stack entry)
-        let targetPageId = returnToPageId;
+        // Returning to a page (or no stack entry).
+        //
+        // `returnToPageId` is a snapshot taken when the user entered component
+        // edit mode and isn't refreshed for non-page entry points (CMS,
+        // Settings, etc.) or after the source page was deleted. In those cases
+        // it would point at a stale/missing page and Next.js would silently
+        // 404 — to the user it just looks like "preview opened the wrong
+        // page". Validate it against the current pages list and silently fall
+        // back to the homepage when it's no longer valid.
+        const isValidReturnPage = returnToPageId
+          && pages.some(p => p.id === returnToPageId);
+        let targetPageId = isValidReturnPage ? returnToPageId : null;
         if (!targetPageId) {
           const homePage = findHomepage(pages);
           const defaultPage = homePage || pages[0];
@@ -1103,6 +1155,12 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
           return;
         }
 
+        // If we fell back, the saved `returnToLayerId` belongs to the original
+        // (now-missing) page and would dangle on the homepage. Drop it.
+        const layerToRestore = isValidReturnPage
+          ? (returnToLayerId || returnDestination?.layerId || undefined)
+          : undefined;
+
         // Clear edit mode state synchronously, then navigate.
         // The URL sync effect will restore the correct layer from the URL.
         setEditingComponentId(null, null);
@@ -1110,7 +1168,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
           targetPageId,
           undefined,
           undefined,
-          returnToLayerId || returnDestination?.layerId || undefined
+          layerToRestore
         );
       }
     } finally {

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -676,10 +676,13 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
   // Mirror the active component variant id into the URL while editing a
   // component, so reloads land back on the same variant. Uses
   // `updateQueryParams` to avoid a router push (no history entry).
+  // Guard on `editingComponentId` so we don't wipe the URL's `?variant=`
+  // param before the init effect has had a chance to read it.
   useEffect(() => {
     if (routeType !== 'component') return;
+    if (!editingComponentId) return;
     updateQueryParams({ variant: editingComponentVariantId ?? null });
-  }, [routeType, editingComponentVariantId, updateQueryParams]);
+  }, [routeType, editingComponentId, editingComponentVariantId, updateQueryParams]);
 
   // Auto-select Body layer when switching pages (not when draft updates)
   useEffect(() => {

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -31,6 +31,7 @@ import { hasComponentOrVariable } from '@/lib/tiptap-utils';
 import LayerContextMenu from '@/app/(builder)/ycode/components/LayerContextMenu';
 import CanvasTextEditor from '@/app/(builder)/ycode/components/CanvasTextEditor';
 import { useComponentsStore } from '@/stores/useComponentsStore';
+import { getComponentVariantLayers } from '@/lib/component-variant-utils';
 import { useCollectionLayerStore } from '@/stores/useCollectionLayerStore';
 import { useFilterStore } from '@/stores/useFilterStore';
 import { useCollectionsStore } from '@/stores/useCollectionsStore';
@@ -1176,8 +1177,12 @@ const LayerItem: React.FC<{
   // here, component content would always render in the default language even
   // when the user previews a non-default locale on a page.
   const transformedComponentLayers = useMemo(() => {
-    if (!isEditMode || !component?.layers?.length) return null;
-    const transformed = transformLayerIdsForInstance(component.layers, layer.id);
+    if (!isEditMode || !component) return null;
+    // Pick the variant the instance is bound to (silently falls back to the
+    // first variant when the requested one was deleted).
+    const variantLayers = getComponentVariantLayers(component, layer.componentVariantId);
+    if (!variantLayers.length) return null;
+    const transformed = transformLayerIdsForInstance(variantLayers, layer.id);
     if (!currentLocale || currentLocale.is_default || !translations) {
       return transformed;
     }
@@ -1185,7 +1190,7 @@ const LayerItem: React.FC<{
       includeIncomplete: true,
       defaultMasterComponentId: component.id,
     });
-  }, [isEditMode, component, layer.id, currentLocale, translations, pageId]);
+  }, [isEditMode, component, layer.id, layer.componentVariantId, currentLocale, translations, pageId]);
 
   // Collect hidden layer IDs from the component's transformed layers
   // Needed because Canvas computes editorHiddenLayerIds from serializeLayers (different ID transform)

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1176,11 +1176,25 @@ const LayerItem: React.FC<{
   // injectTranslatedText pass on the serialized page layers. Without injecting
   // here, component content would always render in the default language even
   // when the user previews a non-default locale on a page.
+  // If this nested-component instance has its variant choice driven by a
+  // parent component variable, resolve the effective variant id from the
+  // parent's override (or the variable's default). Mirrors the SSR branch in
+  // `applyComponentOverrides`; without this the canvas keeps using the
+  // baked-in `componentVariantId` and ignores instance-level overrides.
+  const effectiveVariantId = useMemo(() => {
+    const linkedId = layer.componentVariantVariableId;
+    if (!linkedId) return layer.componentVariantId;
+    const variableDef = parentComponentVariables?.find(v => v.id === linkedId);
+    const overrideValue = parentComponentOverrides?.variant?.[linkedId];
+    const value = (overrideValue ?? variableDef?.default_value) as { variant_id?: string } | undefined;
+    return value?.variant_id ?? layer.componentVariantId;
+  }, [layer.componentVariantVariableId, layer.componentVariantId, parentComponentVariables, parentComponentOverrides]);
+
   const transformedComponentLayers = useMemo(() => {
     if (!isEditMode || !component) return null;
     // Pick the variant the instance is bound to (silently falls back to the
     // first variant when the requested one was deleted).
-    const variantLayers = getComponentVariantLayers(component, layer.componentVariantId);
+    const variantLayers = getComponentVariantLayers(component, effectiveVariantId);
     if (!variantLayers.length) return null;
     const transformed = transformLayerIdsForInstance(variantLayers, layer.id);
     if (!currentLocale || currentLocale.is_default || !translations) {
@@ -1190,7 +1204,7 @@ const LayerItem: React.FC<{
       includeIncomplete: true,
       defaultMasterComponentId: component.id,
     });
-  }, [isEditMode, component, layer.id, layer.componentVariantId, currentLocale, translations, pageId]);
+  }, [isEditMode, component, layer.id, effectiveVariantId, currentLocale, translations, pageId]);
 
   // Collect hidden layer IDs from the component's transformed layers
   // Needed because Canvas computes editorHiddenLayerIds from serializeLayers (different ID transform)

--- a/database/migrations/20260506000001_add_variants_to_components.ts
+++ b/database/migrations/20260506000001_add_variants_to_components.ts
@@ -1,0 +1,44 @@
+import { Knex } from 'knex';
+
+/**
+ * Migration: Add variants column to components table
+ *
+ * Component variants let a single component have multiple named layer trees
+ * (e.g. "Default", "Small", "Large") that share the same component-level
+ * variables. The new `variants` jsonb column stores those trees; the existing
+ * `layers` column is kept in sync with `variants[0].layers` so any reader that
+ * has not been migrated to `variants` still works.
+ *
+ * Idempotent: safe to run multiple times and on freshly-applied template data.
+ */
+export async function up(knex: Knex): Promise<void> {
+  // 1. Add the column if it does not already exist.
+  await knex.raw(`
+    ALTER TABLE components
+    ADD COLUMN IF NOT EXISTS variants jsonb NOT NULL DEFAULT '[]'::jsonb;
+  `);
+
+  // 2. Backfill rows where variants is still empty by wrapping `layers` into a
+  //    single "Default" variant. Skips rows that already have variants so it
+  //    is safe to run again or against partially-migrated template data.
+  await knex.raw(`
+    UPDATE components
+    SET variants = jsonb_build_array(
+      jsonb_build_object(
+        'id', gen_random_uuid()::text,
+        'name', 'Default',
+        'layers', COALESCE(layers, '[]'::jsonb)
+      )
+    )
+    WHERE variants IS NULL OR variants = '[]'::jsonb;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn('components', 'variants');
+  if (hasColumn) {
+    await knex.schema.alterTable('components', (table) => {
+      table.dropColumn('variants');
+    });
+  }
+}

--- a/hooks/use-edit-component.ts
+++ b/hooks/use-edit-component.ts
@@ -45,12 +45,21 @@ export function useEditComponent(): (componentId: string, options?: EditComponen
       currentPageId,
       editingComponentId,
       setSelectedLayerId,
+      setEditingComponentVariantId,
       pushComponentNavigation,
     } = useEditorStore.getState();
     const { pages } = usePagesStore.getState();
 
     const component = getComponentById(componentId);
     if (!component) return;
+
+    // Default to the first variant when entering a component. The URL may
+    // override this via `?variant=…` (handled by the URL→state sync effect),
+    // but seeding here means the editor never starts with a `null` variant.
+    const defaultVariantId = component.variants && component.variants.length > 0
+      ? component.variants[0].id
+      : null;
+    setEditingComponentVariantId(defaultVariantId);
 
     setSelectedLayerId(null);
 
@@ -77,7 +86,7 @@ export function useEditComponent(): (componentId: string, options?: EditComponen
     }
 
     await loadComponentDraft(componentId);
-    openComponent(componentId, currentPageId, undefined, returnToLayerId);
+    openComponent(componentId, currentPageId, undefined, returnToLayerId, defaultVariantId);
 
     // Select an initial layer inside the component if the user hasn't
     // already selected something valid during the await.

--- a/hooks/use-edit-component.ts
+++ b/hooks/use-edit-component.ts
@@ -32,18 +32,25 @@ export interface EditComponentOptions {
    * Defaults to the first child layer of the component.
    */
   initialSelectionLayerId?: string;
+  /**
+   * Variant to open. When entering from an instance configured for a
+   * specific variant, pass its `componentVariantId` here so the editor
+   * opens the correct variant instead of defaulting to the first.
+   */
+  variantId?: string | null;
 }
 
 export function useEditComponent(): (componentId: string, options?: EditComponentOptions) => Promise<void> {
   const { openComponent } = useEditorActions();
 
   return useCallback(async (componentId: string, options: EditComponentOptions = {}) => {
-    const { returnToLayerId, initialSelectionLayerId } = options;
+    const { returnToLayerId, initialSelectionLayerId, variantId: requestedVariantId } = options;
 
     const { loadComponentDraft, getComponentById } = useComponentsStore.getState();
     const {
       currentPageId,
       editingComponentId,
+      editingComponentVariantId,
       setSelectedLayerId,
       setEditingComponentVariantId,
       pushComponentNavigation,
@@ -53,13 +60,15 @@ export function useEditComponent(): (componentId: string, options?: EditComponen
     const component = getComponentById(componentId);
     if (!component) return;
 
-    // Default to the first variant when entering a component. The URL may
-    // override this via `?variant=…` (handled by the URL→state sync effect),
-    // but seeding here means the editor never starts with a `null` variant.
-    const defaultVariantId = component.variants && component.variants.length > 0
-      ? component.variants[0].id
+    // Use the requested variant (from instance) if it exists on the component,
+    // otherwise fall back to the first variant.
+    const validRequestedVariant = requestedVariantId
+      && component.variants?.some(v => v.id === requestedVariantId)
+      ? requestedVariantId
       : null;
-    setEditingComponentVariantId(defaultVariantId);
+    const targetVariantId = validRequestedVariant
+      ?? (component.variants && component.variants.length > 0 ? component.variants[0].id : null);
+    setEditingComponentVariantId(targetVariantId);
 
     setSelectedLayerId(null);
 
@@ -71,6 +80,7 @@ export function useEditComponent(): (componentId: string, options?: EditComponen
           id: editingComponentId,
           name: currentComponent.name,
           layerId: returnToLayerId ?? null,
+          variantId: editingComponentVariantId ?? null,
         });
       }
     } else if (currentPageId) {
@@ -86,18 +96,19 @@ export function useEditComponent(): (componentId: string, options?: EditComponen
     }
 
     await loadComponentDraft(componentId);
-    openComponent(componentId, currentPageId, undefined, returnToLayerId, defaultVariantId);
+    openComponent(componentId, currentPageId, undefined, returnToLayerId, targetVariantId);
 
-    // Select an initial layer inside the component if the user hasn't
-    // already selected something valid during the await.
-    if (component.layers && component.layers.length > 0) {
+    // Select an initial layer inside the target variant's tree.
+    const { getComponentDraftLayers } = useComponentsStore.getState();
+    const variantLayers = getComponentDraftLayers(componentId, targetVariantId);
+    if (variantLayers && variantLayers.length > 0) {
       const currentSelection = useEditorStore.getState().selectedLayerId;
-      const hasValidSelection = currentSelection && findLayerById(component.layers, currentSelection);
+      const hasValidSelection = currentSelection && findLayerById(variantLayers, currentSelection);
       if (!hasValidSelection) {
         const target = initialSelectionLayerId
-          && findLayerById(component.layers, initialSelectionLayerId)
+          && findLayerById(variantLayers, initialSelectionLayerId)
           ? initialSelectionLayerId
-          : component.layers[0].id;
+          : variantLayers[0].id;
         setSelectedLayerId(target);
       }
     }

--- a/hooks/use-editor-url.ts
+++ b/hooks/use-editor-url.ts
@@ -56,6 +56,8 @@ interface EditorUrlState {
   view?: 'desktop' | 'tablet' | 'mobile' | null; // Viewport mode
   rightTab?: 'design' | 'settings' | 'interactions' | null; // Right sidebar tab
   layerId?: string | null; // Selected layer ID
+  /** Selected component variant id while editing a component. */
+  variantId?: string | null;
 }
 
 export function useEditorUrl() {
@@ -208,6 +210,7 @@ export function useEditorUrl() {
     if (componentMatch) {
       const rightTabParam = searchParams?.get('tab');
       const layerParam = searchParams?.get('layer');
+      const variantParam = searchParams?.get('variant');
 
       return {
         type: 'component',
@@ -217,6 +220,7 @@ export function useEditorUrl() {
         sidebarTab: 'layers', // Inferred: components show layers sidebar
         rightTab: rightTabParam as 'design' | 'settings' | 'interactions' | null,
         layerId: layerParam,
+        variantId: variantParam,
       };
     }
 
@@ -355,7 +359,7 @@ export function useEditorUrl() {
   );
 
   const navigateToComponent = useCallback(
-    (componentId: string, rightTab?: string, layerId?: string) => {
+    (componentId: string, rightTab?: string, layerId?: string, variantId?: string | null) => {
       const currentParams = new URLSearchParams(window.location.search);
       const params = new URLSearchParams();
 
@@ -364,6 +368,10 @@ export function useEditorUrl() {
       params.set('tab', tabToUse);
 
       if (layerId) params.set('layer', layerId);
+      // Preserve the active variant on the URL so reloads land back on the
+      // same variant the user was editing.
+      const variantToUse = variantId !== undefined ? variantId : currentParams.get('variant');
+      if (variantToUse) params.set('variant', variantToUse);
 
       const query = params.toString();
       router.push(`/ycode/components/${componentId}${query ? `?${query}` : ''}`);
@@ -381,6 +389,7 @@ export function useEditorUrl() {
       tab?: string;
       layer?: string;
       preview?: string | undefined;
+      variant?: string | null;
     }) => {
       const currentSearchParams = new URLSearchParams(window.location.search);
       const newSearchParams = new URLSearchParams(currentSearchParams);
@@ -416,6 +425,15 @@ export function useEditorUrl() {
           hasChanges = true;
           if (params.preview) newSearchParams.set('preview', params.preview);
           else newSearchParams.delete('preview');
+        }
+      }
+      if ('variant' in params) {
+        const currentVariant = currentSearchParams.get('variant');
+        const nextVariant = params.variant ?? null;
+        if (nextVariant !== currentVariant) {
+          hasChanges = true;
+          if (nextVariant) newSearchParams.set('variant', nextVariant);
+          else newSearchParams.delete('variant');
         }
       }
 
@@ -520,9 +538,9 @@ export function useEditorActions() {
   // Combined action: Open component edit mode (updates state + URL)
   // returnToLayerId is the page/parent layer to restore on exit — NOT the component's layer for the URL
   const openComponent = useCallback(
-    (componentId: string, returnPageId: string | null, rightTab?: string, returnToLayerId?: string) => {
+    (componentId: string, returnPageId: string | null, rightTab?: string, returnToLayerId?: string, variantId?: string | null) => {
       setEditingComponentId(componentId, returnPageId, returnToLayerId);
-      navigateToComponent(componentId, rightTab);
+      navigateToComponent(componentId, rightTab, undefined, variantId ?? undefined);
     },
     [setEditingComponentId, navigateToComponent]
   );

--- a/hooks/use-undo-redo.ts
+++ b/hooks/use-undo-redo.ts
@@ -194,7 +194,17 @@ export function useUndoRedo({
         return draft?.layers || [];
       }
       case 'component': {
-        return componentDrafts[entityId] || [];
+        // Undo/redo currently tracks the component's primary variant. Saving
+        // already records the primary variant's layer tree as the version
+        // payload; reading from the same variant keeps the two consistent.
+        const variantDrafts = componentDrafts[entityId];
+        if (!variantDrafts) return [];
+        const componentEntry = useComponentsStore.getState().getComponentById(entityId);
+        const primaryVariantId = componentEntry?.variants && componentEntry.variants.length > 0
+          ? componentEntry.variants[0].id
+          : Object.keys(variantDrafts)[0];
+        if (!primaryVariantId) return [];
+        return variantDrafts[primaryVariantId] || [];
       }
       case 'layer_style': {
         const style = styles.find((s) => s.id === entityId);
@@ -225,7 +235,15 @@ export function useUndoRedo({
               console.error('   Layer IDs in state:', layerIds);
             }
           }
-          updateComponentDraft(entityId, state as Layer[]);
+          // Apply to the component's primary variant — see getCurrentState.
+          const variantDrafts = useComponentsStore.getState().componentDrafts[entityId];
+          const componentEntry = useComponentsStore.getState().getComponentById(entityId);
+          const primaryVariantId = componentEntry?.variants && componentEntry.variants.length > 0
+            ? componentEntry.variants[0].id
+            : (variantDrafts ? Object.keys(variantDrafts)[0] : null);
+          if (primaryVariantId) {
+            updateComponentDraft(entityId, primaryVariantId, state as Layer[]);
+          }
           break;
         }
         case 'layer_style': {

--- a/lib/client/cssGenerator.ts
+++ b/lib/client/cssGenerator.ts
@@ -219,22 +219,35 @@ async function collectAllLayers(pageLayers: Layer[]): Promise<Layer[]> {
   const { useComponentsStore } = await import('@/stores/useComponentsStore');
   const { components, componentDrafts } = useComponentsStore.getState();
 
-  // Track which components have drafts
+  // `componentDrafts` is keyed by component id then variant id since the
+  // variants refactor (`Record<componentId, Record<variantId, Layer[]>>`).
+  // Track which components have any working draft at all.
   const draftComponentIds = new Set(Object.keys(componentDrafts));
 
   // Collect layers from all components (prefer drafts over saved versions)
   const componentLayers: Layer[] = [];
 
-  // Add component drafts first (these are the latest edits)
-  Object.values(componentDrafts).forEach((layers) => {
-    if (layers && Array.isArray(layers)) {
-      componentLayers.push(...layers);
-    }
+  // Add component drafts first (these are the latest edits). Walk every
+  // variant so classes that only appear in non-primary variants make it into
+  // the compiled stylesheet.
+  Object.values(componentDrafts).forEach((variantMap) => {
+    if (!variantMap || typeof variantMap !== 'object') return;
+    Object.values(variantMap).forEach((variantLayers) => {
+      if (Array.isArray(variantLayers)) {
+        componentLayers.push(...variantLayers);
+      }
+    });
   });
 
-  // Add saved components that don't have drafts
+  // Add saved components that don't have drafts. Same reason as above:
+  // include every variant so e.g. `bg-[#35b7d4]` on Variant 3 is compiled.
   components.forEach((component: Component) => {
-    if (!draftComponentIds.has(component.id) && component.layers && Array.isArray(component.layers)) {
+    if (draftComponentIds.has(component.id)) return;
+    if (component.variants && component.variants.length > 0) {
+      component.variants.forEach((variant) => {
+        if (Array.isArray(variant.layers)) componentLayers.push(...variant.layers);
+      });
+    } else if (Array.isArray(component.layers)) {
       componentLayers.push(...component.layers);
     }
   });

--- a/lib/component-utils.ts
+++ b/lib/component-utils.ts
@@ -238,6 +238,10 @@ export function applyComponentToLayer(layer: Layer, component: Component): Layer
   };
 }
 
+// `getComponentVariantLayers` lives in `lib/component-variant-utils.ts` to
+// avoid a circular import between this module and `lib/layer-utils.ts`.
+export { getComponentVariantLayers } from './component-variant-utils';
+
 /**
  * Detach component from a layer
  * Removes the component link but keeps the layer's own properties

--- a/lib/component-variant-utils.ts
+++ b/lib/component-variant-utils.ts
@@ -1,0 +1,29 @@
+/**
+ * Component variant utilities.
+ *
+ * Kept in a small, dependency-free module so it can be imported from both
+ * `lib/layer-utils.ts` and `lib/component-utils.ts` without creating a
+ * circular import.
+ */
+
+import type { Component, Layer } from '@/types';
+
+/**
+ * Resolve the layer tree for a specific variant of a component.
+ *
+ * Falls back to the first variant when `variantId` is undefined or points at a
+ * variant that no longer exists (e.g. it was deleted while instances were still
+ * referencing it). Falls back to the legacy `component.layers` field for
+ * components persisted before the variants migration.
+ */
+export function getComponentVariantLayers(
+  component: Component,
+  variantId?: string,
+): Layer[] {
+  const variants = component.variants;
+  if (variants && variants.length > 0) {
+    const match = variantId ? variants.find(v => v.id === variantId) : undefined;
+    return (match ?? variants[0]).layers ?? [];
+  }
+  return component.layers ?? [];
+}

--- a/lib/component-variant-utils.ts
+++ b/lib/component-variant-utils.ts
@@ -27,3 +27,72 @@ export function getComponentVariantLayers(
   }
   return component.layers ?? [];
 }
+
+/**
+ * Option for a variant-variable selector. `componentName` is included so
+ * selectors can disambiguate the same variant name across different target
+ * components when a generic Variant variable is linked from instances of more
+ * than one nested component.
+ */
+export interface VariantVariableOption {
+  variant_id: string;
+  variant_name: string;
+  component_id: string;
+  component_name: string;
+}
+
+/**
+ * Collect every (target component, variant) pair reachable through any layer
+ * inside `parentComponent` whose `componentVariantVariableId` points at
+ * `variableId`. Used by both the variables dialog (to pick a default variant)
+ * and the override panel (to choose an override) to populate Selects.
+ *
+ * Walks every variant tree of the parent component, not just the primary one,
+ * so a variant variable that is only linked from layers inside e.g. "Variant 2"
+ * still surfaces options.
+ */
+export function collectVariantVariableOptions(
+  parentComponent: Component | undefined,
+  allComponents: Component[],
+  variableId: string,
+): VariantVariableOption[] {
+  if (!parentComponent || !variableId) return [];
+
+  const seenPairs = new Set<string>();
+  const options: VariantVariableOption[] = [];
+
+  const walk = (layers: Layer[]) => {
+    for (const layer of layers) {
+      if (
+        layer.componentVariantVariableId === variableId
+        && layer.componentId
+      ) {
+        const target = allComponents.find(c => c.id === layer.componentId);
+        if (target?.variants && target.variants.length > 0) {
+          for (const v of target.variants) {
+            const key = `${target.id}::${v.id}`;
+            if (seenPairs.has(key)) continue;
+            seenPairs.add(key);
+            options.push({
+              variant_id: v.id,
+              variant_name: v.name,
+              component_id: target.id,
+              component_name: target.name,
+            });
+          }
+        }
+      }
+      if (layer.children?.length) walk(layer.children);
+    }
+  };
+
+  const variantsToWalk = parentComponent.variants && parentComponent.variants.length > 0
+    ? parentComponent.variants
+    : [{ id: 'legacy', name: 'Default', layers: parentComponent.layers ?? [] }];
+
+  for (const v of variantsToWalk) {
+    if (Array.isArray(v.layers)) walk(v.layers);
+  }
+
+  return options;
+}

--- a/lib/hash-utils.ts
+++ b/lib/hash-utils.ts
@@ -157,23 +157,38 @@ export function generatePageContentHash(
  * Generate a hash for component content
  * Strip UI-only properties (like 'open') before hashing to prevent false changes
  *
- * @param componentData - Component name and layers
+ * Includes every variant's layer tree so edits to non-primary variants
+ * (e.g. "Large") are correctly detected as changes that need republishing.
+ *
+ * @param componentData - Component name, layers, variables, and variants
  * @returns Content hash
  */
 export function generateComponentContentHash(componentData: {
   name: string;
   layers: any;
   variables?: any;
+  variants?: Array<{ id: string; name: string; layers: any }>;
 }): string {
-  // Strip UI properties from layers before hashing
   const layersForHash = Array.isArray(componentData.layers)
     ? stripUIProperties(componentData.layers as Layer[])
     : componentData.layers;
+
+  // Hash every variant's layer tree, not just the primary one. Without this,
+  // editing only a non-primary variant leaves the hash unchanged and the
+  // component is never picked up by `getUnpublishedComponents`.
+  const variantsForHash = Array.isArray(componentData.variants)
+    ? componentData.variants.map(v => ({
+      id: v.id,
+      name: v.name,
+      layers: Array.isArray(v.layers) ? stripUIProperties(v.layers as Layer[]) : v.layers,
+    }))
+    : undefined;
 
   return generateContentHash({
     name: componentData.name,
     layers: layersForHash,
     variables: componentData.variables,
+    variants: variantsForHash,
   });
 }
 

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -8,6 +8,7 @@ import { resolveInlineVariablesFromData } from '@/lib/inline-variables';
 import { DEFAULT_TEXT_STYLES } from '@/lib/text-format-utils';
 import { getCmsFieldBinding } from '@/lib/tiptap-utils';
 import { applyComponentOverrides } from '@/lib/resolve-components';
+import { getComponentVariantLayers } from '@/lib/component-variant-utils';
 import { resolveFieldFromSources } from '@/lib/cms-variables-utils';
 import { isDatePreset, resolveDateFilterValue } from '@/lib/collection-field-utils';
 import { parseMultiReferenceValue } from '@/lib/collection-utils';
@@ -2360,12 +2361,16 @@ function resolveComponentsInLayers(
 
       const component = components.find(c => c.id === layer.componentId);
 
-      if (component && component.layers && component.layers.length > 0) {
+      // Pick the variant layer tree this instance is bound to (silent fallback
+      // to the first variant when the requested one was deleted).
+      const variantLayers = component ? getComponentVariantLayers(component, layer.componentVariantId) : [];
+
+      if (component && variantLayers.length > 0) {
         const innerVisited = new Set(visited);
         innerVisited.add(layer.componentId);
 
-        // The component's first layer is the actual content (Section, etc.)
-        const componentContent = component.layers[0];
+        // The variant's first layer is the actual content (Section, etc.)
+        const componentContent = variantLayers[0];
 
         // Transform all component children with instance-specific IDs
         // This ensures unique layer IDs when multiple instances of the same component exist

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -12,6 +12,7 @@ import { getCollectionVariable, resolveFieldValue, evaluateVisibility, getLayerH
 import { isFieldVariable, isAssetVariable, createDynamicTextVariable, createDynamicRichTextVariable, createAssetVariable, getDynamicTextContent, getVariableStringValue, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
 import { generateImageSrcset, getImageSizes, getOptimizedImageUrl, getAssetProxyUrl, DEFAULT_ASSETS, collectLayerAssetIds } from '@/lib/asset-utils';
 import { resolveComponents, applyComponentOverrides } from '@/lib/resolve-components';
+import { getComponentVariantLayers } from '@/lib/component-variant-utils';
 import { isTiptapDoc, hasBlockElementsWithResolver } from '@/lib/tiptap-utils';
 import { castValue } from '@/lib/collection-utils';
 import { DEFAULT_TEXT_STYLES } from '@/lib/text-format-utils';
@@ -1602,12 +1603,16 @@ async function resolveTiptapComponentCollections(
     // Prevent circular resolution (component embedding itself)
     if (!ancestorComponentIds?.has(componentId)) {
       const comp = components.find(c => c.id === componentId);
-      if (comp?.layers?.length) {
+      // Pick the variant the rich-text node is bound to (falls back to the
+      // first/Default variant when no variant is selected or the requested
+      // one was deleted).
+      const compVariantLayers = comp ? getComponentVariantLayers(comp, node.attrs.componentVariantId) : [];
+      if (comp && compVariantLayers.length) {
         const childAncestors = new Set(ancestorComponentIds);
         childAncestors.add(componentId);
 
         const overrides = node.attrs.componentOverrides ?? undefined;
-        const withOverrides = applyComponentOverrides(comp.layers, overrides, comp.variables);
+        const withOverrides = applyComponentOverrides(compVariantLayers, overrides, comp.variables);
         const withComponents = resolveComponents(withOverrides, components, comp.variables, overrides);
         const withCollections = await resolveCollectionLayers(withComponents, isPublished, undefined, undefined, translations);
 

--- a/lib/repositories/componentRepository.ts
+++ b/lib/repositories/componentRepository.ts
@@ -7,10 +7,11 @@
  */
 
 import { getSupabaseAdmin } from '@/lib/supabase-server';
-import type { Component, Layer } from '@/types';
+import type { Component, ComponentVariant, Layer } from '@/types';
 import { generateComponentContentHash } from '../hash-utils';
 import { deleteTranslationsInBulk, markTranslationsIncomplete } from '@/lib/repositories/translationRepository';
 import { extractLayerContentMap } from '../localisation-utils';
+import { generateId } from '../utils';
 
 /**
  * Input data for creating a new component
@@ -19,6 +20,16 @@ export interface CreateComponentData {
   name: string;
   layers: Layer[];
   variables?: any[]; // Component variables for exposed properties
+  variants?: ComponentVariant[]; // Optional explicit variants; defaults to a single "Default"
+}
+
+/**
+ * Build a variants array from a layers tree. Used when seeding a new component
+ * or when persisting a `variants` change so the legacy `layers` column always
+ * mirrors `variants[0].layers`.
+ */
+function defaultVariantsFromLayers(layers: Layer[]): ComponentVariant[] {
+  return [{ id: generateId('cmpvar'), name: 'Default', layers }];
 }
 
 /**
@@ -120,20 +131,30 @@ export async function createComponent(
     throw new Error('Failed to initialize Supabase client');
   }
 
-  // Calculate content hash
+  // Variants are the source of truth; seed a "Default" variant from `layers`
+  // when none was provided so older callers keep working.
+  const variants: ComponentVariant[] = componentData.variants && componentData.variants.length > 0
+    ? componentData.variants
+    : defaultVariantsFromLayers(componentData.layers);
+  const primaryLayers = variants[0]?.layers ?? componentData.layers;
+
+  // Calculate content hash — includes every variant so non-primary variant
+  // edits are detected by `getUnpublishedComponents`.
   const contentHash = generateComponentContentHash({
     name: componentData.name,
-    layers: componentData.layers,
+    layers: primaryLayers,
     variables: componentData.variables,
+    variants,
   });
 
   const insertData: any = {
     name: componentData.name,
-    layers: componentData.layers,
+    layers: primaryLayers,
+    variants,
     content_hash: contentHash,
     is_published: false,
   };
-  
+
   // Include variables if provided
   if (componentData.variables?.length) {
     insertData.variables = componentData.variables;
@@ -153,11 +174,17 @@ export async function createComponent(
 }
 
 /**
- * Update a component and recalculate content hash
+ * Update a component and recalculate content hash.
+ *
+ * `variants` is the source of truth for the layer trees. When `variants` is
+ * provided, the legacy `layers` column is mirrored to `variants[0].layers` so
+ * any reader that has not been migrated to variants still works. When only
+ * `layers` is provided, `variants[0].layers` is updated in place and the rest
+ * of the variants are preserved.
  */
 export async function updateComponent(
   id: string,
-  updates: Partial<Pick<Component, 'name' | 'layers' | 'variables'>>
+  updates: Partial<Pick<Component, 'name' | 'layers' | 'variables' | 'variants'>>
 ): Promise<Component> {
   const client = await getSupabaseAdmin();
   if (!client) {
@@ -170,44 +197,60 @@ export async function updateComponent(
     throw new Error('Component not found');
   }
 
-  // Detect removed and changed layer content if layers are being updated
-  if (updates.layers !== undefined) {
-    const oldContentMap = extractLayerContentMap(current.layers || [], 'component', id);
-    const newContentMap = extractLayerContentMap(updates.layers, 'component', id);
+  // Reconcile variants and layers so they stay in sync regardless of which one
+  // the caller updated.
+  const currentVariants: ComponentVariant[] = current.variants && current.variants.length > 0
+    ? current.variants
+    : defaultVariantsFromLayers(current.layers || []);
 
-    // Find removed keys (exist in old but not in new)
+  let finalVariants: ComponentVariant[] = currentVariants;
+  if (updates.variants !== undefined) {
+    finalVariants = updates.variants.length > 0
+      ? updates.variants
+      : defaultVariantsFromLayers([]);
+  } else if (updates.layers !== undefined) {
+    finalVariants = currentVariants.map((v, i) => (i === 0 ? { ...v, layers: updates.layers! } : v));
+  }
+  const finalLayers = finalVariants[0]?.layers ?? (updates.layers ?? current.layers ?? []);
+
+  // Detect removed and changed layer content for translation bookkeeping.
+  // We only consider the primary variant layers because translations for the
+  // other variants will be tracked through their own update events.
+  const oldPrimaryLayers = current.layers || [];
+  if (oldPrimaryLayers !== finalLayers) {
+    const oldContentMap = extractLayerContentMap(oldPrimaryLayers, 'component', id);
+    const newContentMap = extractLayerContentMap(finalLayers, 'component', id);
+
     const removedKeys = Object.keys(oldContentMap).filter(key => !(key in newContentMap));
-
-    // Find changed keys (exist in both but value differs)
     const changedKeys = Object.keys(newContentMap).filter(
       key => key in oldContentMap && oldContentMap[key] !== newContentMap[key]
     );
 
-    // Delete translations for removed content
     if (removedKeys.length > 0) {
       await deleteTranslationsInBulk('component', id, removedKeys);
     }
-
-    // Mark translations as incomplete for changed content
     if (changedKeys.length > 0) {
       await markTranslationsIncomplete('component', id, changedKeys);
     }
   }
 
-  // Merge current data with updates for hash calculation
-  const finalData = {
-    name: updates.name !== undefined ? updates.name : current.name,
-    layers: updates.layers !== undefined ? updates.layers : current.layers,
-    variables: updates.variables !== undefined ? updates.variables : current.variables,
-  };
-
-  // Recalculate content hash
-  const contentHash = generateComponentContentHash(finalData);
+  // Recalculate content hash from the final, merged data.
+  const finalName = updates.name !== undefined ? updates.name : current.name;
+  const finalVariables = updates.variables !== undefined ? updates.variables : current.variables;
+  const contentHash = generateComponentContentHash({
+    name: finalName,
+    layers: finalLayers,
+    variables: finalVariables,
+    variants: finalVariants,
+  });
 
   const { data, error } = await client
     .from('components')
     .update({
-      ...updates,
+      ...(updates.name !== undefined ? { name: updates.name } : {}),
+      ...(updates.variables !== undefined ? { variables: updates.variables } : {}),
+      layers: finalLayers,
+      variants: finalVariants,
       content_hash: contentHash,
       updated_at: new Date().toISOString(),
     })
@@ -274,6 +317,7 @@ export async function publishComponent(draftComponentId: string): Promise<Compon
       id: draftComponent.id, // Same ID for draft and published versions
       name: draftComponent.name,
       layers: draftComponent.layers,
+      variants: draftComponent.variants,
       variables: draftComponent.variables,
       content_hash: draftComponent.content_hash, // Copy hash from draft
       is_published: true,
@@ -326,6 +370,7 @@ export async function publishComponents(componentIds: string[]): Promise<{ count
     id: draft.id,
     name: draft.name,
     layers: draft.layers,
+    variants: draft.variants,
     variables: draft.variables,
     content_hash: draft.content_hash,
     is_published: true,

--- a/lib/repositories/layerStyleRepository.ts
+++ b/lib/repositories/layerStyleRepository.ts
@@ -6,7 +6,7 @@
  */
 
 import { getSupabaseAdmin } from '@/lib/supabase-server';
-import type { LayerStyle, Layer } from '@/types';
+import type { LayerStyle, Layer, ComponentVariant } from '@/types';
 import {
   generateLayerStyleContentHash,
   generatePageLayersHash,
@@ -34,6 +34,8 @@ export interface LayerStyleAffectedEntity {
   pageId?: string; // For pages, this is the page.id (not page_layers.id)
   previousLayers: Layer[];
   newLayers: Layer[];
+  previousVariants?: ComponentVariant[];
+  newVariants?: ComponentVariant[];
 }
 
 /**
@@ -573,10 +575,10 @@ export async function findEntitiesUsingLayerStyle(styleId: string): Promise<Laye
     }
   }
 
-  // Find affected components
+  // Find affected components — search all variant layer trees
   const { data: componentRecords, error: compError } = await client
     .from('components')
-    .select('id, name, layers')
+    .select('id, name, layers, variants')
     .eq('is_published', false)
     .is('deleted_at', null);
 
@@ -585,14 +587,29 @@ export async function findEntitiesUsingLayerStyle(styleId: string): Promise<Laye
   }
 
   for (const record of componentRecords || []) {
-    if (layersContainStyle(record.layers || [], styleId)) {
-      const newLayers = detachStyleFromLayersRecursive(record.layers || [], styleId);
+    const variants = record.variants as ComponentVariant[] | undefined;
+    const primaryLayers = record.layers || [];
+
+    const hasStyleInPrimary = layersContainStyle(primaryLayers, styleId);
+    const hasStyleInVariants = Array.isArray(variants) && variants.some(v => layersContainStyle(v.layers ?? [], styleId));
+
+    if (hasStyleInPrimary || hasStyleInVariants) {
+      const newLayers = detachStyleFromLayersRecursive(primaryLayers, styleId);
+      let newVariants: ComponentVariant[] | undefined;
+      if (Array.isArray(variants) && variants.length > 0) {
+        newVariants = variants.map((v, i) => ({
+          ...v,
+          layers: i === 0 ? newLayers : detachStyleFromLayersRecursive(v.layers ?? [], styleId),
+        }));
+      }
       affectedEntities.push({
         type: 'component',
         id: record.id,
         name: record.name,
-        previousLayers: record.layers || [],
+        previousLayers: primaryLayers,
         newLayers,
+        previousVariants: variants || undefined,
+        newVariants,
       });
     }
   }
@@ -656,10 +673,19 @@ export async function softDeleteStyle(id: string): Promise<LayerStyleSoftDeleteR
         console.error(`Failed to update page_layers ${entity.id}:`, updateError);
       }
     } else if (entity.type === 'component') {
+      const contentHash = generateComponentContentHash({
+        name: entity.name,
+        layers: entity.newLayers,
+        variables: undefined,
+        variants: entity.newVariants,
+      });
+
       const { error: updateError } = await client
         .from('components')
         .update({
           layers: entity.newLayers,
+          ...(entity.newVariants ? { variants: entity.newVariants } : {}),
+          content_hash: contentHash,
           updated_at: new Date().toISOString(),
         })
         .eq('id', entity.id)
@@ -828,7 +854,7 @@ export async function syncLayerStyleChangesToDrafts(
   // --- Sync draft components ---
   const { data: componentRecords } = await client
     .from('components')
-    .select('id, name, layers, variables, content_hash')
+    .select('id, name, layers, variants, variables, content_hash')
     .eq('is_published', false)
     .is('deleted_at', null);
 
@@ -844,10 +870,25 @@ export async function syncLayerStyleChangesToDrafts(
       layers = updateLayersWithStyle(layers, style.id, style.classes, style.design);
     }
 
+    // Apply style updates to all variant layer trees so non-primary
+    // variants stay in sync with style changes.
+    let variants: ComponentVariant[] | undefined = record.variants as ComponentVariant[] | undefined;
+    if (Array.isArray(variants) && variants.length > 0) {
+      variants = variants.map((v, i) => {
+        if (i === 0) return { ...v, layers };
+        let variantLayers = v.layers as Layer[] ?? [];
+        for (const style of styles) {
+          variantLayers = updateLayersWithStyle(variantLayers, style.id, style.classes, style.design);
+        }
+        return { ...v, layers: variantLayers };
+      });
+    }
+
     const newHash = generateComponentContentHash({
       name: record.name,
       layers,
       variables: record.variables,
+      variants,
     });
 
     if (newHash !== record.content_hash) {
@@ -856,7 +897,12 @@ export async function syncLayerStyleChangesToDrafts(
       // across draft/published. Always scope the update to the draft row.
       await client
         .from('components')
-        .update({ layers, content_hash: newHash, updated_at: now })
+        .update({
+          layers,
+          ...(variants ? { variants } : {}),
+          content_hash: newHash,
+          updated_at: now,
+        })
         .eq('id', record.id)
         .eq('is_published', false);
     }

--- a/lib/resolve-components.ts
+++ b/lib/resolve-components.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Layer, Component, ComponentVariable, ComponentVariableValue, LayerVariables } from '@/types';
+import { getComponentVariantLayers } from './component-variant-utils';
 
 /**
  * Remap collection_layer_id in a FieldVariable using the ID map.
@@ -555,13 +556,19 @@ export function resolveComponents(
 
       const component = components.find(c => c.id === layer.componentId);
 
-      if (component?.layers?.length) {
+      // Pick the layer tree for the variant this instance is bound to. Falls
+      // back to the first variant when the requested variant no longer exists
+      // (silent fallback for deleted variants) or to the legacy `layers` field
+      // for components stored before the variants migration.
+      const variantLayers = component ? getComponentVariantLayers(component, layer.componentVariantId) : [];
+
+      if (component && variantLayers.length) {
         // Track this component in the resolution chain
         const innerVisited = new Set(visited);
         innerVisited.add(layer.componentId);
 
-        // The component's first layer is the actual content (Section, etc.)
-        const componentContent = component.layers[0];
+        // The variant's first layer is the actual content (Section, etc.)
+        const componentContent = variantLayers[0];
 
         // Recursively resolve nested components, passing current component's
         // variables and this instance's overrides so nested variableLinks resolve correctly

--- a/lib/resolve-components.ts
+++ b/lib/resolve-components.ts
@@ -4,7 +4,7 @@
  * Applies component variable overrides during resolution
  */
 
-import type { Layer, Component, ComponentVariable, ComponentVariableValue, LayerVariables } from '@/types';
+import type { Layer, Component, ComponentVariable, ComponentVariableValue, LayerVariables, VariantSettingsValue } from '@/types';
 import { getComponentVariantLayers } from './component-variant-utils';
 
 /**
@@ -258,6 +258,7 @@ const OVERRIDE_CATEGORIES: OverrideCategory[] = [
   'audio',
   'video',
   'icon',
+  'variant',
 ];
 
 function findOverrideByVariableId(
@@ -329,6 +330,23 @@ export function applyComponentOverrides(
 ): Layer[] {
   return layers.map(layer => {
     let updatedLayer = { ...layer };
+
+    // If this nested-component instance has its variant choice driven by a
+    // parent component variable, resolve the variant id from the parent's
+    // override (or the variable's default) and stamp it on `componentVariantId`
+    // before `resolveComponents` reads it. The parent variable is generic — it
+    // doesn't carry a target component id — so the variant id might not exist
+    // on this layer's referenced component; in that case
+    // `getComponentVariantLayers` falls back to the first variant.
+    if (layer.componentVariantVariableId) {
+      const variableId = layer.componentVariantVariableId;
+      const variableDef = componentVariables?.find(v => v.id === variableId);
+      const overrideValue = overrides?.variant?.[variableId];
+      const value = (overrideValue ?? variableDef?.default_value) as VariantSettingsValue | undefined;
+      if (value && typeof value === 'object' && 'variant_id' in value && value.variant_id) {
+        updatedLayer = { ...updatedLayer, componentVariantId: value.variant_id };
+      }
+    }
 
     // Check if this layer has a text variable linked
     const linkedTextVariableId = layer.variables?.text?.id;

--- a/lib/server/cssGenerator.ts
+++ b/lib/server/cssGenerator.ts
@@ -121,7 +121,15 @@ export async function generateAndSaveDraftCSS(): Promise<string> {
 
   const components: Component[] = await getAllComponents(false);
   for (const component of components) {
-    if (component.layers && Array.isArray(component.layers)) {
+    // Collect classes from every variant — without this, classes that only
+    // appear in non-primary variants (e.g. `bg-[#35b7d4]` on Variant 3) are
+    // missing from the compiled stylesheet and the published instance renders
+    // unstyled even though `resolveComponents` picks the right variant tree.
+    if (component.variants && component.variants.length > 0) {
+      for (const variant of component.variants) {
+        if (Array.isArray(variant.layers)) allLayers.push(...variant.layers);
+      }
+    } else if (Array.isArray(component.layers)) {
       allLayers.push(...component.layers);
     }
   }

--- a/lib/server/cssGenerator.ts
+++ b/lib/server/cssGenerator.ts
@@ -210,9 +210,18 @@ function collectLayersWithComponents(pageLayers: Layer[], components: Component[
       if (layer.componentId && !visitedComponentIds.has(layer.componentId)) {
         visitedComponentIds.add(layer.componentId);
         const component = componentMap.get(layer.componentId);
-        if (component?.layers) {
-          result.push(...component.layers);
-          findComponentRefs(component.layers);
+        if (component) {
+          if (component.variants && component.variants.length > 0) {
+            for (const variant of component.variants) {
+              result.push(...(variant.layers ?? []));
+            }
+            for (const variant of component.variants) {
+              findComponentRefs(variant.layers ?? []);
+            }
+          } else if (component.layers) {
+            result.push(...component.layers);
+            findComponentRefs(component.layers);
+          }
         }
       }
       if (layer.children) {

--- a/lib/variable-utils.ts
+++ b/lib/variable-utils.ts
@@ -23,6 +23,7 @@ export const EMPTY_OVERRIDES: NonNullable<Layer['componentOverrides']> = {
   audio: {},
   video: {},
   icon: {},
+  variant: {},
   variableLinks: {},
 };
 

--- a/stores/useComponentsStore.ts
+++ b/stores/useComponentsStore.ts
@@ -11,11 +11,41 @@ import {
   replaceLayerWithComponentInstance,
   findLayerById,
   cleanLayersForComponentCreation,
+  regenerateIdsWithInteractionRemapping,
 } from '@/lib/layer-utils';
 import { detachStyleFromLayers, updateLayersWithStyle } from '@/lib/layer-style-utils';
 import { scheduleIdle } from '@/lib/schedule-idle';
 import { generateId } from '@/lib/utils';
-import type { Component, Layer } from '@/types';
+import type { Component, ComponentVariant, Layer } from '@/types';
+
+/**
+ * Per-component, per-variant working copy of layers used while editing a
+ * component. Outer key = componentId, inner key = variantId.
+ */
+type ComponentDraftMap = Record<string, Record<string, Layer[]>>;
+
+/**
+ * Build a fresh `variants` array from the latest draft layers, falling back to
+ * each variant's persisted layers when no draft exists for it (e.g. the user
+ * never switched to that variant during this edit session).
+ */
+function buildVariantsFromDrafts(
+  component: Component,
+  drafts: Record<string, Layer[]> | undefined,
+): ComponentVariant[] {
+  const variants = component.variants && component.variants.length > 0
+    ? component.variants
+    : [{ id: generateId('cmpvar'), name: 'Default', layers: component.layers ?? [] }];
+  return variants.map(v => ({ ...v, layers: drafts?.[v.id] ?? v.layers }));
+}
+
+/** Pick the first variant id of a component, used as the safe default. */
+function getPrimaryVariantId(component: Component | undefined): string | null {
+  if (!component) return null;
+  const variants = component.variants;
+  if (variants && variants.length > 0) return variants[0].id;
+  return null;
+}
 
 /** Remove variableLinks entries that point TO a given variable ID (as parent target). */
 function removeVariableLinksPointingTo(layer: Layer, targetVariableId: string): Layer {
@@ -73,11 +103,17 @@ interface ComponentsState {
   components: Component[];
   isLoading: boolean;
   error: string | null;
-  componentDrafts: Record<string, Layer[]>;
   /**
-   * True when a draft has been mutated since it was last loaded or persisted.
-   * Used to skip no-op saves and cross-page sync passes when leaving the
-   * component editor without making any changes.
+   * Per-component, per-variant working copy of layers used while editing a
+   * component. Outer key = componentId, inner key = variantId.
+   */
+  componentDrafts: ComponentDraftMap;
+  /**
+   * True when any variant draft for this component has been mutated since it
+   * was last loaded or persisted. Used to skip no-op saves and cross-page
+   * sync passes when leaving the component editor without making any changes.
+   * Tracked at component granularity (not per-variant) because saves always
+   * persist the whole `variants` array as one unit.
    */
   componentDraftDirty: Record<string, boolean>;
   isSaving: boolean;
@@ -125,9 +161,24 @@ interface ComponentsActions {
 
   // Draft management (for editing mode)
   loadComponentDraft: (componentId: string) => Promise<void>;
-  updateComponentDraft: (componentId: string, layers: Layer[]) => void;
+  updateComponentDraft: (componentId: string, variantId: string, layers: Layer[]) => void;
   saveComponentDraft: (componentId: string) => Promise<void>;
   clearComponentDraft: (componentId: string) => void;
+  /**
+   * Read the current draft layers for a component+variant, falling back to
+   * the persisted variant layers (or the legacy `layers` field) when no
+   * working copy exists yet for that variant.
+   */
+  getComponentDraftLayers: (componentId: string, variantId?: string | null) => Layer[];
+
+  // Variant management
+  addVariant: (componentId: string, fromVariantId?: string | null) => Promise<string | null>;
+  renameVariant: (componentId: string, variantId: string, name: string) => Promise<void>;
+  duplicateVariant: (componentId: string, variantId: string) => Promise<string | null>;
+  deleteVariant: (componentId: string, variantId: string) => Promise<void>;
+  /** Persist a new ordering of a component's variants. Order matters because
+   *  the first variant is the implicit "default" instances fall back to. */
+  reorderVariants: (componentId: string, orderedVariantIds: string[]) => Promise<void>;
 
   // Convenience actions
   renameComponent: (id: string, newName: string) => Promise<void>;
@@ -160,17 +211,30 @@ interface ComponentsActions {
 type ComponentsStore = ComponentsState & ComponentsActions;
 
 export const useComponentsStore = create<ComponentsStore>((set, get) => {
+  /**
+   * Apply a layer transform to every variant on every component (and to every
+   * working draft). Used by global style sync helpers below.
+   */
   const updateComponentLayers = (updateLayers: (layers: Layer[]) => Layer[]) => {
     const { components, componentDrafts } = get();
 
-    const updatedComponents = components.map(component => ({
-      ...component,
-      layers: updateLayers(component.layers),
-    }));
+    const updatedComponents = components.map(component => {
+      const transformedVariants = (component.variants && component.variants.length > 0)
+        ? component.variants.map(v => ({ ...v, layers: updateLayers(v.layers) }))
+        : undefined;
+      return {
+        ...component,
+        layers: updateLayers(component.layers),
+        ...(transformedVariants ? { variants: transformedVariants } : {}),
+      };
+    });
 
-    const updatedDrafts: Record<string, Layer[]> = {};
-    Object.entries(componentDrafts).forEach(([componentId, layers]) => {
-      updatedDrafts[componentId] = updateLayers(layers);
+    const updatedDrafts: ComponentDraftMap = {};
+    Object.entries(componentDrafts).forEach(([componentId, variantDrafts]) => {
+      updatedDrafts[componentId] = {};
+      Object.entries(variantDrafts).forEach(([variantId, layers]) => {
+        updatedDrafts[componentId][variantId] = updateLayers(layers);
+      });
     });
 
     set({ components: updatedComponents, componentDrafts: updatedDrafts });
@@ -337,10 +401,13 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
                 ),
               }));
 
-              // Also update component draft if it's currently being edited
+              // Also update component draft if it's currently being edited.
+              // The legacy `layers` field mirrors the primary variant, so the
+              // detached layers replace that variant's draft.
               const currentDraft = get().componentDrafts[entity.id];
-              if (currentDraft) {
-                get().updateComponentDraft(entity.id, entity.newLayers);
+              const primaryVariantId = getPrimaryVariantId(get().getComponentById(entity.id));
+              if (currentDraft && primaryVariantId) {
+                get().updateComponentDraft(entity.id, primaryVariantId, entity.newLayers);
               }
             }
           }
@@ -442,18 +509,29 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
       }
     },
 
-    // Load component into draft for editing
+    // Load component into draft for editing — clones every variant so the
+    // user can switch between them in the editor without losing edits.
     loadComponentDraft: async (componentId) => {
       const component = get().components.find((c) => c.id === componentId);
       if (component) {
-        const layers = JSON.parse(JSON.stringify(component.layers)); // Deep clone
+        // Backfill a "Default" variant for components that pre-date the
+        // variants migration so the editor always has at least one entry.
+        const variants = component.variants && component.variants.length > 0
+          ? component.variants
+          : [{ id: generateId('cmpvar'), name: 'Default', layers: component.layers ?? [] }];
+
+        const variantDrafts: Record<string, Layer[]> = {};
+        for (const variant of variants) {
+          variantDrafts[variant.id] = JSON.parse(JSON.stringify(variant.layers ?? []));
+        }
+        // Layers used for version tracking — track the primary variant for now.
+        const primaryLayers = variantDrafts[variants[0].id] ?? [];
 
         // Mark entity as initializing BEFORE updating store to prevent false change detection
         try {
           const { markEntityInitializing, updatePreviousState } = await import('@/hooks/use-undo-redo');
           markEntityInitializing('component', componentId);
-          // Also sync the previous state cache with loaded data
-          updatePreviousState('component', componentId, layers);
+          updatePreviousState('component', componentId, primaryLayers);
         } catch (err) {
           console.error('Failed to mark component as initializing:', err);
         }
@@ -461,7 +539,7 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
         set((state) => ({
           componentDrafts: {
             ...state.componentDrafts,
-            [componentId]: layers,
+            [componentId]: variantDrafts,
           },
           componentDraftDirty: {
             ...state.componentDraftDirty,
@@ -471,19 +549,24 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
 
         // Initialize version tracking with loaded state
         import('@/lib/version-tracking').then(({ initializeVersionTracking }) => {
-          initializeVersionTracking('component', componentId, layers);
+          initializeVersionTracking('component', componentId, primaryLayers);
         }).catch((err) => {
           console.error('Failed to initialize component version tracking:', err);
         });
       }
     },
 
-    // Update component draft (triggers auto-save)
-    updateComponentDraft: (componentId, layers) => {
+    // Update component variant draft (triggers auto-save). All variant drafts
+    // for the same component share a single debounced save so we always
+    // persist them together as one `variants` payload.
+    updateComponentDraft: (componentId, variantId, layers) => {
       set((state) => ({
         componentDrafts: {
           ...state.componentDrafts,
-          [componentId]: layers,
+          [componentId]: {
+            ...(state.componentDrafts[componentId] || {}),
+            [variantId]: layers,
+          },
         },
         componentDraftDirty: {
           ...state.componentDraftDirty,
@@ -510,24 +593,50 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
       }));
     },
 
-    // Save component draft to database
-    saveComponentDraft: async (componentId) => {
-      const { componentDrafts, componentDraftDirty } = get();
-      const draftLayers = componentDrafts[componentId];
+    getComponentDraftLayers: (componentId, variantId) => {
+      const component = get().components.find(c => c.id === componentId);
+      const drafts = get().componentDrafts[componentId];
+      const targetVariantId = variantId ?? getPrimaryVariantId(component);
+      if (drafts && targetVariantId && drafts[targetVariantId]) {
+        return drafts[targetVariantId];
+      }
+      // Fall back to persisted variant layers, then to the legacy `layers`.
+      if (component?.variants && component.variants.length > 0) {
+        const match = targetVariantId
+          ? component.variants.find(v => v.id === targetVariantId)
+          : undefined;
+        return (match ?? component.variants[0]).layers ?? [];
+      }
+      return component?.layers ?? [];
+    },
 
-      if (!draftLayers) {
+    // Save the entire variants payload for a component to the database.
+    saveComponentDraft: async (componentId) => {
+      const { componentDrafts, componentDraftDirty, components } = get();
+      const variantDrafts = componentDrafts[componentId];
+
+      if (!variantDrafts || Object.keys(variantDrafts).length === 0) {
         console.warn(`No draft found for component ${componentId}`);
         return;
       }
 
-      // Skip the round-trip entirely when the draft has not been mutated
-      // since it was loaded or last persisted.
+      // Skip the round-trip entirely when nothing has changed since the draft
+      // was loaded or last persisted.
       if (!componentDraftDirty[componentId]) {
         return;
       }
 
-      // Capture the layers we're about to save
-      const layersBeingSaved = draftLayers;
+      const component = components.find(c => c.id === componentId);
+      if (!component) {
+        console.warn(`Component ${componentId} not found in store while saving draft`);
+        return;
+      }
+
+      // Rebuild the variants payload from the latest drafts. Variants the user
+      // never opened during this session keep their persisted layers.
+      const variantsBeingSaved = buildVariantsFromDrafts(component, variantDrafts);
+      // Snapshot the primary variant's layers for change-detection / undo.
+      const layersBeingSaved = variantsBeingSaved[0]?.layers ?? [];
 
       set({ isSaving: true });
 
@@ -535,7 +644,7 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
         const response = await fetch(`/ycode/api/components/${componentId}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ layers: layersBeingSaved }),
+          body: JSON.stringify({ variants: variantsBeingSaved }),
         });
 
         const result = await response.json();
@@ -548,59 +657,54 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
 
         const updatedComponent = result.data;
 
-        // Update the component in the store
-        // Check if layers changed during save (e.g., undo/redo happened)
-        const currentDraft = get().componentDrafts[componentId];
-        const currentLayersJSON = JSON.stringify(currentDraft || []);
-        const savedLayersJSON = JSON.stringify(layersBeingSaved);
+        // Detect whether any variant changed during the save (e.g. undo/redo).
+        const currentDrafts = get().componentDrafts[componentId];
+        const currentVariantsJSON = JSON.stringify(buildVariantsFromDrafts(updatedComponent, currentDrafts));
+        const savedVariantsJSON = JSON.stringify(variantsBeingSaved);
 
-        if (currentLayersJSON === savedLayersJSON) {
-          // Safe to update - no changes made during save
+        if (currentVariantsJSON === savedVariantsJSON) {
           set((state) => ({
             components: state.components.map((c) => (c.id === componentId ? updatedComponent : c)),
             componentDraftDirty: { ...state.componentDraftDirty, [componentId]: false },
             isSaving: false,
           }));
 
-          // Record version for undo/redo only if layers match what we saved
+          // Record version for undo/redo only if variants match what we saved.
           import('@/lib/version-tracking').then(({ recordVersionViaApi }) => {
             recordVersionViaApi('component', componentId, layersBeingSaved);
           }).catch((err) => {
             console.error('Failed to record component version:', err);
           });
         } else {
-          // Layers changed during save - keep local changes
+          // Variants changed mid-save — keep the local copy and let the next
+          // debounced save record the version.
           set((state) => ({
             components: state.components.map((c) => (c.id === componentId ? updatedComponent : c)),
             isSaving: false,
           }));
-
-          // DO NOT record version - the saved state is stale
-          // The new state will trigger another auto-save which will record its own version
         }
 
-        // Trigger component sync across all pages
-        // This will be handled by usePagesStore.updateComponentOnLayers
+        // Trigger component sync across all pages — pages render the primary
+        // variant for back-compat and per-instance variant resolution happens
+        // at render time.
         if (typeof window !== 'undefined') {
           window.dispatchEvent(new CustomEvent('componentUpdated', {
-            detail: { componentId, layers: draftLayers }
+            detail: { componentId, layers: layersBeingSaved }
           }));
 
-          // Regenerate thumbnail in the background (fire-and-forget)
-          triggerThumbnailGeneration(componentId, draftLayers, get().components);
+          triggerThumbnailGeneration(componentId, layersBeingSaved, get().components);
         }
 
-        // Regenerate CSS to include updated component classes.
-        // Run this off the critical path so navigation/UI is not blocked.
-        // Only collect layers from pages that actually contain an instance
-        // of this component (plus the component's own layers).
+        // Regenerate CSS to include updated component classes. Collect layers
+        // from every variant so styles unique to a non-default variant are
+        // also captured.
         scheduleIdle(async () => {
           try {
             const { generateAndSaveCSS } = await import('@/lib/client/cssGenerator');
             const { usePagesStore } = await import('./usePagesStore');
             const { containsComponent } = await import('@/lib/component-utils');
 
-            const allLayers: Layer[] = [...layersBeingSaved];
+            const allLayers: Layer[] = variantsBeingSaved.flatMap(v => v.layers);
             const allDrafts = usePagesStore.getState().draftsByPageId;
             Object.values(allDrafts).forEach((pageDraft) => {
               if (pageDraft.layers && containsComponent(pageDraft.layers, componentId)) {
@@ -653,12 +757,27 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
     },
 
     /**
-     * Create a component from a layer in a component draft
+     * Create a component from a layer in a component draft.
+     *
+     * The action targets whichever variant the editor is currently focused on;
+     * extracting a sub-tree from one variant doesn't change the others.
      */
     createComponentFromLayer: async (componentId, layerId, componentName) => {
-      const { componentDrafts } = get();
-      const layers = componentDrafts[componentId];
-      if (!layers) return null;
+      const { componentDrafts, components } = get();
+      const variantDrafts = componentDrafts[componentId];
+      if (!variantDrafts) return null;
+
+      // Find the variant that actually contains the layer being extracted.
+      let activeVariantId: string | null = null;
+      let layers: Layer[] | null = null;
+      for (const [variantId, variantLayers] of Object.entries(variantDrafts)) {
+        if (findLayerById(variantLayers, layerId)) {
+          activeVariantId = variantId;
+          layers = variantLayers;
+          break;
+        }
+      }
+      if (!activeVariantId || !layers) return null;
 
       const layerToCopy = findLayerById(layers, layerId);
       if (!layerToCopy) return null;
@@ -673,12 +792,13 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
         components: [newComponent, ...state.components],
       }));
 
-      // Replace layer with component instance
+      // Replace the original layer with the new component instance in the
+      // variant we extracted from.
       const newLayers = replaceLayerWithComponentInstance(layers, layerId, newComponent.id);
-      get().updateComponentDraft(componentId, newLayers);
+      get().updateComponentDraft(componentId, activeVariantId, newLayers);
 
       // Generate thumbnail in the background (fire-and-forget)
-      triggerThumbnailGeneration(newComponent.id, newComponent.layers, get().components);
+      triggerThumbnailGeneration(newComponent.id, newComponent.layers, [...components, newComponent]);
 
       return newComponent.id;
     },
@@ -1080,8 +1200,17 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
         });
       };
 
-      // Clean up component's own layers
-      const updatedLayers = component.layers ? unlinkLayersFromVariable(component.layers) : [];
+      // Clean up component's own layers across every variant — variables are
+      // shared across variants so a deleted variable must be unlinked from all
+      // of them. The legacy `layers` field is kept in sync with variants[0].
+      const baselineVariants: ComponentVariant[] = component.variants && component.variants.length > 0
+        ? component.variants
+        : [{ id: generateId('cmpvar'), name: 'Default', layers: component.layers ?? [] }];
+      const updatedVariants = baselineVariants.map(v => ({
+        ...v,
+        layers: unlinkLayersFromVariable(v.layers ?? []),
+      }));
+      const updatedLayers = updatedVariants[0]?.layers ?? [];
 
       try {
         const response = await fetch(`/ycode/api/components/${componentId}`, {
@@ -1089,7 +1218,7 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             variables: updatedVariables,
-            layers: updatedLayers,
+            variants: updatedVariants,
           }),
         });
 
@@ -1099,19 +1228,27 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
           return;
         }
 
-        // Update local state
-        set((state) => ({
-          components: state.components.map((c) =>
-            c.id === componentId ? { ...c, variables: updatedVariables, layers: updatedLayers } : c
-          ),
-          // Also update draft if it exists
-          componentDrafts: {
-            ...state.componentDrafts,
-            ...(state.componentDrafts[componentId] ? {
-              [componentId]: unlinkLayersFromVariable(state.componentDrafts[componentId])
-            } : {}),
-          },
-        }));
+        // Update local state — clean every variant draft for this component.
+        set((state) => {
+          const existingDrafts = state.componentDrafts[componentId];
+          let updatedDrafts: Record<string, Layer[]> | undefined;
+          if (existingDrafts) {
+            updatedDrafts = {};
+            for (const [variantId, layers] of Object.entries(existingDrafts)) {
+              updatedDrafts[variantId] = unlinkLayersFromVariable(layers);
+            }
+          }
+          return {
+            components: state.components.map((c) =>
+              c.id === componentId
+                ? { ...c, variables: updatedVariables, layers: updatedLayers, variants: updatedVariants }
+                : c
+            ),
+            componentDrafts: updatedDrafts
+              ? { ...state.componentDrafts, [componentId]: updatedDrafts }
+              : state.componentDrafts,
+          };
+        });
 
         // Clean up orphaned overrides from page instances
         // Import pages store and clean up componentOverrides that reference the deleted variable
@@ -1168,6 +1305,233 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
         });
       } catch (error) {
         console.error('Failed to delete text variable:', error);
+      }
+    },
+
+    /**
+     * Add a new variant to a component. Optionally seeds it from the layer
+     * tree of an existing variant (the user's "duplicate current variant"
+     * affordance). The variant is persisted via `PUT /api/components/:id` and
+     * appended to the working draft so the editor can switch to it
+     * immediately. Returns the new variant id.
+     */
+    addVariant: async (componentId, fromVariantId) => {
+      const component = get().getComponentById(componentId);
+      if (!component) return null;
+
+      const baseline: ComponentVariant[] = component.variants && component.variants.length > 0
+        ? component.variants
+        : [{ id: generateId('cmpvar'), name: 'Default', layers: component.layers ?? [] }];
+
+      // Pick the variant to clone (caller-specified, otherwise the first).
+      const fromVariant = (fromVariantId && baseline.find(v => v.id === fromVariantId)) || baseline[0];
+
+      // Generate fresh layer IDs so animations / interactions inside the new
+      // variant target its own layers rather than the source variant's.
+      const clonedLayers: Layer[] = (fromVariant.layers ?? []).map(layer =>
+        regenerateIdsWithInteractionRemapping(JSON.parse(JSON.stringify(layer)))
+      );
+
+      // Pick a unique "Variant N" name based on existing variants.
+      const existingNames = new Set(baseline.map(v => v.name));
+      let suffix = baseline.length + 1;
+      let proposedName = `Variant ${suffix}`;
+      while (existingNames.has(proposedName)) {
+        suffix += 1;
+        proposedName = `Variant ${suffix}`;
+      }
+
+      const newVariant: ComponentVariant = {
+        id: generateId('cmpvar'),
+        name: proposedName,
+        layers: clonedLayers,
+      };
+
+      const updatedVariants = [...baseline, newVariant];
+
+      try {
+        const response = await fetch(`/ycode/api/components/${componentId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ variants: updatedVariants }),
+        });
+        const result = await response.json();
+        if (result.error) {
+          console.error('Failed to add variant:', result.error);
+          return null;
+        }
+
+        const updatedComponent: Component = result.data;
+
+        // Seed the working draft for the new variant so the editor can switch
+        // to it without a reload, and refresh the canonical store entry.
+        set((state) => ({
+          components: state.components.map(c => (c.id === componentId ? updatedComponent : c)),
+          componentDrafts: {
+            ...state.componentDrafts,
+            [componentId]: {
+              ...(state.componentDrafts[componentId] || {}),
+              [newVariant.id]: JSON.parse(JSON.stringify(clonedLayers)),
+            },
+          },
+          componentDraftDirty: {
+            ...state.componentDraftDirty,
+            [componentId]: false,
+          },
+        }));
+
+        return newVariant.id;
+      } catch (error) {
+        console.error('Failed to add variant:', error);
+        return null;
+      }
+    },
+
+    renameVariant: async (componentId, variantId, name) => {
+      const component = get().getComponentById(componentId);
+      if (!component?.variants) return;
+      const trimmed = name.trim();
+      if (!trimmed) return;
+
+      const updatedVariants = component.variants.map(v =>
+        v.id === variantId ? { ...v, name: trimmed } : v
+      );
+
+      // Optimistic update so the rename feels instant in the sidebar.
+      set((state) => ({
+        components: state.components.map(c => (c.id === componentId ? { ...c, variants: updatedVariants } : c)),
+      }));
+
+      try {
+        const response = await fetch(`/ycode/api/components/${componentId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ variants: updatedVariants }),
+        });
+        const result = await response.json();
+        if (result.error) {
+          console.error('Failed to rename variant:', result.error);
+          // Roll back on failure.
+          set((state) => ({
+            components: state.components.map(c => (c.id === componentId ? component : c)),
+          }));
+        } else {
+          set((state) => ({
+            components: state.components.map(c => (c.id === componentId ? result.data : c)),
+          }));
+        }
+      } catch (error) {
+        console.error('Failed to rename variant:', error);
+        set((state) => ({
+          components: state.components.map(c => (c.id === componentId ? component : c)),
+        }));
+      }
+    },
+
+    duplicateVariant: async (componentId, variantId) => {
+      return get().addVariant(componentId, variantId);
+    },
+
+    /**
+     * Delete a variant. Refuses to delete the last remaining variant.
+     *
+     * Existing instances that referenced the deleted variant fall back to the
+     * first variant automatically via `getComponentVariantLayers` — no extra
+     * page-level rewriting needed.
+     */
+    deleteVariant: async (componentId, variantId) => {
+      const component = get().getComponentById(componentId);
+      if (!component?.variants || component.variants.length <= 1) return;
+
+      const updatedVariants = component.variants.filter(v => v.id !== variantId);
+      if (updatedVariants.length === component.variants.length) return; // not found
+
+      try {
+        const response = await fetch(`/ycode/api/components/${componentId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ variants: updatedVariants }),
+        });
+        const result = await response.json();
+        if (result.error) {
+          console.error('Failed to delete variant:', result.error);
+          return;
+        }
+
+        const updatedComponent: Component = result.data;
+
+        set((state) => {
+          // Drop the variant draft from the working copy too.
+          const existingDrafts = state.componentDrafts[componentId];
+          let nextDrafts = state.componentDrafts;
+          if (existingDrafts && existingDrafts[variantId]) {
+            const { [variantId]: _, ...rest } = existingDrafts;
+            nextDrafts = { ...state.componentDrafts, [componentId]: rest };
+          }
+          return {
+            components: state.components.map(c => (c.id === componentId ? updatedComponent : c)),
+            componentDrafts: nextDrafts,
+          };
+        });
+      } catch (error) {
+        console.error('Failed to delete variant:', error);
+      }
+    },
+
+    /**
+     * Reorder variants in-place. Persists via the standard component PUT and
+     * mirrors the new order optimistically so the sidebar repaints instantly.
+     * Falls back to the previous order if the server rejects the update.
+     */
+    reorderVariants: async (componentId, orderedVariantIds) => {
+      const component = get().getComponentById(componentId);
+      if (!component?.variants?.length) return;
+
+      const byId = new Map(component.variants.map(v => [v.id, v]));
+      const next = orderedVariantIds
+        .map(id => byId.get(id))
+        .filter((v): v is ComponentVariant => Boolean(v));
+      // Append any variants the caller didn't specify so we never lose data
+      // if the UI somehow sends a partial order.
+      for (const v of component.variants) {
+        if (!orderedVariantIds.includes(v.id)) next.push(v);
+      }
+
+      // Bail if nothing actually changed.
+      const same = next.length === component.variants.length
+        && next.every((v, i) => v.id === component.variants![i].id);
+      if (same) return;
+
+      const previousVariants = component.variants;
+      // Optimistic reorder.
+      set((state) => ({
+        components: state.components.map(c => (c.id === componentId ? { ...c, variants: next } : c)),
+      }));
+
+      try {
+        const response = await fetch(`/ycode/api/components/${componentId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ variants: next }),
+        });
+        const result = await response.json();
+        if (result.error) {
+          console.error('Failed to reorder variants:', result.error);
+          // Roll back on failure.
+          set((state) => ({
+            components: state.components.map(c => (c.id === componentId ? { ...c, variants: previousVariants } : c)),
+          }));
+          return;
+        }
+
+        set((state) => ({
+          components: state.components.map(c => (c.id === componentId ? result.data : c)),
+        }));
+      } catch (error) {
+        console.error('Failed to reorder variants:', error);
+        set((state) => ({
+          components: state.components.map(c => (c.id === componentId ? { ...c, variants: previousVariants } : c)),
+        }));
       }
     },
 

--- a/stores/useComponentsStore.ts
+++ b/stores/useComponentsStore.ts
@@ -194,6 +194,10 @@ interface ComponentsActions {
   addAudioVariable: (componentId: string, name: string) => Promise<string | null>;
   addVideoVariable: (componentId: string, name: string) => Promise<string | null>;
   addIconVariable: (componentId: string, name: string) => Promise<string | null>;
+  /** Add a `'variant'` typed variable. Variant variables expose a parent
+   *  variable that drives the `componentVariantId` of any nested-instance layer
+   *  whose `componentVariantVariableId` points at it. */
+  addVariantVariable: (componentId: string, name: string) => Promise<string | null>;
   updateTextVariable: (componentId: string, variableId: string, updates: { name?: string; placeholder?: string; default_value?: any }) => Promise<void>;
   reorderVariables: (componentId: string, orderedIds: string[]) => Promise<void>;
   deleteTextVariable: (componentId: string, variableId: string) => Promise<void>;
@@ -1089,6 +1093,40 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
       }
     },
 
+    addVariantVariable: async (componentId, name) => {
+      const component = get().getComponentById(componentId);
+      if (!component) return null;
+
+      const variableId = generateId('cpv');
+      const newVariable = { id: variableId, name, type: 'variant' as const };
+      const updatedVariables = [...(component.variables || []), newVariable];
+
+      try {
+        const response = await fetch(`/ycode/api/components/${componentId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ variables: updatedVariables }),
+        });
+
+        const result = await response.json();
+        if (result.error) {
+          console.error('Failed to add variant variable:', result.error);
+          return null;
+        }
+
+        set((state) => ({
+          components: state.components.map((c) =>
+            c.id === componentId ? { ...c, variables: updatedVariables } : c
+          ),
+        }));
+
+        return variableId;
+      } catch (error) {
+        console.error('Failed to add variant variable:', error);
+        return null;
+      }
+    },
+
     // Update a text variable's name and/or default value
     updateTextVariable: async (componentId, variableId, updates) => {
       const component = get().getComponentById(componentId);
@@ -1189,6 +1227,14 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
             };
           }
 
+          // Drop the variant-variable link if it points at the deleted variable.
+          // The layer's own `componentVariantId` (set when the user picked a
+          // variant manually) is preserved as the local fallback.
+          if (updatedLayer.componentVariantVariableId === variableId) {
+            const { componentVariantVariableId: _, ...rest } = updatedLayer;
+            updatedLayer = rest;
+          }
+
           updatedLayer = removeVariableLinksPointingTo(updatedLayer, variableId);
 
           // Recursively process children
@@ -1280,6 +1326,14 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
               }
 
               updatedLayer.componentOverrides = overrides;
+            }
+
+            // Mirror of the editor-side strip: drop dangling variant-variable
+            // links so a deleted variant variable doesn't keep pointing into a
+            // nonexistent parent variable.
+            if (updatedLayer.componentVariantVariableId === variableId) {
+              const { componentVariantVariableId: _, ...rest } = updatedLayer;
+              updatedLayer = rest;
             }
 
             updatedLayer = removeVariableLinksPointingTo(updatedLayer, variableId);

--- a/stores/useEditorStore.ts
+++ b/stores/useEditorStore.ts
@@ -61,6 +61,7 @@ interface EditorActions {
   setActiveUIState: (state: UIState) => void;
   setActiveTextStyleKey: (key: string | null) => void;
   setEditingComponentId: (id: string | null, returnPageId?: string | null, returnToLayerId?: string | null) => void;
+  setEditingComponentVariantId: (id: string | null) => void;
   pushComponentNavigation: (entry: ComponentNavigationEntry) => void;
   getReturnDestination: () => ComponentNavigationEntry | null;
   setBuilderDataPreloaded: (preloaded: boolean) => void;
@@ -111,6 +112,10 @@ interface EditorStoreWithHistory extends EditorState {
   historyIndex: number;
   maxHistorySize: number;
   editingComponentId: string | null;
+  // Currently selected variant id while editing a component. `null` means
+  // "use the first variant" (also the default for components with a single
+  // variant). Cleared whenever `editingComponentId` is cleared.
+  editingComponentVariantId: string | null;
   returnToPageId: string | null;
   returnToLayerId: string | null; // Layer to restore when exiting component edit mode
   componentNavigationStack: ComponentNavigationEntry[]; // Breadcrumb stack for nested component editing
@@ -209,6 +214,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
   historyIndex: -1,
   maxHistorySize: 50,
   editingComponentId: null,
+  editingComponentVariantId: null,
   returnToPageId: null,
   returnToLayerId: null,
   componentNavigationStack: [],
@@ -423,11 +429,16 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     set({
       editingComponentId: id,
+      // Clear the active variant when leaving component edit mode; callers
+      // entering edit mode are expected to set the variant explicitly
+      // (`use-edit-component` does this once the draft has loaded).
+      editingComponentVariantId: id === null ? null : get().editingComponentVariantId,
       returnToPageId: returnPageId,
       returnToLayerId: layerToReturn,
       componentNavigationStack: newStack,
     });
   },
+  setEditingComponentVariantId: (id: string | null) => set({ editingComponentVariantId: id }),
   setBuilderDataPreloaded: (preloaded) => set({ builderDataPreloaded: preloaded }),
 
   /**

--- a/stores/useEditorStore.ts
+++ b/stores/useEditorStore.ts
@@ -36,6 +36,7 @@ export interface ComponentNavigationEntry {
   id: string; // pageId or componentId
   name: string; // Display name for breadcrumb
   layerId?: string | null; // Layer to restore when returning
+  variantId?: string | null; // Variant to restore when returning to a component
 }
 
 export type EditorSidebarTab = 'layers' | 'pages' | 'cms';

--- a/stores/useLayerStylesStore.ts
+++ b/stores/useLayerStylesStore.ts
@@ -210,10 +210,18 @@ export const useLayerStylesStore = create<LayerStylesStore>((set, get) => ({
                 ),
               }));
 
-              // Also update component draft if it's currently being edited
-              const currentDraft = componentsStore.componentDrafts[entity.id];
-              if (currentDraft) {
-                componentsStore.updateComponentDraft(entity.id, entity.newLayers);
+              // Also update the primary variant draft if a working copy
+              // exists. Style detach happens against the legacy `layers`
+              // field, which mirrors variants[0].
+              const variantDrafts = componentsStore.componentDrafts[entity.id];
+              if (variantDrafts) {
+                const updatedComponent = useComponentsStore.getState().getComponentById(entity.id);
+                const primaryVariantId = updatedComponent?.variants && updatedComponent.variants.length > 0
+                  ? updatedComponent.variants[0].id
+                  : Object.keys(variantDrafts)[0];
+                if (primaryVariantId) {
+                  componentsStore.updateComponentDraft(entity.id, primaryVariantId, entity.newLayers);
+                }
               }
             }
           }

--- a/types/index.ts
+++ b/types/index.ts
@@ -401,6 +401,9 @@ export interface Layer {
 
   // Components (reusable layer trees)
   componentId?: string; // Reference to applied Component
+  // Selected variant id within the referenced component. When undefined or
+  // pointing to a missing variant, the first variant ("Default") is used.
+  componentVariantId?: string;
   componentOverrides?: {
     text?: Record<string, ComponentVariableValue>; // ComponentVariable.id → override value (text)
     rich_text?: Record<string, ComponentVariableValue>; // ComponentVariable.id → override value (rich text)
@@ -610,15 +613,29 @@ export interface ComponentVariable {
   default_value?: ComponentVariableValue; // Default value
 }
 
+// A named layer tree variant of a component (e.g. "Default", "Small", "Large").
+// All variants share the same component-level `variables`.
+export interface ComponentVariant {
+  id: string;
+  name: string;
+  layers: Layer[];
+}
+
 // Component Types (Reusable Layer Trees)
 export interface Component {
   id: string;
   name: string;
 
-  // Component data - complete layer tree
+  // Component data - complete layer tree.
+  // Mirrors `variants[0].layers` for backwards compatibility; new code should
+  // read from `variants` via `getComponentVariantLayers()`.
   layers: Layer[];
 
-  // Component variables - exposed properties for overrides
+  // Named layer tree variants. Always has at least one entry ("Default")
+  // after the variants migration runs. Treat this as the source of truth.
+  variants?: ComponentVariant[];
+
+  // Component variables - exposed properties for overrides (shared across variants)
   variables?: ComponentVariable[];
 
   // Versioning fields

--- a/types/index.ts
+++ b/types/index.ts
@@ -404,6 +404,11 @@ export interface Layer {
   // Selected variant id within the referenced component. When undefined or
   // pointing to a missing variant, the first variant ("Default") is used.
   componentVariantId?: string;
+  // When set, the variant for this nested component instance is driven by the
+  // parent component's variable (by id). Resolved during
+  // `applyComponentOverrides` and written back to `componentVariantId` before
+  // the component tree is expanded.
+  componentVariantVariableId?: string;
   componentOverrides?: {
     text?: Record<string, ComponentVariableValue>; // ComponentVariable.id → override value (text)
     rich_text?: Record<string, ComponentVariableValue>; // ComponentVariable.id → override value (rich text)
@@ -412,6 +417,7 @@ export interface Layer {
     audio?: Record<string, ComponentVariableValue>; // ComponentVariable.id → override value (audio)
     video?: Record<string, ComponentVariableValue>; // ComponentVariable.id → override value (video)
     icon?: Record<string, ComponentVariableValue>; // ComponentVariable.id → override value (icon)
+    variant?: Record<string, ComponentVariableValue>; // ComponentVariable.id → override value (variant)
     variableLinks?: Record<string, string>; // childVariableId → parentVariableId (pass-through from nested component to parent)
   };
 
@@ -608,7 +614,7 @@ export interface BlockTemplate {
 export interface ComponentVariable {
   id: string;        // Unique variable ID
   name: string;      // Display name (e.g., "Button title")
-  type?: 'text' | 'rich_text' | 'image' | 'link' | 'audio' | 'video' | 'icon'; // Variable type (defaults to 'text' for backwards compatibility)
+  type?: 'text' | 'rich_text' | 'image' | 'link' | 'audio' | 'video' | 'icon' | 'variant'; // Variable type (defaults to 'text' for backwards compatibility)
   placeholder?: string; // Placeholder text shown in text override inputs
   default_value?: ComponentVariableValue; // Default value
 }
@@ -1245,8 +1251,17 @@ export interface IconSettingsValue {
   src?: AssetVariable | StaticTextVariable;
 }
 
-// Component variable value type (text, image, link, audio, video, and icon variables)
-export type ComponentVariableValue = DynamicTextVariable | DynamicRichTextVariable | ImageSettingsValue | LinkSettingsValue | AudioSettingsValue | VideoSettingsValue | IconSettingsValue;
+// Variant settings value for component variables. Stored on
+// `componentOverrides.variant[<variableId>]` and as `default_value` on a
+// `'variant'`-typed ComponentVariable. The variant_id is matched against the
+// referenced nested component's variants at resolve time; a missing match
+// silently falls back to the layer's own `componentVariantId`.
+export interface VariantSettingsValue {
+  variant_id: string;
+}
+
+// Component variable value type (text, image, link, audio, video, icon, and variant variables)
+export type ComponentVariableValue = DynamicTextVariable | DynamicRichTextVariable | ImageSettingsValue | LinkSettingsValue | AudioSettingsValue | VideoSettingsValue | IconSettingsValue | VariantSettingsValue;
 
 // Pagination Layer Definition (partial Layer for styling pagination controls)
 export interface PaginationLayerConfig {


### PR DESCRIPTION
## Summary

Components can now hold multiple named variant trees (e.g. "Default",
"Small", "Large") that share the same component variables. Page
instances bind to a variant via `componentVariantId` on the layer; the
canvas, SSR, and CSS pipelines all resolve the bound variant and fall
back to the first variant when one is missing.

A nested instance can also link its variant choice to a parent
component variable so a `Card` can expose a `Variant` variable that
swaps the variant of an inner `Button` from the page-level overrides
panel.

## Changes

### Variants base

- Add `ComponentVariant` type, `Component.variants[]`, and
  `Layer.componentVariantId`; idempotent migration adds the jsonb
  column and backfills a "Default" variant from `layers`
- Repository update/publish/create reconcile `variants` and mirror
  `variants[0].layers` to the legacy `layers` column for backwards compat
- Hash component content over every variant so non-primary variant
  edits are picked up by `getUnpublishedComponents`
- New `getComponentVariantLayers` helper used by `resolveComponents`,
  `LayerRenderer`, `lib/layer-utils`, and the rich-text embed path
- CSS generators (client + server) walk every variant so classes
  unique to a non-default variant make it into the stylesheet
- Editor state: `editingComponentVariantId` on the editor store and
  `componentDrafts` reshaped to `Record<componentId, Record<variantId, Layer[]>>`
  with full add/rename/duplicate/delete/reorder actions
- Variants section in the left sidebar styled like the CMS items
  list, with purple active accent and dnd-kit drag-to-reorder
- Variant selector on instances in `ComponentInstanceSidebar`
- Persist active variant in URL via `?variant=` so reloads land back
  on the same variant
- Validate `returnToPageId` when exiting component edit mode and fall
  back to the homepage when the source page no longer exists

### Variant as a component variable

- Add `'variant'` `ComponentVariable` type and `VariantSettingsValue`
- Persist the link via `Layer.componentVariantVariableId` and resolve
  it in `applyComponentOverrides` so SSR and the canvas pick the right
  variant tree before component expansion
- Surface link/create/unlink controls in the instance sidebar and
  variables dialog using the shared `ComponentVariableLabel`
- Walk all parent variants to collect available variant options and
  clean up dangling `componentVariantVariableId` references on delete

## Test plan

- [ ] Create a component, add a second variant, edit it, and confirm
      the canvas reflects the active variant
- [ ] Reload the editor while editing a non-default variant and
      confirm the URL restores the same variant
- [ ] Drop the component on a page, switch the variant via the
      instance sidebar, and confirm the canvas updates
- [ ] Publish and confirm the live site renders the bound variant
      (including styles unique to that variant)
- [ ] Reorder variants by drag and reload — order persists
- [ ] Duplicate, rename, and delete variants from the context menu
- [ ] Delete the source page while editing a component, exit edit
      mode, and confirm we land on the homepage instead of 404
- [ ] Inside a parent component, link a nested instance's variant to
      a new `Variant` variable and verify the linked-pill appears
- [ ] On a page, override the parent's `Variant` variable and confirm
      the nested instance switches variants on the canvas, in preview,
      and on the published site
- [ ] Delete the parent variable and confirm the nested instance
      falls back to its baked-in `componentVariantId`
