### PR TITLE
fix: improve localisation publish, translations, and variable labels

### DIFF
--- a/app/(builder)/ycode/components/LocalizationContent.tsx
+++ b/app/(builder)/ycode/components/LocalizationContent.tsx
@@ -16,6 +16,10 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
 import { InputAutocomplete } from '@/components/ui/input-autocomplete';
 import { LOCALES, extractPageTranslatableItems, extractFolderTranslatableItems, extractComponentTranslatableItems, extractCmsTranslatableItems } from '@/lib/localisation-utils';
+import { findLayerById } from '@/lib/layer-utils';
+import { buildFieldGroupsForLayer } from '@/lib/collection-field-utils';
+import type { TranslatableItem } from '@/lib/localisation-utils';
+import type { Layer, Page } from '@/types';
 import { useLocalisationStore } from '@/stores/useLocalisationStore';
 import { usePagesStore } from '@/stores/usePagesStore';
 import { useCollectionsStore } from '@/stores/useCollectionsStore';
@@ -83,6 +87,25 @@ export default function LocalizationContent({ children }: LocalizationContentPro
   const allFields = useCollectionsStore((state) => state.fields);
   const collections = useCollectionsStore((state) => state.collections);
   const items = useCollectionsStore((state) => state.items);
+
+  /**
+   * Build CMS variable field groups for a translation item using the same
+   * resolution rules as the canvas right-sidebar: walks parent collection
+   * layers and merges page-bound collection fields. Returns `undefined` for
+   * non-layer items (slug, SEO, CMS field translations) so the picker stays
+   * hidden where the canvas wouldn't show one either.
+   */
+  const buildFieldGroupsForTranslationItem = (
+    item: TranslatableItem,
+    layers: Layer[],
+    page?: Page | null,
+  ) => {
+    const match = item.content_key.match(/^layer:([^:]+):/);
+    if (!match) return undefined;
+    const layerId = match[1];
+    if (!findLayerById(layers, layerId)) return undefined;
+    return buildFieldGroupsForLayer(layerId, layers, page || null, allFields, collections);
+  };
 
   // URL management
   const router = useRouter();
@@ -662,44 +685,32 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                               </div>
                             </header>
 
-                            {isExpanded && (() => {
-                              // Build field groups for this page's collection (if dynamic)
-                              const pageCollectionId = page.settings?.cms?.collection_id;
-                              const pageFields = pageCollectionId ? (allFields[pageCollectionId] || []) : [];
-                              const collection = pageCollectionId ? collections.find(c => c.id === pageCollectionId) : null;
-                              const pageFieldGroups = pageFields.length > 0 ? [{
-                                fields: pageFields,
-                                label: collection?.name || 'Page collection fields',
-                                source: 'page' as const,
-                              }] : undefined;
-
-                              return (
-                                <ul className="border-b px-4 py-5 flex flex-col gap-5">
-                                  {filteredItems.map((item) => (
-                                    <TranslationRow
-                                      key={item.key}
-                                      item={item}
-                                      selectedLocaleId={selectedLocaleId}
-                                      localInputValues={localInputValues}
-                                      onLocalValueChange={handleLocalValueChange}
-                                      onLocalValueClear={handleLocalValueClear}
-                                      getTranslationByKey={getTranslationByKey}
-                                      createTranslation={createTranslation}
-                                      updateTranslation={updateTranslation}
-                                      updateTranslationValue={updateTranslationValue}
-                                      updateTranslationStatus={updateTranslationStatus}
-                                      deleteTranslation={deleteTranslation}
-                                      fieldGroups={pageFieldGroups}
-                                      allFields={allFields}
-                                      collections={collections}
-                                      pages={storePages}
-                                      folders={storeFolders}
-                                      sourceItem={page}
-                                    />
-                                  ))}
-                                </ul>
-                              );
-                            })()}
+                            {isExpanded && (
+                              <ul className="border-b px-4 py-5 flex flex-col gap-5">
+                                {filteredItems.map((item) => (
+                                  <TranslationRow
+                                    key={item.key}
+                                    item={item}
+                                    selectedLocaleId={selectedLocaleId}
+                                    localInputValues={localInputValues}
+                                    onLocalValueChange={handleLocalValueChange}
+                                    onLocalValueClear={handleLocalValueClear}
+                                    getTranslationByKey={getTranslationByKey}
+                                    createTranslation={createTranslation}
+                                    updateTranslation={updateTranslation}
+                                    updateTranslationValue={updateTranslationValue}
+                                    updateTranslationStatus={updateTranslationStatus}
+                                    deleteTranslation={deleteTranslation}
+                                    fieldGroups={buildFieldGroupsForTranslationItem(item, layers, page)}
+                                    allFields={allFields}
+                                    collections={collections}
+                                    pages={storePages}
+                                    folders={storeFolders}
+                                    sourceItem={page}
+                                  />
+                                ))}
+                              </ul>
+                            )}
                           </div>
                         );
                       })
