### PR TITLE
fix: wrap single-paragraph rich text on published pages

### DIFF
--- a/lib/text-format-utils.ts
+++ b/lib/text-format-utils.ts
@@ -1149,10 +1149,19 @@ export function renderRichText(
       return null;
     }
     const inlineContent = renderInlineContent(paragraph.content, collectionItemData, pageCollectionItemData, textStyles, isEditMode, linkContext, timezone, layerDataMap, components, renderComponentBlock, ancestorComponentIds, useSpanForParagraphs);
-    if (isEditMode && !isSimpleTextElement) {
+    if (!isSimpleTextElement) {
+      // Wrap so inline nodes (text + <strong>, etc.) form a single flow unit.
+      // Without this, a parent with `flex flex-col` turns each text node /
+      // inline element into separate flex items that stack vertically.
+      const tag = useSpanForParagraphs ? 'span' : 'p';
       const paragraphClass = textStyles?.paragraph?.classes ?? DEFAULT_TEXT_STYLES.paragraph?.classes ?? '';
       const children = Array.isArray(inlineContent) ? inlineContent : [inlineContent];
-      return React.createElement('span', { 'data-style': 'paragraph', 'data-block-index': 0, className: paragraphClass }, ...children);
+      const props: Record<string, any> = { className: paragraphClass || undefined };
+      if (isEditMode) {
+        props['data-style'] = 'paragraph';
+        props['data-block-index'] = 0;
+      }
+      return React.createElement(tag, props, ...children);
     }
     return inlineContent;
   }


### PR DESCRIPTION
## Summary

Fix inline elements (e.g. `<strong>`) inside single-paragraph rich-text
component variable overrides rendering as block on published pages when the
parent layer uses `flex flex-col`.

## Changes

- Always wrap single-paragraph rich-text content in a `<p>` (or `<span>`
  when inside a restrictive tag like `<p>`/`<h1>`) on the public path
- Previously the wrapper was only emitted in edit mode, leaving raw inline
  nodes as direct children of flex containers on generated pages
- Edit-mode data attributes (`data-style`, `data-block-index`) remain
  conditional

## Test plan

- [ ] Publish a page with a rich-text component variable override containing bold text inside a `flex flex-col` parent
- [ ] Verify bold text renders inline (not stacked vertically) on the published page
- [ ] Verify canvas editing still works correctly for the same component
- [ ] Check a rich-text layer inside a `<p>` tag uses `<span>` wrapper (no nested `<p>`)

Made with [Cursor](https://cursor.com)