### PR TITLE
fix: favicon preview and file manager image display

### DIFF
--- a/app/(builder)/ycode/components/FileManagerDialog.tsx
+++ b/app/(builder)/ycode/components/FileManagerDialog.tsx
@@ -378,16 +378,15 @@ function FileGridItem({
                         dangerouslySetInnerHTML={{ __html: content }}
                       />
                     ) : imageUrl ? (
-                      // Image URL
+                      // Image URL — small images stay at natural size and are centered;
+                      // larger ones are constrained to fit the container.
                       <>
                         {/* eslint-disable-next-line @next/next/no-img-element */}
                         <img
-                          className="relative w-full h-full object-contain pointer-events-none rounded-md z-10"
+                          className="relative max-w-full max-h-full object-contain pointer-events-none rounded-md z-10"
                           src={getOptimizedImageUrl(imageUrl)}
                           alt={name}
                           loading="lazy"
-                          width={110}
-                          height={110}
                         />
                       </>
                     ) : null}
@@ -430,11 +429,9 @@ function FileGridItem({
                     <>
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
-                        className="relative w-full h-full object-contain pointer-events-none opacity-40 z-10"
+                        className="relative max-w-full max-h-full object-contain pointer-events-none opacity-40 z-10"
                         src={URL.createObjectURL(file)}
                         alt={name}
-                        width={110}
-                        height={110}
                       />
                       <div className="absolute inset-0 flex items-center justify-center bg-background/20 z-20">
                         <Spinner className="size-10 opacity-60" />

--- a/app/(builder)/ycode/settings/general/page.tsx
+++ b/app/(builder)/ycode/settings/general/page.tsx
@@ -97,6 +97,16 @@ export default function GeneralSettingsPage() {
   const [fileManagerOpen, setFileManagerOpen] = useState(false);
   const [fileManagerMode, setFileManagerMode] = useState<'favicon' | 'webclip'>('favicon');
 
+  // Stable category filter — favicon accepts both raster images and SVG icons.
+  // Memoized to avoid creating a new array on every render, which would cause
+  // the file manager to reload its asset list in a loop.
+  const fileManagerCategory = useMemo(
+    () => fileManagerMode === 'favicon'
+      ? [ASSET_CATEGORIES.IMAGES, ASSET_CATEGORIES.ICONS]
+      : ASSET_CATEGORIES.IMAGES,
+    [fileManagerMode],
+  );
+
   // Assets store for getting asset details
   const assetsById = useAssetsStore((state) => state.assetsById);
   const addAssetsToCache = useAssetsStore((state) => state.addAssetsToCache);
@@ -212,17 +222,21 @@ export default function GeneralSettingsPage() {
       return false;
     }
 
-    // Validate dimensions
-    if (!asset.width || !asset.height) {
-      toast.error(`Unable to determine image dimensions`);
-      return false;
-    }
+    // SVGs scale without quality loss; skip dimension checks entirely
+    const isSvg = asset.mime_type === 'image/svg+xml';
 
-    if (asset.width < minSize || asset.height < minSize) {
-      toast.error(`${label} must be at least ${minSize}x${minSize} pixels`, {
-        description: `Selected image is ${asset.width}x${asset.height} pixels`,
-      });
-      return false;
+    if (!isSvg) {
+      if (!asset.width || !asset.height) {
+        toast.error(`Unable to determine image dimensions`);
+        return false;
+      }
+
+      if (asset.width < minSize || asset.height < minSize) {
+        toast.error(`${label} must be at least ${minSize}x${minSize} pixels`, {
+          description: `Selected image is ${asset.width}x${asset.height} pixels`,
+        });
+        return false;
+      }
     }
 
     // Set the asset ID
@@ -771,7 +785,7 @@ export default function GeneralSettingsPage() {
         onOpenChange={setFileManagerOpen}
         onAssetSelect={handleAssetSelect}
         assetId={fileManagerMode === 'favicon' ? faviconAssetId || null : webClipAssetId || null}
-        category={ASSET_CATEGORIES.IMAGES}
+        category={fileManagerCategory}
       />
 
       {/* Reset Project Confirmation Dialog */}

--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -8,12 +8,12 @@ import 'server-only';
 
 import { cache } from 'react';
 import type { Metadata } from 'next';
-import type { Page } from '@/types';
+import type { Asset, Page } from '@/types';
 import type { CollectionItemWithValues } from '@/types';
 import { resolveInlineVariables, resolveImageUrl } from '@/lib/resolve-cms-variables';
 import { getSettingsByKeys } from '@/lib/repositories/settingsRepository';
 import { getAssetById } from '@/lib/repositories/assetRepository';
-import { getAssetProxyUrl } from '@/lib/asset-utils';
+import { buildSvgDataUrl, getAssetProxyUrl } from '@/lib/asset-utils';
 import { generateColorVariablesCss } from '@/lib/repositories/colorVariableRepository';
 import { getSiteBaseUrl } from '@/lib/url-utils';
 
@@ -30,7 +30,9 @@ export interface GlobalPageSettings {
   globalCustomCodeBody?: string | null;
   ycodeBadge?: boolean;
   faviconUrl?: string | null;
+  faviconMimeType?: string | null;
   webClipUrl?: string | null;
+  webClipMimeType?: string | null;
 }
 
 /** @deprecated Use GlobalPageSettings instead */
@@ -59,11 +61,21 @@ export interface GenerateMetadataOptions {
 }
 
 /**
- * Fetch all global page settings in a single database query
- * Includes SEO settings, published CSS, and global custom code
- * Wrapped with React cache to deduplicate within the same request
+ * Resolve a usable URL for favicon/web-clip assets, falling back to an
+ * inline data URL for SVGs stored without a public_url/storage_path.
  */
-export const fetchGlobalPageSettings = cache(async (): Promise<GlobalPageSettings> => {
+function resolveIconAssetUrl(asset: Asset): string | null {
+  const proxyOrPublic = getAssetProxyUrl(asset) || asset.public_url || null;
+  if (proxyOrPublic) return proxyOrPublic;
+
+  if (asset.mime_type === 'image/svg+xml' && asset.content) {
+    return buildSvgDataUrl(asset.content, asset.width, asset.height);
+  }
+
+  return null;
+}
+
+async function fetchGlobalPageSettingsImpl(isPreview = false): Promise<GlobalPageSettings> {
   const settings = await getSettingsByKeys([
     'google_site_verification',
     'global_canonical_url',
@@ -77,14 +89,19 @@ export const fetchGlobalPageSettings = cache(async (): Promise<GlobalPageSetting
   ]);
 
   // Fetch favicon and web clip asset URLs if IDs are set
+  // In preview mode, read draft assets so the favicon shows before publishing.
   let faviconUrl: string | null = null;
+  let faviconMimeType: string | null = null;
   let webClipUrl: string | null = null;
+  let webClipMimeType: string | null = null;
+  const isAssetPublished = !isPreview;
 
   if (settings.favicon_asset_id) {
     try {
-      const asset = await getAssetById(settings.favicon_asset_id, true);
+      const asset = await getAssetById(settings.favicon_asset_id, isAssetPublished);
       if (asset) {
-        faviconUrl = getAssetProxyUrl(asset) || asset.public_url || null;
+        faviconUrl = resolveIconAssetUrl(asset);
+        faviconMimeType = asset.mime_type || null;
       }
     } catch {
       // Ignore errors fetching favicon
@@ -93,9 +110,10 @@ export const fetchGlobalPageSettings = cache(async (): Promise<GlobalPageSetting
 
   if (settings.web_clip_asset_id) {
     try {
-      const asset = await getAssetById(settings.web_clip_asset_id, true);
+      const asset = await getAssetById(settings.web_clip_asset_id, isAssetPublished);
       if (asset) {
-        webClipUrl = getAssetProxyUrl(asset) || asset.public_url || null;
+        webClipUrl = resolveIconAssetUrl(asset);
+        webClipMimeType = asset.mime_type || null;
       }
     } catch {
       // Ignore errors fetching web clip
@@ -114,12 +132,31 @@ export const fetchGlobalPageSettings = cache(async (): Promise<GlobalPageSetting
     globalCustomCodeBody: settings.custom_code_body || null,
     ycodeBadge: settings.ycode_badge ?? true,
     faviconUrl,
+    faviconMimeType,
     webClipUrl,
+    webClipMimeType,
   };
+}
+
+/**
+ * Fetch all global page settings in a single database query
+ * Includes SEO settings, published CSS, and global custom code
+ * Wrapped with React cache to deduplicate within the same request (non-preview only)
+ */
+const fetchGlobalPageSettingsCached = cache(async (): Promise<GlobalPageSettings> => {
+  return fetchGlobalPageSettingsImpl();
 });
 
+export async function fetchGlobalPageSettings(isPreview = false): Promise<GlobalPageSettings> {
+  if (isPreview) {
+    // Preview mode: bypass cache and read draft assets
+    return fetchGlobalPageSettingsImpl(true);
+  }
+  return fetchGlobalPageSettingsCached();
+}
+
 /** @deprecated Use fetchGlobalPageSettings instead */
-export const fetchGlobalSeoSettings = fetchGlobalPageSettings;
+export const fetchGlobalSeoSettings = fetchGlobalPageSettingsCached;
 
 /**
  * Generate Next.js metadata from a page object
@@ -165,10 +202,11 @@ export async function generatePageMetadata(
   // absolute URLs as strings here instead of relying on metadataBase.
   let siteBaseUrl: string | null = null;
 
-  // Use pre-fetched global SEO settings or fetch if not provided (skip for preview mode)
-  if (!isPreview) {
-    const seoSettings = options.globalSeoSettings || await fetchGlobalSeoSettings();
+  // Always fetch global settings — preview mode reads draft assets so the
+  // favicon and web clip render before the user publishes.
+  const seoSettings = options.globalSeoSettings || await fetchGlobalPageSettings(isPreview);
 
+  if (!isPreview) {
     siteBaseUrl = getSiteBaseUrl({
       globalCanonicalUrl: seoSettings.globalCanonicalUrl,
       primaryDomainUrl,
@@ -192,17 +230,21 @@ export async function generatePageMetadata(
         canonical: canonicalUrl,
       };
     }
+  }
 
-    // Add custom favicon and web clip (apple-touch-icon) from settings
-    // Default favicon is handled by app/icon.svg
-    if (seoSettings.faviconUrl || seoSettings.webClipUrl) {
-      metadata.icons = {};
-      if (seoSettings.faviconUrl) {
-        metadata.icons.icon = seoSettings.faviconUrl;
-      }
-      if (seoSettings.webClipUrl) {
-        metadata.icons.apple = seoSettings.webClipUrl;
-      }
+  // Add custom favicon and web clip (apple-touch-icon) — applies to preview too.
+  // Default favicon is handled by app/icon.svg
+  if (seoSettings.faviconUrl || seoSettings.webClipUrl) {
+    metadata.icons = {};
+    if (seoSettings.faviconUrl) {
+      metadata.icons.icon = seoSettings.faviconMimeType
+        ? { url: seoSettings.faviconUrl, type: seoSettings.faviconMimeType }
+        : seoSettings.faviconUrl;
+    }
+    if (seoSettings.webClipUrl) {
+      metadata.icons.apple = seoSettings.webClipMimeType
+        ? { url: seoSettings.webClipUrl, type: seoSettings.webClipMimeType }
+        : seoSettings.webClipUrl;
     }
   }
 


### PR DESCRIPTION
## Summary

Fix favicon and web clip not rendering in preview, support SVG favicons end-to-end, and resolve a file manager regression where small images were stretched and the asset list reloaded in a loop.

## Changes

- Render favicon and web clip in preview mode by reading draft assets (`is_published: false`) instead of skipping the lookup
- Support SVG favicons by emitting an inline data URL fallback when the asset has no public URL, and pass mime type through to Next.js metadata
- Allow `image/svg+xml` assets in the favicon file picker and skip raster-only dimension checks for SVGs
- Stop stretching small thumbnails in the file manager grid — constrain with `max-w-full max-h-full object-contain` so they render at natural size
- Memoize the favicon `category` array passed to `FileManagerDialog` to prevent a new reference on every render from re-triggering the dialog's category-change effect (which caused the asset list to reload continuously)

## Test plan

- [ ] Open a project preview with a custom favicon set in settings and confirm the browser tab shows it (no fallback to `icon.svg`)
- [ ] Upload an SVG, set it as favicon, and verify it renders in preview and after publishing
- [ ] Open the favicon picker and confirm both image and icon assets are listed
- [ ] Open the file manager with small thumbnails (under 110px) and confirm they render centered at natural size
- [ ] Open the favicon picker and confirm the asset list loads once and stays stable (no flicker / repeated network calls)

Made with [Cursor](https://cursor.com)