### PR TITLE
fix: scope force-visible layers to active interaction targets

### DIFF
--- a/app/(builder)/ycode/components/Canvas.tsx
+++ b/app/(builder)/ycode/components/Canvas.tsx
@@ -105,8 +105,8 @@ interface CanvasProps {
   onComponentEdit?: (componentId: string, instanceLayerId: string) => void;
   /** Component variables when editing a component (for default value display) */
   editingComponentVariables?: ComponentVariable[];
-  /** Disable editor hidden layers (e.g., when Interactions panel is active) */
-  disableEditorHiddenLayers?: boolean;
+  /** Layer IDs to force-show even if they have display:hidden apply_styles */
+  forceVisibleLayerIds?: string[];
   /** Current canvas zoom percentage (100 = 100%) */
   zoom?: number;
   /** Fixed viewport height for stable measurement of content using vh/svh/dvh units */
@@ -314,7 +314,7 @@ const Canvas = React.memo(function Canvas({
   onCanvasClick,
   onComponentEdit,
   editingComponentVariables,
-  disableEditorHiddenLayers = false,
+  forceVisibleLayerIds,
   zoom = 100,
   referenceViewportHeight,
   currentLocale,
@@ -390,10 +390,14 @@ const Canvas = React.memo(function Canvas({
   }, [enrichedPageCollectionItemDataRaw]);
 
   // Collect layer IDs that should be hidden on canvas (display: hidden with on-load)
+  // Exclude layers that are force-visible (targets of the active interaction)
   const editorHiddenLayerIds = useMemo(() => {
-    if (disableEditorHiddenLayers) return undefined;
-    return collectEditorHiddenLayerIds(resolvedLayers);
-  }, [resolvedLayers, disableEditorHiddenLayers]);
+    const hiddenMap = collectEditorHiddenLayerIds(resolvedLayers);
+    if (forceVisibleLayerIds && forceVisibleLayerIds.length > 0) {
+      forceVisibleLayerIds.forEach(id => hiddenMap.delete(id));
+    }
+    return hiddenMap;
+  }, [resolvedLayers, forceVisibleLayerIds]);
 
   // Handle layer click with component resolution
   const handleLayerClick = useCallback((layerId: string, event?: React.MouseEvent) => {

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -644,6 +644,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
   const isPreviewMode = useEditorStore((state) => state.isPreviewMode);
   const activeSidebarTab = useEditorStore((state) => state.activeSidebarTab);
   const activeInteractionTriggerLayerId = useEditorStore((state) => state.activeInteractionTriggerLayerId);
+  const activeInteractionTargetLayerIds = useEditorStore((state) => state.activeInteractionTargetLayerIds);
   const richTextSheetLayerId = useEditorStore((state) => state.richTextSheetLayerId);
   const closeRichTextSheet = useEditorStore((state) => state.closeRichTextSheet);
   const activeSublayerIndex = useEditorStore((state) => state.activeSublayerIndex);
@@ -2685,7 +2686,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
                         onCanvasClick={handleCanvasClick}
                         onComponentEdit={handleCanvasComponentEdit}
                         editingComponentVariables={editingComponentVariables}
-                        disableEditorHiddenLayers={!!activeInteractionTriggerLayerId}
+                        forceVisibleLayerIds={activeInteractionTriggerLayerId ? activeInteractionTargetLayerIds : undefined}
                         zoom={zoom}
                         referenceViewportHeight={defaultCanvasHeight}
                       />


### PR DESCRIPTION
## Summary

Fix hidden layers inside component instances becoming visible when the
Interactions tab is active. Only the specific target layers of the
currently active interaction are now force-shown on the canvas.

## Changes

- Replace blunt `disableEditorHiddenLayers` boolean with `forceVisibleLayerIds` array
- Pass `activeInteractionTargetLayerIds` from the store to scope visibility
- Canvas now removes only those specific IDs from the hidden map instead of discarding it entirely

## Test plan

- [ ] Select a layer with a click interaction that targets a hidden layer — target should become visible on canvas
- [ ] Verify that hidden layers inside unrelated component instances stay hidden
- [ ] Open Interactions tab on a layer with no interactions — all hidden layers remain hidden
- [ ] Switch away from the Interactions tab — all editor-hidden layers return to hidden state

Made with [Cursor](https://cursor.com)