### PR TITLE
feat: export redirects as CSV

### DIFF
--- a/app/(builder)/ycode/settings/redirects/page.tsx
+++ b/app/(builder)/ycode/settings/redirects/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Label } from '@/components/ui/label';
 import {
   FieldDescription,
   FieldLabel,
@@ -25,6 +24,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+
+import { downloadCSV, rowsToCSV } from '@/lib/csv-utils';
 
 import type { Redirect } from '@/types';
 
@@ -160,6 +161,17 @@ export default function RedirectsSettingsPage() {
     setEditingRedirect(null);
   };
 
+  const handleExportCSV = () => {
+    const headers = ['Old URL', 'New URL'];
+    const rows = redirects.map((r) => ({
+      'Old URL': r.oldUrl,
+      'New URL': r.newUrl,
+    }));
+    const csv = rowsToCSV(headers, rows);
+    const timestamp = new Date().toISOString().slice(0, 10);
+    downloadCSV(csv, `redirects-${timestamp}.csv`);
+  };
+
   return (
     <div className="p-8">
       <div className="max-w-3xl mx-auto">
@@ -177,7 +189,15 @@ export default function RedirectsSettingsPage() {
               </FieldDescription>
             </div>
 
-            <div>
+            <div className="flex gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleExportCSV}
+                disabled={isSaving || isLoading || redirects.length === 0}
+              >
+                Export as CSV
+              </Button>
               <Button
                 variant="secondary"
                 size="sm"
@@ -204,16 +224,16 @@ export default function RedirectsSettingsPage() {
               {redirects.map((redirect) => (
                 <div key={redirect.id} className="py-4 flex">
                   <div className="flex-1 flex items-center gap-4">
-                    <Label variant="muted" className="flex-1">
+                    <span className="flex-1 text-xs text-muted-foreground select-text break-all">
                       {redirect.oldUrl}
-                    </Label>
+                    </span>
                     <Icon
                       name="arrowLeft"
-                      className="size-2.5 rotate-180 opacity-50"
+                      className="size-2.5 rotate-180 opacity-50 shrink-0"
                     />
-                    <Label variant="muted" className="flex-1">
+                    <span className="flex-1 text-xs text-muted-foreground select-text break-all">
                       {redirect.newUrl}
-                    </Label>
+                    </span>
                   </div>
 
                   <DropdownMenu>

--- a/lib/csv-utils.ts
+++ b/lib/csv-utils.ts
@@ -356,6 +356,51 @@ export interface ParsedCSV {
 }
 
 /**
+ * Escape a single CSV field (RFC 4180): wraps in quotes when needed and
+ * doubles internal quote characters.
+ */
+function escapeCSVField(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\r\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Convert an array of objects into a CSV string. The provided headers
+ * define both the column order and the keys read from each row.
+ */
+export function rowsToCSV<T extends Record<string, unknown>>(
+  headers: string[],
+  rows: T[]
+): string {
+  const headerLine = headers.map(escapeCSVField).join(',');
+  const dataLines = rows.map((row) =>
+    headers.map((header) => escapeCSVField(row[header])).join(',')
+  );
+  return [headerLine, ...dataLines].join('\n');
+}
+
+/**
+ * Trigger a browser download for the given CSV string. No-op on the server.
+ */
+export function downloadCSV(csv: string, filename: string): void {
+  if (typeof window === 'undefined') return;
+
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/**
  * Parse CSV text into headers and rows.
  * Handles quoted fields, escaped quotes, and multi-line values inside quotes.
  */


### PR DESCRIPTION
## Summary

Allow users to export their redirects to a CSV file from the redirects settings page, and make the redirect URLs selectable so they can be copied directly.

## Changes

- Add `Export as CSV` action (ghost button) on the redirects settings page
- Export the list as `redirects-YYYY-MM-DD.csv` with `Old URL` / `New URL` columns
- Add `rowsToCSV` and `downloadCSV` helpers in `lib/csv-utils.ts` (RFC 4180 escaping)
- Replace the `Label` components used to render the URL pairs with selectable `span`s so users can copy the old/new URL values directly

## Test plan

- [ ] Open Settings → Redirects with at least one redirect and click `Export as CSV` — a `redirects-<date>.csv` file is downloaded with `Old URL,New URL` headers
- [ ] Verify URLs containing commas, quotes or newlines are escaped correctly in the CSV
- [ ] Confirm the button is disabled when there are no redirects or while saving/loading
- [ ] Select and copy text from the old/new URL columns in the redirect list

Made with [Cursor](https://cursor.com)