### PR TITLE
fix: cap image srcset descriptors at source intrinsic width

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -2179,7 +2179,6 @@ const LayerItemImpl: React.FC<{
       const effectiveLoading = isLcpCandidate ? 'eager' : imgLoadingAttr;
 
       const optimizedSrc = getOptimizedImageUrl(finalImageUrl, 1920, 85);
-      const srcset = generateImageSrcset(finalImageUrl);
 
       // Prefer an explicit `sizes` attribute. Otherwise, if we have an
       // intrinsic pixel width, emit a media-aware sizes string so browsers
@@ -2191,6 +2190,12 @@ const LayerItemImpl: React.FC<{
         : null;
       const sizes = explicitSizes
         || (widthForSizes ? `(max-width: 768px) 100vw, ${widthForSizes}px` : getImageSizes());
+
+      // Pass intrinsic width so srcset descriptors don't exceed the source's
+      // natural size (the proxy won't upscale; mismatched descriptors break
+      // browser intrinsic-dimension math and shrink the rendered image).
+      const intrinsicWidthForSrcset = widthForSizes ? parseInt(widthForSizes, 10) : null;
+      const srcset = generateImageSrcset(finalImageUrl, undefined, undefined, intrinsicWidthForSrcset);
 
       const imageProps: Record<string, any> = {
         ...elementProps,

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -963,7 +963,6 @@ const LayerItem: React.FC<{
       const effectiveLoading = isLcpCandidate ? 'eager' : imgLoadingAttr;
 
       const optimizedSrc = getOptimizedImageUrl(finalImageUrl, 1920, 85);
-      const srcset = generateImageSrcset(finalImageUrl);
 
       // Prefer an explicit `sizes` attribute. Otherwise, if we have an
       // intrinsic pixel width, emit a media-aware sizes string so browsers
@@ -975,6 +974,12 @@ const LayerItem: React.FC<{
         : null;
       const sizes = explicitSizes
         || (widthForSizes ? `(max-width: 768px) 100vw, ${widthForSizes}px` : getImageSizes());
+
+      // Pass intrinsic width so srcset descriptors don't exceed the source's
+      // natural size (the proxy won't upscale; mismatched descriptors break
+      // browser intrinsic-dimension math and shrink the rendered image).
+      const intrinsicWidthForSrcset = widthForSizes ? parseInt(widthForSizes, 10) : null;
+      const srcset = generateImageSrcset(finalImageUrl, undefined, undefined, intrinsicWidthForSrcset);
 
       const imageProps: Record<string, any> = {
         ...elementProps,

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -502,7 +502,7 @@ export default async function PageRenderer({
     const candidateAsset = resolvedAssetsWithMime[lcpCandidate.assetId];
     if (candidateAsset?.url) {
       lcpPreloadSrc = getOptimizedImageUrl(candidateAsset.url, 1920, 85);
-      lcpPreloadSrcset = generateImageSrcset(candidateAsset.url) || null;
+      lcpPreloadSrcset = generateImageSrcset(candidateAsset.url, undefined, undefined, candidateAsset.width) || null;
       lcpPreloadSizes = candidateAsset.width
         ? `(max-width: 768px) 100vw, ${candidateAsset.width}px`
         : getImageSizes();

--- a/lib/asset-utils.ts
+++ b/lib/asset-utils.ts
@@ -380,6 +380,12 @@ export function getOptimizedImageUrl(
  * @param url - Original image URL
  * @param sizes - Array of widths in pixels (default: see below)
  * @param quality - Image quality 0-100 (default: 85)
+ * @param intrinsicWidth - Source image natural width. When provided, caps
+ *   variants to it so descriptors match the file the proxy returns (Sharp
+ *   runs with `withoutEnlargement: true`). Without this, a 1512px source
+ *   with a `?width=1920 1920w` descriptor sends a 1512px file: browsers
+ *   then compute `intrinsic = 1512 / (1920/1512) = 1190px` and render the
+ *   image ~21% smaller than intended.
  * @returns Srcset string with multiple size options
  *
  * Default ladder: 320, 480, 640, 750, 828, 1080, 1280, 1536, 1920.
@@ -406,19 +412,32 @@ export function getOptimizedImageUrl(
 export function generateImageSrcset(
   url: string,
   sizes: number[] = [320, 480, 640, 750, 828, 1080, 1280, 1536, 1920],
-  quality: number = 85
+  quality: number = 85,
+  intrinsicWidth?: number | null
 ): string {
   if (!isTransformableUrl(url)) return '';
+
+  // Cap descriptors at the source's natural width when known and smaller than
+  // our default top-end. This keeps `descriptor === file actual width` so the
+  // browser's intrinsic-size math stays correct (see param docs above).
+  let effectiveSizes = sizes;
+  if (intrinsicWidth && intrinsicWidth > 0) {
+    const maxDefault = sizes[sizes.length - 1];
+    if (intrinsicWidth < maxDefault) {
+      effectiveSizes = sizes.filter((w) => w < intrinsicWidth);
+      effectiveSizes.push(intrinsicWidth);
+    }
+  }
 
   try {
     if (isProxyUrl(url)) {
       const baseUrl = url.split('?')[0];
-      return sizes
+      return effectiveSizes
         .map((width) => `${baseUrl}?width=${width}&quality=${quality} ${width}w`)
         .join(', ');
     }
 
-    const srcsetEntries = sizes.map((width) => {
+    const srcsetEntries = effectiveSizes.map((width) => {
       const sizeUrl = new URL(url);
       sizeUrl.searchParams.set('width', width.toString());
       sizeUrl.searchParams.set('quality', quality.toString());

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -4171,15 +4171,30 @@ function layerToHtml(
       } else if (imageSrc.type === 'asset') {
         resolvedSrcValue = undefined;
       }
-      if (resolvedSrcValue && resolvedSrcValue.trim()) {
-        const optimizedSrc = getOptimizedImageUrl(resolvedSrcValue, 1920, 85);
-        attrs.push(`src="${escapeHtml(optimizedSrc)}"`);
+    }
 
-        const srcset = generateImageSrcset(resolvedSrcValue);
-        if (srcset) {
-          attrs.push(`srcset="${escapeHtml(srcset)}"`);
-          attrs.push(`sizes="${escapeHtml(getImageSizes())}"`);
-        }
+    // Resolve intrinsic width/height up front: needed both for the width/
+    // height attributes (CLS prevention) and to cap srcset descriptors so
+    // they don't exceed the source's natural size.
+    let imgWidth = layer.attributes?.width as string | undefined;
+    let imgHeight = layer.attributes?.height as string | undefined;
+    if ((!imgWidth || !imgHeight) && resolvedSrcValue && assetMap) {
+      const matchedAsset = Object.values(assetMap).find(a => a.public_url === resolvedSrcValue);
+      if (matchedAsset?.width && matchedAsset?.height) {
+        if (!imgWidth) imgWidth = String(matchedAsset.width);
+        if (!imgHeight) imgHeight = String(matchedAsset.height);
+      }
+    }
+
+    if (resolvedSrcValue && resolvedSrcValue.trim()) {
+      const optimizedSrc = getOptimizedImageUrl(resolvedSrcValue, 1920, 85);
+      attrs.push(`src="${escapeHtml(optimizedSrc)}"`);
+
+      const intrinsicWidthForSrcset = imgWidth ? parseInt(imgWidth, 10) : null;
+      const srcset = generateImageSrcset(resolvedSrcValue, undefined, undefined, intrinsicWidthForSrcset);
+      if (srcset) {
+        attrs.push(`srcset="${escapeHtml(srcset)}"`);
+        attrs.push(`sizes="${escapeHtml(getImageSizes())}"`);
       }
     }
     attrs.push('data-layer-type="image"');
@@ -4190,16 +4205,6 @@ function layerToHtml(
       attrs.push(`alt="${escapeHtml(resolvedAlt)}"`);
     }
 
-    // Set width/height from explicit attributes or intrinsic asset dimensions (prevents CLS)
-    let imgWidth = layer.attributes?.width as string | undefined;
-    let imgHeight = layer.attributes?.height as string | undefined;
-    if ((!imgWidth || !imgHeight) && resolvedSrcValue && assetMap) {
-      const matchedAsset = Object.values(assetMap).find(a => a.public_url === resolvedSrcValue);
-      if (matchedAsset?.width && matchedAsset?.height) {
-        if (!imgWidth) imgWidth = String(matchedAsset.width);
-        if (!imgHeight) imgHeight = String(matchedAsset.height);
-      }
-    }
     if (imgWidth) attrs.push(`width="${escapeHtml(imgWidth)}"`);
     if (imgHeight) attrs.push(`height="${escapeHtml(imgHeight)}"`);
 


### PR DESCRIPTION
## Summary

Migrated images were rendering ~21% smaller than their natural size because the `srcset` advertised descriptors larger than the source image. The proxy runs Sharp with `withoutEnlargement: true`, so the file returned for `?width=1920 1920w` against a 1512px source is still 1512px — but the browser still trusts the `1920w` descriptor and computes intrinsic width as `actual / (descriptor / sizes)`. For a 1512px source that's `1512 / (1920 / 1512) ≈ 1190px`, shrinking the rendered image accordingly.

## Changes

- Add an optional `intrinsicWidth` parameter to `generateImageSrcset` that caps the descriptor ladder at the source's natural width when smaller than the default top-end (1920)
- Thread the resolved `imgWidth` through to `generateImageSrcset` in `LayerRenderer`, `LayerRendererPublic`, `PageRenderer` (LCP preload), and `page-fetcher` (SSR HTML)
- In `page-fetcher`, resolve `imgWidth`/`imgHeight` before emitting `srcset` so the cap can apply

## Test plan

- [ ] Migrate a legacy project with hero images smaller than 1920px wide — image renders at its natural width (or the containing block width, whichever is smaller), matching the legacy behavior
- [ ] Confirm srcset for a 1512px source no longer includes `1536w`/`1920w` entries, ends at `1512w`
- [ ] Confirm srcset for a 4000px source still ends at `1920w` (default cap respected)
- [ ] Verify LCP image preload `<link>` srcset is also capped

Made with [Cursor](https://cursor.com)