### PR TITLE
fix: correct canvas scrollbar behavior in fit width/height modes

### DIFF
--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -831,15 +831,16 @@ const CenterCanvas = React.memo(function CenterCanvas({
     iframeRef,
   });
 
-  // Calculate final iframe height — always stretch so the scaled canvas fills the
-  // visible viewport at any zoom level. When the actual content is taller than the
-  // viewport, use the content height instead so scrolling works naturally.
+  // Size the iframe element to exactly fill the visible canvas area at the
+  // current zoom. The iframe's native scrolling then handles document content
+  // taller than this — giving a single, properly-bounded scrollbar inside the
+  // canvas instead of an (invisible) outer container scroll. Content height
+  // (iframeContentHeight) still drives Fit Height zoom calc separately.
   const finalIframeHeight = useMemo(() => {
     if (editingComponentId) return iframeContentHeight;
     if (!containerHeight || zoom <= 0) return iframeContentHeight;
 
-    const minHeightForZoom = (containerHeight - CANVAS_PADDING) / (zoom / 100);
-    return Math.max(iframeContentHeight, minHeightForZoom);
+    return (containerHeight - CANVAS_PADDING) / (zoom / 100);
   }, [iframeContentHeight, containerHeight, zoom, editingComponentId]);
 
   const previewObserverRef = useRef<ResizeObserver | null>(null);

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -589,6 +589,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
   const canvasContainerRef = useRef<HTMLDivElement>(null);
   const previewContainerRef = useRef<HTMLDivElement>(null);
   const [previewContentHeight, setPreviewContentHeight] = useState(0);
+  const [previewContainerHeight, setPreviewContainerHeight] = useState(0);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   // State for iframe element (for SelectionOverlay)
@@ -843,6 +844,17 @@ const CenterCanvas = React.memo(function CenterCanvas({
     return (containerHeight - CANVAS_PADDING) / (zoom / 100);
   }, [iframeContentHeight, containerHeight, zoom, editingComponentId]);
 
+  // Same logic as finalIframeHeight, applied to the preview iframe. Sizing the
+  // wrapper to the measured scrollHeight is unstable on pages that pin absolute
+  // elements to the viewport (e.g. `bottom: -6rem` with no positioned ancestor)
+  // — once `h-full` is restored after measurement, those elements extend past
+  // the wrapper. Sizing to the visible container area instead lets the iframe
+  // scroll internally and keeps the scrollbar bounded and accurate.
+  const finalPreviewIframeHeight = useMemo(() => {
+    if (!previewContainerHeight || previewZoom <= 0) return 0;
+    return (previewContainerHeight - CANVAS_PADDING) / (previewZoom / 100);
+  }, [previewContainerHeight, previewZoom]);
+
   const previewObserverRef = useRef<ResizeObserver | null>(null);
 
   /** Measure the preview iframe content and set up a ResizeObserver for re-measurement */
@@ -965,32 +977,38 @@ const CenterCanvas = React.memo(function CenterCanvas({
   const isInitialScrollRef = useRef(true);
 
   const scrollCanvasToLayer = useCallback((layerId: string, smooth: boolean, force = false) => {
-    const scrollEl = scrollContainerRef.current;
-    if (!canvasIframeElement || !scrollEl) return;
+    if (!canvasIframeElement) return;
 
     const iframeDoc = canvasIframeElement.contentDocument;
-    if (!iframeDoc) return;
+    const iframeWin = canvasIframeElement.contentWindow;
+    if (!iframeDoc || !iframeWin) return;
 
     const el = iframeDoc.querySelector(`[data-layer-id="${layerId}"]`) as HTMLElement;
     if (!el) return;
 
+    // Scrolling happens inside the iframe (the iframe element is sized to the
+    // visible canvas area; its own document handles overflow). All coordinates
+    // here are in the iframe's coordinate system, so zoom doesn't apply.
+    const scrollEl = iframeDoc.scrollingElement || iframeDoc.documentElement;
     const elRect = el.getBoundingClientRect();
-    const iframeRect = canvasIframeElement.getBoundingClientRect();
-    const zoomScale = zoom / 100;
-    const elTopInScroll = iframeRect.top - scrollEl.getBoundingClientRect().top + scrollEl.scrollTop + elRect.top * zoomScale;
-    const elBottomInScroll = elTopInScroll + elRect.height * zoomScale;
-    const viewTop = scrollEl.scrollTop;
-    const viewBottom = scrollEl.scrollTop + scrollEl.clientHeight;
+    const currentScroll = scrollEl.scrollTop;
+    const viewHeight = scrollEl.clientHeight;
 
-    if (!force && elTopInScroll >= viewTop && elBottomInScroll <= viewBottom) return;
+    const elTopInDoc = currentScroll + elRect.top;
+    const elBottomInDoc = elTopInDoc + elRect.height;
+    const viewTop = currentScroll;
+    const viewBottom = viewTop + viewHeight;
 
-    const elScaledHeight = elRect.height * zoomScale;
-    const fitsInView = elScaledHeight <= scrollEl.clientHeight;
+    if (!force && elTopInDoc >= viewTop && elBottomInDoc <= viewBottom) return;
+
+    const fitsInView = elRect.height <= viewHeight;
     const targetScroll = fitsInView
-      ? elTopInScroll - (scrollEl.clientHeight / 2) + (elScaledHeight / 2)
-      : elTopInScroll;
+      ? elTopInDoc - viewHeight / 2 + elRect.height / 2
+      : elTopInDoc;
+    // scrollEl.scrollTo starts the animation more reliably than iframeWin.scrollTo
+    // across browsers, which avoids a noticeable lag before smooth scrolling begins.
     scrollEl.scrollTo({ top: Math.max(0, targetScroll), behavior: smooth ? 'smooth' : 'auto' });
-  }, [canvasIframeElement, zoom]);
+  }, [canvasIframeElement]);
 
   const scrollCanvasToLayerRef = useRef(scrollCanvasToLayer);
   scrollCanvasToLayerRef.current = scrollCanvasToLayer;
@@ -1011,7 +1029,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
 
     let attempts = 0;
     const maxAttempts = 20;
-    const delay = isInitial ? 200 : 50;
+    let timeoutId: number | undefined;
 
     const tryScroll = () => {
       const iframeDoc = canvasIframeElement.contentDocument;
@@ -1026,9 +1044,18 @@ const CenterCanvas = React.memo(function CenterCanvas({
       scrollCanvasToLayer(selectedLayerId, !isInitial);
     };
 
-    let timeoutId = window.setTimeout(tryScroll, delay);
+    // Try synchronously first — the layer is almost always already in the DOM
+    // when selection changes, so we can start scrolling immediately. Only the
+    // initial selection on page load needs a deferred attempt while layers mount.
+    if (isInitial) {
+      timeoutId = window.setTimeout(tryScroll, 200);
+    } else {
+      tryScroll();
+    }
 
-    return () => clearTimeout(timeoutId);
+    return () => {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    };
   }, [selectedLayerId, canvasIframeElement, isCanvasReady, scrollCanvasToLayer]);
 
   // Re-scroll when content height changes during initial load (images loading shifts layout)
@@ -1088,6 +1115,20 @@ const CenterCanvas = React.memo(function CenterCanvas({
 
     return () => resizeObserver.disconnect();
   }, [isCanvasReady]);
+
+  // Track preview container height so the preview iframe wrapper can be sized
+  // to fit the visible area (mirrors the canvas container tracking).
+  useEffect(() => {
+    const container = previewContainerRef.current;
+    if (!container) return;
+
+    const update = () => setPreviewContainerHeight(container.clientHeight);
+    update();
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(container);
+
+    return () => resizeObserver.disconnect();
+  }, [isPreviewMode]);
 
   const layers = useMemo(() => {
     // If editing a component, show component layers
@@ -2884,7 +2925,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
               minWidth: viewportMode === 'desktop' && previewZoomMode === 'autofit'
                 ? viewportSizes[viewportMode].width
                 : undefined,
-              height: previewContentHeight > 0 ? `${previewContentHeight}px` : '100%',
+              height: finalPreviewIframeHeight > 0 ? `${finalPreviewIframeHeight}px` : '100%',
               flexShrink: 0,
               transition: 'none',
             }}

--- a/lib/canvas-utils.ts
+++ b/lib/canvas-utils.ts
@@ -16,25 +16,109 @@ export const CANVAS_PADDING = CANVAS_BORDER * 2;
 
 const VIEWPORT_HEIGHT_UNITS = ['vh', 'svh', 'dvh', 'lvh'] as const;
 
-const VIEWPORT_HEIGHT_PATTERN = new RegExp(
-  `^(min-h|max-h|h)-\\[(\\d+(?:\\.\\d+)?)(${VIEWPORT_HEIGHT_UNITS.join('|')})\\]$`
+/**
+ * Maps a Tailwind utility prefix to the CSS properties it sets.
+ * Multi-axis utilities (e.g. `mx`, `py`, `inset-y`) map to multiple properties.
+ */
+const PREFIX_TO_CSS_PROPS: Record<string, string[]> = {
+  // Sizing
+  h: ['height'],
+  'min-h': ['min-height'],
+  'max-h': ['max-height'],
+  w: ['width'],
+  'min-w': ['min-width'],
+  'max-w': ['max-width'],
+  size: ['width', 'height'],
+
+  // Margin
+  m: ['margin'],
+  mx: ['margin-left', 'margin-right'],
+  my: ['margin-top', 'margin-bottom'],
+  mt: ['margin-top'],
+  mr: ['margin-right'],
+  mb: ['margin-bottom'],
+  ml: ['margin-left'],
+  ms: ['margin-inline-start'],
+  me: ['margin-inline-end'],
+
+  // Padding
+  p: ['padding'],
+  px: ['padding-left', 'padding-right'],
+  py: ['padding-top', 'padding-bottom'],
+  pt: ['padding-top'],
+  pr: ['padding-right'],
+  pb: ['padding-bottom'],
+  pl: ['padding-left'],
+  ps: ['padding-inline-start'],
+  pe: ['padding-inline-end'],
+
+  // Position
+  top: ['top'],
+  right: ['right'],
+  bottom: ['bottom'],
+  left: ['left'],
+  start: ['inset-inline-start'],
+  end: ['inset-inline-end'],
+  inset: ['top', 'right', 'bottom', 'left'],
+  'inset-x': ['left', 'right'],
+  'inset-y': ['top', 'bottom'],
+
+  // Gap
+  gap: ['gap'],
+  'gap-x': ['column-gap'],
+  'gap-y': ['row-gap'],
+
+  // Translate (uses CSS variables; we emit the resolved transform directly)
+  'translate-x': ['translate-x'],
+  'translate-y': ['translate-y'],
+  translate: ['translate-x', 'translate-y'],
+};
+
+const PREFIXES_PATTERN = Object.keys(PREFIX_TO_CSS_PROPS)
+  .map(p => p.replace(/-/g, '\\-'))
+  .sort((a, b) => b.length - a.length) // Longest first so e.g. `min-h` matches before `m`
+  .join('|');
+
+const VIEWPORT_LENGTH_PATTERN = new RegExp(
+  `^(${PREFIXES_PATTERN})-\\[(-?\\d+(?:\\.\\d+)?)(${VIEWPORT_HEIGHT_UNITS.join('|')})\\]$`
 );
 
-const NAMED_VIEWPORT_UTILITIES = new Set([
-  'h-screen', 'min-h-screen', 'max-h-screen',
-  'h-dvh', 'min-h-dvh', 'max-h-dvh',
-  'h-svh', 'min-h-svh', 'max-h-svh',
-  'h-lvh', 'min-h-lvh', 'max-h-lvh',
-]);
-
-function getCssProp(prefix: string): string {
-  if (prefix === 'min-h') return 'min-height';
-  if (prefix === 'max-h') return 'max-height';
-  return 'height';
-}
+/**
+ * Static utilities that resolve to 100vh equivalents (h-screen, min-h-dvh, etc.).
+ * All become the reference height in pixels.
+ */
+const NAMED_VIEWPORT_UTILITIES: Record<string, string> = {
+  'h-screen': 'height',
+  'min-h-screen': 'min-height',
+  'max-h-screen': 'max-height',
+  'h-dvh': 'height',
+  'min-h-dvh': 'min-height',
+  'max-h-dvh': 'max-height',
+  'h-svh': 'height',
+  'min-h-svh': 'min-height',
+  'max-h-svh': 'max-height',
+  'h-lvh': 'height',
+  'min-h-lvh': 'min-height',
+  'max-h-lvh': 'max-height',
+};
 
 function escapeSelector(cls: string): string {
   return cls.replace(/([[\](){}.:!#%^&*+?<>~=|@/\\])/g, '\\$1');
+}
+
+/** Builds the CSS declarations for a class given its CSS properties and a pixel value. */
+function buildDeclarations(props: string[], pixels: number): string {
+  const declarations: string[] = [];
+  for (const prop of props) {
+    if (prop === 'translate-x') {
+      declarations.push(`--tw-translate-x:${pixels}px`);
+    } else if (prop === 'translate-y') {
+      declarations.push(`--tw-translate-y:${pixels}px`);
+    } else {
+      declarations.push(`${prop}:${pixels}px !important`);
+    }
+  }
+  return declarations.join(';');
 }
 
 /**
@@ -42,6 +126,10 @@ function escapeSelector(cls: string): string {
  * fixed pixel values based on a reference viewport height. This prevents a
  * feedback loop where the iframe expands to fit content, viewport-unit layers
  * grow with it, and the measured height keeps increasing.
+ *
+ * Covers all Tailwind length utilities (sizing, margin, padding, position,
+ * gap, translate), not just height ones — otherwise classes like
+ * `mt-[10vh]` keep recalculating against the iframe's growing height.
  */
 export function updateViewportOverrides(doc: Document, referenceHeight: number): void {
   if (referenceHeight <= 0) return;
@@ -65,20 +153,22 @@ export function updateViewportOverrides(doc: Document, referenceHeight: number):
       // would apply the override at ALL breakpoints, which is incorrect
       if (cls.includes(':')) continue;
 
-      if (NAMED_VIEWPORT_UTILITIES.has(cls)) {
+      const namedProp = NAMED_VIEWPORT_UTILITIES[cls];
+      if (namedProp) {
         seen.add(cls);
-        const prop = getCssProp(cls.split('-')[0] === 'min' ? 'min-h' : cls.split('-')[0] === 'max' ? 'max-h' : 'h');
-        rules.push(`.${escapeSelector(cls)}{${prop}:${referenceHeight}px !important}`);
+        rules.push(`.${escapeSelector(cls)}{${namedProp}:${referenceHeight}px !important}`);
         continue;
       }
 
-      const match = cls.match(VIEWPORT_HEIGHT_PATTERN);
+      const match = cls.match(VIEWPORT_LENGTH_PATTERN);
       if (match) {
         seen.add(cls);
         const [, prefix, value] = match;
         const pixels = (parseFloat(value) / 100) * referenceHeight;
-        const prop = getCssProp(prefix);
-        rules.push(`.${escapeSelector(cls)}{${prop}:${pixels}px !important}`);
+        const props = PREFIX_TO_CSS_PROPS[prefix];
+        if (props) {
+          rules.push(`.${escapeSelector(cls)}{${buildDeclarations(props, pixels)}}`);
+        }
       }
     }
   });
@@ -93,6 +183,14 @@ export function updateViewportOverrides(doc: Document, referenceHeight: number):
  * Measures the actual content extent (bottom of last visible child) rather than
  * scrollHeight, which includes viewport-filling styles like h-full / min-h-screen
  * on html/body that inflate the measured height beyond actual content.
+ *
+ * Only iterates direct children of <body> (with display:contents recursion).
+ * Deep recursion is intentionally avoided: descendants positioned absolutely
+ * relative to the iframe viewport (e.g. `position: absolute; bottom: -6rem`
+ * with no positioned ancestor) would extend past iframe bottom and create a
+ * feedback loop — each measurement would grow the iframe, pushing the absolute
+ * further down, growing the iframe again. In-flow content is already captured
+ * by the body container's height.
  */
 export function measureContentExtent(doc: Document): number {
   const body = doc.body;
@@ -104,7 +202,7 @@ export function measureContentExtent(doc: Document): number {
 
   const measure = (parent: Element) => {
     for (let i = 0; i < parent.children.length; i++) {
-      const el = parent.children[i] as HTMLElement;
+      const el = parent.children[i];
       if (el.tagName === 'SCRIPT' || el.tagName === 'STYLE' || el.tagName === 'LINK') continue;
 
       // display:contents elements have no box — recurse into their children
@@ -120,6 +218,7 @@ export function measureContentExtent(doc: Document): number {
   };
 
   measure(body);
+
   return Math.max(maxBottom, 0);
 }
 


### PR DESCRIPTION
## Summary

Fix canvas scrollbar rendering in both Fit Width and Fit Height zoom modes. The scrollbar was either invisible, misaligned, or unbounded due to the outer scroll container handling overflow instead of the iframe itself. Also fixes scroll-to-selected-layer and the preview iframe having the same issue.

## Changes

- Size the canvas iframe element to the visible area at current zoom so content overflow produces a native scrollbar inside the iframe
- Apply the same visible-area sizing to the preview iframe wrapper
- Expand viewport-unit overrides to all Tailwind length utilities (margin, padding, position, gap, translate) to prevent vh-driven feedback loops
- Keep `measureContentExtent` shallow (direct body children only) to avoid feedback loops with viewport-pinned absolute elements
- Scroll to selected layer inside the iframe document instead of the outer container
- Remove the 50ms delay on layer selection scroll — try synchronously first, defer only on initial page load

## Test plan

- [ ] Open a page in Fit Width mode — scrollbar should be visible, bounded, and track position accurately
- [ ] Switch to Fit Height mode — entire page height should be visible without zooming to 100%
- [ ] Select a layer that is off-screen — canvas should scroll to it immediately
- [ ] Open preview mode — scrollbar should behave identically to the canvas
- [ ] Test with pages using `vh` units in margins/padding/position — no layout feedback loops
- [ ] Verify component editing canvas is unaffected (uses content height directly)

Made with [Cursor](https://cursor.com)