### PR TITLE
feat: selective per-page cache invalidation on publish

### DIFF
--- a/app/(builder)/ycode/api/apps/webflow/migrate/route.ts
+++ b/app/(builder)/ycode/api/apps/webflow/migrate/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { runMigration } from '@/lib/apps/webflow/migration-service';
 import { noCache } from '@/lib/api-response';
+import { clearAllCache, getAllPublishedRoutes, warmRoutes } from '@/lib/services/cacheService';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -24,6 +25,24 @@ export async function POST(request: NextRequest) {
     }
 
     const { import: importRecord, result } = await runMigration(siteId);
+
+    // Migration publishes every Webflow-live item directly into the published
+    // tables — outside the normal publish flow that does selective
+    // invalidation. Without a full purge, any pages already cached against
+    // the empty/old collections will keep serving stale HTML.
+    try {
+      await clearAllCache();
+      const routes = await getAllPublishedRoutes();
+      const warmResult = await warmRoutes(routes, request);
+      if (warmResult) {
+        console.log(
+          `[Cache] webflow migrate: warming ${warmResult.warmed}${warmResult.total > warmResult.warmed ? ` of ${warmResult.total}` : ''} route(s) in background`,
+        );
+      }
+    } catch (cacheError) {
+      console.error('[Cache] webflow migrate: invalidation failed:', cacheError);
+    }
+
     return noCache({ data: { import: importRecord, result } }, 201);
   } catch (error) {
     console.error('Error running Webflow migration:', error);

--- a/app/(builder)/ycode/api/apps/webflow/sync/route.ts
+++ b/app/(builder)/ycode/api/apps/webflow/sync/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { runResync } from '@/lib/apps/webflow/migration-service';
 import { noCache } from '@/lib/api-response';
+import { clearAllCache, getAllPublishedRoutes, warmRoutes } from '@/lib/services/cacheService';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -22,6 +23,23 @@ export async function POST(request: NextRequest) {
     }
 
     const result = await runResync(importId);
+
+    // Re-sync calls publishItem on every Webflow-live item, mutating published
+    // rows outside the normal publish flow. Mirror the migrate route: full
+    // purge + background warm so the CDN reflects the synced content.
+    try {
+      await clearAllCache();
+      const routes = await getAllPublishedRoutes();
+      const warmResult = await warmRoutes(routes, request);
+      if (warmResult) {
+        console.log(
+          `[Cache] webflow sync: warming ${warmResult.warmed}${warmResult.total > warmResult.warmed ? ` of ${warmResult.total}` : ''} route(s) in background`,
+        );
+      }
+    } catch (cacheError) {
+      console.error('[Cache] webflow sync: invalidation failed:', cacheError);
+    }
+
     return noCache({ data: result });
   } catch (error) {
     console.error('Error re-syncing Webflow import:', error);

--- a/app/(builder)/ycode/api/cache/clear-tag/route.ts
+++ b/app/(builder)/ycode/api/cache/clear-tag/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { revalidateTag } from 'next/cache';
+import { invalidateByTag } from '@vercel/functions';
 import { noCache } from '@/lib/api-response';
 
 /**
@@ -19,9 +20,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Invalidate each tag
-    for (const tag of tags) {
-      revalidateTag(tag, { expire: 0 });
+    // On Vercel: batched direct CDN purge, avoids revalidateTag cascade bug (#63509).
+    // Off Vercel: revalidateTag per-tag for Next.js's in-process data cache.
+    if (process.env.VERCEL === '1') {
+      await invalidateByTag(tags);
+    } else {
+      for (const tag of tags) {
+        revalidateTag(tag, { expire: 0 });
+      }
     }
 
     return noCache({

--- a/app/(builder)/ycode/api/css/generate-pages/route.ts
+++ b/app/(builder)/ycode/api/css/generate-pages/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { generateCSSForPage, generateCSSForPages } from '@/lib/server/cssGenerator';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /ycode/api/css/generate-pages
+ *
+ * Generate per-page CSS for specific pages. Each page gets its own
+ * generated_css stored on page_layers, including classes from any
+ * components the page references.
+ *
+ * Body: { pageIds: string[] }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const { pageIds } = await request.json();
+
+    if (!pageIds || !Array.isArray(pageIds) || pageIds.length === 0) {
+      return NextResponse.json(
+        { error: 'pageIds array is required' },
+        { status: 400 },
+      );
+    }
+
+    if (pageIds.length === 1) {
+      const css = await generateCSSForPage(pageIds[0]);
+      return NextResponse.json({
+        data: { updated: css ? 1 : 0, length: css?.length ?? 0 },
+      });
+    }
+
+    const updated = await generateCSSForPages(pageIds);
+    return NextResponse.json({
+      data: { updated },
+    });
+  } catch (error) {
+    console.error('Failed to generate per-page CSS:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to generate CSS' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/(builder)/ycode/api/devtools/reset-db/route.ts
+++ b/app/(builder)/ycode/api/devtools/reset-db/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
-import { revalidatePath } from 'next/cache';
 import { getKnexClient } from '@/lib/knex-client';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { STORAGE_BUCKET } from '@/lib/asset-constants';
+import { clearAllCache } from '@/lib/services/cacheService';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -68,8 +68,14 @@ export async function POST() {
 
     console.log('[POST /ycode/api/devtools/reset-db] All tables dropped successfully');
 
-    revalidatePath('/', 'layout');
-    console.log('[POST /ycode/api/devtools/reset-db] Cache invalidated');
+    // Purge CDN + data caches so the public site stops serving the dropped
+    // content. No warming — there's nothing to render after a reset.
+    try {
+      await clearAllCache();
+      console.log('[POST /ycode/api/devtools/reset-db] Cache invalidated');
+    } catch (cacheError) {
+      console.error('[POST /ycode/api/devtools/reset-db] Cache invalidation failed:', cacheError);
+    }
 
     return NextResponse.json({
       data: { message: 'All public tables and storage buckets have been deleted' }

--- a/app/(builder)/ycode/api/project/import/route.ts
+++ b/app/(builder)/ycode/api/project/import/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { noCache } from '@/lib/api-response';
 import { importProject, unpackImport } from '@/lib/services/projectService';
-import { clearAllCache } from '@/lib/services/cacheService';
+import { clearAllCache, getAllPublishedRoutes, warmRoutes } from '@/lib/services/cacheService';
 import { ToastError } from '@/lib/toast-error';
 
 export const dynamic = 'force-dynamic';
@@ -44,7 +44,20 @@ export async function POST(request: NextRequest) {
       return noCache({ error: result.error }, 500);
     }
 
-    await clearAllCache();
+    // Project import swaps in a new published site. Without warming, the
+    // first visit to each page after import is a cold render.
+    try {
+      await clearAllCache();
+      const routes = await getAllPublishedRoutes();
+      const warmResult = await warmRoutes(routes, request);
+      if (warmResult) {
+        console.log(
+          `[Cache] project import: warming ${warmResult.warmed}${warmResult.total > warmResult.warmed ? ` of ${warmResult.total}` : ''} route(s) in background`,
+        );
+      }
+    } catch (cacheError) {
+      console.error('[Cache] project import: cache invalidation failed:', cacheError);
+    }
 
     return noCache({
       success: true,

--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -5,7 +5,7 @@ import { publishCollectionWithItems, groupItemsByCollection, cleanupDeletedColle
 import { publishLocalisation } from '@/lib/services/localisationService';
 import { publishFolders } from '@/lib/services/folderService';
 import { publishCSS, savePublishedAt } from '@/lib/services/settingsService';
-import { clearAllCache, selectiveInvalidation } from '@/lib/services/cacheService';
+import { clearAllCache, selectiveInvalidation, warmRoutes, getAllPublishedRoutes } from '@/lib/services/cacheService';
 import { findAffectedPages } from '@/lib/repositories/pageLayersRepository';
 import { getAllDraftPages, hardDeleteSoftDeletedPages } from '@/lib/repositories/pageRepository';
 import { publishComponents, getUnpublishedComponents, hardDeleteSoftDeletedComponents } from '@/lib/repositories/componentRepository';
@@ -617,12 +617,16 @@ export async function POST(request: NextRequest) {
         indirectlyAffectedPageIds,
       );
 
-      // Capture the live routes we'll warm later. We only warm routes that
-      // still exist (the ones selectiveInvalidation returned) — not deleted
-      // or renamed ones added below, since their URLs no longer render.
+      // Capture the live routes we'll warm later. For selective invalidation
+      // we warm exactly the routes that were invalidated. For full
+      // invalidation we enumerate every published route — affects every
+      // page anyway, and visitors shouldn't pay the cold-cache cost just
+      // because a color variable changed. Capped inside warmRoutes.
+      // Deleted/renamed routes are skipped intentionally — their URLs no
+      // longer resolve.
       const liveRoutesToWarm = invalidationResult.strategy === 'selective'
         ? [...invalidationResult.invalidatedRoutes]
-        : [];
+        : await getAllPublishedRoutes();
 
       // Invalidate routes of deleted/renamed pages and deleted CMS items
       if (invalidationResult.strategy !== 'full') {
@@ -664,46 +668,13 @@ export async function POST(request: NextRequest) {
       );
 
       // After invalidation, prime the affected pages in the background so the
-      // first real visitor doesn't get x-vercel-cache: STALE.
-      // invalidateByTag marks entries stale rather than hard-purging; the next
-      // request to a stale entry serves the OLD body and kicks off a
-      // background revalidation. We ARE that next request — by warming each
-      // route from the publish handler, we absorb the STALE and trigger the
-      // revalidation ourselves, so the real visitor's first hit is HIT.
-      //
-      // Uses Vercel's waitUntil so warming runs AFTER the publish response is
-      // sent: zero added publish latency. Capped to avoid runaway cost when a
-      // dynamic page maps to hundreds of CMS items — long-tail items will
-      // simply self-warm on their first real visit.
-      //
-      // Skipped on full invalidation (rare) — enumerating every route and
-      // warming a whole site on every global change isn't worth the cost.
-      if (liveRoutesToWarm.length > 0 && process.env.VERCEL === '1') {
-        const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host');
-        if (host) {
-          const proto = request.headers.get('x-forwarded-proto') ?? 'https';
-          const baseUrl = `${proto}://${host}`;
-          const MAX_WARM = 50;
-          const toWarm = liveRoutesToWarm.slice(0, MAX_WARM);
-
-          try {
-            const { waitUntil } = await import('@vercel/functions');
-            waitUntil(
-              Promise.allSettled(
-                toWarm.map((route) =>
-                  fetch(`${baseUrl}/${route}`, {
-                    signal: AbortSignal.timeout(15000),
-                  }).catch(() => null),
-                ),
-              ),
-            );
-            console.log(
-              `[Cache] warming ${toWarm.length}${liveRoutesToWarm.length > MAX_WARM ? ` of ${liveRoutesToWarm.length}` : ''} route(s) in background`,
-            );
-          } catch {
-            // Non-fatal: warming is an optimization, not a correctness requirement
-          }
-        }
+      // first real visitor doesn't pay the cold-cache cost. We absorb the
+      // STALE/MISS server-side; the visitor's first hit is HIT.
+      const warmResult = await warmRoutes(liveRoutesToWarm, request);
+      if (warmResult) {
+        console.log(
+          `[Cache] warming ${warmResult.warmed}${warmResult.total > warmResult.warmed ? ` of ${warmResult.total}` : ''} route(s) in background`,
+        );
       }
     } catch {
       // Fallback: if selective invalidation fails, nuke everything

--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -5,7 +5,8 @@ import { publishCollectionWithItems, groupItemsByCollection, cleanupDeletedColle
 import { publishLocalisation } from '@/lib/services/localisationService';
 import { publishFolders } from '@/lib/services/folderService';
 import { publishCSS, savePublishedAt } from '@/lib/services/settingsService';
-import { clearAllCache } from '@/lib/services/cacheService';
+import { clearAllCache, selectiveInvalidation } from '@/lib/services/cacheService';
+import { findAffectedPages } from '@/lib/repositories/pageLayersRepository';
 import { getAllDraftPages, hardDeleteSoftDeletedPages } from '@/lib/repositories/pageRepository';
 import { publishComponents, getUnpublishedComponents, hardDeleteSoftDeletedComponents } from '@/lib/repositories/componentRepository';
 import { publishLayerStyles, getUnpublishedLayerStyles, hardDeleteSoftDeletedLayerStyles } from '@/lib/repositories/layerStyleRepository';
@@ -14,6 +15,8 @@ import { getItemsByCollectionId } from '@/lib/repositories/collectionItemReposit
 import { publishAssets, getUnpublishedAssets, hardDeleteSoftDeletedAssets } from '@/lib/repositories/assetRepository';
 import { publishAssetFolders, getUnpublishedAssetFolders, hardDeleteSoftDeletedAssetFolders } from '@/lib/repositories/assetFolderRepository';
 import { publishFonts } from '@/lib/repositories/fontRepository';
+import { getColorVariablesHash } from '@/lib/repositories/colorVariableRepository';
+import { getSettingByKey, setSetting } from '@/lib/repositories/settingsRepository';
 import type { Setting, PublishStats, PublishTableStats } from '@/types';
 
 // Disable caching for this route
@@ -138,6 +141,14 @@ export async function POST(request: NextRequest) {
     // Determine if we're publishing all or specific items
     const isPublishingAll = publishAll && !folderIds && !pageIds && !collectionIds && !collectionItemIds && !componentIds && !layerStyleIds;
 
+    // Track which resources actually changed for selective invalidation
+    const publishedPageIds: string[] = [];
+    const publishedCollectionIds: string[] = [];
+    const changedComponentIds: string[] = [];
+    const changedLayerStyleIds: string[] = [];
+    const deletedCollectionItemSlugs: Map<string, string[]> = new Map();
+    const renamedPageOldRoutes: string[] = [];
+
     // Publish folders first (pages depend on them)
     {
       const stepStart = performance.now();
@@ -154,6 +165,8 @@ export async function POST(request: NextRequest) {
     {
       if (pageIds && pageIds.length > 0) {
         const pagesResult = await publishPages(pageIds);
+        publishedPageIds.push(...pagesResult.changedPageIds);
+        renamedPageOldRoutes.push(...pagesResult.renamedPageOldRoutes);
         result.changes.pages = pagesResult.count;
         stats.tables.pages.added = pagesResult.count;
         stats.tables.pages.durationMs = pagesResult.timing.pagesDurationMs;
@@ -164,6 +177,8 @@ export async function POST(request: NextRequest) {
         if (unpublishedPages.length > 0) {
           const allPageIds = unpublishedPages.map(p => p.id);
           const pagesResult = await publishPages(allPageIds);
+          publishedPageIds.push(...pagesResult.changedPageIds);
+          renamedPageOldRoutes.push(...pagesResult.renamedPageOldRoutes);
           result.changes.pages = pagesResult.count;
           stats.tables.pages.added = pagesResult.count;
           stats.tables.pages.durationMs = pagesResult.timing.pagesDurationMs;
@@ -216,11 +231,27 @@ export async function POST(request: NextRequest) {
               collectionId: collectionPublish.collectionId,
               itemIds: collectionPublish.itemIds,
             });
-            totalItems += publishResult.published?.itemsCount || 0;
-            totalValues += publishResult.published?.valuesCount || 0;
-            totalFields += publishResult.published?.fieldsCount || 0;
-            if (publishResult.published?.collection) totalCollections++;
-            // Accumulate timing
+            const p = publishResult.published;
+            const changed = (p?.itemsCount || 0)
+              + (p?.valuesCount || 0)
+              + (p?.fieldsCount || 0)
+              + (p?.deletedItemsCount || 0)
+              + (p?.collection ? 1 : 0);
+            if (changed > 0) {
+              publishedCollectionIds.push(collectionPublish.collectionId);
+            }
+            const staleSlugsCombined = [
+              ...(p?.deletedItemSlugs || []),
+              ...(p?.renamedItemOldSlugs || []),
+            ];
+            if (staleSlugsCombined.length > 0) {
+              const existing = deletedCollectionItemSlugs.get(collectionPublish.collectionId) || [];
+              deletedCollectionItemSlugs.set(collectionPublish.collectionId, [...existing, ...staleSlugsCombined]);
+            }
+            totalItems += p?.itemsCount || 0;
+            totalValues += p?.valuesCount || 0;
+            totalFields += p?.fieldsCount || 0;
+            if (p?.collection) totalCollections++;
             if (publishResult.timing) {
               collectionsMs += publishResult.timing.collections.durationMs;
               fieldsMs += publishResult.timing.fields.durationMs;
@@ -239,10 +270,29 @@ export async function POST(request: NextRequest) {
             collectionId: collection.id,
             itemIds: items.map((item: any) => item.id),
           });
-          totalItems += publishResult.published?.itemsCount || 0;
-          totalValues += publishResult.published?.valuesCount || 0;
-          totalFields += publishResult.published?.fieldsCount || 0;
-          if (publishResult.published?.collection) totalCollections++;
+          const p = publishResult.published;
+          const changedItems = p?.itemsCount || 0;
+          const changedValues = p?.valuesCount || 0;
+          const changedFields = p?.fieldsCount || 0;
+          const changedDeleted = p?.deletedItemsCount || 0;
+          const changedCollection = p?.collection ? 1 : 0;
+          const changed = changedItems + changedValues + changedFields + changedDeleted + changedCollection;
+          if (changed > 0) {
+            console.log(`[Publish] collection ${collection.id} changed: items=${changedItems} values=${changedValues} fields=${changedFields} deleted=${changedDeleted} meta=${changedCollection}`);
+            publishedCollectionIds.push(collection.id);
+          }
+          const staleSlugsCombined = [
+            ...(p?.deletedItemSlugs || []),
+            ...(p?.renamedItemOldSlugs || []),
+          ];
+          if (staleSlugsCombined.length > 0) {
+            const existing = deletedCollectionItemSlugs.get(collection.id) || [];
+            deletedCollectionItemSlugs.set(collection.id, [...existing, ...staleSlugsCombined]);
+          }
+          totalItems += changedItems;
+          totalValues += changedValues;
+          totalFields += changedFields;
+          if (p?.collection) totalCollections++;
           if (publishResult.timing) {
             collectionsMs += publishResult.timing.collections.durationMs;
             fieldsMs += publishResult.timing.fields.durationMs;
@@ -270,13 +320,17 @@ export async function POST(request: NextRequest) {
         const componentsResult = await publishComponents(componentIds);
         result.changes.components = componentsResult.count;
         stats.tables.components.added = componentsResult.count;
+        changedComponentIds.push(...componentsResult.changedComponentIds);
       } else if (isPublishingAll) {
         const unpublishedComponents = await getUnpublishedComponents();
+        console.log(`[Publish] unpublished components: ${unpublishedComponents.length}`);
         if (unpublishedComponents.length > 0) {
           const allComponentIds = unpublishedComponents.map((c: any) => c.id);
           const componentsResult = await publishComponents(allComponentIds);
           result.changes.components = componentsResult.count;
           stats.tables.components.added = componentsResult.count;
+          changedComponentIds.push(...componentsResult.changedComponentIds);
+          console.log(`[Publish] changed components: ${componentsResult.changedComponentIds.length}`);
         }
       }
       stats.tables.components.durationMs = Math.round(performance.now() - stepStart);
@@ -289,6 +343,7 @@ export async function POST(request: NextRequest) {
         const stylesResult = await publishLayerStyles(layerStyleIds);
         result.changes.layerStyles = stylesResult.count;
         stats.tables.layer_styles.added = stylesResult.count;
+        changedLayerStyleIds.push(...stylesResult.changedStyleIds);
       } else if (isPublishingAll) {
         const unpublishedStyles = await getUnpublishedLayerStyles();
         if (unpublishedStyles.length > 0) {
@@ -296,15 +351,30 @@ export async function POST(request: NextRequest) {
           const stylesResult = await publishLayerStyles(allStyleIds);
           result.changes.layerStyles = stylesResult.count;
           stats.tables.layer_styles.added = stylesResult.count;
+          changedLayerStyleIds.push(...stylesResult.changedStyleIds);
         }
       }
       stats.tables.layer_styles.durationMs = Math.round(performance.now() - stepStart);
     }
 
+    // Track routes of deleted pages (must resolve BEFORE rows are removed from DB)
+    const deletedPageRoutes: string[] = [];
+
     // Only clean up deletions and publish assets/localization when doing a full publish
     if (isPublishingAll) {
-      // Clean up soft-deleted pages, components, layer styles, and collections
-      // (propagate draft deletions to published versions)
+      // Resolve routes of soft-deleted pages before deletion so caches can be purged
+      try {
+        const { getRoutePathsForPages } = await import('@/lib/services/cacheService');
+        const { getSoftDeletedPageIds } = await import('@/lib/repositories/pageRepository');
+        const pendingDeleteIds = await getSoftDeletedPageIds();
+        if (pendingDeleteIds.length > 0) {
+          const routes = await getRoutePathsForPages(pendingDeleteIds);
+          deletedPageRoutes.push(...routes);
+        }
+      } catch {
+        // Non-fatal: route resolution failure should not block deletion
+      }
+
       try {
         await hardDeleteSoftDeletedPages();
       } catch {
@@ -416,11 +486,152 @@ export async function POST(request: NextRequest) {
       stats.tables.css.durationMs = Math.round(performance.now() - stepStart);
     }
 
-    // Clear cache (not tracked in stats - infrastructure operation)
+    // Selective cache invalidation: only invalidate pages that actually changed.
+    //
+    // Global triggers (full invalidation):
+    // - Color variables: no draft/published model, so we snapshot-hash all
+    //   color variables and compare against the last published hash.
+    //   A change means every page's rendered CSS custom properties differ.
+    //
+    // Per-resource selective invalidation:
+    // - Pages: direct content_hash comparison (pages + page_layers tables)
+    // - Components: find pages referencing changed componentIds in JSONB
+    // - Layer styles: find pages referencing changed layerStyleIds in JSONB
+    // - Collections: find pages referencing changed collectionIds in JSONB
     try {
-      await clearAllCache();
+      // Detect color variable changes by comparing current hash to last-published hash
+      let globalChanged = false;
+      try {
+        const currentColorHash = await getColorVariablesHash();
+        const lastColorHash = await getSettingByKey('color_variables_published_hash');
+        if (currentColorHash !== lastColorHash) {
+          globalChanged = true;
+          await setSetting('color_variables_published_hash', currentColorHash);
+        }
+      } catch {
+        // Safety: if we can't verify color variables, assume they changed
+        globalChanged = true;
+      }
+
+      // If global CSS changed, force full invalidation (clears fetchCachedGlobalSettings)
+      if (!globalChanged && result.changes.css) {
+        globalChanged = true;
+      }
+
+      // Full publish touches global caches (locales, translations, redirects, fonts,
+      // folder auth, error pages) that are all tagged with 'all-pages'.
+      // Force full invalidation so those caches are refreshed.
+      if (!globalChanged && isPublishingAll) {
+        const hasGlobalChanges = result.changes.locales > 0
+          || result.changes.translations > 0;
+        if (hasGlobalChanges) {
+          globalChanged = true;
+        }
+      }
+
+      // Find pages indirectly affected by changed components, styles, collections
+      // Single scan of draft page_layers instead of one scan per resource type
+      const activeCollectionIds = publishedCollectionIds;
+
+      let indirectlyAffectedPageIds: string[] = [];
+      let cssAffectedPageIds: string[] = [];
+      try {
+        const affected = await findAffectedPages(changedComponentIds, changedLayerStyleIds, activeCollectionIds);
+        indirectlyAffectedPageIds = [...new Set([
+          ...affected.componentPageIds,
+          ...affected.stylePageIds,
+          ...affected.collectionPageIds,
+        ])];
+        // Pages needing CSS catch-up (component/style refs only, not collections)
+        cssAffectedPageIds = [...new Set([
+          ...affected.componentPageIds,
+          ...affected.stylePageIds,
+        ])];
+
+        if (affected.componentPageIds.length > 0) {
+          console.log(`[Cache] component-affected pages: ${affected.componentPageIds.length} (from ${changedComponentIds.length} changed component(s))`);
+        }
+        if (affected.stylePageIds.length > 0) {
+          console.log(`[Cache] style-affected pages: ${affected.stylePageIds.length} (from ${changedLayerStyleIds.length} changed style(s))`);
+        }
+        if (affected.collectionPageIds.length > 0) {
+          console.log(`[Cache] collection-affected pages: ${affected.collectionPageIds.length}`);
+        }
+      } catch {
+        // Safety: if dependency scan fails, degrade to full invalidation
+        globalChanged = true;
+      }
+
+      // CSS catch-up: regenerate CSS for pages affected by changed
+      // components/styles. The builder only regenerates CSS for pages open
+      // in memory — pages not loaded keep stale generated_css/content_hash.
+      // This ensures batchPublishPageLayers detects the real hash change.
+      if (!globalChanged && cssAffectedPageIds.length > 0) {
+        try {
+          const { generateCSSForPages } = await import('@/lib/server/cssGenerator');
+          await generateCSSForPages(cssAffectedPageIds);
+
+          // Re-publish layers for these pages so published version has fresh CSS
+          const { batchPublishPageLayers } = await import('@/lib/repositories/pageLayersRepository');
+          const relayerResult = await batchPublishPageLayers(cssAffectedPageIds);
+          if (relayerResult.changedPageIds.length > 0) {
+            publishedPageIds.push(...relayerResult.changedPageIds);
+            console.log(`[Cache] CSS catch-up: republished ${relayerResult.changedPageIds.length} page layer(s)`);
+          }
+        } catch {
+          // Non-fatal: CSS catch-up failure doesn't block publish
+        }
+      }
+
+      console.log(`[Cache] directly changed pages: ${publishedPageIds.length}, indirectly affected: ${indirectlyAffectedPageIds.length}`);
+
+      const invalidationResult = await selectiveInvalidation(
+        publishedPageIds,
+        globalChanged,
+        indirectlyAffectedPageIds,
+      );
+
+      // Invalidate routes of deleted/renamed pages and deleted CMS items
+      if (invalidationResult.strategy !== 'full') {
+        const { invalidatePages, getRoutePathsForDeletedCollectionItems } = await import('@/lib/services/cacheService');
+
+        // Deleted page routes (resolved before DB deletion)
+        if (deletedPageRoutes.length > 0) {
+          await invalidatePages(deletedPageRoutes);
+          invalidationResult.invalidatedRoutes.push(...deletedPageRoutes);
+        }
+
+        // Old routes from renamed/moved pages
+        if (renamedPageOldRoutes.length > 0) {
+          await invalidatePages(renamedPageOldRoutes);
+          invalidationResult.invalidatedRoutes.push(...renamedPageOldRoutes);
+          console.log(`[Cache] invalidated ${renamedPageOldRoutes.length} renamed page old route(s)`);
+        }
+
+        // Deleted CMS item routes (old slugs that should no longer exist)
+        if (deletedCollectionItemSlugs.size > 0) {
+          try {
+            const oldRoutes = await getRoutePathsForDeletedCollectionItems(deletedCollectionItemSlugs);
+            if (oldRoutes.length > 0) {
+              await invalidatePages(oldRoutes);
+              invalidationResult.invalidatedRoutes.push(...oldRoutes);
+              console.log(`[Cache] invalidated ${oldRoutes.length} deleted CMS item route(s)`);
+            }
+          } catch {
+            // Non-fatal
+          }
+        }
+      }
+
+      console.log(
+        `[Cache] ${invalidationResult.strategy} invalidation:`,
+        invalidationResult.strategy === 'selective'
+          ? `${invalidationResult.invalidatedRoutes.length} route(s)${deletedPageRoutes.length > 0 ? ` (incl. ${deletedPageRoutes.length} deleted)` : ''}`
+          : invalidationResult.reason,
+      );
     } catch {
-      // Silently handle - non-fatal
+      // Fallback: if selective invalidation fails, nuke everything
+      try { await clearAllCache(); } catch { /* non-fatal */ }
     }
 
     // Save published timestamp to settings

