### PR TITLE
fix: render block content from rich-text cms bindings

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -607,45 +607,49 @@ const LayerItemImpl: React.FC<{
   const textVariable = layer.variables?.text;
   let useSpanForParagraphs = false;
 
-  if (!isSimpleTextLayer) {
-    const restrictiveBlockTags = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'a', 'button'];
-    const isRestrictiveTag = restrictiveBlockTags.includes(htmlTag);
+  const restrictiveBlockTags = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'a', 'button'];
+  const isRestrictiveTag = restrictiveBlockTags.includes(htmlTag);
 
-    if (isRestrictiveTag) {
-      let hasLists = false;
+  if (isRestrictiveTag) {
+    let hasLists = false;
 
-      if (textVariable?.type === 'dynamic_rich_text') {
-        hasLists = hasBlockElementsWithInlineVariables(
-          textVariable as any,
-          collectionLayerData,
-          pageCollectionItemData || undefined
-        );
-      }
+    if (textVariable?.type === 'dynamic_rich_text') {
+      hasLists = hasBlockElementsWithInlineVariables(
+        textVariable as any,
+        collectionLayerData,
+        pageCollectionItemData || undefined
+      );
+    }
 
-      // Also check resolved component variable value for block elements
-      if (!hasLists) {
-        const componentVariables = parentComponentVariables || editingComponentVariables;
-        const linkedVariableId = (textVariable as any)?.id;
-        if (linkedVariableId && componentVariables) {
-          const variableDef = componentVariables.find(v => v.id === linkedVariableId);
-          const overrideCategory = variableDef?.type === 'rich_text' ? 'rich_text' : 'text';
-          const overrideValue = parentComponentOverrides?.[overrideCategory]?.[linkedVariableId];
-          const valueToCheck = overrideValue ?? variableDef?.default_value;
-          if (valueToCheck && 'type' in valueToCheck && valueToCheck.type === 'dynamic_rich_text') {
-            hasLists = hasBlockElementsWithInlineVariables(
-              valueToCheck as any,
-              collectionLayerData,
-              pageCollectionItemData || undefined
-            );
-          }
+    // Also check resolved component variable value for block elements
+    if (!hasLists) {
+      const componentVariables = parentComponentVariables || editingComponentVariables;
+      const linkedVariableId = (textVariable as any)?.id;
+      if (linkedVariableId && componentVariables) {
+        const variableDef = componentVariables.find(v => v.id === linkedVariableId);
+        const overrideCategory = variableDef?.type === 'rich_text' ? 'rich_text' : 'text';
+        const overrideValue = parentComponentOverrides?.[overrideCategory]?.[linkedVariableId];
+        const valueToCheck = overrideValue ?? variableDef?.default_value;
+        if (valueToCheck && 'type' in valueToCheck && valueToCheck.type === 'dynamic_rich_text') {
+          hasLists = hasBlockElementsWithInlineVariables(
+            valueToCheck as any,
+            collectionLayerData,
+            pageCollectionItemData || undefined
+          );
         }
       }
+    }
 
-      if (hasLists) {
-        htmlTag = 'div';
-      } else if (textVariable?.type === 'dynamic_rich_text' || (textVariable as any)?.id) {
-        useSpanForParagraphs = true;
-      }
+    if (hasLists) {
+      // Block-level expansion (lists, tables, embedded components) cannot live
+      // inside <p>/<h*>/<span>; switch the wrapper to a <div> regardless of
+      // whether this is a simple text layer or a richText layer.
+      htmlTag = 'div';
+    } else if (!isSimpleTextLayer && (textVariable?.type === 'dynamic_rich_text' || (textVariable as any)?.id)) {
+      // For non-simple-text layers with rich-text content but no block
+      // expansion, render paragraphs as <span class="block"> to keep them
+      // valid inside the existing wrapper.
+      useSpanForParagraphs = true;
     }
   }
 

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -419,26 +419,28 @@ const LayerItem: React.FC<{
   const textVariable = layer.variables?.text;
   let useSpanForParagraphs = false;
 
-  if (!isSimpleTextLayer) {
-    const restrictiveBlockTags = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'a', 'button'];
-    const isRestrictiveTag = restrictiveBlockTags.includes(htmlTag);
+  // Detect block-level expansion (lists, tables, headings, embedded components,
+  // or a rich_text CMS variable that expands to blocks). This decides both the
+  // wrapper tag and whether the content can be flattened to a single paragraph.
+  const hasBlockExpansion = textVariable?.type === 'dynamic_rich_text'
+    ? hasBlockElementsWithInlineVariables(
+        textVariable as any,
+        collectionLayerData,
+        pageCollectionItemData || undefined,
+    )
+    : false;
 
-    if (isRestrictiveTag) {
-      let hasLists = false;
+  const restrictiveBlockTags = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'a', 'button'];
+  const isRestrictiveTag = restrictiveBlockTags.includes(htmlTag);
 
-      if (textVariable?.type === 'dynamic_rich_text') {
-        hasLists = hasBlockElementsWithInlineVariables(
-          textVariable as any,
-          collectionLayerData,
-          pageCollectionItemData || undefined
-        );
-      }
-
-      if (hasLists) {
-        htmlTag = 'div';
-      } else if (textVariable?.type === 'dynamic_rich_text' || (textVariable as any)?.id) {
-        useSpanForParagraphs = true;
-      }
+  if (isRestrictiveTag) {
+    if (hasBlockExpansion) {
+      // Block-level expansion cannot live inside <p>/<h*>/<span>; switch the
+      // wrapper to a <div> regardless of whether this is a simple text layer
+      // or a richText layer.
+      htmlTag = 'div';
+    } else if (!isSimpleTextLayer && (textVariable?.type === 'dynamic_rich_text' || (textVariable as any)?.id)) {
+      useSpanForParagraphs = true;
     }
   }
 
@@ -569,10 +571,15 @@ const LayerItem: React.FC<{
 
     // DynamicRichTextVariable format (with formatting)
     if (textVariable?.type === 'dynamic_rich_text') {
-      const variable = isSimpleTextLayer
+      // Simple text layers (text/heading) normally collapse all paragraphs
+      // into one to fit the layer's single-tag wrapper. Skip flattening when
+      // the content expands to block elements (e.g. a CMS rich_text variable
+      // resolving to headings/tables/lists), otherwise that formatting is lost.
+      const shouldFlatten = isSimpleTextLayer && !hasBlockExpansion;
+      const variable = shouldFlatten
         ? { ...textVariable, data: { ...textVariable.data, content: flattenTiptapParagraphs(textVariable.data.content) } }
         : textVariable;
-      return renderRichText(variable as any, collectionLayerData, pageCollectionItemData || undefined, layer.textStyles, useSpanForParagraphs, false, linkContext, timezone, effectiveLayerDataMap, allComponents, renderComponentBlock, effectiveAncestorIds, isSimpleTextLayer);
+      return renderRichText(variable as any, collectionLayerData, pageCollectionItemData || undefined, layer.textStyles, useSpanForParagraphs, false, linkContext, timezone, effectiveLayerDataMap, allComponents, renderComponentBlock, effectiveAncestorIds, shouldFlatten);
     }
 
     // Check for inline variables in DynamicTextVariable format (legacy)


### PR DESCRIPTION
## Summary

A `text`/`heading` layer bound to a CMS `rich_text` field (or whose `dynamic_rich_text` content otherwise expands to block elements) was producing invalid HTML on canvas and losing all formatting on the public/preview renderer.

Two issues fixed:

1. **Hydration error** — `<table>`/`<div>` rendered inside `<p>` because the restrictive-tag → `<div>` override was guarded behind `!isSimpleTextLayer` and skipped for `text`/`heading` layers.
2. **Preview lost formatting** — `LayerRendererPublic` ran `flattenTiptapParagraphs()` on simple text layers unconditionally, collapsing headings, tables, blockquotes, lists, and images into a single paragraph joined by `<br>`s.

## Changes

- Run the restrictive-tag override for simple text layers too, so the wrapper switches to `<div>` whenever the rich-text content (including a CMS `rich_text` variable expansion) contains block elements
- Compute `hasBlockExpansion` once in `LayerRendererPublic` and use it to both pick the wrapper tag and decide whether to flatten — flattening is now skipped when block expansion is present
- Pass the same `shouldFlatten` value through to `renderRichText` as `isSimpleTextElement` so nested rendering matches the wrapper choice
- Mirrored to both `LayerRenderer.tsx` (canvas) and `LayerRendererPublic.tsx` (SSR)

## Test plan

- [ ] Bind a `text` layer to a CMS `rich_text` field whose value contains headings, paragraphs, blockquote, image, and a table
- [ ] On canvas: confirm headings/blockquote/image/table render with their styles (no hydration warning in console)
- [ ] On preview: confirm the same content renders with full formatting (no flattened plain text + `<br>`)
- [ ] Verify a plain `text` layer with `dynamic_text` content still renders as `<p>` (no regression)
- [ ] Verify a `richText` layer with static content (no CMS binding) still renders correctly

Made with [Cursor](https://cursor.com)