### PR TITLE
fix: allow clearing link variable overrides in instance sidebar

### DIFF
--- a/app/(builder)/ycode/components/ComponentVariableOverrides.tsx
+++ b/app/(builder)/ycode/components/ComponentVariableOverrides.tsx
@@ -170,7 +170,7 @@ export default function ComponentVariableOverrides({
     (category: 'image' | 'link' | 'audio' | 'video' | 'icon', variableId: string) => {
       const override = componentOverrides?.[category]?.[variableId];
       const def = variables.find(v => v.id === variableId)?.default_value;
-      return override ?? def;
+      return override !== undefined ? override : def;
     },
     [componentOverrides, variables],
   );

--- a/app/(builder)/ycode/components/ComponentVariablesDialog.tsx
+++ b/app/(builder)/ycode/components/ComponentVariablesDialog.tsx
@@ -297,9 +297,9 @@ export default function ComponentVariablesDialog({
   };
 
   // Handle link default value change (via LinkSettings standalone mode)
-  const handleLinkDefaultValueChange = (value: LinkSettingsValue) => {
+  const handleLinkDefaultValueChange = (value: LinkSettingsValue | null) => {
     if (!componentId || !selectedVariableId) return;
-    updateTextVariable(componentId, selectedVariableId, { default_value: value });
+    updateTextVariable(componentId, selectedVariableId, { default_value: value ?? undefined });
   };
 
   const handleAudioDefaultValueChange = (value: AudioSettingsValue) => {

--- a/app/(builder)/ycode/components/FormSettings.tsx
+++ b/app/(builder)/ycode/components/FormSettings.tsx
@@ -64,7 +64,7 @@ export default function FormSettings({ layer, onLayerUpdate }: FormSettingsProps
   const formSettings: FormSettingsType = layer?.settings?.form || {};
   const successAction = formSettings.success_action || 'message';
   const handleRedirectLinkChange = useCallback(
-    (value: LinkSettingsValue) => {
+    (value: LinkSettingsValue | null) => {
       if (!layer) return;
 
       onLayerUpdate(layer.id, {
@@ -72,7 +72,7 @@ export default function FormSettings({ layer, onLayerUpdate }: FormSettingsProps
           ...layer.settings,
           form: {
             ...layer.settings?.form,
-            redirect_url: value,
+            redirect_url: value ?? undefined,
           },
         },
       });

--- a/app/(builder)/ycode/components/LinkSettings.tsx
+++ b/app/(builder)/ycode/components/LinkSettings.tsx
@@ -63,8 +63,8 @@ interface LayerModeProps {
 // Standalone mode props - for component variables
 interface StandaloneModeProps {
   mode: 'standalone';
-  value: LinkSettingsValue | undefined;
-  onChange: (value: LinkSettingsValue) => void;
+  value: LinkSettingsValue | null | undefined;
+  onChange: (value: LinkSettingsValue | null) => void;
   layer?: never;
   onLayerUpdate?: never;
 }
@@ -311,6 +311,8 @@ export default function LinkSettings(props: LinkSettingsProps) {
       | { value: LinkType | 'none'; label: string; icon: string; disabled?: boolean }
       | { type: 'separator' }
     > = [
+      { value: 'none', label: 'No link', icon: 'none' },
+      { type: 'separator' },
       { value: 'page', label: 'Page', icon: 'page' },
       { value: 'asset', label: 'Asset', icon: 'paperclip' },
       { value: 'field', label: 'CMS field', icon: 'database', disabled: linkFieldGroups.length === 0 },
@@ -344,8 +346,8 @@ export default function LinkSettings(props: LinkSettingsProps) {
   const updateLinkSettings = useCallback(
     (newSettings: Partial<LinkSettingsType> | null) => {
       if (isStandaloneMode) {
-        // In standalone mode, call onChange with the new settings
-        standaloneOnChange?.(newSettings as LinkSettingsType);
+        // In standalone mode, call onChange with the new settings (null = explicit "no link" override)
+        standaloneOnChange?.(newSettings as LinkSettingsType | null);
         return;
       }
 
@@ -694,7 +696,7 @@ export default function LinkSettings(props: LinkSettingsProps) {
       {isStandaloneMode && !useStackedLayout && typeLabel && (
         <Label variant="muted">{typeLabel}</Label>
       )}
-      <div className={useStackedLayout ? '' : 'col-span-2 *:w-full'}>
+      <div className={useStackedLayout ? '*:w-full' : 'col-span-2 *:w-full'}>
         {linkedLinkVariable ? (
           <Button
             asChild
@@ -720,7 +722,7 @@ export default function LinkSettings(props: LinkSettingsProps) {
           </Button>
         ) : (
           <Select
-            value={linkType === 'none' ? '' : linkType}
+            value={linkType}
             onValueChange={(value) => handleLinkTypeChange(value as LinkType | 'none')}
             disabled={isLockedByOther}
           >
@@ -729,7 +731,7 @@ export default function LinkSettings(props: LinkSettingsProps) {
                 ? () => handleLinkTypeChange('none')
                 : undefined}
             >
-              <SelectValue placeholder="Page or URL..." />
+              <SelectValue placeholder="No link" />
             </SelectTrigger>
             <SelectContent>
               {linkTypeOptions.map((option, index) => {
@@ -934,7 +936,7 @@ export default function LinkSettings(props: LinkSettingsProps) {
       {isStandaloneMode && !useStackedLayout && <Label variant="muted">Anchor</Label>}
       {useStackedLayout && <Label variant="muted" className="mb-1.5">Anchor</Label>}
 
-      <div className={useStackedLayout ? '' : 'col-span-2 *:w-full'}>
+      <div className={useStackedLayout ? '*:w-full' : 'col-span-2 *:w-full'}>
         <Select
           value={anchorLayerId || ''}
           onValueChange={handleAnchorLayerIdChange}

--- a/lib/resolve-components.ts
+++ b/lib/resolve-components.ts
@@ -405,10 +405,12 @@ export function applyComponentOverrides(
     // Check if this layer has a link variable linked
     const linkedLinkVariableId = (layer.variables?.link as any)?.variable_id;
     if (linkedLinkVariableId) {
-      // Check for override first, then fall back to variable's default value
+      // Check for override first, then fall back to variable's default value.
+      // Use `!== undefined` (not `??`) so an explicit `null` override (user cleared
+      // the link via "No link") is respected instead of reverting to the default.
       const overrideValue = overrides?.link?.[linkedLinkVariableId];
       const variableDef = componentVariables?.find(v => v.id === linkedLinkVariableId);
-      const linkValue = (overrideValue ?? variableDef?.default_value) as any;
+      const linkValue = (overrideValue !== undefined ? overrideValue : variableDef?.default_value) as any;
 
       if (linkValue) {
         // Apply the value to this layer's link variable, keeping the variable_id for reference
@@ -419,6 +421,11 @@ export function applyComponentOverrides(
             link: { ...linkValue, variable_id: linkedLinkVariableId },
           },
         };
+      } else {
+        // Explicit "No link" — strip any inherited link settings from the layer
+        // so the rendered element has no href / link wrapper.
+        const { link: _ignored, ...restVariables } = updatedLayer.variables ?? {};
+        updatedLayer = { ...updatedLayer, variables: restVariables };
       }
     }
 


### PR DESCRIPTION
## Summary

The link variable type selector in the component instance sidebar had three issues: it rendered as a small chip instead of full-width, the "x" clear button silently fell back to the default value, and there was no explicit "No link" option in the dropdown.

## Changes

- Add "No link" option (with `none` icon and separator) to the link type dropdown in `LinkSettings`
- Preserve explicit `null` overrides in `ComponentVariableOverrides.getTypedValue` so clearing a link variable sticks instead of reverting to the default
- Widen `LinkSettings` standalone `value`/`onChange` types to allow `null` (the actual clear payload) and update consumers (`ComponentVariablesDialog`, `FormSettings`) to handle it
- Apply `*:w-full` in standalone stacked layout so the link type and anchor selectors span the container width

## Test plan

- [ ] Open a component instance with a link variable override and confirm the type selector is full-width
- [ ] Open the type dropdown and pick "No link" — confirm it persists (no fallback to the default link)
- [ ] Pick another type, then click the "x" — confirm it switches to "No link" and stays
- [ ] Edit the link variable's default in the component definition — confirm the override doesn't pick it up after explicit clear
- [ ] Verify the redirect link picker in form settings still works (sets/clears redirect_url)

Made with [Cursor](https://cursor.com)