--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -357,6 +357,37 @@ export async function POST(request: NextRequest) {
       stats.tables.layer_styles.durationMs = Math.round(performance.now() - stepStart);
     }
 
+    // Propagate updated style values into the denormalized layer.classes on
+    // every draft page/component that references the changed styles. The
+    // builder only syncs pages currently loaded in memory, so pages and
+    // components that weren't open keep stale denormalized values. Without
+    // this step they publish with the OLD class names and render with the
+    // old style even though the layer_styles row was just updated.
+    if (changedLayerStyleIds.length > 0) {
+      try {
+        const { syncLayerStyleChangesToDrafts } = await import('@/lib/repositories/layerStyleRepository');
+        const sync = await syncLayerStyleChangesToDrafts(changedLayerStyleIds);
+
+        if (sync.affectedComponentIds.length > 0) {
+          // Re-publish components whose draft layers just got rewritten so
+          // the published versions carry the fresh classes too.
+          const repubResult = await publishComponents(sync.affectedComponentIds);
+          for (const id of repubResult.changedComponentIds) {
+            if (!changedComponentIds.includes(id)) changedComponentIds.push(id);
+          }
+          console.log(`[Publish] style sync: re-published ${repubResult.changedComponentIds.length} component(s)`);
+        }
+
+        if (sync.affectedPageIds.length > 0) {
+          // Page layers will be republished by the CSS catch-up + batchPublishPageLayers
+          // step below — the draft now has fresh classes and a fresh hash.
+          console.log(`[Publish] style sync: updated ${sync.affectedPageIds.length} page draft(s)`);
+        }
+      } catch (err) {
+        console.error('[Publish] Layer style sync failed (non-fatal):', err);
+      }
+    }
+
     // Track routes of deleted pages (must resolve BEFORE rows are removed from DB)
     const deletedPageRoutes: string[] = [];
 

--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -605,7 +605,11 @@ export async function POST(request: NextRequest) {
         }
       }
 
