### PR TITLE
fix: tint published icons and guard null select value

### DIFF
--- a/app/site.css
+++ b/app/site.css
@@ -42,6 +42,20 @@
   }
 }
 
+/* Force inline SVG fill/stroke attributes (even on nested nodes) to inherit
+   the icon layer's text color — matches the legacy `<i>` wrapper behavior so
+   migrated icons with hard-coded colors still tint with `text-*` utilities.
+   Note: must not blanket-apply `fill: currentColor` to the root <svg>, since
+   that would override `fill="none"` and solid-fill stroke-only icons. */
+[data-icon] [fill]:not([fill="none"]) {
+  fill: currentColor;
+}
+
+[data-icon] [stroke]:not([stroke="none"]),
+[data-icon] [stroke-width] {
+  stroke: currentColor;
+}
+
 /* Custom dropdown chevron for native <select> elements on published pages.
    The native arrow is removed by the inline `ycode-form-reset` styles in
    PageRenderer.tsx; this rule restores a consistent chevron. */

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -2300,6 +2300,12 @@ const LayerItemImpl: React.FC<{
         elementProps.name = layer.settings?.id || layer.id;
       }
 
+      // Drop null/undefined value so the select can fall back to defaultValue
+      // (React warns about a null value prop on <select>).
+      if ('value' in elementProps && elementProps.value == null) {
+        delete elementProps.value;
+      }
+
       // In edit mode, keep value controlled (canvas selects aren't interactive)
       // so the rendered selection reflects default changes in real time.
       // In preview/published, convert to defaultValue so the field is uncontrolled


### PR DESCRIPTION
## Summary

Two unrelated regressions on published/preview pages: icon SVGs uploaded with hardcoded fills no longer inherited the parent's text color, and selects bound to a null value triggered a React warning.

## Changes

- Re-add the `[data-icon] [fill]:not([fill="none"])` / `[stroke]` `currentColor` rule to `app/site.css`. It was dropped when the (site) route group moved off `app/globals.css` to the slim `site.css` bundle (170744d5), so `text-*` utilities on the icon's ancestor no longer tinted the SVG on published pages.
- In `LayerRenderer`, drop `null`/`undefined` `value` from `<select>` `elementProps` before the controlled-vs-uncontrolled branching. Avoids React's "value prop on select should not be null" warning and lets the placeholder `defaultValue` take effect.

## Test plan

- [ ] On a published or preview page, verify an icon layer with `text-red-500` (or any text color override / hover) renders the SVG in that color even when the asset SVG has hardcoded `fill="#xxx"`.
- [ ] Hover a collection card with `hover:text-[color:var(...)]` and confirm the inner icon tints to match.
- [ ] Add a `<select>` whose value variable is currently empty/null and confirm no React console warning is emitted in dev.
- [ ] In edit mode the select still shows its placeholder option; in preview/published it remains interactive.

Made with [Cursor](https://cursor.com)