@@ -754,7 +765,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                             </header>
 
                             <ul className="border-b px-4 py-5 flex flex-col gap-5">
-                              {translatableItems.map((item) => (
+                              {filteredItems.map((item) => (
                                 <TranslationRow
                                   key={item.key}
                                   item={item}
@@ -817,7 +828,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                             </header>
 
                             <ul className="border-b px-4 py-5 flex flex-col gap-5">
-                              {translatableItems.map((item) => (
+                              {filteredItems.map((item) => (
                                 <TranslationRow
                                   key={item.key}
                                   item={item}
@@ -831,6 +842,9 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                                   updateTranslationValue={updateTranslationValue}
                                   updateTranslationStatus={updateTranslationStatus}
                                   deleteTranslation={deleteTranslation}
+                                  fieldGroups={buildFieldGroupsForTranslationItem(item, layers)}
+                                  allFields={allFields}
+                                  collections={collections}
                                 />
                               ))}
                             </ul>

--- a/app/(builder)/ycode/components/RichTextEditor.tsx
+++ b/app/(builder)/ycode/components/RichTextEditor.tsx
@@ -130,6 +130,23 @@ export interface RichTextEditorHandle {
 export type { FieldVariable } from '@/types';
 
 /**
+ * Rename legacy `image` nodes to `richTextImage` so migrated docs render in the
+ * editor. The new schema only registers `richTextImage`; unknown node types are
+ * silently dropped on load.
+ */
+function normalizeLegacyTiptapDoc<T>(doc: T): T {
+  if (!doc || typeof doc !== 'object') return doc;
+  const node = doc as any;
+  if (node.type === 'image') {
+    node.type = 'richTextImage';
+  }
+  if (Array.isArray(node.content)) {
+    node.content.forEach((child: any) => normalizeLegacyTiptapDoc(child));
+  }
+  return doc;
+}
+
+/**
  * DynamicVariable with React node view for the sidebar rich-text editor.
  * Extends the shared extension with a Badge-based node view.
  */
@@ -522,12 +539,12 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
       if (withFormatting) {
         // For formatting mode, expect TipTap JSON
         if (typeof value === 'object' && value !== null) {
-          return value;
+          return normalizeLegacyTiptapDoc(value);
         }
         // Try to parse JSON string (in case DB returned stringified JSON)
         if (typeof value === 'string' && value.startsWith('{')) {
           try {
-            return JSON.parse(value);
+            return normalizeLegacyTiptapDoc(JSON.parse(value));
           } catch {
             // Not valid JSON, fall through
           }

--- a/app/(builder)/ycode/components/RichTextEditor.tsx
+++ b/app/(builder)/ycode/components/RichTextEditor.tsx
@@ -30,6 +30,7 @@ import ListItem from '@tiptap/extension-list-item';
 import Heading from '@tiptap/extension-heading';
 import Blockquote from '@tiptap/extension-blockquote';
 import Code from '@tiptap/extension-code';
+import HardBreak from '@tiptap/extension-hard-break';
 import HorizontalRule from '@tiptap/extension-horizontal-rule';
 import { cn } from '@/lib/utils';
 import type { CollectionField, Collection } from '@/types';
@@ -451,6 +452,7 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
       Document,
       Paragraph,
       Text,
+      HardBreak,
       History,
       DynamicVariableWithNodeView,
       DynamicStyle,
@@ -543,7 +545,12 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
     editorProps: {
       attributes: {
         class: cn(
-          'w-full min-w-0 border border-transparent bg-input transition-[color,box-shadow] outline-none rounded-lg flex flex-col gap-3',
+          'w-full min-w-0 border border-transparent bg-input transition-[color,box-shadow] outline-none rounded-lg flex flex-col',
+          // Full variant gets `gap-3` for doc-style paragraph spacing; compact
+          // variant (sidebar inputs / translation rows) matches the canvas,
+          // which flattens multi-paragraph simple-text content into one
+          // paragraph with line breaks — no inter-paragraph gap.
+          isFullVariant && 'gap-3',
           'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[0px]',
           'disabled:cursor-not-allowed disabled:opacity-50',
           'rich-text-editor',
@@ -683,6 +690,33 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
       hasChanged = currentValue !== value;
     }
 
+    // Walk a Tiptap doc and replace `attrs.label` on every `dynamicVariable` node
+    // with the live label resolved from current fields. The stored label is only a
+    // fallback so the chip stays accurate even when field names change.
+    const refreshNodeLabels = (content: any[]): { content: any[]; updated: boolean } => {
+      let updated = false;
+      const walked = content.map((node: any) => {
+        if (node.type === 'dynamicVariable' && node.attrs?.variable) {
+          const variable = node.attrs.variable;
+          if (variable.type === 'field' && variable.data?.field_id) {
+            const newLabel = getVariableLabel(variable, fields, allFields);
+            if (newLabel && node.attrs.label !== newLabel) {
+              updated = true;
+              return { ...node, attrs: { ...node.attrs, label: newLabel } };
+            }
+          }
+        } else if (node.content) {
+          const childResult = refreshNodeLabels(node.content);
+          if (childResult.updated) {
+            updated = true;
+            return { ...node, content: childResult.content };
+          }
+        }
+        return node;
+      });
+      return { content: walked, updated };
+    };
+
     if (hasChanged) {
       // Check if editor was focused before updating content
       const wasFocused = editor.isFocused;
@@ -702,6 +736,14 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
       } else {
         content = parseValueToContent(typeof value === 'string' ? value : '', fields, undefined, allFields);
       }
+      // Refresh cached labels on initial set as well — the stored value may have
+      // stale labels from migrations or older edits.
+      if (fields && content?.content) {
+        const refreshed = refreshNodeLabels(content.content);
+        if (refreshed.updated) {
+          content = { ...content, content: refreshed.content };
+        }
+      }
       editor.commands.setContent(content);
 
       // Reset internal update flag — setContent triggers onUpdate synchronously
@@ -714,41 +756,12 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
         setTimeout(() => { editor.commands.focus('end'); }, 0);
       }
     } else if (fields) {
-      // Update labels for existing nodes when fields change
+      // Update labels for existing nodes when fields change without a value change
       const json = editor.getJSON();
-      let updated = false;
-
-      const updateNodeLabels = (content: any[]): any[] => {
-        return content.map((node: any) => {
-          if (node.type === 'dynamicVariable' && node.attrs?.variable) {
-            const variable = node.attrs.variable;
-            if (variable.type === 'field' && variable.data?.field_id) {
-              const newLabel = getVariableLabel(variable, fields, allFields);
-              if (node.attrs.label !== newLabel) {
-                updated = true;
-                return {
-                  ...node,
-                  attrs: {
-                    ...node.attrs,
-                    label: newLabel,
-                  },
-                };
-              }
-            }
-          } else if (node.content) {
-            return {
-              ...node,
-              content: updateNodeLabels(node.content),
-            };
-          }
-          return node;
-        });
-      };
-
       if (json.content) {
-        const updatedContent = updateNodeLabels(json.content);
-        if (updated) {
-          editor.commands.setContent({ ...json, content: updatedContent });
+        const refreshed = refreshNodeLabels(json.content);
+        if (refreshed.updated) {
+          editor.commands.setContent({ ...json, content: refreshed.content });
           isInternalUpdateRef.current = false;
         }
       }

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -1913,8 +1913,8 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         isSaving={routeType === 'settings' || routeType === 'localization' || routeType === 'profile' || routeType === 'forms' || routeType === 'integrations' ? false : isCurrentlySaving}
         hasUnsavedChanges={routeType === 'settings' || routeType === 'localization' || routeType === 'profile' || routeType === 'forms' || routeType === 'integrations' ? false : hasUnsavedChanges}
         lastSaved={routeType === 'settings' || routeType === 'localization' || routeType === 'profile' || routeType === 'forms' || routeType === 'integrations' ? null : lastSaved}
-        isPublishing={routeType === 'settings' || routeType === 'localization' || routeType === 'profile' || routeType === 'forms' || routeType === 'integrations' ? false : isPublishing}
-        setIsPublishing={routeType === 'settings' || routeType === 'localization' || routeType === 'profile' || routeType === 'forms' || routeType === 'integrations' ? () => {} : setIsPublishing}
+        isPublishing={isPublishing}
+        setIsPublishing={setIsPublishing}
         saveImmediately={routeType === 'settings' || routeType === 'localization' || routeType === 'profile' || routeType === 'forms' || routeType === 'integrations' ? async () => {} : saveImmediately}
         activeTab={routeType === 'settings' || routeType === 'localization' || routeType === 'profile' || routeType === 'forms' || routeType === 'integrations' ? 'pages' : activeTab}
         onExitComponentEditMode={handleExitComponentEditMode}

--- a/lib/localisation-utils.ts
+++ b/lib/localisation-utils.ts
@@ -9,6 +9,7 @@ import {
 import { createDynamicTextVariable, createDynamicRichTextVariable, createDynamicRichTextVariableFromPlainText, createAssetVariable } from '@/lib/variable-utils';
 import { castValue } from '@/lib/collection-utils';
 import { tiptapDocHasFormatting, tiptapDocToCanonicalString, hasVariableNode, hasAnyTextOrVariable } from '@/lib/tiptap-utils';
+import { isRichTextLayer } from '@/lib/layer-utils';
 import { looksLikeFormattedHtml } from '@/lib/translation-classification';
 import type { IconProps } from '@/components/ui/icon';
 
@@ -326,11 +327,17 @@ function classifyLayerTextForTranslation(
   const textVariable = layer.variables?.text;
   if (!textVariable) return null;
 
+  // Only true rich-text layers (block-level editor with paragraphs/headings/
+  // lists) open in the doc-style sheet. Simple text/heading layers flatten
+  // multi-paragraph content to line breaks on canvas, so the translation
+  // editor should stay inline and compact to match.
+  const isRichLayer = isRichTextLayer(layer);
+
   if (textVariable.type === 'dynamic_text') {
     const text = textVariable.data.content;
     if (!text || typeof text !== 'string' || !text.trim()) return null;
     if (looksLikeFormattedHtml(text) || text.includes('<ycode-inline-variable>')) {
-      return { contentType: 'richtext', value: text.trim(), openInSheet: true };
+      return { contentType: 'richtext', value: text.trim(), openInSheet: isRichLayer };
     }
     return { contentType: 'text', value: text.trim(), openInSheet: false };
   }
@@ -342,7 +349,7 @@ function classifyLayerTextForTranslation(
     if (tiptapDocHasFormatting(doc) || hasVariableNode(doc)) {
       const json = JSON.stringify(doc);
       if (!hasAnyTextOrVariable(doc)) return null;
-      return { contentType: 'richtext', value: json, openInSheet: true };
+      return { contentType: 'richtext', value: json, openInSheet: isRichLayer };
     }
 
     const canonical = tiptapDocToCanonicalString(doc).trim();
@@ -447,7 +454,11 @@ function extractLayerTranslatableItems(
   items: TranslatableItem[]
 ): void {
   for (const layer of layers) {
-    if (layer.key === 'localeSelectorLabel') continue;
+    // The locale-selector label renders the active locale name dynamically and
+    // doesn't need translating. Skip the whole subtree by its parent (`name`)
+    // as well as the inner label layer (`key`) — older content may be missing
+    // the `localeSelectorLabel` key.
+    if (layer.name === 'localeSelector' || layer.key === 'localeSelectorLabel') continue;
 
     const classification = classifyLayerTextForTranslation(layer);
 
@@ -530,7 +541,8 @@ function extractSeoItems(
 /**
  * Extract all translatable items from a page (slug, SEO, and layers)
  * Ordered: slug first, then SEO settings, then layer texts
- * Note: Dynamic page slugs are excluded from translation
+ * Note: Dynamic page slugs and index pages (homepage / folder index) are
+ * excluded — their slug doesn't contribute to the URL.
  */
 export function extractPageTranslatableItems(
   page: Page,
@@ -539,8 +551,8 @@ export function extractPageTranslatableItems(
 ): TranslatableItem[] {
   const items: TranslatableItem[] = [];
 
-  // 1. Extract slug (first) - exclude dynamic pages
-  if (!page.is_dynamic && page.slug && page.slug.trim()) {
+  // 1. Extract slug (first) - exclude dynamic, index, and error pages
+  if (!page.is_dynamic && !page.is_index && !page.error_page && page.slug && page.slug.trim()) {
     const localeName = locale?.label || 'localized';
     items.push({
       key: `page:${page.id}:slug`,
@@ -909,7 +921,7 @@ export function extractLayerTranslatableItemsShallow(
 ): TranslatableItem[] {
   const items: TranslatableItem[] = [];
 
-  if (layer.key === 'localeSelectorLabel') return items;
+  if (layer.name === 'localeSelector' || layer.key === 'localeSelectorLabel') return items;
 
   const classification = classifyLayerTextForTranslation(layer);
   if (classification) {

--- a/lib/services/localisationService.ts
+++ b/lib/services/localisationService.ts
@@ -64,62 +64,27 @@ export async function publishLocalisation(): Promise<PublishLocalisationResult> 
       }
     }
 
-    // Step 3: Insert or update published locales
+    // Step 3: Upsert published locales
     if (activeDraftLocales.length > 0) {
-      // First, fetch existing published locales to determine insert vs update
-      const { data: existingPublished } = await client
+      const publishedLocales = activeDraftLocales.map((locale: Locale) => ({
+        id: locale.id,
+        code: locale.code,
+        label: locale.label,
+        is_default: locale.is_default,
+        is_published: true,
+        created_at: locale.created_at,
+        updated_at: locale.updated_at,
+        deleted_at: null,
+      }));
+
+      const { error: upsertError } = await client
         .from('locales')
-        .select('id')
-        .eq('is_published', true)
-        .in('id', activeDraftLocales.map((l: Locale) => l.id));
+        .upsert(publishedLocales, {
+          onConflict: 'id,is_published',
+        });
 
-      const existingPublishedIds = new Set(existingPublished?.map(l => l.id) || []);
-
-      const localesToInsert: any[] = [];
-      const localesToUpdate: any[] = [];
-
-      for (const locale of activeDraftLocales) {
-        const publishedData = {
-          id: locale.id,
-          code: locale.code,
-          label: locale.label,
-          is_default: locale.is_default,
-          is_published: true,
-          created_at: locale.created_at,
-          updated_at: locale.updated_at,
-          deleted_at: null,
-        };
-
-        if (existingPublishedIds.has(locale.id)) {
-          localesToUpdate.push(publishedData);
-        } else {
-          localesToInsert.push(publishedData);
-        }
-      }
-
-      // Insert new published locales
-      if (localesToInsert.length > 0) {
-        const { error: insertError } = await client
-          .from('locales')
-          .insert(localesToInsert);
-
-        if (insertError) {
-          throw new Error(`Failed to insert published locales: ${insertError.message}`);
-        }
-      }
-
-      // Update existing published locales (batch operation)
-      if (localesToUpdate.length > 0) {
-        // Use upsert for updates since we know these records exist
-        const { error: updateError } = await client
-          .from('locales')
-          .upsert(localesToUpdate, {
-            onConflict: 'id,is_published',
-          });
-
-        if (updateError) {
-          throw new Error(`Failed to update published locales: ${updateError.message}`);
-        }
+      if (upsertError) {
+        throw new Error(`Failed to upsert published locales: ${upsertError.message}`);
       }
 
       publishedLocalesCount = activeDraftLocales.length;
@@ -160,66 +125,31 @@ export async function publishLocalisation(): Promise<PublishLocalisationResult> 
       }
     }
 
-    // Step 6: Insert or update published translations
+    // Step 6: Upsert published translations
     if (activeDraftTranslations.length > 0) {
-      // First, fetch existing published translations to determine insert vs update
-      const { data: existingPublished } = await client
+      const publishedTranslations = activeDraftTranslations.map((translation: Translation) => ({
+        id: translation.id,
+        locale_id: translation.locale_id,
+        source_type: translation.source_type,
+        source_id: translation.source_id,
+        content_key: translation.content_key,
+        content_type: translation.content_type,
+        content_value: translation.content_value,
+        is_completed: translation.is_completed,
+        is_published: true,
+        created_at: translation.created_at,
+        updated_at: translation.updated_at,
+        deleted_at: null,
+      }));
+
+      const { error: upsertError } = await client
         .from('translations')
-        .select('id')
-        .eq('is_published', true)
-        .in('id', activeDraftTranslations.map((t: Translation) => t.id));
+        .upsert(publishedTranslations, {
+          onConflict: 'id,is_published',
+        });
 
-      const existingPublishedIds = new Set(existingPublished?.map(t => t.id) || []);
-
-      const translationsToInsert: any[] = [];
-      const translationsToUpdate: any[] = [];
-
-      for (const translation of activeDraftTranslations) {
-        const publishedData = {
-          id: translation.id,
-          locale_id: translation.locale_id,
-          source_type: translation.source_type,
-          source_id: translation.source_id,
-          content_key: translation.content_key,
-          content_type: translation.content_type,
-          content_value: translation.content_value,
-          is_completed: translation.is_completed,
-          is_published: true,
-          created_at: translation.created_at,
-          updated_at: translation.updated_at,
-          deleted_at: null,
-        };
-
-        if (existingPublishedIds.has(translation.id)) {
-          translationsToUpdate.push(publishedData);
-        } else {
-          translationsToInsert.push(publishedData);
-        }
-      }
-
-      // Insert new published translations
-      if (translationsToInsert.length > 0) {
-        const { error: insertError } = await client
-          .from('translations')
-          .insert(translationsToInsert);
-
-        if (insertError) {
-          throw new Error(`Failed to insert published translations: ${insertError.message}`);
-        }
-      }
-
-      // Update existing published translations (batch operation)
-      if (translationsToUpdate.length > 0) {
-        // Use upsert for updates since we know these records exist
-        const { error: updateError } = await client
-          .from('translations')
-          .upsert(translationsToUpdate, {
-            onConflict: 'id,is_published',
-          });
-
-        if (updateError) {
-          throw new Error(`Failed to update published translations: ${updateError.message}`);
-        }
+      if (upsertError) {
+        throw new Error(`Failed to upsert published translations: ${upsertError.message}`);
       }
 
       publishedTranslationsCount = activeDraftTranslations.length;

--- a/lib/text-format-utils.ts
+++ b/lib/text-format-utils.ts
@@ -631,8 +631,9 @@ function renderInlineContent(
       return [React.createElement(HtmlEmbedRenderer, { key, code: htmlCode })];
     }
 
-    // Handle richTextImage nodes that may appear inline from CMS rich_text expansion
-    if (node.type === 'richTextImage') {
+    // Handle richTextImage nodes that may appear inline from CMS rich_text expansion.
+    // Legacy migrated content may use `image` as the node type — accept both.
+    if (node.type === 'richTextImage' || node.type === 'image') {
       const imgProps: Record<string, any> = {
         key,
         src: node.attrs?.src || '',
@@ -864,7 +865,7 @@ function renderBlock(
     );
   }
 
-  if (block.type === 'richTextImage') {
+  if (block.type === 'richTextImage' || block.type === 'image') {
     const imgProps: Record<string, any> = {
       key,
       src: block.attrs?.src || '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ycode",
-  "version": "1.4.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ycode",
-      "version": "1.4.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -1397,9 +1397,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1413,9 +1413,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -1429,9 +1429,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -1445,11 +1445,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1461,11 +1464,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1477,11 +1483,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1493,11 +1502,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1509,9 +1521,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -1525,9 +1537,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -6952,12 +6964,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
-      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -7038,9 +7050,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -7543,9 +7555,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7686,9 +7698,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -9142,12 +9154,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.4",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -9161,14 +9173,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {


### PR DESCRIPTION
## Summary

Fix multiple localisation issues: duplicate key constraint violations when publishing,
incorrect items appearing in the translation UI, and missing/stale CMS variable chip
labels in the translation rich-text editor.

## Changes

- Replace separate insert/update publish paths with atomic upsert for both locales
  and translations to prevent duplicate key constraint violations
- Exclude homepage, error page, and locale-selector layers from translatable items
- Use `filteredItems` consistently in the localization page to avoid mixing
  translated and untranslated component translations
- Fix publish button not disabling when triggered from non-builder routes
- Build per-layer CMS field groups for translation rows so the variable picker
  matches the canvas context (reference fields, nested collections)
- Refresh inline-variable chip labels dynamically from live field data on editor
  mount, so labels stay accurate after field renames or migrations
- Add TipTap HardBreak extension and fix compact editor paragraph spacing to
  match canvas rendering of simple text layers

## Test plan

- [ ] Publish locales/translations — should not throw duplicate key errors
- [ ] Homepage and error page slugs should not appear in translatable items
- [ ] Locale selector text should not appear in component translations
- [ ] Component translations tab with filter shows only matching items
- [ ] Translation rows for layers with CMS bindings show the variable picker
- [ ] Inline variable chips in translations display "Parent Field Name" format
  for reference-traversed bindings, not just the final field name
- [ ] Renaming a CMS field updates the chip label in translation rows without
  re-saving
- [ ] Publish button disables correctly from /ycode/localization route


Made with [Cursor](https://cursor.com)