### PR TITLE
feat: server search in canvas CMS item selector

### DIFF
--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -54,6 +54,7 @@ import { CollectionFieldSelector } from './CollectionFieldSelector';
 import SelectionOverlay from '@/components/SelectionOverlay';
 import RichTextLinkPopover from './RichTextLinkPopover';
 import PageSelector from './PageSelector';
+import CollectionItemSelector from './CollectionItemSelector';
 import RichTextEditorSheet from './RichTextEditorSheet';
 
 // 6. Utils
@@ -710,7 +711,6 @@ const CenterCanvas = React.memo(function CenterCanvas({
     setReportedContentWidth(0);
   }, [editingComponentId]);
 
-  const getDropdownItems = useCollectionsStore((state) => state.getDropdownItems);
   const collectionItemsFromStore = useCollectionsStore((state) => state.items);
   const collectionsFromStore = useCollectionsStore((state) => state.collections);
   const collectionFieldsFromStore = useCollectionsStore((state) => state.fields);
@@ -737,9 +737,6 @@ const CenterCanvas = React.memo(function CenterCanvas({
     if (editingComponentVariantId && drafts[editingComponentVariantId]) return editingComponentVariantId;
     return Object.keys(drafts)[0] || null;
   }, [editingComponentId, editingComponentVariantId, componentDrafts]);
-  const [collectionItems, setCollectionItems] = useState<Array<{ id: string; label: string }>>([]);
-  const [collectionItemSearch, setCollectionItemSearch] = useState('');
-
   // Get editing component's variables for default value display
   // Depends on `components` array to react to variable changes
   const editingComponentVariables = useMemo(() => {
@@ -747,7 +744,6 @@ const CenterCanvas = React.memo(function CenterCanvas({
     const component = components.find(c => c.id === editingComponentId);
     return component?.variables;
   }, [editingComponentId, components]);
-  const [isLoadingItems, setIsLoadingItems] = useState(false);
 
   // Undo/Redo hook - tracks versions for the current entity (page or component)
   const undoRedoEntityType = editingComponentId ? 'component' : 'page_layers';
@@ -1997,34 +1993,6 @@ const CenterCanvas = React.memo(function CenterCanvas({
     setupPreviewMeasurement();
   }, [setupPreviewMeasurement]);
 
-  // Load collection items when dynamic page is selected
-  useEffect(() => {
-    if (!collectionId || !currentPage?.is_dynamic) {
-      setCollectionItems([]);
-      setIsLoadingItems(false);
-      return;
-    }
-
-    const loadItems = async () => {
-      setIsLoadingItems(true);
-      try {
-        const itemsWithLabels = await getDropdownItems(collectionId);
-        setCollectionItems(itemsWithLabels);
-        // Auto-select first item if none selected
-        if (!currentPageCollectionItemId && itemsWithLabels.length > 0) {
-          setCurrentPageCollectionItemId(itemsWithLabels[0].id);
-        }
-      } catch (error) {
-        console.error('Failed to load collection items:', error);
-      } finally {
-        setIsLoadingItems(false);
-      }
-    };
-
-    loadItems();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [collectionId, currentPage?.is_dynamic, getDropdownItems]);
-
   // Get return page for component edit mode
   const returnToPage = useMemo(() => {
     return returnToPageId ? pages.find(p => p.id === returnToPageId) : null;
@@ -2182,64 +2150,11 @@ const CenterCanvas = React.memo(function CenterCanvas({
 
             {/* Collection item selector for dynamic pages */}
             {currentPage?.is_dynamic && collectionId && (
-              <Select
-                value={currentPageCollectionItemId || ''}
-                onValueChange={(value) => {
-                  setCurrentPageCollectionItemId(value);
-                  setCollectionItemSearch('');
-                }}
-                onOpenChange={(open) => {
-                  if (!open) setCollectionItemSearch('');
-                }}
-                disabled={isLoadingItems || collectionItems.length === 0}
-              >
-                <SelectTrigger className="w-24 justify-between" size="sm">
-                  {isLoadingItems ? (
-                    <Spinner className="size-3" />
-                  ) : (
-                    <div className="flex items-center gap-1.5 min-w-0 flex-1">
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span className="shrink-0">
-                            <Icon name="database" className="size-3 opacity-50" />
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent>Collection item</TooltipContent>
-                      </Tooltip>
-                      <span className="truncate">
-                        {collectionItems.find(item => item.id === currentPageCollectionItemId)?.label || 'Select item'}
-                      </span>
-                    </div>
-                  )}
-                </SelectTrigger>
-
-                <SelectContent
-                  searchable
-                  searchValue={collectionItemSearch}
-                  onSearchChange={setCollectionItemSearch}
-                  searchPlaceholder="Search items..."
-                  align="start"
-                  className="w-72"
-                >
-                  {(() => {
-                    const filtered = collectionItems.filter(item =>
-                      item.label.toLowerCase().includes(collectionItemSearch.toLowerCase())
-                    );
-                    if (filtered.length === 0) {
-                      return (
-                        <div className="px-2 py-4 text-center text-xs text-muted-foreground">
-                          {collectionItemSearch ? 'No items found' : 'No items available'}
-                        </div>
-                      );
-                    }
-                    return filtered.map((item) => (
-                      <SelectItem key={item.id} value={item.id}>
-                        {item.label}
-                      </SelectItem>
-                    ));
-                  })()}
-                </SelectContent>
-              </Select>
+              <CollectionItemSelector
+                collectionId={collectionId}
+                value={currentPageCollectionItemId}
+                onValueChange={setCurrentPageCollectionItemId}
+              />
             )}
           </div>
         )}

--- a/app/(builder)/ycode/components/CollectionItemSelector.tsx
+++ b/app/(builder)/ycode/components/CollectionItemSelector.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Icon } from '@/components/ui/icon';
+import { useDebounce } from '@/hooks/use-debounce';
+import { useCollectionsStore } from '@/stores/useCollectionsStore';
+
+interface CollectionItemSelectorProps {
+  collectionId: string;
+  value: string | null;
+  onValueChange: (id: string) => void;
+}
+
+const SEARCH_LIMIT = 50;
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Top-bar picker for the active collection item on dynamic pages.
+ *
+ * Items are sourced from the preloaded store cache; typing triggers a
+ * debounced server search that merges results into the cache so the
+ * canvas can resolve items beyond the initial preload window.
+ */
+export default function CollectionItemSelector({
+  collectionId,
+  value,
+  onValueChange,
+}: CollectionItemSelectorProps) {
+  const itemsByCollection = useCollectionsStore((s) => s.items);
+  const fieldsByCollection = useCollectionsStore((s) => s.fields);
+  const searchAndMergeItems = useCollectionsStore((s) => s.searchAndMergeItems);
+
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebounce(search, SEARCH_DEBOUNCE_MS);
+  const [isSearching, setIsSearching] = useState(false);
+
+  const dropdownItems = useMemo(() => {
+    const items = itemsByCollection[collectionId] || [];
+    const fields = fieldsByCollection[collectionId] || [];
+    const nameField = fields.find((f) => f.key === 'name');
+    return items.map((item) => {
+      let label = `Item ${item.id.slice(0, 8)}`;
+      if (nameField) {
+        const nameValue = item.values?.[nameField.id];
+        if (nameValue !== null && nameValue !== undefined && String(nameValue).trim() !== '') {
+          label = String(nameValue);
+        }
+      }
+      return { id: item.id, label };
+    });
+  }, [collectionId, itemsByCollection, fieldsByCollection]);
+
+  const trimmedSearch = debouncedSearch.trim();
+
+  useEffect(() => {
+    if (!trimmedSearch) {
+      setIsSearching(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsSearching(true);
+    searchAndMergeItems(collectionId, trimmedSearch, SEARCH_LIMIT)
+      .finally(() => {
+        if (!cancelled) setIsSearching(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [collectionId, trimmedSearch, searchAndMergeItems]);
+
+  // Auto-select the first item when none is selected yet
+  useEffect(() => {
+    if (!value && dropdownItems.length > 0) {
+      onValueChange(dropdownItems[0].id);
+    }
+  }, [value, dropdownItems, onValueChange]);
+
+  const filteredItems = useMemo(() => {
+    if (!search.trim()) return dropdownItems;
+    const needle = search.toLowerCase();
+    return dropdownItems.filter((item) => item.label.toLowerCase().includes(needle));
+  }, [dropdownItems, search]);
+
+  const selectedLabel = dropdownItems.find((item) => item.id === value)?.label || 'Select item';
+  const hasNoItems = dropdownItems.length === 0 && !isSearching;
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) setSearch('');
+  };
+
+  return (
+    <Select
+      value={value || ''}
+      onValueChange={(next) => {
+        onValueChange(next);
+        setSearch('');
+      }}
+      onOpenChange={handleOpenChange}
+      disabled={hasNoItems}
+    >
+      <SelectTrigger className="w-24 justify-between" size="sm">
+        <div className="flex items-center gap-1.5 min-w-0 flex-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="shrink-0">
+                <Icon name="database" className="size-3 opacity-50" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>Collection item</TooltipContent>
+          </Tooltip>
+          <span className="truncate">{selectedLabel}</span>
+        </div>
+      </SelectTrigger>
+
+      <SelectContent
+        searchable
+        searchValue={search}
+        onSearchChange={setSearch}
+        searchPlaceholder="Search items..."
+        searchLoading={isSearching}
+        align="start"
+        className="min-w-72 max-w-96"
+      >
+        {filteredItems.length === 0 ? (
+          <div className="px-2 py-4 text-center text-xs text-muted-foreground">
+            {search ? (isSearching ? 'Searching...' : 'No items found') : 'No items available'}
+          </div>
+        ) : (
+          filteredItems.map((item) => (
+            <SelectItem key={item.id} value={item.id}>
+              <span className="truncate">{item.label}</span>
+            </SelectItem>
+          ))
+        )}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -8,6 +8,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 import Icon from '@/components/ui/icon';
 import { Input } from '@/components/ui/input';
+import { Spinner } from '@/components/ui/spinner';
 
 function Select({
   ...props
@@ -108,12 +109,14 @@ function SelectContent({
   searchValue,
   onSearchChange,
   searchPlaceholder,
+  searchLoading,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content> & {
   searchable?: boolean;
   searchValue?: string;
   onSearchChange?: (value: string) => void;
   searchPlaceholder?: string;
+  searchLoading?: boolean;
 }) {
   const searchInputRef = React.useRef<HTMLInputElement>(null);
   const isSearchFocusedRef = React.useRef(false);
@@ -139,22 +142,28 @@ function SelectContent({
             onPointerDown={(e) => e.stopPropagation()}
             onPointerUp={(e) => e.stopPropagation()}
           >
-            <Input
-              ref={searchInputRef}
-              size="xs"
-              placeholder={searchPlaceholder || 'Search...'}
-              value={searchValue}
-              onChange={(e) => onSearchChange?.(e.target.value)}
-              onKeyDown={(e) => e.stopPropagation()}
-              onFocus={() => { isSearchFocusedRef.current = true; }}
-              onBlur={() => {
-                requestAnimationFrame(() => {
-                  if (isSearchFocusedRef.current) {
-                    searchInputRef.current?.focus();
-                  }
-                });
-              }}
-            />
+            <div className="relative">
+              <Input
+                ref={searchInputRef}
+                size="xs"
+                placeholder={searchPlaceholder || 'Search...'}
+                value={searchValue}
+                onChange={(e) => onSearchChange?.(e.target.value)}
+                onKeyDown={(e) => e.stopPropagation()}
+                onFocus={() => { isSearchFocusedRef.current = true; }}
+                onBlur={() => {
+                  requestAnimationFrame(() => {
+                    if (isSearchFocusedRef.current) {
+                      searchInputRef.current?.focus();
+                    }
+                  });
+                }}
+                className={cn(searchLoading && 'pr-7')}
+              />
+              {searchLoading && (
+                <Spinner className="absolute right-2 top-1/2 -translate-y-1/2 size-3.5" />
+              )}
+            </div>
           </div>
         )}
         <SelectScrollUpButton />

--- a/stores/useCollectionsStore.ts
+++ b/stores/useCollectionsStore.ts
@@ -53,6 +53,7 @@ interface CollectionsActions {
   loadItems: (collectionId: string, page?: number, limit?: number, sortBy?: string, sortOrder?: string) => Promise<void>;
   loadPublishedItems: (collectionId: string) => Promise<void>;
   getDropdownItems: (collectionId: string) => Promise<Array<{ id: string; label: string }>>;
+  searchAndMergeItems: (collectionId: string, query: string, limit?: number) => Promise<Array<{ id: string; label: string }>>;
   createItem: (collectionId: string, values: Record<string, any>, statusAction?: StatusAction) => Promise<CollectionItemWithValues>;
   updateItem: (collectionId: string, itemId: string, values: Record<string, any>) => Promise<void>;
   deleteItem: (collectionId: string, itemId: string) => Promise<void>;
@@ -1213,40 +1214,73 @@ export const useCollectionsStore = create<CollectionsStore>((set, get) => ({
   getDropdownItems: async (collectionId: string) => {
     try {
       const state = get();
-
-      // Fields and items are ALWAYS preloaded before UI renders
-      // No defensive loading needed - guaranteed to be available
       const collectionFields = state.fields[collectionId] || [];
       const items = state.items[collectionId] || [];
 
-      // Find the name field (field with key = 'name')
       const nameField = collectionFields.find(field => field.key === 'name');
-
       if (!nameField) {
         console.warn(`Name field not found for collection ${collectionId}. Available fields:`, collectionFields.map(f => ({ id: f.id, key: f.key, name: f.name })));
       }
 
-      // Map items to { id, label } format
-      const itemsWithLabels = items.map(item => {
-        let label = `Item ${item.id.slice(0, 8)}`;
-
-        if (nameField) {
-          const nameValue = item.values?.[nameField.id];
-          if (nameValue !== null && nameValue !== undefined && String(nameValue).trim() !== '') {
-            label = String(nameValue);
-          }
-        }
-
-        return {
-          id: item.id,
-          label,
-        };
-      });
-
-      return itemsWithLabels;
+      return items.map(item => ({ id: item.id, label: getCollectionItemLabel(item, collectionFields) }));
     } catch (error) {
       console.error('Failed to get dropdown items:', error);
       return [];
     }
   },
+
+  searchAndMergeItems: async (collectionId: string, query: string, limit = 50) => {
+    try {
+      const response = await collectionsApi.getItems(collectionId, {
+        search: query,
+        limit,
+        includeAssets: true,
+      });
+
+      if (response.error) throw new Error(response.error);
+
+      const fetched = response.data?.items || [];
+
+      if (response.data?.referencedAssets?.length) {
+        useAssetsStore.getState().addAssetsToCache(response.data.referencedAssets);
+      }
+
+      // Merge fetched items into the store (dedupe by id) so the canvas can
+      // resolve them for slug/preview rendering when the user picks an item
+      // that wasn't part of the initial preload.
+      set(state => {
+        const existing = state.items[collectionId] || [];
+        const existingIds = new Set(existing.map(item => item.id));
+        const newItems = fetched.filter(item => !existingIds.has(item.id));
+        if (newItems.length === 0) return state;
+        return {
+          items: {
+            ...state.items,
+            [collectionId]: [...existing, ...newItems],
+          },
+        };
+      });
+
+      const fields = get().fields[collectionId] || [];
+      return fetched.map(item => ({ id: item.id, label: getCollectionItemLabel(item, fields) }));
+    } catch (error) {
+      console.error('Failed to search collection items:', error);
+      return [];
+    }
+  },
 }));
+
+/**
+ * Resolve a human-readable label for a collection item using the `name` field
+ * when present, falling back to a short id-based placeholder.
+ */
+function getCollectionItemLabel(item: CollectionItemWithValues, fields: CollectionField[]): string {
+  const nameField = fields.find(field => field.key === 'name');
+  if (nameField) {
+    const nameValue = item.values?.[nameField.id];
+    if (nameValue !== null && nameValue !== undefined && String(nameValue).trim() !== '') {
+      return String(nameValue);
+    }
+  }
+  return `Item ${item.id.slice(0, 8)}`;
+}


### PR DESCRIPTION
## Summary

The canvas CMS item picker (next to the page selector on dynamic pages) only displayed the first 25 preloaded items, so users couldn't reach items further down a large collection. Typing now triggers a debounced server search that merges results into the collections store, mirroring the legacy builder UX while staying scalable for large collections.

## Changes

- Add `searchAndMergeItems` action to `useCollectionsStore` that fetches matching items via the existing `?search=` API and merges them (dedupe by id) into the cache, so canvas slug resolution and rendering work for any picked item
- Extract `getCollectionItemLabel` helper used by both `getDropdownItems` and the new search action
- Extract the inline picker into a dedicated `CollectionItemSelector` component with debounced search (300ms), auto-select of the first item, and ellipsis truncation for long labels
- Add a `searchLoading` prop to `SelectContent` that renders a spinner inside the search input on the right
- Drop the now-unused inline picker state and effect from `CenterCanvas.tsx`

## Test plan

- [ ] Open a dynamic page with more than 25 items in the bound collection
- [ ] Verify the picker shows 25 items initially and the first one is auto-selected
- [ ] Type a query that matches an item beyond the preloaded set and confirm it appears in the dropdown
- [ ] Confirm the loading spinner shows inside the search input while fetching
- [ ] Pick a searched item and confirm the canvas renders its data and the slug resolves correctly
- [ ] Confirm long item labels truncate with an ellipsis and the dropdown caps at a reasonable width

Made with [Cursor](https://cursor.com)