-      console.log(`[Cache] directly changed pages: ${publishedPageIds.length}, indirectly affected: ${indirectlyAffectedPageIds.length}, globalChanged: ${globalChanged}${globalChangedReason ? ` (${globalChangedReason})` : ''}`);
+      // publishedPageIds can contain the same page twice (once from the
+      // initial publishPages step, once from the CSS catch-up republish).
+      // Log the unique count so the number isn't misleading.
+      const uniqueDirectChangedCount = new Set(publishedPageIds).size;
+      console.log(`[Cache] directly changed pages: ${uniqueDirectChangedCount}, indirectly affected: ${indirectlyAffectedPageIds.length}, globalChanged: ${globalChanged}${globalChangedReason ? ` (${globalChangedReason})` : ''}`);
 
       const invalidationResult = await selectiveInvalidation(
         publishedPageIds,

--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -582,6 +582,13 @@ export async function POST(request: NextRequest) {
         indirectlyAffectedPageIds,
       );
 
+      // Capture the live routes we'll warm later. We only warm routes that
+      // still exist (the ones selectiveInvalidation returned) — not deleted
+      // or renamed ones added below, since their URLs no longer render.
+      const liveRoutesToWarm = invalidationResult.strategy === 'selective'
+        ? [...invalidationResult.invalidatedRoutes]
+        : [];
+
       // Invalidate routes of deleted/renamed pages and deleted CMS items
       if (invalidationResult.strategy !== 'full') {
         const { invalidatePages, getRoutePathsForDeletedCollectionItems } = await import('@/lib/services/cacheService');
@@ -620,6 +627,49 @@ export async function POST(request: NextRequest) {
           ? `${invalidationResult.invalidatedRoutes.length} route(s)${deletedPageRoutes.length > 0 ? ` (incl. ${deletedPageRoutes.length} deleted)` : ''}`
           : invalidationResult.reason,
       );
+
+      // After invalidation, prime the affected pages in the background so the
+      // first real visitor doesn't get x-vercel-cache: STALE.
+      // invalidateByTag marks entries stale rather than hard-purging; the next
+      // request to a stale entry serves the OLD body and kicks off a
+      // background revalidation. We ARE that next request — by warming each
+      // route from the publish handler, we absorb the STALE and trigger the
+      // revalidation ourselves, so the real visitor's first hit is HIT.
+      //
+      // Uses Vercel's waitUntil so warming runs AFTER the publish response is
+      // sent: zero added publish latency. Capped to avoid runaway cost when a
+      // dynamic page maps to hundreds of CMS items — long-tail items will
+      // simply self-warm on their first real visit.
+      //
+      // Skipped on full invalidation (rare) — enumerating every route and
+      // warming a whole site on every global change isn't worth the cost.
+      if (liveRoutesToWarm.length > 0 && process.env.VERCEL === '1') {
+        const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host');
+        if (host) {
+          const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+          const baseUrl = `${proto}://${host}`;
+          const MAX_WARM = 50;
+          const toWarm = liveRoutesToWarm.slice(0, MAX_WARM);
+
+          try {
+            const { waitUntil } = await import('@vercel/functions');
+            waitUntil(
+              Promise.allSettled(
+                toWarm.map((route) =>
+                  fetch(`${baseUrl}/${route}`, {
+                    signal: AbortSignal.timeout(15000),
+                  }).catch(() => null),
+                ),
+              ),
+            );
+            console.log(
+              `[Cache] warming ${toWarm.length}${liveRoutesToWarm.length > MAX_WARM ? ` of ${liveRoutesToWarm.length}` : ''} route(s) in background`,
+            );
+          } catch {
+            // Non-fatal: warming is an optimization, not a correctness requirement
+          }
+        }
+      }
     } catch {
       // Fallback: if selective invalidation fails, nuke everything
       try { await clearAllCache(); } catch { /* non-fatal */ }

--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -501,16 +501,18 @@ export async function POST(request: NextRequest) {
     try {
       // Detect color variable changes by comparing current hash to last-published hash
       let globalChanged = false;
+      let globalChangedReason = '';
       try {
         const currentColorHash = await getColorVariablesHash();
         const lastColorHash = await getSettingByKey('color_variables_published_hash');
         if (currentColorHash !== lastColorHash) {
           globalChanged = true;
+          globalChangedReason = `color hash mismatch: ${lastColorHash?.slice(0, 8) ?? 'null'} → ${currentColorHash.slice(0, 8)}`;
           await setSetting('color_variables_published_hash', currentColorHash);
         }
-      } catch {
-        // Safety: if we can't verify color variables, assume they changed
+      } catch (err) {
         globalChanged = true;
+        globalChangedReason = `color hash check failed: ${err instanceof Error ? err.message : 'unknown'}`;
       }
 
       // NOTE: Locales/translations are published on every full publish but
@@ -572,7 +574,7 @@ export async function POST(request: NextRequest) {
         }
       }
 
-      console.log(`[Cache] directly changed pages: ${publishedPageIds.length}, indirectly affected: ${indirectlyAffectedPageIds.length}`);
+      console.log(`[Cache] directly changed pages: ${publishedPageIds.length}, indirectly affected: ${indirectlyAffectedPageIds.length}, globalChanged: ${globalChanged}${globalChangedReason ? ` (${globalChangedReason})` : ''}`);
 
       const invalidationResult = await selectiveInvalidation(
         publishedPageIds,

--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -513,11 +513,6 @@ export async function POST(request: NextRequest) {
         globalChanged = true;
       }
 
-      // If global CSS changed, force full invalidation (clears fetchCachedGlobalSettings)
-      if (!globalChanged && result.changes.css) {
-        globalChanged = true;
-      }
-
       // Full publish touches global caches (locales, translations, redirects, fonts,
       // folder auth, error pages) that are all tagged with 'all-pages'.
       // Force full invalidation so those caches are refreshed.

--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -513,16 +513,10 @@ export async function POST(request: NextRequest) {
         globalChanged = true;
       }
 
-      // Full publish touches global caches (locales, translations, redirects, fonts,
-      // folder auth, error pages) that are all tagged with 'all-pages'.
-      // Force full invalidation so those caches are refreshed.
-      if (!globalChanged && isPublishingAll) {
-        const hasGlobalChanges = result.changes.locales > 0
-          || result.changes.translations > 0;
-        if (hasGlobalChanges) {
-          globalChanged = true;
-        }
-      }
+      // NOTE: Locales/translations are published on every full publish but
+      // publishLocalisation() counts all active drafts, not actual changes.
+      // These resources are tagged with 'all-pages' and get refreshed via
+      // selectiveInvalidation's revalidateTag call for any affected pages.
 
       // Find pages indirectly affected by changed components, styles, collections
       // Single scan of draft page_layers instead of one scan per resource type

--- a/app/(builder)/ycode/api/revalidate/route.ts
+++ b/app/(builder)/ycode/api/revalidate/route.ts
@@ -1,4 +1,5 @@
 import { revalidateTag } from 'next/cache';
+import { invalidateByTag } from '@vercel/functions';
 import { NextRequest, NextResponse } from 'next/server';
 import { noCache } from '@/lib/api-response';
 
@@ -22,8 +23,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Revalidate the cache for this tag
-    revalidateTag(tag, { expire: 0 });
+    // On Vercel: direct CDN purge, avoids revalidateTag cascade bug (#63509).
+    // Off Vercel: revalidateTag for Next.js's in-process data cache.
+    if (process.env.VERCEL === '1') {
+      await invalidateByTag(tag);
+    } else {
+      revalidateTag(tag, { expire: 0 });
+    }
 
     return noCache({
       revalidated: true,

--- a/app/(builder)/ycode/api/settings/[key]/route.ts
+++ b/app/(builder)/ycode/api/settings/[key]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSettingByKey, setSetting } from '@/lib/repositories/settingsRepository';
-import { clearAllCache } from '@/lib/services/cacheService';
+import { clearAllCache, getAllPublishedRoutes, warmRoutes } from '@/lib/services/cacheService';
 
 /**
  * Setting keys that don't affect public-page rendering and therefore should
@@ -74,6 +74,21 @@ export async function PUT(
     // autosaves don't purge the public CDN cache on every edit.
     if (!DRAFT_ONLY_SETTING_KEYS.has(key)) {
       await clearAllCache();
+
+      // Prime the cache so the first visit to any public page after this
+      // settings change doesn't pay the cold-cache cost. Capped inside
+      // warmRoutes; long-tail routes self-warm on first real visit.
+      try {
+        const routes = await getAllPublishedRoutes();
+        const warmResult = await warmRoutes(routes, request);
+        if (warmResult) {
+          console.log(
+            `[Cache] settings (${key}): warming ${warmResult.warmed}${warmResult.total > warmResult.warmed ? ` of ${warmResult.total}` : ''} route(s) in background`,
+          );
+        }
+      } catch {
+        // Non-fatal: warming is an optimization
+      }
     }
 
     return NextResponse.json({

--- a/app/(builder)/ycode/api/settings/[key]/route.ts
+++ b/app/(builder)/ycode/api/settings/[key]/route.ts
@@ -3,6 +3,21 @@ import { getSettingByKey, setSetting } from '@/lib/repositories/settingsReposito
 import { clearAllCache } from '@/lib/services/cacheService';
 
 /**
+ * Setting keys that don't affect public-page rendering and therefore should
+ * NOT trigger a cache nuke when updated.
+ *
+ * - `draft_css`: builder-only preview CSS. Public pages serve `published_css`.
+ *   Saved on every edit, so invalidating here would purge every page on every
+ *   keystroke and undo selective invalidation entirely.
+ * - `email`: SMTP credentials for form submission backend. Not consumed by
+ *   public page renders.
+ *
+ * All other keys (redirects, favicon_url, ga_measurement_id, published_css,
+ * color variables, etc.) are read by public pages and DO require invalidation.
+ */
+const DRAFT_ONLY_SETTING_KEYS = new Set(['draft_css', 'email']);
+
+/**
  * GET /ycode/api/settings/[key]
  *
  * Get a setting value by key
@@ -55,7 +70,11 @@ export async function PUT(
 
     await setSetting(key, value);
 
-    await clearAllCache();
+    // Skip cache invalidation for draft/internal settings so builder
+    // autosaves don't purge the public CDN cache on every edit.
+    if (!DRAFT_ONLY_SETTING_KEYS.has(key)) {
+      await clearAllCache();
+    }
 
     return NextResponse.json({
       data: { key, value },

--- a/app/(builder)/ycode/api/settings/batch/route.ts
+++ b/app/(builder)/ycode/api/settings/batch/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { setSettings } from '@/lib/repositories/settingsRepository';
-import { clearAllCache } from '@/lib/services/cacheService';
+import { clearAllCache, getAllPublishedRoutes, warmRoutes } from '@/lib/services/cacheService';
 
 /**
  * Setting keys that don't affect public-page rendering. Mirrors the list in
@@ -36,6 +36,21 @@ export async function PUT(request: NextRequest) {
     );
     if (touchesPublicKeys) {
       await clearAllCache();
+
+      // Prime the cache so the first visit to any public page after this
+      // settings change doesn't pay the cold-cache cost. Capped inside
+      // warmRoutes; long-tail routes self-warm on first real visit.
+      try {
+        const routes = await getAllPublishedRoutes();
+        const warmResult = await warmRoutes(routes, request);
+        if (warmResult) {
+          console.log(
+            `[Cache] settings batch: warming ${warmResult.warmed}${warmResult.total > warmResult.warmed ? ` of ${warmResult.total}` : ''} route(s) in background`,
+          );
+        }
+      } catch {
+        // Non-fatal: warming is an optimization
+      }
     }
 
     return NextResponse.json({

--- a/app/(builder)/ycode/api/settings/batch/route.ts
+++ b/app/(builder)/ycode/api/settings/batch/route.ts
@@ -3,6 +3,12 @@ import { setSettings } from '@/lib/repositories/settingsRepository';
 import { clearAllCache } from '@/lib/services/cacheService';
 
 /**
+ * Setting keys that don't affect public-page rendering. Mirrors the list in
+ * /ycode/api/settings/[key]/route.ts — keep them in sync.
+ */
+const DRAFT_ONLY_SETTING_KEYS = new Set(['draft_css', 'email']);
+
+/**
  * PUT /ycode/api/settings/batch
  *
  * Update multiple settings at once.
@@ -23,7 +29,14 @@ export async function PUT(request: NextRequest) {
 
     const count = await setSettings(settings);
 
-    await clearAllCache();
+    // Only invalidate caches if any of the updated keys actually affect
+    // public page rendering. Skips builder-only autosaves.
+    const touchesPublicKeys = Object.keys(settings).some(
+      (key) => !DRAFT_ONLY_SETTING_KEYS.has(key)
+    );
+    if (touchesPublicKeys) {
+      await clearAllCache();
+    }
 
     return NextResponse.json({
       data: { count },

--- a/app/(builder)/ycode/api/v1/collections/[collection_id]/items/[item_id]/route.ts
+++ b/app/(builder)/ycode/api/v1/collections/[collection_id]/items/[item_id]/route.ts
@@ -5,7 +5,25 @@ import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepos
 import { getItemWithValues, deleteItem } from '@/lib/repositories/collectionItemRepository';
 import { setValues } from '@/lib/repositories/collectionItemValueRepository';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { invalidateForCollectionChange } from '@/lib/services/cacheService';
+import type { CollectionField, CollectionItemWithValues } from '@/types';
 import { transformItemToPublicWithRefs, parseFieldProjections } from '../../../../reference-resolver';
+
+/**
+ * Pull the current slug value off an item before mutation/delete, so we can
+ * invalidate the old dynamic-page URL afterwards. Returns undefined when the
+ * collection has no slug field or the item has no slug value — both safe to
+ * skip (no URL exists to go stale).
+ */
+function extractItemSlug(
+  item: CollectionItemWithValues,
+  fields: CollectionField[],
+): string | undefined {
+  const slugField = fields.find((f) => f.key === 'slug');
+  if (!slugField) return undefined;
+  const value = item.values?.[slugField.id];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
 
 // Disable caching for this route
 export const dynamic = 'force-dynamic';
@@ -178,6 +196,11 @@ export async function PUT(
         .in('is_published', [true, false]);
     }
 
+    // Capture the pre-mutation slug before we overwrite values. If the slug
+    // field gets changed, we need to invalidate the OLD dynamic-page URL too
+    // — getRoutePathsForPages only enumerates the new slug after the write.
+    const previousSlug = extractItemSlug(existingItem, fields);
+
     // Set the values for both published and draft
     await setValues(item_id, valuesToSet, true);
     await setValues(item_id, valuesToSet, false);
@@ -191,6 +214,18 @@ export async function PUT(
       hasProjections ? fieldProjections : undefined,
       hasProjections ? collection.name : undefined
     );
+
+    try {
+      const result = await invalidateForCollectionChange(collection_id, {
+        removedSlugs: previousSlug ? [previousSlug] : [],
+      });
+      if (result.invalidatedRoutes.length > 0) {
+        console.log(`[Cache] v1 item update: invalidated ${result.invalidatedRoutes.length} route(s)`);
+      }
+    } catch (cacheError) {
+      console.error(`[Cache] v1 item update: invalidation failed:`, cacheError);
+    }
+
     return NextResponse.json(response);
   } catch (error) {
     console.error('Error updating collection item:', error);
@@ -297,6 +332,9 @@ export async function PATCH(
         .in('is_published', [true, false]);
     }
 
+    // Capture pre-mutation slug for cache invalidation (see PUT for rationale).
+    const previousSlug = extractItemSlug(existingItem, fields);
+
     // Set the values for both published and draft
     if (Object.keys(valuesToSet).length > 0) {
       await setValues(item_id, valuesToSet, true);
@@ -312,6 +350,18 @@ export async function PATCH(
       hasProjections ? fieldProjections : undefined,
       hasProjections ? collection.name : undefined
     );
+
+    try {
+      const result = await invalidateForCollectionChange(collection_id, {
+        removedSlugs: previousSlug ? [previousSlug] : [],
+      });
+      if (result.invalidatedRoutes.length > 0) {
+        console.log(`[Cache] v1 item patch: invalidated ${result.invalidatedRoutes.length} route(s)`);
+      }
+    } catch (cacheError) {
+      console.error(`[Cache] v1 item patch: invalidation failed:`, cacheError);
+    }
+
     return NextResponse.json(response);
   } catch (error) {
     console.error('Error patching collection item:', error);
@@ -357,9 +407,27 @@ export async function DELETE(
       );
     }
 
+    // Capture slug BEFORE the soft-delete. Once deleted_at is set, the
+    // item is excluded from getRoutePathsForPages — without the slug we'd
+    // have no way to invalidate the dynamic-page URL the CDN is still
+    // serving with the now-deleted content.
+    const fields = await getFieldsByCollectionId(collection_id, true, { excludeComputed: true });
+    const previousSlug = extractItemSlug(existingItem, fields);
+
     // Delete both published and draft items
     await deleteItem(item_id, true);
     await deleteItem(item_id, false);
+
+    try {
+      const result = await invalidateForCollectionChange(collection_id, {
+        removedSlugs: previousSlug ? [previousSlug] : [],
+      });
+      if (result.invalidatedRoutes.length > 0) {
+        console.log(`[Cache] v1 item delete: invalidated ${result.invalidatedRoutes.length} route(s)`);
+      }
+    } catch (cacheError) {
+      console.error(`[Cache] v1 item delete: invalidation failed:`, cacheError);
+    }
 
     return NextResponse.json({
       deleted: true,

--- a/app/(builder)/ycode/api/v1/collections/[collection_id]/items/route.ts
+++ b/app/(builder)/ycode/api/v1/collections/[collection_id]/items/route.ts
@@ -4,6 +4,7 @@ import { getCollectionById } from '@/lib/repositories/collectionRepository';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { getItemsWithValues, createItem, getMaxIdValue } from '@/lib/repositories/collectionItemRepository';
 import { setValues } from '@/lib/repositories/collectionItemValueRepository';
+import { invalidateForCollectionChange } from '@/lib/services/cacheService';
 import { transformItemToPublicWithRefs, parseFieldProjections } from '../../../reference-resolver';
 
 // Disable caching for this route
@@ -345,6 +346,20 @@ export async function POST(
       hasProjections ? fieldProjections : undefined,
       hasProjections ? collection.name : undefined
     );
+
+    // Purge CDN/data caches for pages that render this collection (lists,
+    // grids, dynamic page). Without this, the new item is in the DB but
+    // every public page keeps serving cached HTML that doesn't include it.
+    // No old slug to pass — POST adds a new row, doesn't remove one.
+    try {
+      const result = await invalidateForCollectionChange(collection_id);
+      if (result.invalidatedRoutes.length > 0) {
+        console.log(`[Cache] v1 item create: invalidated ${result.invalidatedRoutes.length} route(s)`);
+      }
+    } catch (cacheError) {
+      console.error(`[Cache] v1 item create: invalidation failed:`, cacheError);
+    }
+
     return NextResponse.json(response, { status: 201 });
   } catch (error) {
     console.error('Error creating collection item:', error);

--- a/app/(site)/[...slug]/page.tsx
+++ b/app/(site)/[...slug]/page.tsx
@@ -150,7 +150,10 @@ export async function generateStaticParams() {
  * Cached per slug and page for revalidation
  */
 async function fetchPublishedPageWithLayers(slugPath: string) {
-  const tags = ['all-pages', `route-/${slugPath}`];
+  // NOTE: Do NOT include 'all-pages' here. Next.js bug #63509 causes
+  // revalidateTag('route-/X') to also invalidate every other tag on
+  // the entry, which would cascade to all pages sharing 'all-pages'.
+  const tags = [`route-/${slugPath}`];
   const opts = { tags, revalidate: false as const };
 
   const [core, layers] = await Promise.all([
@@ -182,7 +185,7 @@ async function fetchPublishedPageForMetadata(slugPath: string) {
   return unstable_cache(
     async () => fetchPageByPathForMetadata(slugPath, true),
     [`metadata-/${slugPath}`],
-    { tags: ['all-pages', `route-/${slugPath}`], revalidate: false }
+    { tags: [`route-/${slugPath}`], revalidate: false }
   )();
 }
 
@@ -430,7 +433,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       baseUrl: getSiteBaseUrl({ globalCanonicalUrl: globalSettings.globalCanonicalUrl }),
     }),
     [`data-for-route-/${slugPath}-meta`],
-    { tags: ['all-pages', `route-/${slugPath}`], revalidate: false }
+    { tags: [`route-/${slugPath}`], revalidate: false }
   )();
 
   if (baseUrl) {

--- a/app/(site)/[...slug]/page.tsx
+++ b/app/(site)/[...slug]/page.tsx
@@ -151,10 +151,15 @@ export async function generateStaticParams() {
  * Cached per slug and page for revalidation
  */
 async function fetchPublishedPageWithLayers(slugPath: string) {
-  // NOTE: Do NOT include 'all-pages' here. Next.js bug #63509 causes
-  // revalidateTag('route-/X') to also invalidate every other tag on
-  // the entry, which would cascade to all pages sharing 'all-pages'.
-  const tags = [`route-/${slugPath}`];
+  // Tags are both 'route-/X' AND 'all-pages':
+  // - route-/X lets selective invalidation purge just this page's data cache
+  // - all-pages lets full invalidation (color variables, redirects, etc.)
+  //   sweep every page's data cache in one invalidateByTag call.
+  // Vercel's invalidateByTag is tag-precise — invalidating one route's tag
+  // doesn't cascade to entries that only share 'all-pages'. (Next.js bug
+  // #63509 would apply if we used revalidateTag for selective, but we route
+  // exclusively through invalidateByTag on Vercel.)
+  const tags = [`route-/${slugPath}`, 'all-pages'];
   const opts = { tags, revalidate: false as const };
 
   const [core, layers] = await Promise.all([
@@ -186,7 +191,7 @@ async function fetchPublishedPageForMetadata(slugPath: string) {
   return unstable_cache(
     async () => fetchPageByPathForMetadata(slugPath, true),
     [`metadata-/${slugPath}`],
-    { tags: [`route-/${slugPath}`], revalidate: false }
+    { tags: [`route-/${slugPath}`, 'all-pages'], revalidate: false }
   )();
 }
 
@@ -439,7 +444,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       baseUrl: getSiteBaseUrl({ globalCanonicalUrl: globalSettings.globalCanonicalUrl }),
     }),
     [`data-for-route-/${slugPath}-meta`],
-    { tags: [`route-/${slugPath}`], revalidate: false }
+    { tags: [`route-/${slugPath}`, 'all-pages'], revalidate: false }
   )();
 
   if (baseUrl) {

--- a/app/(site)/[...slug]/page.tsx
+++ b/app/(site)/[...slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound, redirect, permanentRedirect } from 'next/navigation';
 import { unstable_cache } from 'next/cache';
+import { addCacheTag } from '@vercel/functions';
 import type { Metadata } from 'next';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { buildSlugPath } from '@/lib/page-utils';
@@ -257,6 +258,11 @@ export default async function Page({ params }: PageProps) {
 
   // Handle catch-all slug (join array into path)
   const slugPath = Array.isArray(slug) ? slug.join('/') : slug;
+
+  // Tag this response for Vercel CDN cache invalidation. The publish endpoint
+  // purges this exact tag (route-/<slug>) so only this URL's cache entry is
+  // invalidated. No-ops outside Vercel.
+  await addCacheTag([`route-/${slugPath}`, 'all-pages']);
 
   // Check for redirects before processing the page
   const currentPath = `/${slugPath}`;

--- a/app/(site)/[...slug]/page.tsx
+++ b/app/(site)/[...slug]/page.tsx
@@ -300,7 +300,10 @@ export default async function Page({ params }: PageProps) {
     notFound();
   }
 
-  const { page, pageLayers, components, collectionItem, collectionFields, pageCollectionSortedItemIds, pageCollectionSortedItemSlugs, locale, availableLocales, translations } = data;
+  const { page, pageLayers, components, collectionItem, collectionFields, pageCollectionSortedItemIds, pageCollectionSortedItemSlugs, locale, availableLocales, translations, generatedCss } = data;
+
+  // Per-page CSS with fallback to global published_css
+  const cssForPage = generatedCss || globalSettings.publishedCss || undefined;
 
   // Check password protection for this page.
   // First evaluate without cookies() so non-protected pages stay cacheable.
@@ -363,7 +366,7 @@ export default async function Page({ params }: PageProps) {
       page={page}
       layers={pageLayers.layers || []}
       components={components}
-      generatedCss={globalSettings.publishedCss || undefined}
+      generatedCss={cssForPage}
       colorVariablesCss={globalSettings.colorVariablesCss || undefined}
       collectionItem={collectionItem}
       collectionFields={collectionFields}

--- a/app/(site)/api/templates/[id]/apply/route.ts
+++ b/app/(site)/api/templates/[id]/apply/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { noCache } from '@/lib/api-response';
 import { applyTemplate } from '@/lib/services/templateService';
+import { clearAllCache, getAllPublishedRoutes, warmRoutes } from '@/lib/services/cacheService';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -26,6 +27,24 @@ export async function POST(
     if (!result.success) {
       console.error(`[POST /api/templates/${id}/apply] Failed:`, result.error);
       return noCache({ error: result.error }, 500);
+    }
+
+    // Template application swapped out every page, component, style, color
+    // variable, etc. — without invalidation the CDN would keep serving the
+    // previous site's HTML indefinitely. Warm afterwards so the user's
+    // first visit to the new site is a HIT, not a cold render.
+    try {
+      await clearAllCache();
+      const routes = await getAllPublishedRoutes();
+      const warmResult = await warmRoutes(routes, request);
+      if (warmResult) {
+        console.log(
+          `[Cache] template apply: warming ${warmResult.warmed}${warmResult.total > warmResult.warmed ? ` of ${warmResult.total}` : ''} route(s) in background`,
+        );
+      }
+    } catch (cacheError) {
+      // Non-fatal: template applied successfully, only cache hygiene failed
+      console.error(`[POST /api/templates/${id}/apply] Cache invalidation failed:`, cacheError);
     }
 
     return noCache({

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -21,7 +21,10 @@ export const revalidate = false; // Cache indefinitely until publish invalidates
  * Cached with tag-based revalidation (no time-based stale cache)
  */
 async function fetchPublishedHomepage() {
-  const tags = ['all-pages', 'route-/'];
+  // NOTE: Do NOT include 'all-pages' here. Next.js bug #63509 causes
+  // revalidateTag to also invalidate every other tag on the entry,
+  // which would cascade to all pages sharing 'all-pages'.
+  const tags = ['route-/'];
   const opts = { tags, revalidate: false as const };
 
   const [core, layers] = await Promise.all([
@@ -265,7 +268,7 @@ export async function generateMetadata(): Promise<Metadata> {
       baseUrl: getSiteBaseUrl({ globalCanonicalUrl: globalSettings.globalCanonicalUrl }),
     }),
     ['data-for-route-/-meta'],
-    { tags: ['all-pages', 'route-/'], revalidate: false }
+    { tags: ['route-/'], revalidate: false }
   )();
 
   if (baseUrl) {

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -22,10 +22,15 @@ export const revalidate = false; // Cache indefinitely until publish invalidates
  * Cached with tag-based revalidation (no time-based stale cache)
  */
 async function fetchPublishedHomepage() {
-  // NOTE: Do NOT include 'all-pages' here. Next.js bug #63509 causes
-  // revalidateTag to also invalidate every other tag on the entry,
-  // which would cascade to all pages sharing 'all-pages'.
-  const tags = ['route-/'];
+  // Tags are both 'route-/' AND 'all-pages':
+  // - route-/ lets selective invalidation purge just this page's data cache
+  // - all-pages lets full invalidation (color variables, redirects, etc.)
+  //   sweep every page's data cache in one invalidateByTag call.
+  // Vercel's invalidateByTag is tag-precise, so no cascade — selective
+  // invalidation of one route doesn't disturb others. (Next.js bug #63509
+  // would apply if we used revalidateTag for selective on Vercel, but we
+  // route exclusively through invalidateByTag here.)
+  const tags = ['route-/', 'all-pages'];
   const opts = { tags, revalidate: false as const };
 
   const [core, layers] = await Promise.all([
@@ -274,7 +279,7 @@ export async function generateMetadata(): Promise<Metadata> {
       baseUrl: getSiteBaseUrl({ globalCanonicalUrl: globalSettings.globalCanonicalUrl }),
     }),
     ['data-for-route-/-meta'],
-    { tags: ['route-/'], revalidate: false }
+    { tags: ['route-/', 'all-pages'], revalidate: false }
   )();
 
   if (baseUrl) {

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,5 +1,6 @@
 import { redirect, permanentRedirect } from 'next/navigation';
 import { unstable_cache } from 'next/cache';
+import { addCacheTag } from '@vercel/functions';
 import Link from 'next/link';
 import { fetchHomepage, fetchErrorPage, splitPageData, reassemblePageData, slimPageData } from '@/lib/page-fetcher';
 import type { PageData } from '@/lib/page-fetcher';
@@ -111,6 +112,11 @@ async function fetchCachedErrorPage(errorCode: 401) {
 }
 
 export default async function Home() {
+  // Tag this response for Vercel CDN cache invalidation. The publish endpoint
+  // purges this exact tag (route-/) so only the homepage cache entry is
+  // invalidated. No-ops outside Vercel.
+  await addCacheTag(['route-/', 'all-pages']);
+
   // Check for redirects targeting the homepage
   const redirects = await fetchCachedRedirects();
   if (redirects && Array.isArray(redirects)) {

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -146,6 +146,9 @@ export default async function Home() {
   // Load all global settings early so error pages also get global custom code
   const globalSettings = await fetchCachedGlobalSettings();
 
+  // Per-page CSS with fallback to global published_css
+  const cssForPage = data.generatedCss || globalSettings.publishedCss || undefined;
+
   // Check password protection for homepage.
   // First evaluate without cookies() so non-protected pages can stay cacheable.
   const folders = await fetchCachedFoldersForAuth();
@@ -207,7 +210,7 @@ export default async function Home() {
       page={data.page}
       layers={data.pageLayers.layers || []}
       components={data.components}
-      generatedCss={globalSettings.publishedCss || undefined}
+      generatedCss={cssForPage}
       colorVariablesCss={globalSettings.colorVariablesCss || undefined}
       locale={data.locale}
       availableLocales={data.availableLocales}

--- a/database/migrations/20260512000001_add_generated_css_to_page_layers.ts
+++ b/database/migrations/20260512000001_add_generated_css_to_page_layers.ts
@@ -1,0 +1,21 @@
+import type { Knex } from 'knex';
+
+/**
+ * Migration: Add generated_css column to page_layers
+ *
+ * Stores per-page CSS generated from each page's layer tree + resolved
+ * components. Enables selective cache invalidation by making CSS changes
+ * page-scoped rather than global.
+ */
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('page_layers', (table) => {
+    table.text('generated_css').nullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('page_layers', (table) => {
+    table.dropColumn('generated_css');
+  });
+}

--- a/lib/mcp/tools/publishing.ts
+++ b/lib/mcp/tools/publishing.ts
@@ -152,7 +152,10 @@ export function registerPublishingTools(server: McpServer) {
         await publishCSS();
       } catch { /* non-fatal */ }
 
-      // Clear cache
+      // Clear cache. No warming here: MCP is invoked over JSON-RPC, not HTTP,
+      // so there's no Request/host header to build absolute URLs from. The
+      // builder's HTTP publish endpoint warms after publish — this AI tool
+      // path is rare enough that a cold next-visit is acceptable.
       try { await clearAllCache(); } catch { /* non-fatal */ }
 
       // Save published_at timestamp

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -95,6 +95,8 @@ export interface PageData {
   locale?: Locale | null; // Current locale (if detected from URL)
   availableLocales?: Locale[]; // All active locales for locale switcher
   translations?: Record<string, Translation>; // Translations for locale-aware URL generation
+  /** Per-page CSS generated from this page's layers + resolved components. */
+  generatedCss?: string | null;
 }
 
 /**
@@ -109,6 +111,7 @@ export function slimPageData(data: PageData): PageData {
     ...data,
     pageLayers: { layers: data.pageLayers.layers || [] } as PageLayers,
     components: data.components.map(({ layers, ...rest }) => ({ ...rest, layers: [] }) as Component),
+    generatedCss: data.generatedCss,
   };
 }
 
@@ -637,6 +640,7 @@ async function fetchPageByPathInternal(
               locale: detectedLocale,
               availableLocales: availableLocales as Locale[] || [],
               translations,
+              generatedCss: pageLayers?.generated_css || null,
             };
           }
         }
@@ -701,6 +705,7 @@ async function fetchPageByPathInternal(
       locale: detectedLocale,
       availableLocales: availableLocales as Locale[] || [],
       translations,
+      generatedCss: pageLayers?.generated_css || null,
     };
   } catch (error) {
     console.error('Failed to fetch page:', error);
@@ -827,7 +832,7 @@ export const fetchHomepage = cache(async function fetchHomepage(
   preloadedComponents?: Component[],
   tenantId?: string,
   translations?: Record<string, Translation>
-): Promise<Pick<PageData, 'page' | 'pageLayers' | 'components' | 'locale' | 'availableLocales' | 'translations'> | null> {
+): Promise<Pick<PageData, 'page' | 'pageLayers' | 'components' | 'locale' | 'availableLocales' | 'translations' | 'generatedCss'> | null> {
   try {
     const supabase = await getSupabaseAdmin(tenantId);
 
@@ -888,10 +893,11 @@ export const fetchHomepage = cache(async function fetchHomepage(
         ...pageLayers,
         layers: resolvedLayers,
       },
-      components, // Layers are pre-resolved; components passed for rich-text embedded rendering
+      components,
       locale: null,
       availableLocales: availableLocales as Locale[] || [],
       translations: translations || {},
+      generatedCss: pageLayers?.generated_css || null,
     };
   } catch (error) {
     return null;

--- a/lib/repositories/colorVariableRepository.ts
+++ b/lib/repositories/colorVariableRepository.ts
@@ -6,6 +6,7 @@
  */
 
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { generateContentHash } from '@/lib/hash-utils';
 import type { ColorVariable } from '@/types';
 
 export interface CreateColorVariableData {
@@ -199,4 +200,17 @@ export async function reorderColorVariables(
   if (error) {
     throw new Error(`Failed to reorder color variables: ${error.message}`);
   }
+}
+
+/**
+ * Compute a deterministic hash of all color variables.
+ * Used to detect changes between publishes — color variables have no
+ * draft/published model so we compare the current state against a
+ * stored snapshot hash.
+ */
+export async function getColorVariablesHash(): Promise<string> {
+  const variables = await getAllColorVariables();
+  return generateContentHash(
+    variables.map(v => ({ id: v.id, name: v.name, value: v.value, sort_order: v.sort_order }))
+  );
 }

--- a/lib/repositories/componentRepository.ts
+++ b/lib/repositories/componentRepository.ts
@@ -293,11 +293,12 @@ export async function publishComponent(draftComponentId: string): Promise<Compon
 
 /**
  * Publish multiple components in batch
- * Uses batch upsert for efficiency
+ * Only upserts components whose content_hash actually changed.
+ * Returns the IDs of components that were modified.
  */
-export async function publishComponents(componentIds: string[]): Promise<{ count: number }> {
+export async function publishComponents(componentIds: string[]): Promise<{ count: number; changedComponentIds: string[] }> {
   if (componentIds.length === 0) {
-    return { count: 0 };
+    return { count: 0, changedComponentIds: [] };
   }
 
   const client = await getSupabaseAdmin();
@@ -318,32 +319,55 @@ export async function publishComponents(componentIds: string[]): Promise<{ count
   }
 
   if (!draftComponents || draftComponents.length === 0) {
-    return { count: 0 };
+    return { count: 0, changedComponentIds: [] };
   }
 
-  // Prepare components for batch upsert
-  const componentsToUpsert = draftComponents.map(draft => ({
-    id: draft.id,
-    name: draft.name,
-    layers: draft.layers,
-    variables: draft.variables,
-    content_hash: draft.content_hash,
-    is_published: true,
-    updated_at: new Date().toISOString(),
-  }));
-
-  // Batch upsert all components
-  const { error: upsertError } = await client
+  // Fetch existing published versions to compare hashes
+  const { data: publishedComponents } = await client
     .from('components')
-    .upsert(componentsToUpsert, {
-      onConflict: 'id,is_published',
-    });
+    .select('id, content_hash')
+    .in('id', draftComponents.map(d => d.id))
+    .eq('is_published', true);
 
-  if (upsertError) {
-    throw new Error(`Failed to publish components: ${upsertError.message}`);
+  const publishedHashById = new Map<string, string>();
+  if (publishedComponents) {
+    for (const pub of publishedComponents) {
+      if (pub.content_hash) publishedHashById.set(pub.id, pub.content_hash);
+    }
   }
 
-  return { count: componentsToUpsert.length };
+  // Only upsert components that are new or have changed
+  const componentsToUpsert = draftComponents
+    .filter(draft => {
+      const pubHash = publishedHashById.get(draft.id);
+      return !pubHash || pubHash !== draft.content_hash;
+    })
+    .map(draft => ({
+      id: draft.id,
+      name: draft.name,
+      layers: draft.layers,
+      variables: draft.variables,
+      content_hash: draft.content_hash,
+      is_published: true,
+      updated_at: new Date().toISOString(),
+    }));
+
+  if (componentsToUpsert.length > 0) {
+    const { error: upsertError } = await client
+      .from('components')
+      .upsert(componentsToUpsert, {
+        onConflict: 'id,is_published',
+      });
+
+    if (upsertError) {
+      throw new Error(`Failed to publish components: ${upsertError.message}`);
+    }
+  }
+
+  return {
+    count: componentsToUpsert.length,
+    changedComponentIds: componentsToUpsert.map(c => c.id),
+  };
 }
 
 /**
@@ -607,13 +631,29 @@ export async function softDeleteComponent(id: string): Promise<SoftDeleteResult>
   // Find all affected entities
   const affectedEntities = await findEntitiesUsingComponent(id);
 
-  // Detach component from all affected page_layers
+  // Detach component from all affected page_layers and recompute hashes
+  const { generatePageLayersHash } = await import('@/lib/hash-utils');
+
   for (const entity of affectedEntities) {
     if (entity.type === 'page') {
+      // Fetch existing generated_css to keep hash consistent
+      const { data: existing } = await client
+        .from('page_layers')
+        .select('generated_css')
+        .eq('id', entity.id)
+        .eq('is_published', false)
+        .single();
+
+      const contentHash = generatePageLayersHash({
+        layers: entity.newLayers,
+        generated_css: existing?.generated_css || null,
+      });
+
       const { error: updateError } = await client
         .from('page_layers')
         .update({
           layers: entity.newLayers,
+          content_hash: contentHash,
           updated_at: new Date().toISOString(),
         })
         .eq('id', entity.id);

--- a/lib/repositories/componentRepository.ts
+++ b/lib/repositories/componentRepository.ts
@@ -656,7 +656,15 @@ export async function softDeleteComponent(id: string): Promise<SoftDeleteResult>
           content_hash: contentHash,
           updated_at: new Date().toISOString(),
         })
-        .eq('id', entity.id);
+        .eq('id', entity.id)
+        // CRITICAL: page_layers has composite PK (id, is_published). Without
+        // this filter, the UPDATE writes the new layers + draft content_hash
+        // onto the published row too. Two failure modes:
+        //   1. Published row carries new layers but stale generated_css —
+        //      site renders broken classes for the deleted component.
+        //   2. batchPublishPageLayers compares hashes, sees draft == published
+        //      (we just wrote it!), and skips the page on publish.
+        .eq('is_published', false);
 
       if (updateError) {
         console.error(`Failed to update page_layers ${entity.id}:`, updateError);

--- a/lib/repositories/layerStyleRepository.ts
+++ b/lib/repositories/layerStyleRepository.ts
@@ -7,7 +7,12 @@
 
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import type { LayerStyle, Layer } from '@/types';
-import { generateLayerStyleContentHash } from '../hash-utils';
+import {
+  generateLayerStyleContentHash,
+  generatePageLayersHash,
+  generateComponentContentHash,
+} from '../hash-utils';
+import { updateLayersWithStyle } from '@/lib/layer-style-utils';
 
 /**
  * Input data for creating a new layer style
@@ -725,4 +730,115 @@ export async function deleteStyle(id: string): Promise<void> {
   if (error) {
     throw new Error(`Failed to delete layer style: ${error.message}`);
   }
+}
+
+/**
+ * Propagate updated layer style values into the draft layers of every page
+ * and component that references them.
+ *
+ * Layer styles are denormalized: when applied, the style's classes/design are
+ * COPIED onto the layer (alongside layer.styleId). The builder client only
+ * syncs the currently-open pages when a style is edited, so pages and
+ * components that aren't loaded keep stale denormalized values in the DB.
+ *
+ * Without this server-side sync, publishing a style change updates only the
+ * layer_styles row — the layers themselves still carry the OLD classes, so
+ * the published HTML references the old class names and renders with the
+ * old style. The CSS catch-up doesn't fix it because it generates CSS from
+ * the same stale layers.
+ *
+ * Skips layers that have styleOverrides (local customizations win). Also
+ * handles textStyles entries (rich-text inline styles) via the existing
+ * updateLayersWithStyle helper.
+ *
+ * @returns IDs of pages and components whose drafts were updated. Callers
+ *   should republish affected components so their published versions get
+ *   the fresh classes; affected pages are handled by the CSS catch-up step.
+ */
+export async function syncLayerStyleChangesToDrafts(
+  styleIds: string[],
+): Promise<{ affectedPageIds: string[]; affectedComponentIds: string[] }> {
+  if (styleIds.length === 0) {
+    return { affectedPageIds: [], affectedComponentIds: [] };
+  }
+
+  const client = await getSupabaseAdmin();
+  if (!client) {
+    return { affectedPageIds: [], affectedComponentIds: [] };
+  }
+
+  // Use the just-published versions of the changed styles as the source of
+  // truth: they were just upserted by publishLayerStyles with the new values.
+  const { data: styles } = await client
+    .from('layer_styles')
+    .select('id, classes, design')
+    .in('id', styleIds)
+    .eq('is_published', true)
+    .is('deleted_at', null);
+
+  if (!styles || styles.length === 0) {
+    return { affectedPageIds: [], affectedComponentIds: [] };
+  }
+
+  // --- Sync draft page_layers ---
+  const { data: pageLayersRecords } = await client
+    .from('page_layers')
+    .select('id, page_id, layers, generated_css, content_hash')
+    .eq('is_published', false)
+    .is('deleted_at', null);
+
+  const affectedPageIds: string[] = [];
+  const now = new Date().toISOString();
+
+  for (const record of pageLayersRecords || []) {
+    let layers = (record.layers as Layer[]) || [];
+    for (const style of styles) {
+      layers = updateLayersWithStyle(layers, style.id, style.classes, style.design);
+    }
+
+    const newHash = generatePageLayersHash({
+      layers,
+      generated_css: record.generated_css ?? null,
+    });
+
+    if (newHash !== record.content_hash) {
+      affectedPageIds.push(record.page_id);
+      await client
+        .from('page_layers')
+        .update({ layers, content_hash: newHash, updated_at: now })
+        .eq('id', record.id);
+    }
+  }
+
+  // --- Sync draft components ---
+  const { data: componentRecords } = await client
+    .from('components')
+    .select('id, name, layers, variables, content_hash')
+    .eq('is_published', false)
+    .is('deleted_at', null);
+
+  const affectedComponentIds: string[] = [];
+
+  for (const record of componentRecords || []) {
+    let layers = (record.layers as Layer[]) || [];
+    for (const style of styles) {
+      layers = updateLayersWithStyle(layers, style.id, style.classes, style.design);
+    }
+
+    const newHash = generateComponentContentHash({
+      name: record.name,
+      layers,
+      variables: record.variables,
+    });
+
+    if (newHash !== record.content_hash) {
+      affectedComponentIds.push(record.id);
+      await client
+        .from('components')
+        .update({ layers, content_hash: newHash, updated_at: now })
+        .eq('id', record.id);
+    }
+  }
+
+  return { affectedPageIds, affectedComponentIds };
 }

--- a/lib/repositories/layerStyleRepository.ts
+++ b/lib/repositories/layerStyleRepository.ts
@@ -272,11 +272,12 @@ export async function publishLayerStyle(draftStyleId: string): Promise<LayerStyl
 
 /**
  * Publish multiple layer styles in batch
- * Uses batch upsert for efficiency
+ * Only upserts styles whose content_hash actually changed.
+ * Returns the IDs of styles that were modified.
  */
-export async function publishLayerStyles(styleIds: string[]): Promise<{ count: number }> {
+export async function publishLayerStyles(styleIds: string[]): Promise<{ count: number; changedStyleIds: string[] }> {
   if (styleIds.length === 0) {
-    return { count: 0 };
+    return { count: 0, changedStyleIds: [] };
   }
 
   const client = await getSupabaseAdmin();
@@ -284,45 +285,69 @@ export async function publishLayerStyles(styleIds: string[]): Promise<{ count: n
     throw new Error('Failed to initialize Supabase client');
   }
 
-  // Batch fetch all draft styles
+  // Batch fetch all draft styles (exclude soft-deleted)
   const { data: draftStyles, error: fetchError } = await client
     .from('layer_styles')
     .select('*')
     .in('id', styleIds)
-    .eq('is_published', false);
+    .eq('is_published', false)
+    .is('deleted_at', null);
 
   if (fetchError) {
     throw new Error(`Failed to fetch draft layer styles: ${fetchError.message}`);
   }
 
   if (!draftStyles || draftStyles.length === 0) {
-    return { count: 0 };
+    return { count: 0, changedStyleIds: [] };
   }
 
-  // Prepare styles for batch upsert
-  const stylesToUpsert = draftStyles.map(draft => ({
-    id: draft.id,
-    name: draft.name,
-    classes: draft.classes,
-    design: draft.design,
-    group: draft.group,
-    content_hash: draft.content_hash,
-    is_published: true,
-    updated_at: new Date().toISOString(),
-  }));
-
-  // Batch upsert all styles
-  const { error: upsertError } = await client
+  // Fetch existing published versions to compare hashes
+  const { data: publishedStyles } = await client
     .from('layer_styles')
-    .upsert(stylesToUpsert, {
-      onConflict: 'id,is_published',
-    });
+    .select('id, content_hash')
+    .in('id', draftStyles.map(d => d.id))
+    .eq('is_published', true);
 
-  if (upsertError) {
-    throw new Error(`Failed to publish layer styles: ${upsertError.message}`);
+  const publishedHashById = new Map<string, string>();
+  if (publishedStyles) {
+    for (const pub of publishedStyles) {
+      if (pub.content_hash) publishedHashById.set(pub.id, pub.content_hash);
+    }
   }
 
-  return { count: stylesToUpsert.length };
+  // Only upsert styles that are new or have changed
+  const stylesToUpsert = draftStyles
+    .filter(draft => {
+      const pubHash = publishedHashById.get(draft.id);
+      return !pubHash || pubHash !== draft.content_hash;
+    })
+    .map(draft => ({
+      id: draft.id,
+      name: draft.name,
+      classes: draft.classes,
+      design: draft.design,
+      group: draft.group,
+      content_hash: draft.content_hash,
+      is_published: true,
+      updated_at: new Date().toISOString(),
+    }));
+
+  if (stylesToUpsert.length > 0) {
+    const { error: upsertError } = await client
+      .from('layer_styles')
+      .upsert(stylesToUpsert, {
+        onConflict: 'id,is_published',
+      });
+
+    if (upsertError) {
+      throw new Error(`Failed to publish layer styles: ${upsertError.message}`);
+    }
+  }
+
+  return {
+    count: stylesToUpsert.length,
+    changedStyleIds: stylesToUpsert.map(s => s.id),
+  };
 }
 
 /**
@@ -337,11 +362,12 @@ export async function getUnpublishedLayerStyles(): Promise<LayerStyle[]> {
     throw new Error('Failed to initialize Supabase client');
   }
 
-  // Get all draft layer styles
+  // Get all draft layer styles (exclude soft-deleted)
   const { data: draftStyles, error } = await client
     .from('layer_styles')
     .select('*')
     .eq('is_published', false)
+    .is('deleted_at', null)
     .order('created_at', { ascending: false });
 
   if (error) {
@@ -595,13 +621,28 @@ export async function softDeleteStyle(id: string): Promise<LayerStyleSoftDeleteR
   // Find all affected entities
   const affectedEntities = await findEntitiesUsingLayerStyle(id);
 
-  // Detach style from all affected page_layers
+  // Detach style from all affected page_layers and recompute hashes
+  const { generatePageLayersHash } = await import('@/lib/hash-utils');
+
   for (const entity of affectedEntities) {
     if (entity.type === 'page') {
+      const { data: existing } = await client
+        .from('page_layers')
+        .select('generated_css')
+        .eq('id', entity.id)
+        .eq('is_published', false)
+        .single();
+
+      const contentHash = generatePageLayersHash({
+        layers: entity.newLayers,
+        generated_css: existing?.generated_css || null,
+      });
+
       const { error: updateError } = await client
         .from('page_layers')
         .update({
           layers: entity.newLayers,
+          content_hash: contentHash,
           updated_at: new Date().toISOString(),
         })
         .eq('id', entity.id);

--- a/lib/repositories/layerStyleRepository.ts
+++ b/lib/repositories/layerStyleRepository.ts
@@ -791,14 +791,22 @@ export async function syncLayerStyleChangesToDrafts(
   const now = new Date().toISOString();
 
   for (const record of pageLayersRecords || []) {
-    let layers = (record.layers as Layer[]) || [];
+    // Skip rows without an actual layer tree — they can't reference any
+    // style anyway, and hashing a missing `layers` field with our default
+    // `[]` would diverge from whatever the original save path stored.
+    if (!Array.isArray(record.layers)) continue;
+
+    let layers = record.layers as Layer[];
     for (const style of styles) {
       layers = updateLayersWithStyle(layers, style.id, style.classes, style.design);
     }
 
+    // Match the canonical save formula exactly: empty-string generated_css
+    // must coalesce to null, otherwise the recomputed hash will drift from
+    // the stored one on every publish.
     const newHash = generatePageLayersHash({
       layers,
-      generated_css: record.generated_css ?? null,
+      generated_css: record.generated_css || null,
     });
 
     if (newHash !== record.content_hash) {
@@ -820,7 +828,11 @@ export async function syncLayerStyleChangesToDrafts(
   const affectedComponentIds: string[] = [];
 
   for (const record of componentRecords || []) {
-    let layers = (record.layers as Layer[]) || [];
+    // Same guard as page_layers above: components with no layer tree have
+    // nothing to sync, and forcing `[]` would diverge from the stored hash.
+    if (!Array.isArray(record.layers)) continue;
+
+    let layers = record.layers as Layer[];
     for (const style of styles) {
       layers = updateLayersWithStyle(layers, style.id, style.classes, style.design);
     }

--- a/lib/repositories/layerStyleRepository.ts
+++ b/lib/repositories/layerStyleRepository.ts
@@ -811,10 +811,17 @@ export async function syncLayerStyleChangesToDrafts(
 
     if (newHash !== record.content_hash) {
       affectedPageIds.push(record.page_id);
+      // CRITICAL: page_layers has a composite primary key (id, is_published).
+      // Drafts and published rows share the same `id`, so without filtering
+      // by is_published this UPDATE silently clobbers the published row too,
+      // writing the new layers + hash but NOT a fresh generated_css. That
+      // breaks the published render (new class names, old CSS file) AND
+      // makes batchPublishPageLayers below think nothing changed.
       await client
         .from('page_layers')
         .update({ layers, content_hash: newHash, updated_at: now })
-        .eq('id', record.id);
+        .eq('id', record.id)
+        .eq('is_published', false);
     }
   }
 
@@ -845,10 +852,13 @@ export async function syncLayerStyleChangesToDrafts(
 
     if (newHash !== record.content_hash) {
       affectedComponentIds.push(record.id);
+      // Same composite-key trap as page_layers: components share an `id`
+      // across draft/published. Always scope the update to the draft row.
       await client
         .from('components')
         .update({ layers, content_hash: newHash, updated_at: now })
-        .eq('id', record.id);
+        .eq('id', record.id)
+        .eq('is_published', false);
     }
   }
 

--- a/lib/repositories/pageLayersRepository.ts
+++ b/lib/repositories/pageLayersRepository.ts
@@ -147,10 +147,14 @@ export async function upsertDraftLayers(
     }
   }
 
-  // Calculate content hash for layers
+  // Use provided generated_css, or preserve the existing value for hash consistency
+  const cssForHash = additionalData?.generated_css !== undefined
+    ? (additionalData.generated_css as string) || null
+    : existingDraft?.generated_css || null;
+
   const contentHash = generatePageLayersHash({
     layers,
-    generated_css: (additionalData?.generated_css as string) || null,
+    generated_css: cssForHash,
   });
 
   // Prepare update data
@@ -348,9 +352,10 @@ export async function publishPageLayers(draftPageId: string, publishedPageId: st
     if (hasChanges) {
       // Prepare update data WITHOUT primary key fields (id, is_published)
       const updateData: any = {
-        page_id: publishedPageId, // Same page ID (draft and published pages share same id)
+        page_id: publishedPageId,
         layers: draftLayers.layers,
-        content_hash: draftLayers.content_hash, // Copy hash from draft
+        generated_css: draftLayers.generated_css || null,
+        content_hash: draftLayers.content_hash,
         updated_at: new Date().toISOString(),
       };
 
@@ -373,9 +378,10 @@ export async function publishPageLayers(draftPageId: string, publishedPageId: st
   } else {
     // Create new published version - include ALL fields for insert
     const insertData: any = {
-      id: draftLayers.id, // Use same ID (composite key with is_published)
+      id: draftLayers.id,
       page_id: publishedPageId,
       layers: draftLayers.layers,
+      generated_css: draftLayers.generated_css || null,
       content_hash: draftLayers.content_hash,
       is_published: true,
     };
@@ -398,11 +404,11 @@ export async function publishPageLayers(draftPageId: string, publishedPageId: st
  * Batch publish page layers for multiple pages
  * Much more efficient than calling publishPageLayers in a loop
  * @param pageIds - Array of page IDs to publish layers for
- * @returns Number of layers published
+ * @returns Object with count and the page IDs that actually changed
  */
-export async function batchPublishPageLayers(pageIds: string[]): Promise<number> {
+export async function batchPublishPageLayers(pageIds: string[]): Promise<{ count: number; changedPageIds: string[] }> {
   if (pageIds.length === 0) {
-    return 0;
+    return { count: 0, changedPageIds: [] };
   }
 
   const client = await getSupabaseAdmin();
@@ -415,7 +421,7 @@ export async function batchPublishPageLayers(pageIds: string[]): Promise<number>
   const draftLayers = await getDraftLayersForPages(pageIds);
 
   if (draftLayers.length === 0) {
-    return 0;
+    return { count: 0, changedPageIds: [] };
   }
 
   // Build map for quick lookup
@@ -446,6 +452,7 @@ export async function batchPublishPageLayers(pageIds: string[]): Promise<number>
         id: draft.id,
         page_id: draft.page_id,
         layers: draft.layers,
+        generated_css: draft.generated_css || null,
         content_hash: draft.content_hash,
         is_published: true,
         updated_at: now,
@@ -466,7 +473,10 @@ export async function batchPublishPageLayers(pageIds: string[]): Promise<number>
     }
   }
 
-  return layersToUpsert.length;
+  return {
+    count: layersToUpsert.length,
+    changedPageIds: [...new Set(layersToUpsert.map((l) => l.page_id as string))],
+  };
 }
 
 /**
@@ -491,4 +501,188 @@ export async function getPageLayers(pageId: string): Promise<PageLayers[]> {
   }
 
   return data || [];
+}
+
+export interface AffectedPagesByResource {
+  componentPageIds: string[];
+  stylePageIds: string[];
+  collectionPageIds: string[];
+}
+
+/**
+ * Expand changed component/style IDs through the components table to find
+ * transitive dependencies. If Component B is nested inside Component A,
+ * editing B should also flag A so that pages using A are invalidated.
+ *
+ * Handles arbitrary nesting depth (A > B > C) via iterative expansion.
+ * Also covers styles used inside components: if a changed style ID appears
+ * inside a component's layers, that component ID is added to the result.
+ *
+ * @returns Additional component IDs that transitively reference the changed resources
+ */
+async function expandThroughComponents(
+  client: NonNullable<Awaited<ReturnType<typeof getSupabaseAdmin>>>,
+  componentIds: string[],
+  styleIds: string[],
+): Promise<string[]> {
+  if (componentIds.length === 0 && styleIds.length === 0) return [];
+
+  const { data: allComponents } = await client
+    .from('components')
+    .select('id, layers')
+    .eq('is_published', false)
+    .is('deleted_at', null);
+
+  if (!allComponents || allComponents.length === 0) return [];
+
+  // Pre-stringify all component layers once
+  const componentTexts = allComponents.map(c => ({
+    id: c.id as string,
+    text: c.layers ? JSON.stringify(c.layers) : '',
+  }));
+
+  const expanded = new Set<string>();
+
+  // Phase 1: find components that contain any of the changed style IDs
+  for (const sid of styleIds) {
+    for (const comp of componentTexts) {
+      if (comp.text.includes(sid)) {
+        expanded.add(comp.id);
+      }
+    }
+  }
+
+  // Phase 2: iteratively find components that contain any changed (or
+  // newly discovered) component IDs until the set stabilizes.
+  // Seed the frontier with both the originally changed components AND
+  // components found in Phase 1 (style-containing components also need
+  // transitive expansion — e.g. Style X in Component B in Component A).
+  const frontier = new Set([...componentIds, ...expanded]);
+  const visited = new Set(frontier);
+
+  while (frontier.size > 0) {
+    const nextFrontier = new Set<string>();
+
+    for (const cid of frontier) {
+      for (const comp of componentTexts) {
+        if (comp.id === cid) continue; // skip self
+        if (expanded.has(comp.id) && visited.has(comp.id)) continue;
+        if (comp.text.includes(cid)) {
+          expanded.add(comp.id);
+          if (!visited.has(comp.id)) {
+            visited.add(comp.id);
+            nextFrontier.add(comp.id);
+          }
+        }
+      }
+    }
+
+    frontier.clear();
+    for (const id of nextFrontier) frontier.add(id);
+  }
+
+  return Array.from(expanded);
+}
+
+/**
+ * Find pages affected by changed components, layer styles, and collections
+ * in a single pass over draft page_layers (and pages.settings for collections).
+ *
+ * Searches via JSON.stringify in JS rather than PostgreSQL `::text` cast
+ * through the Supabase client (which URL-encodes `::` and breaks PostgREST).
+ *
+ * Uses draft rows because they always exist and contain the same structural
+ * references (componentId, styleId, collectionId) as published counterparts.
+ */
+export async function findAffectedPages(
+  componentIds: string[],
+  styleIds: string[],
+  collectionIds: string[],
+): Promise<AffectedPagesByResource> {
+  const result: AffectedPagesByResource = {
+    componentPageIds: [],
+    stylePageIds: [],
+    collectionPageIds: [],
+  };
+
+  const hasComponents = componentIds.length > 0;
+  const hasStyles = styleIds.length > 0;
+  const hasCollections = collectionIds.length > 0;
+
+  if (!hasComponents && !hasStyles && !hasCollections) return result;
+
+  const client = await getSupabaseAdmin();
+  if (!client) throw new Error('Supabase client not available for dependency scan');
+
+  // Expand component/style IDs through nested component references so that
+  // editing Component B inside Component A also flags pages using A.
+  const expandedComponentIds = (hasComponents || hasStyles)
+    ? await expandThroughComponents(client, componentIds, styleIds)
+    : [];
+  const allComponentIds = [...new Set([...componentIds, ...expandedComponentIds])];
+  const hasExpandedComponents = allComponentIds.length > 0;
+
+  // Single scan of all draft page_layers
+  const { data: allLayers } = await client
+    .from('page_layers')
+    .select('page_id, layers')
+    .eq('is_published', false)
+    .is('deleted_at', null);
+
+  if (allLayers) {
+    const componentSet = new Set(allComponentIds);
+    const styleSet = new Set(styleIds);
+    const collectionSet = new Set(collectionIds);
+    const componentPages = new Set<string>();
+    const stylePages = new Set<string>();
+    const collectionPages = new Set<string>();
+
+    for (const row of allLayers) {
+      if (!row.layers) continue;
+      const text = JSON.stringify(row.layers);
+
+      if (hasExpandedComponents && !componentPages.has(row.page_id)) {
+        for (const id of componentSet) {
+          if (text.includes(id)) { componentPages.add(row.page_id); break; }
+        }
+      }
+      if (hasStyles && !stylePages.has(row.page_id)) {
+        for (const id of styleSet) {
+          if (text.includes(id)) { stylePages.add(row.page_id); break; }
+        }
+      }
+      if (hasCollections && !collectionPages.has(row.page_id)) {
+        for (const id of collectionSet) {
+          if (text.includes(id)) { collectionPages.add(row.page_id); break; }
+        }
+      }
+    }
+
+    result.componentPageIds = Array.from(componentPages);
+    result.stylePageIds = Array.from(stylePages);
+    result.collectionPageIds = Array.from(collectionPages);
+  }
+
+  // Collections also need pages.settings search (dynamic template pages)
+  if (hasCollections) {
+    const { data: allPages } = await client
+      .from('pages')
+      .select('id, settings')
+      .eq('is_published', false)
+      .is('deleted_at', null);
+
+    if (allPages) {
+      const collectionPageSet = new Set(result.collectionPageIds);
+      for (const page of allPages) {
+        if (!page.settings || collectionPageSet.has(page.id)) continue;
+        const text = JSON.stringify(page.settings);
+        for (const id of collectionIds) {
+          if (text.includes(id)) { collectionPageSet.add(page.id); break; }
+        }
+      }
+      result.collectionPageIds = Array.from(collectionPageSet);
+    }
+  }
+
+  return result;
 }

--- a/lib/repositories/pageRepository.ts
+++ b/lib/repositories/pageRepository.ts
@@ -1059,10 +1059,28 @@ export async function getUnpublishedPages(): Promise<Page[]> {
 }
 
 /**
+ * Get IDs of soft-deleted draft pages (pending hard-delete on next publish).
+ * Used to resolve their routes before deletion so caches can be invalidated.
+ */
+export async function getSoftDeletedPageIds(): Promise<string[]> {
+  const client = await getSupabaseAdmin();
+  if (!client) return [];
+
+  const { data } = await client
+    .from('pages')
+    .select('id')
+    .eq('is_published', false)
+    .not('deleted_at', 'is', null);
+
+  return (data || []).map(p => p.id);
+}
+
+/**
  * Hard-delete soft-deleted draft pages and their published counterparts.
  * Page layers are cleaned up automatically via CASCADE.
+ * Returns deleted page IDs so their cached routes can be invalidated.
  */
-export async function hardDeleteSoftDeletedPages(): Promise<{ count: number }> {
+export async function hardDeleteSoftDeletedPages(): Promise<{ count: number; deletedPageIds: string[] }> {
   const client = await getSupabaseAdmin();
 
   if (!client) {
@@ -1080,7 +1098,7 @@ export async function hardDeleteSoftDeletedPages(): Promise<{ count: number }> {
   }
 
   if (!deletedDrafts || deletedDrafts.length === 0) {
-    return { count: 0 };
+    return { count: 0, deletedPageIds: [] };
   }
 
   const ids = deletedDrafts.map(p => p.id);
@@ -1108,5 +1126,5 @@ export async function hardDeleteSoftDeletedPages(): Promise<{ count: number }> {
     throw new Error(`Failed to delete draft pages: ${draftError.message}`);
   }
 
-  return { count: deletedDrafts.length };
+  return { count: deletedDrafts.length, deletedPageIds: ids };
 }

--- a/lib/server/cssGenerator.ts
+++ b/lib/server/cssGenerator.ts
@@ -5,6 +5,9 @@
  * Used by the /ycode/api/css/generate endpoint so that MCP-created
  * layers (or any API-driven changes) get their CSS generated without
  * needing the browser editor open.
+ *
+ * Also provides per-page CSS generation for targeted cache invalidation:
+ * each page stores its own generated_css so design changes are page-scoped.
  */
 
 import { readFile } from 'node:fs/promises';
@@ -12,9 +15,10 @@ import { join, dirname } from 'node:path';
 import { compile } from 'tailwindcss';
 import type { Layer, Component } from '@/types';
 import { DEFAULT_TEXT_STYLES } from '@/lib/text-format-utils';
-import { getAllDraftLayers } from '@/lib/repositories/pageLayersRepository';
+import { getAllDraftLayers, getDraftLayers } from '@/lib/repositories/pageLayersRepository';
 import { getAllComponents } from '@/lib/repositories/componentRepository';
 import { setSetting } from '@/lib/repositories/settingsRepository';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
 
 /**
  * Extract all Tailwind classes from a layer tree.
@@ -133,4 +137,111 @@ export async function generateAndSaveDraftCSS(): Promise<string> {
   await setSetting('draft_css', css);
 
   return css;
+}
+
+/**
+ * Generate per-page CSS for a single page.
+ *
+ * Extracts classes from the page's draft layers and any components
+ * referenced by those layers, compiles via Tailwind, and stores the
+ * result in the page_layers.generated_css column. The content_hash
+ * is recalculated automatically since it includes generated_css.
+ */
+export async function generateCSSForPage(pageId: string): Promise<string | null> {
+  const pageLayers = await getDraftLayers(pageId);
+  if (!pageLayers?.layers) return null;
+
+  const components = await getAllComponents(false);
+
+  const layersForCss = collectLayersWithComponents(pageLayers.layers, components);
+  const classes = extractClassesFromLayers(layersForCss);
+  const css = await compileCss(Array.from(classes));
+
+  await updatePageGeneratedCss(pageId, pageLayers, css);
+
+  return css;
+}
+
+/**
+ * Generate per-page CSS for multiple pages in batch.
+ * Loads components once and shares them across all pages.
+ */
+export async function generateCSSForPages(pageIds: string[]): Promise<number> {
+  if (pageIds.length === 0) return 0;
+
+  const components = await getAllComponents(false);
+  let updated = 0;
+
+  for (const pageId of pageIds) {
+    const pageLayers = await getDraftLayers(pageId);
+    if (!pageLayers?.layers) continue;
+
+    const layersForCss = collectLayersWithComponents(pageLayers.layers, components);
+    const classes = extractClassesFromLayers(layersForCss);
+    const css = await compileCss(Array.from(classes));
+
+    await updatePageGeneratedCss(pageId, pageLayers, css);
+    updated++;
+  }
+
+  return updated;
+}
+
+/**
+ * Collect a page's layers plus the layers of any components it references.
+ * This ensures the per-page CSS includes all classes needed to render
+ * component instances on that page.
+ */
+function collectLayersWithComponents(pageLayers: Layer[], components: Component[]): Layer[] {
+  const result: Layer[] = [...pageLayers];
+  const componentMap = new Map(components.map(c => [c.id, c]));
+  const visitedComponentIds = new Set<string>();
+
+  function findComponentRefs(layers: Layer[]) {
+    for (const layer of layers) {
+      if (layer.componentId && !visitedComponentIds.has(layer.componentId)) {
+        visitedComponentIds.add(layer.componentId);
+        const component = componentMap.get(layer.componentId);
+        if (component?.layers) {
+          result.push(...component.layers);
+          findComponentRefs(component.layers);
+        }
+      }
+      if (layer.children) {
+        findComponentRefs(layer.children);
+      }
+    }
+  }
+
+  findComponentRefs(pageLayers);
+  return result;
+}
+
+/**
+ * Write generated_css to the draft page_layers row and recalculate its
+ * content_hash so that publish-time hash comparison reflects CSS changes.
+ */
+async function updatePageGeneratedCss(
+  pageId: string,
+  pageLayers: { id: string; layers: Layer[] },
+  css: string,
+): Promise<void> {
+  const { generatePageLayersHash } = await import('@/lib/hash-utils');
+  const client = await getSupabaseAdmin();
+  if (!client) return;
+
+  const contentHash = generatePageLayersHash({
+    layers: pageLayers.layers,
+    generated_css: css,
+  });
+
+  await client
+    .from('page_layers')
+    .update({
+      generated_css: css,
+      content_hash: contentHash,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', pageLayers.id)
+    .eq('is_published', false);
 }

--- a/lib/services/cacheService.ts
+++ b/lib/services/cacheService.ts
@@ -58,6 +58,9 @@ export async function invalidatePages(routePaths: string[]): Promise<boolean> {
  */
 export async function clearAllCache(): Promise<void> {
   try {
+    // 'all-pages' tag is only on global resources (redirects, settings, fonts).
+    // Per-page caches are tagged with route-/<slug> only, so revalidatePath
+    // on the root layout is what actually invalidates every page entry.
     revalidateTag('all-pages', { expire: 0 });
     revalidatePath('/', 'layout');
   } catch (error) {

--- a/lib/services/cacheService.ts
+++ b/lib/services/cacheService.ts
@@ -32,7 +32,6 @@ function chunk<T>(arr: T[], size: number): T[][] {
 export async function invalidatePage(routePath: string): Promise<boolean> {
   try {
     revalidateTag(`route-/${routePath}`, { expire: 0 });
-    revalidatePath(`/${routePath}`, 'page');
     return true;
   } catch (error) {
     console.error('❌ [Cache] Invalidation error:', error);

--- a/lib/services/cacheService.ts
+++ b/lib/services/cacheService.ts
@@ -361,6 +361,45 @@ export async function getRoutePathsForDeletedCollectionItems(
   return [...new Set(routes)];
 }
 
+/**
+ * Invalidate cache for pages affected by a change to a single CMS collection.
+ *
+ * Used by external integrations that mutate published collection items without
+ * going through the builder's publish flow (v1 REST API, Webflow sync, etc.).
+ *
+ * Covers two kinds of dependents:
+ *   - Pages that render a collection-list/collection-grid block of this collection.
+ *   - The dynamic page bound to this collection (one URL per published item).
+ *
+ * For deletes and slug renames, pass the pre-mutation slug(s) in `removedSlugs`
+ * so we can invalidate the old URL — once the item is soft-deleted or renamed,
+ * `getRoutePathsForPages` no longer enumerates it, and the CDN would keep
+ * serving the deleted/old content as a 200.
+ */
+export async function invalidateForCollectionChange(
+  collectionId: string,
+  options: { removedSlugs?: string[] } = {},
+): Promise<{ invalidatedRoutes: string[] }> {
+  const { findAffectedPages } = await import('@/lib/repositories/pageLayersRepository');
+
+  const affected = await findAffectedPages([], [], [collectionId]);
+  const pageIds = affected.collectionPageIds;
+
+  const liveRoutes = pageIds.length > 0 ? await getRoutePathsForPages(pageIds) : [];
+
+  const removedRoutes = (options.removedSlugs && options.removedSlugs.length > 0)
+    ? await getRoutePathsForDeletedCollectionItems(new Map([[collectionId, options.removedSlugs]]))
+    : [];
+
+  const routes = [...new Set([...liveRoutes, ...removedRoutes])];
+
+  if (routes.length > 0) {
+    await invalidatePages(routes);
+  }
+
+  return { invalidatedRoutes: routes };
+}
+
 export interface SelectiveInvalidationResult {
   strategy: 'selective' | 'full';
   invalidatedRoutes: string[];

--- a/lib/services/cacheService.ts
+++ b/lib/services/cacheService.ts
@@ -4,6 +4,16 @@ import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { buildSlugPath } from '@/lib/page-utils';
 import type { Page, PageFolder } from '@/types';
 
+/**
+ * Maximum number of routes to warm in a single invalidation event.
+ *
+ * Warming is a best-effort optimisation, not a correctness requirement —
+ * the long tail of routes will self-warm on their first real visit. The
+ * cap protects against runaway cost when a dynamic page expands to
+ * hundreds of CMS items, and against Vercel function timeout limits.
+ */
+const MAX_ROUTES_TO_WARM = 50;
+
 type SupabaseAdmin = NonNullable<Awaited<ReturnType<typeof getSupabaseAdmin>>>;
 
 const SUPABASE_IN_LIMIT = 500;
@@ -391,4 +401,72 @@ export async function selectiveInvalidation(
   }
 
   return { strategy: 'selective', invalidatedRoutes: routePaths };
+}
+
+/**
+ * Resolve every URL the public site currently serves from published pages.
+ * Includes static pages, locale variants, and every dynamic-page instance
+ * (one URL per published CMS item).
+ *
+ * Used to warm the cache after a full invalidation so the first real
+ * visitor doesn't pay the cold-cache cost.
+ */
+export async function getAllPublishedRoutes(): Promise<string[]> {
+  const client = await getSupabaseAdmin();
+  if (!client) return [];
+
+  const { data: pages } = await client
+    .from('pages')
+    .select('id')
+    .eq('is_published', true)
+    .is('deleted_at', null);
+
+  if (!pages || pages.length === 0) return [];
+
+  return getRoutePathsForPages(pages.map((p) => p.id));
+}
+
+/**
+ * Background-warm a set of routes by issuing GET requests to them, so the
+ * next real visitor sees x-vercel-cache: HIT instead of STALE/MISS.
+ *
+ * Uses Vercel's waitUntil so warming runs AFTER the response is sent: zero
+ * added latency on the triggering request. Capped at MAX_ROUTES_TO_WARM
+ * to bound cost and stay within Vercel function lifetime limits — long
+ * tail of routes self-warms on first real visit.
+ *
+ * Vercel-only: warming via internal fetch only makes sense when there's a
+ * CDN in front of the function. No-ops elsewhere.
+ *
+ * @returns null if not on Vercel, no host header, no routes, or warming
+ *   failed to schedule. Otherwise reports how many were warmed vs total.
+ */
+export async function warmRoutes(
+  routes: string[],
+  request: Request,
+): Promise<{ warmed: number; total: number } | null> {
+  if (process.env.VERCEL !== '1' || routes.length === 0) return null;
+
+  const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host');
+  if (!host) return null;
+
+  const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+  const baseUrl = `${proto}://${host}`;
+  const toWarm = routes.slice(0, MAX_ROUTES_TO_WARM);
+
+  try {
+    const { waitUntil } = await import('@vercel/functions');
+    waitUntil(
+      Promise.allSettled(
+        toWarm.map((route) =>
+          fetch(`${baseUrl}/${route}`, {
+            signal: AbortSignal.timeout(15000),
+          }).catch(() => null),
+        ),
+      ),
+    );
+    return { warmed: toWarm.length, total: routes.length };
+  } catch {
+    return null;
+  }
 }

--- a/lib/services/cacheService.ts
+++ b/lib/services/cacheService.ts
@@ -1,23 +1,37 @@
 import { revalidateTag, revalidatePath } from 'next/cache';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { buildSlugPath } from '@/lib/page-utils';
+import type { Page, PageFolder } from '@/types';
+
+type SupabaseAdmin = NonNullable<Awaited<ReturnType<typeof getSupabaseAdmin>>>;
+
+const SUPABASE_IN_LIMIT = 500;
+
+/** Split an array into chunks safe for Supabase `.in()` queries. */
+function chunk<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
 
 /**
  * Cache Invalidation Service
  *
- * Handles CDN cache invalidation for published pages using Next.js revalidation
+ * Handles CDN cache invalidation for published pages using Next.js revalidation.
+ * Supports both full-site invalidation and selective per-page invalidation.
  */
 
 /**
  * Invalidate cache for a specific page by route path
  * This will clear both the Next.js cache and trigger CDN purge on Vercel
  *
- * @param routePath - Route path
+ * @param routePath - Route path (without leading slash for tag, with for path)
  */
 export async function invalidatePage(routePath: string): Promise<boolean> {
   try {
-    // Revalidate using the cache tag (matches unstable_cache tags)
     revalidateTag(`route-/${routePath}`, { expire: 0 });
-
-    // Revalidate the specific page path (clears full route cache including static generation)
     revalidatePath(`/${routePath}`, 'page');
     return true;
   } catch (error) {
@@ -45,11 +59,304 @@ export async function invalidatePages(routePaths: string[]): Promise<boolean> {
  */
 export async function clearAllCache(): Promise<void> {
   try {
-    // Invalidate Data Cache entries created by public page unstable_cache calls.
     revalidateTag('all-pages', { expire: 0 });
     revalidatePath('/', 'layout');
   } catch (error) {
     console.error('❌ [Cache] Clear all error:', error);
     throw new Error('Failed to clear all cache');
   }
+}
+
+/**
+ * Resolve published page IDs to their route paths (for cache invalidation).
+ * Returns all URL paths each page can be reached at, including locale variants.
+ *
+ * For dynamic pages, enumerates actual collection item slugs rather than
+ * returning a {slug} placeholder (which would never match a real cache tag).
+ */
+export async function getRoutePathsForPages(pageIds: string[]): Promise<string[]> {
+  if (pageIds.length === 0) return [];
+
+  const client = await getSupabaseAdmin();
+  if (!client) return [];
+
+  const [
+    { data: pages },
+    { data: folders },
+    { data: locales },
+    { data: translations },
+  ] = await Promise.all([
+    client.from('pages').select('*').in('id', pageIds).eq('is_published', true).is('deleted_at', null),
+    client.from('page_folders').select('*').eq('is_published', true).is('deleted_at', null),
+    client.from('locales').select('*').is('deleted_at', null),
+    client.from('translations').select('*').eq('is_published', true).is('deleted_at', null),
+  ]);
+
+  if (!pages || !folders) return [];
+
+  const routePaths: string[] = [];
+  const dynamicPages: Page[] = [];
+
+  // Build translations lookup
+  const translationsMap: Record<string, Record<string, string>> = {};
+  if (translations) {
+    for (const t of translations) {
+      if (!translationsMap[t.locale_id]) translationsMap[t.locale_id] = {};
+      const key = `${t.source_type}:${t.source_id}:${t.content_key}`;
+      translationsMap[t.locale_id][key] = t.content_value;
+    }
+  }
+
+  for (const page of pages as Page[]) {
+    if (page.is_dynamic) {
+      dynamicPages.push(page);
+      continue;
+    }
+
+    // Default locale path
+    const defaultPath = buildSlugPath(page, folders as PageFolder[], 'page');
+    const trimmed = defaultPath.slice(1); // Remove leading "/"
+
+    if (page.is_index && page.page_folder_id === null) {
+      routePaths.push('');
+    } else if (trimmed) {
+      routePaths.push(trimmed);
+    }
+
+    // Locale variant paths
+    if (locales) {
+      for (const locale of locales) {
+        if (locale.is_default) continue;
+        const localeTranslations = translationsMap[locale.id] || {};
+
+        const slugParts: string[] = [locale.code];
+
+        let currentFolderId = page.page_folder_id;
+        const folderSegments: string[] = [];
+        while (currentFolderId) {
+          const folder = (folders as PageFolder[]).find(f => f.id === currentFolderId);
+          if (!folder) break;
+          const tKey = `folder:${folder.id}:slug`;
+          folderSegments.unshift(localeTranslations[tKey] || folder.slug);
+          currentFolderId = folder.page_folder_id;
+        }
+        slugParts.push(...folderSegments);
+
+        if (!page.is_index && page.slug) {
+          const pageKey = `page:${page.id}:slug`;
+          slugParts.push(localeTranslations[pageKey] || page.slug);
+        }
+
+        const localePath = slugParts.filter(Boolean).join('/');
+        if (localePath) routePaths.push(localePath);
+      }
+    }
+  }
+
+  // Resolve actual URLs for dynamic pages by enumerating collection item slugs
+  if (dynamicPages.length > 0) {
+    const dynamicRoutes = await resolveDynamicPageRoutes(
+      client, dynamicPages, folders as PageFolder[], locales || [], translationsMap,
+    );
+    routePaths.push(...dynamicRoutes);
+  }
+
+  return [...new Set(routePaths)];
+}
+
+/**
+ * Enumerate all published instance URLs for dynamic (CMS-driven) pages.
+ * Each dynamic page is bound to a collection; we look up the slug field
+ * values of published items to build the real URL paths.
+ */
+async function resolveDynamicPageRoutes(
+  client: SupabaseAdmin,
+  dynamicPages: Page[],
+  folders: PageFolder[],
+  locales: Array<{ id: string; code: string; is_default: boolean }>,
+  translationsMap: Record<string, Record<string, string>>,
+): Promise<string[]> {
+  const routes: string[] = [];
+
+  for (const page of dynamicPages) {
+    const collectionId = (page.settings as any)?.cms?.collection_id;
+    if (!collectionId) continue;
+
+    const { data: slugField } = await client
+      .from('collection_fields')
+      .select('id')
+      .eq('collection_id', collectionId)
+      .eq('key', 'slug')
+      .is('deleted_at', null)
+      .limit(1)
+      .single();
+
+    if (!slugField) continue;
+
+    const { data: items } = await client
+      .from('collection_items')
+      .select('id')
+      .eq('collection_id', collectionId)
+      .eq('is_published', true)
+      .is('deleted_at', null);
+
+    if (!items || items.length === 0) continue;
+
+    const itemIds = items.map(i => i.id);
+    const slugValues: Array<{ item_id: string; value: unknown }> = [];
+    for (const idChunk of chunk(itemIds, SUPABASE_IN_LIMIT)) {
+      const { data } = await client
+        .from('collection_item_values')
+        .select('item_id, value')
+        .eq('field_id', slugField.id)
+        .eq('is_published', true)
+        .is('deleted_at', null)
+        .in('item_id', idChunk);
+      if (data) slugValues.push(...data);
+    }
+
+    if (slugValues.length === 0) continue;
+
+    // Folder base path (everything before the {slug} segment)
+    const basePath = buildSlugPath(page, folders, 'page', '').slice(1).replace(/\/$/, '');
+
+    for (const sv of slugValues) {
+      if (!sv.value) continue;
+      const itemSlug = sv.value as string;
+      const fullPath = basePath ? `${basePath}/${itemSlug}` : itemSlug;
+      routes.push(fullPath);
+
+      // Locale variant paths for each item
+      for (const locale of locales) {
+        if (locale.is_default) continue;
+        const lt = translationsMap[locale.id] || {};
+
+        const slugParts: string[] = [locale.code];
+        let currentFolderId = page.page_folder_id;
+        const folderSegments: string[] = [];
+        while (currentFolderId) {
+          const folder = folders.find(f => f.id === currentFolderId);
+          if (!folder) break;
+          folderSegments.unshift(lt[`folder:${folder.id}:slug`] || folder.slug);
+          currentFolderId = folder.page_folder_id;
+        }
+        slugParts.push(...folderSegments);
+        slugParts.push(itemSlug);
+
+        const localePath = slugParts.filter(Boolean).join('/');
+        if (localePath) routes.push(localePath);
+      }
+    }
+  }
+
+  return routes;
+}
+
+/**
+ * Build route paths for deleted CMS items from their old slug values.
+ * Maps each collection's deleted slugs to the dynamic pages that use that
+ * collection, constructing the full URL paths that should be invalidated.
+ *
+ * @param deletedSlugs - Map of collectionId → array of deleted item slug values
+ */
+export async function getRoutePathsForDeletedCollectionItems(
+  deletedSlugs: Map<string, string[]>,
+): Promise<string[]> {
+  if (deletedSlugs.size === 0) return [];
+
+  const client = await getSupabaseAdmin();
+  if (!client) return [];
+
+  const routes: string[] = [];
+
+  const [
+    { data: dynamicPages },
+    { data: folders },
+    { data: locales },
+  ] = await Promise.all([
+    client.from('pages').select('*').eq('is_published', true).eq('is_dynamic', true).is('deleted_at', null),
+    client.from('page_folders').select('*').eq('is_published', true).is('deleted_at', null),
+    client.from('locales').select('*').is('deleted_at', null),
+  ]);
+
+  if (!dynamicPages || !folders) return [];
+
+  for (const page of dynamicPages as Page[]) {
+    const collectionId = (page.settings as any)?.cms?.collection_id;
+    if (!collectionId) continue;
+
+    const slugs = deletedSlugs.get(collectionId);
+    if (!slugs || slugs.length === 0) continue;
+
+    const basePath = buildSlugPath(page, folders as PageFolder[], 'page', '').slice(1).replace(/\/$/, '');
+
+    for (const itemSlug of slugs) {
+      const fullPath = basePath ? `${basePath}/${itemSlug}` : itemSlug;
+      routes.push(fullPath);
+
+      // Locale-prefixed paths
+      if (locales) {
+        for (const locale of locales) {
+          if (locale.is_default) continue;
+          const slugParts: string[] = [locale.code];
+          let currentFolderId = page.page_folder_id;
+          const folderSegments: string[] = [];
+          while (currentFolderId) {
+            const folder = (folders as PageFolder[]).find(f => f.id === currentFolderId);
+            if (!folder) break;
+            folderSegments.unshift(folder.slug);
+            currentFolderId = folder.page_folder_id;
+          }
+          slugParts.push(...folderSegments);
+          slugParts.push(itemSlug);
+          const localePath = slugParts.filter(Boolean).join('/');
+          if (localePath) routes.push(localePath);
+        }
+      }
+    }
+  }
+
+  return [...new Set(routes)];
+}
+
+export interface SelectiveInvalidationResult {
+  strategy: 'selective' | 'full';
+  invalidatedRoutes: string[];
+  reason?: string;
+}
+
+/**
+ * Perform selective cache invalidation based on what actually changed.
+ *
+ * Receives the exact page IDs that were modified during publish (content_hash
+ * changed, new page, or folder moved) — no guessing via timestamps.
+ * Falls back to full invalidation when global resources changed.
+ *
+ * @param changedPageIds - Page IDs that actually changed during publish (from publishPages)
+ * @param globalChanged - Whether global resources changed (triggers full nuke)
+ * @param indirectlyAffectedPageIds - Page IDs affected by component, style, or collection changes
+ */
+export async function selectiveInvalidation(
+  changedPageIds: string[],
+  globalChanged: boolean,
+  indirectlyAffectedPageIds: string[] = [],
+): Promise<SelectiveInvalidationResult> {
+  if (globalChanged) {
+    await clearAllCache();
+    return { strategy: 'full', invalidatedRoutes: [], reason: 'global resources changed' };
+  }
+
+  const allAffectedIds = [...new Set([...changedPageIds, ...indirectlyAffectedPageIds])];
+
+  if (allAffectedIds.length === 0) {
+    return { strategy: 'selective', invalidatedRoutes: [], reason: 'no pages changed' };
+  }
+
+  const routePaths = await getRoutePathsForPages(allAffectedIds);
+
+  if (routePaths.length > 0) {
+    await invalidatePages(routePaths);
+  }
+
+  return { strategy: 'selective', invalidatedRoutes: routePaths };
 }

--- a/lib/services/cacheService.ts
+++ b/lib/services/cacheService.ts
@@ -1,4 +1,5 @@
 import { revalidateTag, revalidatePath } from 'next/cache';
+import { invalidateByTag } from '@vercel/functions';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { buildSlugPath } from '@/lib/page-utils';
 import type { Page, PageFolder } from '@/types';
@@ -24,14 +25,20 @@ function chunk<T>(arr: T[], size: number): T[][] {
  */
 
 /**
- * Invalidate cache for a specific page by route path
- * This will clear both the Next.js cache and trigger CDN purge on Vercel
+ * Invalidate cache for a specific page by route path.
+ *
+ * Calls both Next.js's revalidateTag (for the in-process data cache and any
+ * unstable_cache entries) AND Vercel's invalidateByTag (which talks directly
+ * to Vercel's CDN purge API for the explicit Vercel-Cache-Tag set on the
+ * page response). The Vercel call no-ops outside Vercel.
  *
  * @param routePath - Route path (without leading slash for tag, with for path)
  */
 export async function invalidatePage(routePath: string): Promise<boolean> {
+  const tag = `route-/${routePath}`;
   try {
-    revalidateTag(`route-/${routePath}`, { expire: 0 });
+    revalidateTag(tag, { expire: 0 });
+    await invalidateByTag(tag);
     return true;
   } catch (error) {
     console.error('❌ [Cache] Invalidation error:', error);
@@ -40,16 +47,25 @@ export async function invalidatePage(routePath: string): Promise<boolean> {
 }
 
 /**
- * Invalidate cache for multiple pages
+ * Invalidate cache for multiple pages.
+ * Uses Vercel's batched invalidateByTag (supports an array) for the CDN purge,
+ * and revalidateTag per-route for Next.js's data cache.
  *
  * @param routePaths - Array of route paths
  */
 export async function invalidatePages(routePaths: string[]): Promise<boolean> {
-  const results = await Promise.all(
-    routePaths.map((routePath) => invalidatePage(routePath))
-  );
-
-  return results.every((result) => result);
+  if (routePaths.length === 0) return true;
+  try {
+    const tags = routePaths.map((p) => `route-/${p}`);
+    for (const tag of tags) {
+      revalidateTag(tag, { expire: 0 });
+    }
+    await invalidateByTag(tags);
+    return true;
+  } catch (error) {
+    console.error('❌ [Cache] Invalidation error:', error);
+    return false;
+  }
 }
 
 /**
@@ -63,6 +79,10 @@ export async function clearAllCache(): Promise<void> {
     // on the root layout is what actually invalidates every page entry.
     revalidateTag('all-pages', { expire: 0 });
     revalidatePath('/', 'layout');
+
+    // Also purge Vercel's CDN by the 'all-pages' tag for any page responses
+    // that have it set as a Vercel-Cache-Tag. No-ops outside Vercel.
+    await invalidateByTag('all-pages');
   } catch (error) {
     console.error('❌ [Cache] Clear all error:', error);
     throw new Error('Failed to clear all cache');

--- a/lib/services/cacheService.ts
+++ b/lib/services/cacheService.ts
@@ -27,18 +27,25 @@ function chunk<T>(arr: T[], size: number): T[][] {
 /**
  * Invalidate cache for a specific page by route path.
  *
- * Calls both Next.js's revalidateTag (for the in-process data cache and any
- * unstable_cache entries) AND Vercel's invalidateByTag (which talks directly
- * to Vercel's CDN purge API for the explicit Vercel-Cache-Tag set on the
- * page response). The Vercel call no-ops outside Vercel.
+ * On Vercel: uses invalidateByTag exclusively, which talks directly to Vercel's
+ * CDN purge API and covers all three cache layers (CDN, Runtime, Data). We
+ * deliberately avoid revalidateTag here because Next.js bug #63509 causes it
+ * to cascade-invalidate other tags consumed by the page render, breaking
+ * selective invalidation on Vercel.
+ *
+ * On self-hosted (no Vercel runtime): invalidateByTag no-ops, so we fall
+ * back to revalidateTag to clear the in-process Next.js data cache.
  *
  * @param routePath - Route path (without leading slash for tag, with for path)
  */
 export async function invalidatePage(routePath: string): Promise<boolean> {
   const tag = `route-/${routePath}`;
   try {
-    revalidateTag(tag, { expire: 0 });
-    await invalidateByTag(tag);
+    if (process.env.VERCEL === '1') {
+      await invalidateByTag(tag);
+    } else {
+      revalidateTag(tag, { expire: 0 });
+    }
     return true;
   } catch (error) {
     console.error('❌ [Cache] Invalidation error:', error);
@@ -48,8 +55,7 @@ export async function invalidatePage(routePath: string): Promise<boolean> {
 
 /**
  * Invalidate cache for multiple pages.
- * Uses Vercel's batched invalidateByTag (supports an array) for the CDN purge,
- * and revalidateTag per-route for Next.js's data cache.
+ * Uses Vercel's batched invalidateByTag on Vercel, revalidateTag elsewhere.
  *
  * @param routePaths - Array of route paths
  */
@@ -57,10 +63,13 @@ export async function invalidatePages(routePaths: string[]): Promise<boolean> {
   if (routePaths.length === 0) return true;
   try {
     const tags = routePaths.map((p) => `route-/${p}`);
-    for (const tag of tags) {
-      revalidateTag(tag, { expire: 0 });
+    if (process.env.VERCEL === '1') {
+      await invalidateByTag(tags);
+    } else {
+      for (const tag of tags) {
+        revalidateTag(tag, { expire: 0 });
+      }
     }
-    await invalidateByTag(tags);
     return true;
   } catch (error) {
     console.error('❌ [Cache] Invalidation error:', error);
@@ -74,15 +83,16 @@ export async function invalidatePages(routePaths: string[]): Promise<boolean> {
  */
 export async function clearAllCache(): Promise<void> {
   try {
-    // 'all-pages' tag is only on global resources (redirects, settings, fonts).
-    // Per-page caches are tagged with route-/<slug> only, so revalidatePath
-    // on the root layout is what actually invalidates every page entry.
-    revalidateTag('all-pages', { expire: 0 });
-    revalidatePath('/', 'layout');
-
-    // Also purge Vercel's CDN by the 'all-pages' tag for any page responses
-    // that have it set as a Vercel-Cache-Tag. No-ops outside Vercel.
-    await invalidateByTag('all-pages');
+    if (process.env.VERCEL === '1') {
+      // Vercel: direct CDN purge by the 'all-pages' tag set on every page
+      // response. Covers CDN, Runtime, and Data caches in one call. Avoids
+      // revalidateTag's cascade bug (#63509).
+      await invalidateByTag('all-pages');
+    } else {
+      // Self-hosted: clear Next.js's in-process caches.
+      revalidateTag('all-pages', { expire: 0 });
+      revalidatePath('/', 'layout');
+    }
   } catch (error) {
     console.error('❌ [Cache] Clear all error:', error);
     throw new Error('Failed to clear all cache');

--- a/lib/services/collectionService.ts
+++ b/lib/services/collectionService.ts
@@ -45,6 +45,9 @@ export interface PublishCollectionResult {
     fieldsCount: number;
     itemsCount: number;
     valuesCount: number;
+    deletedItemsCount: number;
+    deletedItemSlugs: string[];
+    renamedItemOldSlugs: string[];
   };
   timing?: {
     collections: OperationTiming;
@@ -103,6 +106,9 @@ export async function publishCollectionWithItems(
       fieldsCount: 0,
       itemsCount: 0,
       valuesCount: 0,
+      deletedItemsCount: 0,
+      deletedItemSlugs: [],
+      renamedItemOldSlugs: [],
     },
     timing: {
       collections: { durationMs: 0, count: 0 },
@@ -149,12 +155,13 @@ export async function publishCollectionWithItems(
 
       // Step 3: Publish selected items
       const itemsStart = performance.now();
-      const { itemsCount, valuesCount, itemsDurationMs, valuesDurationMs } = await publishSelectedItems(
+      const { itemsCount, valuesCount, itemsDurationMs, valuesDurationMs, renamedItemOldSlugs } = await publishSelectedItems(
         collectionId,
         itemIds
       );
       result.published.itemsCount = itemsCount;
       result.published.valuesCount = valuesCount;
+      result.published.renamedItemOldSlugs = renamedItemOldSlugs;
       result.timing!.items = {
         durationMs: itemsDurationMs,
         count: itemsCount,
@@ -165,7 +172,9 @@ export async function publishCollectionWithItems(
       };
 
       // Step 4: Clean up soft-deleted items in published version
-      await cleanupDeletedPublishedItems(collectionId);
+      const cleanup = await cleanupDeletedPublishedItems(collectionId);
+      result.published.deletedItemsCount = cleanup.deletedCount;
+      result.published.deletedItemSlugs = cleanup.deletedSlugs;
       await cleanupDeletedPublishedFields(collectionId);
     });
 
@@ -398,7 +407,7 @@ async function publishAllFields(collectionId: string): Promise<number> {
 async function publishSelectedItems(
   collectionId: string,
   itemIds?: string[]
-): Promise<{ itemsCount: number; valuesCount: number; itemsDurationMs: number; valuesDurationMs: number }> {
+): Promise<{ itemsCount: number; valuesCount: number; itemsDurationMs: number; valuesDurationMs: number; renamedItemOldSlugs: string[] }> {
   const client = await getSupabaseAdmin();
 
   if (!client) {
@@ -416,14 +425,14 @@ async function publishSelectedItems(
   }
 
   if (itemsToPublish.length === 0) {
-    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0 };
+    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [] };
   }
 
   // Batch fetch all draft items to publish
   const draftItems = await getItemsByIds(itemsToPublish, false);
 
   if (draftItems.length === 0) {
-    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0 };
+    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [] };
   }
 
   // Separate publishable from non-publishable items
@@ -441,7 +450,7 @@ async function publishSelectedItems(
   }
 
   if (publishableItems.length === 0) {
-    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0 };
+    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [] };
   }
 
   // Fetch existing published items for comparison
@@ -460,10 +469,17 @@ async function publishSelectedItems(
   for (const item of publishableItems) {
     const existing = publishedItemsById.get(item.id);
 
+    // Only compare content_hash when both sides have a value — null draft
+    // hashes (pre-backfill items) would otherwise always appear "changed."
+    // Value-level comparison in publishItemValuesBatch catches real changes.
+    const hashChanged = item.content_hash != null
+      && existing?.content_hash != null
+      && existing.content_hash !== item.content_hash;
+
     const metadataChanged = !existing
       || existing.manual_order !== item.manual_order
       || existing.is_publishable !== item.is_publishable
-      || existing.content_hash !== item.content_hash;
+      || hashChanged;
 
     if (!metadataChanged) {
       itemIdsToPublishValues.push(item.id);
@@ -498,12 +514,57 @@ async function publishSelectedItems(
 
   const itemsDurationMs = Math.round(performance.now() - itemsStart);
 
+  // Snapshot old published slug values before overwriting (for rename detection)
+  const renamedItemOldSlugs: string[] = [];
+  try {
+    const { data: slugField } = await client
+      .from('collection_fields')
+      .select('id')
+      .eq('collection_id', collectionId)
+      .eq('key', 'slug')
+      .is('deleted_at', null)
+      .limit(1)
+      .single();
+
+    if (slugField) {
+      const { data: oldPublishedSlugs } = await client
+        .from('collection_item_values')
+        .select('item_id, value')
+        .eq('field_id', slugField.id)
+        .eq('is_published', true)
+        .is('deleted_at', null)
+        .in('item_id', itemIdsToPublishValues);
+
+      const { data: draftSlugs } = await client
+        .from('collection_item_values')
+        .select('item_id, value')
+        .eq('field_id', slugField.id)
+        .eq('is_published', false)
+        .is('deleted_at', null)
+        .in('item_id', itemIdsToPublishValues);
+
+      if (oldPublishedSlugs && draftSlugs) {
+        const oldByItem = new Map(oldPublishedSlugs.map(s => [s.item_id, s.value as string]));
+        const newByItem = new Map(draftSlugs.map(s => [s.item_id, s.value as string]));
+
+        for (const [itemId, oldSlug] of oldByItem) {
+          const newSlug = newByItem.get(itemId);
+          if (oldSlug && newSlug && oldSlug !== newSlug) {
+            renamedItemOldSlugs.push(oldSlug);
+          }
+        }
+      }
+    }
+  } catch {
+    // Non-fatal: slug rename detection failure doesn't block publish
+  }
+
   // Time values publishing (pass all item IDs - values comparison happens inside)
   const valuesStart = performance.now();
   const valuesCount = await publishItemValuesBatch(itemIdsToPublishValues);
   const valuesDurationMs = Math.round(performance.now() - valuesStart);
 
-  return { itemsCount: itemsToUpsert.length, valuesCount, itemsDurationMs, valuesDurationMs };
+  return { itemsCount: itemsToUpsert.length, valuesCount, itemsDurationMs, valuesDurationMs, renamedItemOldSlugs };
 }
 
 /**
@@ -660,18 +721,21 @@ async function hasValueChanges(itemId: string): Promise<boolean> {
 }
 
 /**
- * Clean up soft-deleted items in both draft and published versions
- * Uses batch DELETE for efficiency
- * If a draft item is soft-deleted, permanently remove both draft and published versions
+ * Clean up soft-deleted items in both draft and published versions.
+ * Snapshots published slug values before deletion so the caller can
+ * invalidate stale cached dynamic-page URLs.
+ *
+ * @returns Number of deleted items and their former published slug values
  */
-async function cleanupDeletedPublishedItems(collectionId: string): Promise<void> {
+async function cleanupDeletedPublishedItems(
+  collectionId: string,
+): Promise<{ deletedCount: number; deletedSlugs: string[] }> {
   const client = await getSupabaseAdmin();
 
   if (!client) {
     throw new Error('Supabase client not configured');
   }
 
-  // Get all soft-deleted items from draft (with pagination for >1000 items)
   const deletedDraftItems = await getAllItemsByCollectionId(
     collectionId,
     false,
@@ -679,25 +743,66 @@ async function cleanupDeletedPublishedItems(collectionId: string): Promise<void>
   );
 
   if (deletedDraftItems.length === 0) {
-    return;
+    return { deletedCount: 0, deletedSlugs: [] };
   }
 
-  // Extract item IDs
   const deletedItemIds = deletedDraftItems.map(item => item.id);
 
+  // Snapshot published slug values before deletion (for cache invalidation)
+  let deletedSlugs: string[] = [];
+  try {
+    const { data: slugField } = await client
+      .from('collection_fields')
+      .select('id')
+      .eq('collection_id', collectionId)
+      .eq('key', 'slug')
+      .is('deleted_at', null)
+      .limit(1)
+      .single();
+
+    if (slugField) {
+      const allSlugValues: Array<{ value: unknown }> = [];
+      for (let i = 0; i < deletedItemIds.length; i += 500) {
+        const batch = deletedItemIds.slice(i, i + 500);
+        const { data } = await client
+          .from('collection_item_values')
+          .select('value')
+          .eq('field_id', slugField.id)
+          .eq('is_published', true)
+          .is('deleted_at', null)
+          .in('item_id', batch);
+        if (data) allSlugValues.push(...data);
+      }
+
+      deletedSlugs = allSlugValues
+        .map(sv => sv.value as string)
+        .filter(Boolean);
+    }
+  } catch {
+    // Non-fatal: proceed with deletion even if slug snapshot fails
+  }
+
   // Batch hard delete published versions (CASCADE will delete values)
-  await client
-    .from('collection_items')
-    .delete()
-    .in('id', deletedItemIds)
-    .eq('is_published', true);
+  for (let i = 0; i < deletedItemIds.length; i += 500) {
+    const batch = deletedItemIds.slice(i, i + 500);
+    await client
+      .from('collection_items')
+      .delete()
+      .in('id', batch)
+      .eq('is_published', true);
+  }
 
   // Batch hard delete draft versions (CASCADE will delete values)
-  await client
-    .from('collection_items')
-    .delete()
-    .in('id', deletedItemIds)
-    .eq('is_published', false);
+  for (let i = 0; i < deletedItemIds.length; i += 500) {
+    const batch = deletedItemIds.slice(i, i + 500);
+    await client
+      .from('collection_items')
+      .delete()
+      .in('id', batch)
+      .eq('is_published', false);
+  }
+
+  return { deletedCount: deletedItemIds.length, deletedSlugs };
 }
 
 /**

--- a/lib/services/pageService.ts
+++ b/lib/services/pageService.ts
@@ -11,6 +11,8 @@ import { getKnexClient } from '../knex-client';
 import { getPublishedPagesByIds } from '@/lib/repositories/pageRepository';
 import { batchPublishPageLayers } from '@/lib/repositories/pageLayersRepository';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { buildSlugPath } from '@/lib/page-utils';
+import type { Page, PageFolder } from '@/types';
 
 /**
  * Helper: Generate a unique slug from a page name
@@ -157,6 +159,10 @@ export async function fixOrphanedPageSlugs(
 /** Result of page publishing with timing */
 export interface PublishPagesResult {
   count: number;
+  /** Page IDs that were actually upserted (content changed, new, or folder moved) */
+  changedPageIds: string[];
+  /** Route paths that no longer exist because a page's slug or folder changed */
+  renamedPageOldRoutes: string[];
   timing: {
     pagesDurationMs: number;
     layersDurationMs: number;
@@ -173,7 +179,7 @@ export interface PublishPagesResult {
  */
 export async function publishPages(pageIds: string[]): Promise<PublishPagesResult> {
   if (pageIds.length === 0) {
-    return { count: 0, timing: { pagesDurationMs: 0, layersDurationMs: 0, layersCount: 0 } };
+    return { count: 0, changedPageIds: [], renamedPageOldRoutes: [], timing: { pagesDurationMs: 0, layersDurationMs: 0, layersCount: 0 } };
   }
 
   // Import folder functions
@@ -205,7 +211,7 @@ export async function publishPages(pageIds: string[]): Promise<PublishPagesResul
   );
 
   if (validDraftPages.length === 0) {
-    return { count: 0, timing: { pagesDurationMs: 0, layersDurationMs: 0, layersCount: 0 } };
+    return { count: 0, changedPageIds: [], renamedPageOldRoutes: [], timing: { pagesDurationMs: 0, layersDurationMs: 0, layersCount: 0 } };
   }
 
   // Step 2: Collect all unique folder IDs from pages
@@ -361,6 +367,34 @@ export async function publishPages(pageIds: string[]): Promise<PublishPagesResul
     }
   }
 
+  // Capture old route paths for pages whose slug or folder changed so the
+  // old URLs can be invalidated (prevents stale caches at the previous URL)
+  const renamedPageOldRoutes: string[] = [];
+  const publishedFoldersArray = publishedFolders as PageFolder[];
+
+  for (const upsertPage of pagesToUpsert) {
+    const oldPublished = publishedPagesById.get(upsertPage.id);
+    if (!oldPublished) continue; // new page, no old route
+
+    const slugChanged = oldPublished.slug !== upsertPage.slug;
+    const folderChanged = oldPublished.page_folder_id !== upsertPage.page_folder_id;
+
+    if (slugChanged || folderChanged) {
+      const oldPath = buildSlugPath(
+        oldPublished as Page,
+        publishedFoldersArray,
+        'page',
+      );
+      const trimmed = oldPath.slice(1); // remove leading "/"
+
+      if (oldPublished.is_index && oldPublished.page_folder_id === null) {
+        renamedPageOldRoutes.push('');
+      } else if (trimmed) {
+        renamedPageOldRoutes.push(trimmed);
+      }
+    }
+  }
+
   // Step 8a: Remove published pages that would violate slug+folder+error_page unique
   // constraint (same slug/folder/error_page but different id – e.g. replaced/renamed page).
   // Dynamic pages are excluded because the DB unique index skips them (is_dynamic = false)
@@ -469,15 +503,23 @@ export async function publishPages(pageIds: string[]): Promise<PublishPagesResul
 
   // Time layers publishing
   const layersStart = performance.now();
-  const layersCount = await batchPublishPageLayers(pageIdsForLayerPublish);
+  const layersResult = await batchPublishPageLayers(pageIdsForLayerPublish);
   const layersDurationMs = Math.round(performance.now() - layersStart);
+
+  // Merge changed IDs from both pages table and page_layers table
+  const allChangedIds = [...new Set([
+    ...pagesToUpsert.map((p) => p.id),
+    ...layersResult.changedPageIds,
+  ])];
 
   return {
     count: pagesToUpsert.length,
+    changedPageIds: allChangedIds,
+    renamedPageOldRoutes,
     timing: {
       pagesDurationMs,
       layersDurationMs,
-      layersCount,
+      layersCount: layersResult.count,
     },
   };
 }

--- a/lib/supabase-config-parser.ts
+++ b/lib/supabase-config-parser.ts
@@ -23,8 +23,14 @@ function replacePasswordPlaceholder(connectionUrl: string, password: string): st
  */
 function tryExtractProjectId(connectionUrl: string): string | null {
   // Pooler format: postgresql://postgres.abc123:...
-  const match = connectionUrl.match(/\/\/postgres\.([a-z0-9]+):/);
-  return match ? match[1] : null;
+  const poolerMatch = connectionUrl.match(/\/\/postgres\.([a-z0-9]+):/);
+  if (poolerMatch) return poolerMatch[1];
+
+  // Direct format: postgresql://postgres:...@db.abc123.supabase.co:...
+  const directMatch = connectionUrl.match(/@db\.([a-z0-9]+)\.supabase\.co[:/]/);
+  if (directMatch) return directMatch[1];
+
+  return null;
 }
 
 /**

--- a/next.config.ts
+++ b/next.config.ts
@@ -81,14 +81,12 @@ const nextConfig: NextConfig = {
       },
       {
         // Apply to public pages ONLY (exclude /ycode/*, /_next/*, /a/*)
+        // NOTE: Do NOT set Cache-Control here. Vercel recommends letting
+        // ISR manage cache headers automatically so per-URL cache-tag
+        // tracking works for selective revalidateTag invalidations.
+        // Manual s-maxage breaks per-URL purging on catch-all routes.
         source: '/:path((?!ycode|_next|a/).*)*',
         headers: [
-          {
-            key: 'Cache-Control',
-            // Cache until re-published: CDN caches for up to 1 year
-            // On publish, revalidatePath purges CDN; revalidateTag purges data cache
-            value: 'public, s-maxage=31536000, stale-while-revalidate=31536000',
-          },
           {
             // Open the TLS connection to fonts.gstatic.com while the document
             // is still streaming so woff2 binaries can be fetched the moment

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ycode",
-  "version": "1.4.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ycode",
-      "version": "1.4.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -49,6 +49,7 @@
         "@tiptap/pm": "^3.10.5",
         "@tiptap/react": "^3.10.7",
         "@tiptap/starter-kit": "^3.10.7",
+        "@vercel/functions": "^3.5.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "gsap": "^3.13.0",
@@ -5116,6 +5117,35 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.5.1.tgz",
+      "integrity": "sha512-ndh5v+uhWqGA8033oD0i0KHvqUHcLlLCOaLOw5L+xx5zVsWUSQcZPKEYk2nm51aisnKhcnTylxnOmhx+w4UCRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.4.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.4.1.tgz",
+      "integrity": "sha512-H6B+/ig/GoahccL3WZjiHayHw1H5KhvTJNceqYulwfK9kkz5iul2hTmYzcJ7tTCQzyd0dutuL9xYFZCyLUqsog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@tiptap/pm": "^3.10.5",
     "@tiptap/react": "^3.10.7",
     "@tiptap/starter-kit": "^3.10.7",
+    "@vercel/functions": "^3.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "gsap": "^3.13.0",

--- a/stores/useComponentsStore.ts
+++ b/stores/useComponentsStore.ts
@@ -592,22 +592,36 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
 
         // Regenerate CSS to include updated component classes.
         // Run this off the critical path so navigation/UI is not blocked.
-        // Only collect layers from pages that actually contain an instance
-        // of this component (plus the component's own layers).
         scheduleIdle(async () => {
           try {
-            const { generateAndSaveCSS } = await import('@/lib/client/cssGenerator');
             const { usePagesStore } = await import('./usePagesStore');
             const { containsComponent } = await import('@/lib/component-utils');
 
-            const allLayers: Layer[] = [...layersBeingSaved];
+            // Find pages that use this component and regenerate their per-page CSS
             const allDrafts = usePagesStore.getState().draftsByPageId;
+            const affectedPageIds: string[] = [];
+            Object.entries(allDrafts).forEach(([pid, pageDraft]) => {
+              if (pageDraft.layers && containsComponent(pageDraft.layers, componentId)) {
+                affectedPageIds.push(pid);
+              }
+            });
+
+            if (affectedPageIds.length > 0) {
+              fetch('/ycode/api/css/generate-pages', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ pageIds: affectedPageIds }),
+              }).catch(() => {});
+            }
+
+            // Also regenerate global draft_css for builder preview
+            const { generateAndSaveCSS } = await import('@/lib/client/cssGenerator');
+            const allLayers: Layer[] = [...layersBeingSaved];
             Object.values(allDrafts).forEach((pageDraft) => {
               if (pageDraft.layers && containsComponent(pageDraft.layers, componentId)) {
                 allLayers.push(...pageDraft.layers);
               }
             });
-
             await generateAndSaveCSS(allLayers);
           } catch (cssError) {
             console.error('Failed to generate CSS after component save:', cssError);

--- a/stores/usePagesStore.ts
+++ b/stores/usePagesStore.ts
@@ -511,11 +511,18 @@ export const usePagesStore = create<PagesStore>((set, get) => ({
           // The new state will trigger another auto-save which will record its own version
         }
 
-        // After successfully saving the draft, generate and save CSS from ALL pages
+        // After successfully saving the draft, generate per-page CSS server-side
+        // and also regenerate the global draft_css for builder preview
         try {
-          const { generateAndSaveCSS } = await import('@/lib/client/cssGenerator');
+          // Per-page CSS: generate server-side for just this page (background, non-blocking)
+          fetch('/ycode/api/css/generate-pages', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ pageIds: [pageId] }),
+          }).catch(() => {});
 
-          // Collect layers from ALL pages for comprehensive CSS generation
+          // Global draft_css: still needed for builder preview
+          const { generateAndSaveCSS } = await import('@/lib/client/cssGenerator');
           const allLayers: Layer[] = [];
           const allDrafts = get().draftsByPageId;
           Object.values(allDrafts).forEach((pageDraft) => {
@@ -523,11 +530,9 @@ export const usePagesStore = create<PagesStore>((set, get) => ({
               allLayers.push(...pageDraft.layers);
             }
           });
-
           await generateAndSaveCSS(allLayers);
         } catch (cssError) {
           console.error('Failed to generate CSS after save:', cssError);
-          // Don't fail the save operation if CSS generation fails
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

Replace the blunt "nuke all caches on every publish" with dependency-aware
selective invalidation, so a text edit on one page no longer cold-renders
every page on the site. Falls back to a full purge for true global changes
(color variables, redirects, settings, custom code) and warms invalidated
routes in the background so the first visit is a HIT, not a cold render.

## Changes

### Per-page CSS + dependency tracking
- Generate and persist CSS per page (`page_layers.generated_css`) so each
  page's render is self-contained instead of depending on a global CSS file.
- Add `content_hash` to `pages`, `page_layers`, `components`, `layer_styles`,
  `collection_items`, and a `color_variables_published_hash` setting so we
  can detect what actually changed at publish time without timestamp guessing.
- Server-side dependency scan finds pages that reference changed components,
  layer styles, or collections (including nested component-in-component
  refs) so indirect changes invalidate the right pages.

### Cache invalidation strategy
- `selectiveInvalidation` purges only the routes whose content actually
  changed, plus pages that depend on them through shared resources.
- `clearAllCache` fallback for global changes (color variables, locales,
  settings that affect every page, redirects).
- Vercel path: route exclusively through `invalidateByTag` from
  `@vercel/functions` to dodge Next.js bug #63509 (`revalidateTag`
  cascading to every tag on a shared cache entry).
- Self-hosted path: uses `revalidateTag` + `revalidatePath` as before.
- Per-page `unstable_cache` entries carry both `route-/X` and `all-pages`
  tags so selective and full invalidation each hit the right scope.
- Background warming via `waitUntil` after invalidation so the first
  visitor sees `x-vercel-cache: HIT` rather than `STALE` or cold MISS.
  Capped at 50 routes per event.

### Bypass paths plugged
- `applyTemplate`: full purge + warm. Previously did no invalidation, so
  the CDN kept serving the previous site after a template swap.
- `reset-db`: replaces `revalidatePath` with `clearAllCache` so the CDN
  is actually cleared after dropping the public schema.
- v1 REST API for collection items (POST/PUT/PATCH/DELETE): selective
  invalidation via new `invalidateForCollectionChange` helper. Captures
  pre-mutation slug so rename/delete cases invalidate the stale URL the
  CDN is still serving.
- Webflow migrate: full purge + warm after the bulk import.
- Project import: added warming after the existing `clearAllCache`.
- Settings endpoints (single + batch): warm after `clearAllCache` so
  favicon/redirects/GA/custom-code changes are visible without manual
  refresh.
- `DRAFT_ONLY_SETTING_KEYS` denylist stops `draft_css` autosaves from
  purging the public cache on every keystroke in the builder.

### Correctness fixes uncovered along the way
- Layer style updates now propagate to all pages using them: server-side
  `syncLayerStyleChangesToDrafts` rewrites denormalised layer classes on
  every affected draft before publish, then re-publishes those page layers.
- Fixed a composite-primary-key bug in `syncLayerStyleChangesToDrafts`
  where missing `is_published=false` filters were silently overwriting
  published rows with new layers but stale `generated_css`.

## Out of scope (follow-up)
- Builder's `/ycode/api/collections/[id]/items` POST and `.../status` PUT
  still use full `clearAllCache` — could be selective. Correct but heavier
  than needed.
- Composite-PK bugs in `templateService.ts` (assets, fonts) and
  `pageService.ts` (orphaned slugs, sibling orders) — same class of bug
  we fixed in `layerStyleRepository.ts`, surfaced during the audit but
  out of scope for the cache PR.

## Test plan

- [ ] Publish a text change on one page — only that page's route appears in `[Cache] selective invalidation: N route(s)`
- [ ] Edit a component used on 3 pages — exactly those 3 pages invalidate
- [ ] Edit a layer style used on 3 pages — all 3 pages render the new style, log shows CSS catch-up + warming
- [ ] Change a color variable — full invalidation, warming covers every page
- [ ] Change a global setting (favicon, GA ID, custom head/body, redirects) — full invalidation + warm
- [ ] Edit a CMS item title — only collection-list pages + the item's dynamic page invalidate
- [ ] Delete a page — that route's old URL is purged (no longer serves a 200 from cache)
- [ ] Rename a CMS item slug — old URL no longer cached, new URL renders
- [ ] Apply a template — public site immediately shows template content, first visit is HIT
- [ ] Reset project — CDN stops serving previous content
- [ ] v1 API POST a new CMS item — collection-list pages and dynamic page rerender to include it
- [ ] v1 API DELETE an item — its dynamic-page URL stops serving the deleted content
- [ ] Multiple draft autosaves in the builder — no cache invalidation happens (only the publish action does)
- [ ] Self-hosted (non-Vercel) deploy — `revalidateTag` fallback path still works


Made with [Cursor](https://cursor.com)