### PR TITLE
fix: inject custom head CSS into builder canvas

### DIFF
--- a/app/(builder)/ycode/components/Canvas.tsx
+++ b/app/(builder)/ycode/components/Canvas.tsx
@@ -23,9 +23,12 @@ import { CanvasPortalProvider } from '@/lib/canvas-portal-context';
 import { cn } from '@/lib/utils';
 import { loadSwiperCss } from '@/lib/slider-utils';
 import { resolveReferenceFieldsSync } from '@/lib/collection-utils';
+import { extractStyleBlockContents } from '@/lib/parse-head-html';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { useFontsStore } from '@/stores/useFontsStore';
 import { useColorVariablesStore } from '@/stores/useColorVariablesStore';
+import { usePagesStore } from '@/stores/usePagesStore';
+import { useSettingsStore } from '@/stores/useSettingsStore';
 
 import { injectTranslatedText } from '@/lib/localisation-utils';
 
@@ -539,6 +542,47 @@ export default function Canvas({
     }
     styleEl.textContent = colorVarCss;
   }, [iframeReady, colorVarCss]);
+
+  // Inject user-defined custom CSS from `<style>` blocks in head custom code
+  // so `:root { --x: ... }` variables (and any other CSS) live-preview in the
+  // canvas — matching the legacy `#custom-css-style` injection in IFrame.vue.
+  // Page-editing context: global head + current page head custom code.
+  // Component-editing context: global head only (no page bound to the canvas).
+  // Scripts and other head HTML are intentionally ignored to keep the canvas
+  // sandbox safe; full execution still happens on the published/preview site
+  // via PageRenderer + CustomCodeInjector.
+  const globalCustomCodeHead = useSettingsStore(
+    (state) => state.settingsByKey['custom_code_head'] as string | null
+  );
+  const pageCustomCodeHead = usePagesStore((state) => {
+    if (!pageId || editingComponentId) return null;
+    const page = state.pages.find((p) => p.id === pageId);
+    return page?.settings?.custom_code?.head || null;
+  });
+
+  const customHeadCss = useMemo(() => {
+    const segments: string[] = [];
+    const globalCss = extractStyleBlockContents(globalCustomCodeHead);
+    if (globalCss) segments.push(globalCss);
+    const pageCss = extractStyleBlockContents(pageCustomCodeHead);
+    if (pageCss) segments.push(pageCss);
+    return segments.join('\n');
+  }, [globalCustomCodeHead, pageCustomCodeHead]);
+
+  useEffect(() => {
+    if (!iframeReady || !iframeRef.current) return;
+    const iframeDoc = iframeRef.current.contentDocument;
+    if (!iframeDoc) return;
+
+    const STYLE_ID = 'ycode-custom-head-css';
+    let styleEl = iframeDoc.getElementById(STYLE_ID) as HTMLStyleElement | null;
+    if (!styleEl) {
+      styleEl = iframeDoc.createElement('style');
+      styleEl.id = STYLE_ID;
+      iframeDoc.head.appendChild(styleEl);
+    }
+    styleEl.textContent = customHeadCss;
+  }, [iframeReady, customHeadCss]);
 
   // Render content into iframe
   useEffect(() => {

--- a/lib/parse-head-html.ts
+++ b/lib/parse-head-html.ts
@@ -38,6 +38,25 @@ function extractInnerHtml(full: string, tag: string): string {
   return m ? m[1] : '';
 }
 
+const STYLE_BLOCK_REGEX = /<style[^>]*>([\s\S]*?)<\/style\s*>/gi;
+
+/**
+ * Concatenates the inner CSS of every `<style>` block in an HTML string.
+ * Used by the builder canvas to live-preview user-defined CSS variables
+ * declared in custom head code, without executing any `<script>` tags.
+ */
+export function extractStyleBlockContents(html: string | null | undefined): string {
+  if (!html) return '';
+  const parts: string[] = [];
+  STYLE_BLOCK_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = STYLE_BLOCK_REGEX.exec(html)) !== null) {
+    const inner = match[1].trim();
+    if (inner) parts.push(inner);
+  }
+  return parts.join('\n');
+}
+
 /**
  * Renders global head HTML as React elements for direct placement inside
  * the root layout's <head>. Bypasses next/script to avoid self.__next_s


### PR DESCRIPTION
## Summary

Replicate the legacy `#custom-css-style` injection inside the new builder iframe so user-defined `<style>` blocks in custom head code (global + page) live-preview in the canvas. Previously, CSS variables declared in custom code were invisible in the builder, breaking utilities like `text-[var(--my-brand)]` even though they rendered correctly on the published site.

## Changes

- Add `extractStyleBlockContents` helper in `lib/parse-head-html.ts` to pull raw CSS from `<style>` blocks
- Subscribe `Canvas` to global custom head code (`useSettingsStore`) and page custom head code (`usePagesStore`)
- Inject the concatenated CSS into the iframe head as `<style id="ycode-custom-head-css">`
- Page editing context: global head + current page head custom code
- Component editing context: global head only (no page is bound to the canvas)
- Skip `<script>` and other head HTML — the builder sandbox stays safe; full execution still happens on the published/preview site via `PageRenderer` + `CustomCodeInjector`

## Test plan

- [ ] In Settings → General → Custom code → Header, add `<style>:root { --brand: #ff5500; }</style>`
- [ ] On a layer, set a Tailwind utility like `text-[var(--brand)]` and verify the color previews live in the canvas
- [ ] Open a page's settings → Custom code → Header, add a page-scoped variable, and verify it overrides/extends the global one only on that page
- [ ] Open a component for editing and confirm only global custom CSS is applied (no page CSS leaks)
- [ ] Publish the site and verify rendered output is unchanged

Made with [Cursor](https://cursor.com)