### PR TITLE
fix: prevent infinite refetch for empty collection layers

### DIFF
--- a/stores/useCollectionLayerStore.ts
+++ b/stores/useCollectionLayerStore.ts
@@ -100,7 +100,7 @@ export const useCollectionLayerStore = create<CollectionLayerStore>((set, get) =
     offset?: number,
     filters?: Array<{ fieldId: string; operator: string; value: string }>
   ) => {
-    const { layerData, loading, layerConfig } = get();
+    const { loading, layerConfig } = get();
 
     // Skip for virtual collections (multi-asset)
     if (collectionId === MULTI_ASSET_COLLECTION_ID) {
@@ -112,7 +112,9 @@ export const useCollectionLayerStore = create<CollectionLayerStore>((set, get) =
       return;
     }
 
-    // Check if we already have data with the same config
+    // Check if we already fetched with the same config.
+    // `layerConfig[layerId]` is only set after a successful fetch, so its presence
+    // signals "already fetched" regardless of whether the result was empty.
     const existingConfig = layerConfig[layerId];
     const filtersMatch = JSON.stringify(existingConfig?.filters) === JSON.stringify(filters);
     const configMatches = existingConfig &&
@@ -123,8 +125,9 @@ export const useCollectionLayerStore = create<CollectionLayerStore>((set, get) =
       existingConfig.offset === offset &&
       filtersMatch;
 
-    // Skip if we have data and config matches
-    if (layerData[layerId]?.length > 0 && configMatches) {
+    // Skip if config matches — prevents refetching when a collection legitimately
+    // returns an empty array (otherwise the layer would loop fetching forever).
+    if (configMatches) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Collection layers whose query legitimately returned zero items entered an infinite refetch loop, hammering `/ycode/api/collections/{id}/items` on every render across the builder. The skip condition required `layerData[layerId]?.length > 0`, so an empty result never cached and the effect re-ran indefinitely.

## Changes

- Drop the `length > 0` check and trust the cached `layerConfig` alone — its presence already proves the fetch completed successfully
- Remove the now-unused `layerData` destructure

## Test plan

- [ ] Open a page containing a collection layer whose filters yield zero results — confirm only one `items` request fires
- [ ] Open a page with a non-empty collection layer — confirm data still renders and refetches only when config (filters/sort/limit/offset) changes
- [ ] Reload the builder on `/ycode/collections/[id]` — confirm no repeating `items?sortBy=manual&sortOrder=desc` requests in the network tab

Made with [Cursor](https://cursor.com)