### PR TITLE
fix: respect hidden class on icon layers

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -169,8 +169,10 @@
   }
 }
 
-/* Icon SVG styling */
-[data-icon] {
+/* Icon SVG styling — exclude `.hidden` so Tailwind's `display: none` always
+   wins for hidden icons (this author rule is unlayered and would otherwise
+   beat any layered `.hidden` utility). */
+[data-icon]:not(.hidden) {
   display: inline-block;
 }
 

--- a/lib/canvas-utils.ts
+++ b/lib/canvas-utils.ts
@@ -261,7 +261,7 @@ export function getCanvasIframeHtml(mountId: string = 'canvas-mount'): string {
       background-size: 16px 16px !important;
     }
   </style>
-  <link rel="stylesheet" href="/canvas.css?v=0.2.1.1">
+  <link rel="stylesheet" href="/canvas.css?v=0.2.1.2">
   <style id="ycode-viewport-overrides">
     /* Dynamically populated: overrides vh/svh/dvh/lvh with fixed px values */
   </style>

--- a/public/canvas.css
+++ b/public/canvas.css
@@ -60,8 +60,10 @@
   min-height: 3rem;
 }
 
-/* Icon SVG styling */
-[data-icon] {
+/* Icon SVG styling — exclude `.hidden` so Tailwind's `display: none` always
+   wins for hidden icons. This author rule is unlayered and would otherwise
+   beat any layered `.hidden` utility from the Tailwind Browser CDN. */
+[data-icon]:not(.hidden) {
   display: inline-block;
 }
 


### PR DESCRIPTION
## Summary

Icons with the `hidden` Tailwind class stayed visible because the
`[data-icon] { display: inline-block }` rule is unlayered author CSS and
beats any layered `.hidden` utility — regardless of selector specificity.
Carve `.hidden` out of the icon selector so Tailwind's `display: none` is
the only `display` declaration on hidden icons.

## Changes

- Change `[data-icon]` to `[data-icon]:not(.hidden)` in `public/canvas.css`
- Mirror the same change in `app/globals.css` for public pages
- Bump `canvas.css` cache-busting version to force iframe reload

## Test plan

- [ ] In the builder, add an icon layer and toggle the `hidden` utility — icon disappears
- [ ] Verify FAQ accordion (which uses `hidden` minus-icon swap) renders the correct icon
- [ ] Confirm icons without `hidden` still render `display: inline-block`
- [ ] Publish a page and verify `hidden` icons stay hidden on the public site

Made with [Cursor](https://cursor.com)