### PR TITLE
fix: prevent zero-width image attrs from breaking srcset

### DIFF
--- a/app/(builder)/ycode/components/ImageSettings.tsx
+++ b/app/(builder)/ycode/components/ImageSettings.tsx
@@ -280,12 +280,16 @@ export default function ImageSettings(props: ImageSettingsProps) {
   }, [isStandaloneMode, updateStandaloneValue, layer, onLayerUpdate]);
 
   const handleWidthChange = useCallback((value: string) => {
+    // Drop empty/zero values — `width="0"` short-circuits the asset-dimension
+    // fallback at render time and produces broken sizes/srcset math.
+    const trimmed = value.trim();
+    const sanitized = trimmed && parseInt(trimmed, 10) > 0 ? trimmed : undefined;
     if (isStandaloneMode) {
-      updateStandaloneValue({ width: value || undefined });
+      updateStandaloneValue({ width: sanitized });
     } else if (layer && onLayerUpdate) {
       const newAttributes = { ...layer.attributes };
-      if (value) {
-        newAttributes.width = value;
+      if (sanitized) {
+        newAttributes.width = sanitized;
       } else {
         delete newAttributes.width;
       }
@@ -294,12 +298,14 @@ export default function ImageSettings(props: ImageSettingsProps) {
   }, [isStandaloneMode, updateStandaloneValue, layer, onLayerUpdate]);
 
   const handleHeightChange = useCallback((value: string) => {
+    const trimmed = value.trim();
+    const sanitized = trimmed && parseInt(trimmed, 10) > 0 ? trimmed : undefined;
     if (isStandaloneMode) {
-      updateStandaloneValue({ height: value || undefined });
+      updateStandaloneValue({ height: sanitized });
     } else if (layer && onLayerUpdate) {
       const newAttributes = { ...layer.attributes };
-      if (value) {
-        newAttributes.height = value;
+      if (sanitized) {
+        newAttributes.height = sanitized;
       } else {
         delete newAttributes.height;
       }

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -22,7 +22,7 @@ import { DEFAULT_ASSETS, ASSET_CATEGORIES, isAssetOfType } from '@/lib/asset-uti
 import { parseMultiAssetFieldValue, buildAssetVirtualValues } from '@/lib/multi-asset-utils';
 import { parseMultiReferenceValue, resolveReferenceFieldsSync } from '@/lib/collection-utils';
 import { MULTI_ASSET_COLLECTION_ID } from '@/lib/collection-field-utils';
-import { generateImageSrcset, getImageSizes, getOptimizedImageUrl } from '@/lib/asset-utils';
+import { buildImageSizes, generateImageSrcset, getOptimizedImageUrl, parseImageDimension } from '@/lib/asset-utils';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { toast } from 'sonner';
 import { resolveInlineVariablesFromData } from '@/lib/inline-variables';
@@ -2168,9 +2168,11 @@ const LayerItemImpl: React.FC<{
       // Use default image if URL is empty or invalid
       const finalImageUrl = imageUrl && imageUrl.trim() !== '' ? imageUrl : DEFAULT_ASSETS.IMAGE;
 
-      // Resolve intrinsic dimensions: explicit attributes > asset record > URL reverse-lookup
-      let imgWidth = layer.attributes?.width != null ? String(layer.attributes.width) : undefined;
-      let imgHeight = layer.attributes?.height != null ? String(layer.attributes.height) : undefined;
+      // Resolve intrinsic dimensions: explicit attributes > asset record > URL reverse-lookup.
+      // Zero/invalid attribute values are ignored so the asset fallback still runs
+      // (e.g. when a layer stores width="0" from an older bug or manual edit).
+      let imgWidth: string | undefined = parseImageDimension(layer.attributes?.width as string | number | undefined)?.toString();
+      let imgHeight: string | undefined = parseImageDimension(layer.attributes?.height as string | number | undefined)?.toString();
 
       if (!imgWidth || !imgHeight) {
         const assetId = isAssetVariable(imageVariable) ? getAssetId(imageVariable) : undefined;
@@ -2204,17 +2206,14 @@ const LayerItemImpl: React.FC<{
       // download a more appropriately sized variant on desktop. Falls back
       // to `100vw` when width is unknown.
       const explicitSizes = (layer.attributes?.sizes as string | undefined)?.trim();
-      const widthForSizes = imgWidth && /^\d+(\.\d+)?(px)?$/i.test(imgWidth)
-        ? imgWidth.replace(/px$/i, '')
-        : null;
-      const sizes = explicitSizes
-        || (widthForSizes ? `(max-width: 768px) 100vw, ${widthForSizes}px` : getImageSizes());
+      const intrinsicWidth = parseImageDimension(imgWidth);
+      const intrinsicHeight = parseImageDimension(imgHeight);
+      const sizes = explicitSizes || buildImageSizes(intrinsicWidth);
 
       // Pass intrinsic width so srcset descriptors don't exceed the source's
       // natural size (the proxy won't upscale; mismatched descriptors break
       // browser intrinsic-dimension math and shrink the rendered image).
-      const intrinsicWidthForSrcset = widthForSizes ? parseInt(widthForSizes, 10) : null;
-      const srcset = generateImageSrcset(finalImageUrl, undefined, undefined, intrinsicWidthForSrcset);
+      const srcset = generateImageSrcset(finalImageUrl, undefined, undefined, intrinsicWidth);
 
       const imageProps: Record<string, any> = {
         ...elementProps,
@@ -2223,8 +2222,12 @@ const LayerItemImpl: React.FC<{
         decoding: 'async',
       };
 
-      if (imgWidth) imageProps.width = imgWidth;
-      if (imgHeight) imageProps.height = imgHeight;
+      // Set only positive intrinsic values; otherwise drop any `width="0"`/
+      // `height="0"` that leaked in via normalizedAttributes.
+      if (intrinsicWidth) imageProps.width = intrinsicWidth;
+      else delete imageProps.width;
+      if (intrinsicHeight) imageProps.height = intrinsicHeight;
+      else delete imageProps.height;
       if (effectiveLoading) imageProps.loading = effectiveLoading;
       if (isLcpCandidate) imageProps.fetchPriority = 'high';
 

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -22,7 +22,7 @@ import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
 import { getDynamicTextContent, getImageUrlFromVariable, getVideoUrlFromVariable, getIframeUrlFromVariable, isFieldVariable, isAssetVariable, isStaticTextVariable, isDynamicTextVariable, getStaticTextContent, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
 import { getTranslatedAssetId, getTranslatedText } from '@/lib/locale-runtime';
 import { isValidLinkSettings, generateLinkHref, resolveLinkAttrs, isLinkAtCollectionBoundary, type LinkResolutionContext } from '@/lib/link-utils';
-import { DEFAULT_ASSETS, generateImageSrcset, getImageSizes, getOptimizedImageUrl } from '@/lib/asset-utils';
+import { DEFAULT_ASSETS, buildImageSizes, generateImageSrcset, getOptimizedImageUrl, parseImageDimension } from '@/lib/asset-utils';
 import { resolveInlineVariablesFromData } from '@/lib/inline-variables';
 import { renderRichText, hasBlockElementsWithInlineVariables, getTextStyleClasses, flattenTiptapParagraphs, type RichTextLinkContext, type RenderComponentBlockFn } from '@/lib/text-format-utils';
 import { combineBgValues, mergeStaticBgVars } from '@/lib/tailwind-class-mapper';
@@ -951,9 +951,11 @@ const LayerItem: React.FC<{
       // Use default image if URL is empty or invalid
       const finalImageUrl = imageUrl && imageUrl.trim() !== '' ? imageUrl : DEFAULT_ASSETS.IMAGE;
 
-      // Resolve intrinsic dimensions: explicit attributes > asset record > URL reverse-lookup
-      let imgWidth = layer.attributes?.width != null ? String(layer.attributes.width) : undefined;
-      let imgHeight = layer.attributes?.height != null ? String(layer.attributes.height) : undefined;
+      // Resolve intrinsic dimensions: explicit attributes > asset record > URL reverse-lookup.
+      // Zero/invalid attribute values are ignored so the asset fallback still runs
+      // (e.g. when a layer stores width="0" from an older bug or manual edit).
+      let imgWidth: string | undefined = parseImageDimension(layer.attributes?.width as string | number | undefined)?.toString();
+      let imgHeight: string | undefined = parseImageDimension(layer.attributes?.height as string | number | undefined)?.toString();
 
       if (!imgWidth || !imgHeight) {
         const assetId = isAssetVariable(imageVariable) ? getAssetId(imageVariable) : undefined;
@@ -987,17 +989,14 @@ const LayerItem: React.FC<{
       // download a more appropriately sized variant on desktop. Falls back
       // to `100vw` when width is unknown.
       const explicitSizes = (layer.attributes?.sizes as string | undefined)?.trim();
-      const widthForSizes = imgWidth && /^\d+(\.\d+)?(px)?$/i.test(imgWidth)
-        ? imgWidth.replace(/px$/i, '')
-        : null;
-      const sizes = explicitSizes
-        || (widthForSizes ? `(max-width: 768px) 100vw, ${widthForSizes}px` : getImageSizes());
+      const intrinsicWidth = parseImageDimension(imgWidth);
+      const intrinsicHeight = parseImageDimension(imgHeight);
+      const sizes = explicitSizes || buildImageSizes(intrinsicWidth);
 
       // Pass intrinsic width so srcset descriptors don't exceed the source's
       // natural size (the proxy won't upscale; mismatched descriptors break
       // browser intrinsic-dimension math and shrink the rendered image).
-      const intrinsicWidthForSrcset = widthForSizes ? parseInt(widthForSizes, 10) : null;
-      const srcset = generateImageSrcset(finalImageUrl, undefined, undefined, intrinsicWidthForSrcset);
+      const srcset = generateImageSrcset(finalImageUrl, undefined, undefined, intrinsicWidth);
 
       const imageProps: Record<string, any> = {
         ...elementProps,
@@ -1006,8 +1005,12 @@ const LayerItem: React.FC<{
         decoding: 'async',
       };
 
-      if (imgWidth) imageProps.width = imgWidth;
-      if (imgHeight) imageProps.height = imgHeight;
+      // Set only positive intrinsic values; otherwise drop any `width="0"`/
+      // `height="0"` that leaked in via normalizedAttributes.
+      if (intrinsicWidth) imageProps.width = intrinsicWidth;
+      else delete imageProps.width;
+      if (intrinsicHeight) imageProps.height = intrinsicHeight;
+      else delete imageProps.height;
       if (effectiveLoading) imageProps.loading = effectiveLoading;
       if (isLcpCandidate) imageProps.fetchPriority = 'high';
 

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -12,7 +12,7 @@ import { resolveCustomCodePlaceholders } from '@/lib/resolve-cms-variables';
 import { renderRootLayoutHeadCode } from '@/lib/parse-head-html';
 import { generateInitialAnimationCSS, type HiddenLayerInfo } from '@/lib/animation-utils';
 import { buildCustomFontsCss, buildFontClassesCss, fetchGoogleFontsCss, getGoogleFontLinks } from '@/lib/font-utils';
-import { collectLayerAssetIds, findLcpCandidate, generateImageSrcset, getAssetProxyUrl, getImageSizes, getOptimizedImageUrl } from '@/lib/asset-utils';
+import { buildImageSizes, collectLayerAssetIds, findLcpCandidate, generateImageSrcset, getAssetProxyUrl, getOptimizedImageUrl } from '@/lib/asset-utils';
 import { getAllPages } from '@/lib/repositories/pageRepository';
 import { getAllPageFolders } from '@/lib/repositories/pageFolderRepository';
 import { getMapboxAccessToken, getGoogleMapsEmbedApiKey } from '@/lib/map-server';
@@ -503,9 +503,7 @@ export default async function PageRenderer({
     if (candidateAsset?.url) {
       lcpPreloadSrc = getOptimizedImageUrl(candidateAsset.url, 1920, 85);
       lcpPreloadSrcset = generateImageSrcset(candidateAsset.url, undefined, undefined, candidateAsset.width) || null;
-      lcpPreloadSizes = candidateAsset.width
-        ? `(max-width: 768px) 100vw, ${candidateAsset.width}px`
-        : getImageSizes();
+      lcpPreloadSizes = buildImageSizes(candidateAsset.width || null);
     }
   }
 

--- a/lib/asset-utils.ts
+++ b/lib/asset-utils.ts
@@ -480,6 +480,27 @@ export function getImageSizes(): string {
   return '100vw';
 }
 
+/**
+ * Parse an image dimension attribute into a positive pixel value.
+ * Accepts `"320"` or `"320px"`. Returns null for empty, zero, or non-numeric input,
+ * preventing meaningless `width="0"` attributes from skewing srcset/sizes math.
+ */
+export function parseImageDimension(value: string | number | undefined | null): number | null {
+  if (value == null) return null;
+  const str = String(value).trim();
+  if (!/^\d+(\.\d+)?(px)?$/i.test(str)) return null;
+  const num = parseFloat(str.replace(/px$/i, ''));
+  return num > 0 ? num : null;
+}
+
+/**
+ * Build a responsive `sizes` attribute. With a known intrinsic width, browsers
+ * pick a smaller srcset variant on desktop; without it, fall back to 100vw.
+ */
+export function buildImageSizes(intrinsicWidth: number | null): string {
+  return intrinsicWidth ? `(max-width: 768px) 100vw, ${intrinsicWidth}px` : getImageSizes();
+}
+
 // Semantic layer names whose descendant images are almost never the LCP
 // (logos, menus, footer marks). Tracked via ancestor walk in
 // `findLcpCandidateLayerId` so we don't accidentally prioritize a header

--- a/lib/file-upload.ts
+++ b/lib/file-upload.ts
@@ -126,8 +126,8 @@ async function convertImageToWebP(file: File): Promise<{
   buffer: Buffer;
   mimeType: string;
   fileExtension: string;
-  width: number;
-  height: number;
+  width: number | null;
+  height: number | null;
 } | null> {
   try {
     // Only convert raster images (skip SVG, GIF with animations, etc.)
@@ -152,8 +152,8 @@ async function convertImageToWebP(file: File): Promise<{
       buffer: webpBuffer,
       mimeType: 'image/webp',
       fileExtension: 'webp',
-      width: metadata.width || 0,
-      height: metadata.height || 0,
+      width: metadata.width || null,
+      height: metadata.height || null,
     };
   } catch (error) {
     console.error('Error converting image to WebP:', error);
@@ -240,10 +240,11 @@ export async function uploadFile(
       fileExtension = webpConversion.fileExtension;
       mimeType = webpConversion.mimeType;
       fileSize = webpConversion.buffer.length;
-      dimensions = {
-        width: webpConversion.width,
-        height: webpConversion.height,
-      };
+      // Only persist dimensions when both are positive; zero/unknown values
+      // would otherwise produce invalid `width="0"` attributes on render.
+      dimensions = (webpConversion.width && webpConversion.height)
+        ? { width: webpConversion.width, height: webpConversion.height }
+        : null;
     } else {
       // Use original file
       fileToUpload = file;

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -10,7 +10,7 @@ import { enrichItemsWithCountValues } from '@/lib/repositories/collectionCountRe
 import type { Page, PageFolder, PageLayers, Component, ComponentVariable, CollectionItemWithValues, CollectionField, Layer, CollectionPaginationMeta, Translation, Locale } from '@/types';
 import { getCollectionVariable, resolveFieldValue, evaluateVisibility, getLayerHtmlTag, filterDisabledSliderLayers } from '@/lib/layer-utils';
 import { isFieldVariable, isAssetVariable, createDynamicTextVariable, createDynamicRichTextVariable, createAssetVariable, getDynamicTextContent, getVariableStringValue, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
-import { generateImageSrcset, getImageSizes, getOptimizedImageUrl, getAssetProxyUrl, DEFAULT_ASSETS, collectLayerAssetIds, buildSvgDataUrl } from '@/lib/asset-utils';
+import { buildImageSizes, generateImageSrcset, getOptimizedImageUrl, getAssetProxyUrl, DEFAULT_ASSETS, collectLayerAssetIds, buildSvgDataUrl, parseImageDimension } from '@/lib/asset-utils';
 import { resolveComponents, applyComponentOverrides } from '@/lib/resolve-components';
 import { getComponentVariantLayers } from '@/lib/component-variant-utils';
 import { isTiptapDoc, hasBlockElementsWithResolver } from '@/lib/tiptap-utils';
@@ -4186,15 +4186,17 @@ function layerToHtml(
       }
     }
 
+    const intrinsicWidth = parseImageDimension(imgWidth);
+    const intrinsicHeight = parseImageDimension(imgHeight);
+
     if (resolvedSrcValue && resolvedSrcValue.trim()) {
       const optimizedSrc = getOptimizedImageUrl(resolvedSrcValue, 1920, 85);
       attrs.push(`src="${escapeHtml(optimizedSrc)}"`);
 
-      const intrinsicWidthForSrcset = imgWidth ? parseInt(imgWidth, 10) : null;
-      const srcset = generateImageSrcset(resolvedSrcValue, undefined, undefined, intrinsicWidthForSrcset);
+      const srcset = generateImageSrcset(resolvedSrcValue, undefined, undefined, intrinsicWidth);
       if (srcset) {
         attrs.push(`srcset="${escapeHtml(srcset)}"`);
-        attrs.push(`sizes="${escapeHtml(getImageSizes())}"`);
+        attrs.push(`sizes="${escapeHtml(buildImageSizes(intrinsicWidth))}"`);
       }
     }
     attrs.push('data-layer-type="image"');
@@ -4205,8 +4207,8 @@ function layerToHtml(
       attrs.push(`alt="${escapeHtml(resolvedAlt)}"`);
     }
 
-    if (imgWidth) attrs.push(`width="${escapeHtml(imgWidth)}"`);
-    if (imgHeight) attrs.push(`height="${escapeHtml(imgHeight)}"`);
+    if (intrinsicWidth) attrs.push(`width="${intrinsicWidth}"`);
+    if (intrinsicHeight) attrs.push(`height="${intrinsicHeight}"`);
 
     const imgLoadingAttr = layer.attributes?.loading;
     if (imgLoadingAttr) attrs.push(`loading="${escapeHtml(String(imgLoadingAttr))}"`);


### PR DESCRIPTION
## Summary

Fix blurry images on desktop caused by `width="0"` / `height="0"` on image
layers producing `sizes="…, 0px"`, which made browsers pick the smallest
srcset variant. Sanitize dimensions at upload, render, and HTML export time.

## Changes

- Add `parseImageDimension` and `buildImageSizes` helpers in `lib/asset-utils.ts`
- Ignore zero/invalid width/height in React renderers and static HTML export
- Strip leaked `width="0"` attributes from normalized layer attributes
- Stop WebP upload from persisting `width=0` / `height=0` when metadata is missing
- Sanitize width/height inputs in ImageSettings to prevent saving zero values
- Use shared `buildImageSizes` for LCP preload sizing

## Test plan

- [ ] Publish a page with a full-width image and confirm desktop is sharp (not 320w)
- [ ] Inspect `<img>`: `sizes` should be `100vw` or `(max-width: 768px) 100vw, {width}px`, never `0px`
- [ ] Verify rich-text embedded component images with variable overrides get correct `width`/`height` from asset metadata
- [ ] Upload a new image and confirm asset record has positive width/height (or null, not 0)
- [ ] Clear width/height in ImageSettings — attributes should be removed, not saved as `0`

Made with [Cursor](https://cursor.com)