### PR TITLE
feat: server search for CMS items in link selectors

### DIFF
--- a/app/(builder)/ycode/components/CollectionLinkFieldInput.tsx
+++ b/app/(builder)/ycode/components/CollectionLinkFieldInput.tsx
@@ -7,7 +7,7 @@
  * Supports URL, Page, and Asset link types.
  */
 
-import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import React, { useCallback, useMemo, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -20,15 +20,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import type { CollectionLinkValue, CollectionLinkType, CollectionItemWithValues } from '@/types';
+import type { CollectionLinkValue, CollectionLinkType } from '@/types';
 import { usePagesStore } from '@/stores/usePagesStore';
-import { useCollectionsStore } from '@/stores/useCollectionsStore';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { useAssetsStore } from '@/stores/useAssetsStore';
-import { collectionsApi } from '@/lib/api';
 import { getAssetIcon } from '@/lib/asset-utils';
 import { findLayersWithAnchorId } from '@/lib/layer-utils';
 import { getLayerIcon, getLayerName } from '@/lib/layer-display-utils';
+import LinkCollectionItemPicker from './LinkCollectionItemPicker';
 import PageSelector from './PageSelector';
 
 interface CollectionLinkFieldInputProps {
@@ -73,15 +72,10 @@ export default function CollectionLinkFieldInput({
   onChange,
   disabled = false,
 }: CollectionLinkFieldInputProps) {
-  const [collectionItems, setCollectionItems] = useState<CollectionItemWithValues[]>([]);
-  const [loadingItems, setLoadingItems] = useState(false);
-  const [collectionItemSearch, setCollectionItemSearch] = useState('');
-
   // Stores
   const pages = usePagesStore((state) => state.pages);
   const draftsByPageId = usePagesStore((state) => state.draftsByPageId);
   const loadDraft = usePagesStore((state) => state.loadDraft);
-  const { fields: collectionsFields } = useCollectionsStore();
   const openFileManager = useEditorStore((state) => state.openFileManager);
   const getAsset = useAssetsStore((state) => state.getAsset);
 
@@ -125,55 +119,10 @@ export default function CollectionLinkFieldInput({
   // Check if selected page is dynamic
   const isDynamicPage = selectedPage?.is_dynamic || false;
   const pageCollectionId = selectedPage?.settings?.cms?.collection_id || null;
+  const collectionPickerId = isDynamicPage ? pageCollectionId : null;
 
-  // Get slug field for the collection
+  // Slug field used as a label fallback when the item has no `name` value
   const slugFieldId = selectedPage?.settings?.cms?.slug_field_id || null;
-  const collectionFields = pageCollectionId ? collectionsFields[pageCollectionId] || [] : [];
-  const nameField = collectionFields.find((f) => f.key === 'name');
-
-  // Load collection items when dynamic page is selected
-  useEffect(() => {
-    if (!pageCollectionId || !isDynamicPage) {
-      setCollectionItems([]);
-      return;
-    }
-
-    const loadItems = async () => {
-      setLoadingItems(true);
-      try {
-        const response = await collectionsApi.getItems(pageCollectionId);
-        if (response.data) {
-          setCollectionItems(response.data.items || []);
-        }
-      } catch (error) {
-        console.error('Failed to load collection items:', error);
-      } finally {
-        setLoadingItems(false);
-      }
-    };
-
-    loadItems();
-  }, [pageCollectionId, isDynamicPage]);
-
-  // Get display name for collection item
-  const getItemDisplayName = useCallback((itemId: string): string => {
-    const item = collectionItems.find((i) => i.id === itemId);
-    if (!item) return itemId;
-
-    // Try name field first
-    if (nameField && item.values[nameField.id]) {
-      return item.values[nameField.id];
-    }
-
-    // Try slug field
-    if (slugFieldId && item.values[slugFieldId]) {
-      return item.values[slugFieldId];
-    }
-
-    // Fallback to first value
-    const firstValue = Object.values(item.values)[0];
-    return firstValue || itemId;
-  }, [collectionItems, nameField, slugFieldId]);
 
   // Update link value helper
   const updateLinkValue = useCallback(
@@ -379,49 +328,13 @@ export default function CollectionLinkFieldInput({
             <div className="flex-1 min-w-0">
               <div className="flex flex-col gap-1.5">
                 <Label className="text-xs text-muted-foreground">CMS item</Label>
-                <Select
-                  value={collectionItemId || ''}
-                  onValueChange={(value) => {
-                    handleCollectionItemChange(value);
-                    setCollectionItemSearch('');
-                  }}
-                  onOpenChange={(open) => {
-                    if (!open) setCollectionItemSearch('');
-                  }}
-                  disabled={disabled || loadingItems}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder={loadingItems ? 'Loading...' : 'Select...'} />
-                  </SelectTrigger>
-                  <SelectContent
-                    searchable
-                    searchValue={collectionItemSearch}
-                    onSearchChange={setCollectionItemSearch}
-                    searchPlaceholder="Search items..."
-                    className="w-72"
-                  >
-                    {(() => {
-                      const query = collectionItemSearch.trim().toLowerCase();
-                      const filtered = query
-                        ? collectionItems.filter(item =>
-                          getItemDisplayName(item.id).toLowerCase().includes(query)
-                        )
-                        : collectionItems;
-                      if (filtered.length === 0) {
-                        return (
-                          <div className="px-2 py-4 text-center text-xs text-muted-foreground">
-                            {query ? 'No items found' : 'No items available'}
-                          </div>
-                        );
-                      }
-                      return filtered.map((item) => (
-                        <SelectItem key={item.id} value={item.id}>
-                          {getItemDisplayName(item.id)}
-                        </SelectItem>
-                      ));
-                    })()}
-                  </SelectContent>
-                </Select>
+                <LinkCollectionItemPicker
+                  collectionId={collectionPickerId}
+                  value={collectionItemId}
+                  onChange={handleCollectionItemChange}
+                  slugFieldId={slugFieldId}
+                  disabled={disabled}
+                />
               </div>
             </div>
           )}

--- a/app/(builder)/ycode/components/LinkCollectionItemPicker.tsx
+++ b/app/(builder)/ycode/components/LinkCollectionItemPicker.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import {
+  Select,
+  SelectContent,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useCollectionItemSearch } from '@/hooks/use-collection-item-search';
+import LinkItemOptions, { resolveCollectionItemSelectLabel } from './LinkItemOptions';
+import type { ReferenceItemOption } from '@/lib/collection-field-utils';
+
+interface LinkCollectionItemPickerProps {
+  /** Collection id whose items power the picker; null disables it. */
+  collectionId: string | null;
+  /** Currently selected value (item id, keyword, or reference value). */
+  value: string | null;
+  onChange: (value: string) => void;
+  /** Dynamic-resolution / reference options. All default to off/empty so the
+   *  picker can be used in simpler contexts (e.g. collection field editing). */
+  canUseCurrentPageItem?: boolean;
+  canUseCurrentCollectionItem?: boolean;
+  canUseNextPreviousItem?: boolean;
+  referenceItemOptions?: ReferenceItemOption[];
+  /** Optional slug field id used as a label fallback after the `name` field */
+  slugFieldId?: string | null;
+  disabled?: boolean;
+}
+
+/**
+ * Searchable CMS-item picker used by link settings. Wraps `Select` with the
+ * shared `useCollectionItemSearch` hook (preload + debounced server search +
+ * lazy hydration of the selected item) and the keyword/reference options
+ * defined by `LinkItemOptions`.
+ */
+export default function LinkCollectionItemPicker({
+  collectionId,
+  value,
+  onChange,
+  canUseCurrentPageItem = false,
+  canUseCurrentCollectionItem = false,
+  canUseNextPreviousItem = false,
+  referenceItemOptions = [],
+  slugFieldId,
+  disabled = false,
+}: LinkCollectionItemPickerProps) {
+  const {
+    search,
+    setSearch,
+    isSearching,
+    items,
+    fields,
+    resetSearch,
+  } = useCollectionItemSearch(collectionId, value);
+
+  // Resolve the trigger label ourselves so it stays visible even when the
+  // selected item is filtered out of the dropdown by the active search. We
+  // can't pass this through `SelectValue` children — Radix uses that node as
+  // a portal target and React warns when we set text content on it.
+  const resolvedLabel = resolveCollectionItemSelectLabel(value, items, fields, referenceItemOptions, slugFieldId);
+
+  return (
+    <Select
+      value={value || ''}
+      onValueChange={(next) => {
+        onChange(next);
+        resetSearch();
+      }}
+      onOpenChange={(open) => {
+        if (!open) resetSearch();
+      }}
+      disabled={disabled}
+    >
+      <SelectTrigger className="w-full">
+        {resolvedLabel ? <span className="truncate">{resolvedLabel}</span> : <SelectValue placeholder="Select..." />}
+      </SelectTrigger>
+      <SelectContent
+        searchable
+        searchValue={search}
+        onSearchChange={setSearch}
+        searchLoading={isSearching}
+        searchPlaceholder="Search items..."
+        className="w-72"
+      >
+        <LinkItemOptions
+          canUseCurrentPageItem={canUseCurrentPageItem}
+          canUseCurrentCollectionItem={canUseCurrentCollectionItem}
+          canUseNextPreviousItem={canUseNextPreviousItem}
+          referenceItemOptions={referenceItemOptions}
+          collectionItems={items}
+          collectionFields={fields}
+          searchValue={search}
+          isSearching={isSearching}
+          slugFieldId={slugFieldId}
+        />
+      </SelectContent>
+    </Select>
+  );
+}

--- a/app/(builder)/ycode/components/LinkItemOptions.tsx
+++ b/app/(builder)/ycode/components/LinkItemOptions.tsx
@@ -20,13 +20,54 @@ interface CollectionItemSelectOptionsProps {
   collectionFields: CollectionField[];
   /** Optional search string to filter visible options by their display label */
   searchValue?: string;
+  /** When true, a debounced server search is in flight; show a loading state instead of "No items" */
+  isSearching?: boolean;
+  /** Optional slug field id used as a label fallback after the `name` field */
+  slugFieldId?: string | null;
 }
 
-function getDisplayName(item: CollectionItemWithValues, collectionFields: CollectionField[]): string {
+/**
+ * Resolve a CMS item's display label using its `name` field, then an optional
+ * `slug` field, then the first stored value, then the raw id. Exported so the
+ * link selectors can render the trigger label even when the selected item is
+ * filtered out of the visible list.
+ */
+export function getCollectionItemDisplayName(
+  item: CollectionItemWithValues,
+  collectionFields: CollectionField[],
+  slugFieldId?: string | null
+): string {
   const nameField = collectionFields.find(f => f.key === 'name');
   if (nameField && item.values[nameField.id]) return item.values[nameField.id];
+  if (slugFieldId && item.values[slugFieldId]) return item.values[slugFieldId];
   const values = Object.values(item.values);
   return values[0] || item.id;
+}
+
+/**
+ * Resolve the trigger label for any value the CMS item picker can hold:
+ * concrete item ids, dynamic-resolution keywords, or reference-field options.
+ * Returns null when the value cannot be resolved (e.g. unknown id).
+ */
+export function resolveCollectionItemSelectLabel(
+  value: string | null | undefined,
+  collectionItems: CollectionItemWithValues[],
+  collectionFields: CollectionField[],
+  referenceItemOptions: ReferenceItemOption[],
+  slugFieldId?: string | null
+): string | null {
+  if (!value) return null;
+  switch (value) {
+    case COLLECTION_ITEM_KEYWORDS.CURRENT_PAGE: return 'Current page item';
+    case COLLECTION_ITEM_KEYWORDS.CURRENT_COLLECTION: return 'Current collection item';
+    case COLLECTION_ITEM_KEYWORDS.PREVIOUS_ITEM: return 'Previous item';
+    case COLLECTION_ITEM_KEYWORDS.NEXT_ITEM: return 'Next item';
+  }
+  const refOption = referenceItemOptions.find(opt => opt.value === value);
+  if (refOption) return refOption.label;
+  const item = collectionItems.find(i => i.id === value);
+  if (item) return getCollectionItemDisplayName(item, collectionFields, slugFieldId);
+  return null;
 }
 
 /**
@@ -46,6 +87,8 @@ export default function LinkItemOptions({
   collectionItems,
   collectionFields,
   searchValue,
+  isSearching = false,
+  slugFieldId,
 }: CollectionItemSelectOptionsProps) {
   const query = searchValue?.trim().toLowerCase() ?? '';
   const matches = (label: string) => !query || label.toLowerCase().includes(query);
@@ -55,7 +98,7 @@ export default function LinkItemOptions({
   const showPreviousItem = canUseNextPreviousItem && matches('Previous item');
   const showNextItem = canUseNextPreviousItem && matches('Next item');
   const filteredReferenceOptions = referenceItemOptions.filter(opt => matches(opt.label));
-  const filteredItems = collectionItems.filter(item => matches(getDisplayName(item, collectionFields)));
+  const filteredItems = collectionItems.filter(item => matches(getCollectionItemDisplayName(item, collectionFields, slugFieldId)));
 
   const hasSpecialOptions =
     showCurrentPageItem ||
@@ -65,10 +108,10 @@ export default function LinkItemOptions({
     filteredReferenceOptions.length > 0;
   const hasAnyResults = hasSpecialOptions || filteredItems.length > 0;
 
-  if (!hasAnyResults && query) {
+  if (!hasAnyResults) {
     return (
       <div className="px-2 py-4 text-center text-xs text-muted-foreground">
-        No items found
+        {isSearching ? 'Searching...' : (query ? 'No items found' : 'No items available')}
       </div>
     );
   }
@@ -103,7 +146,7 @@ export default function LinkItemOptions({
       {hasSpecialOptions && filteredItems.length > 0 && <SelectSeparator />}
       {filteredItems.map((item) => (
         <SelectItem key={item.id} value={item.id}>
-          {getDisplayName(item, collectionFields)}
+          {getCollectionItemDisplayName(item, collectionFields, slugFieldId)}
         </SelectItem>
       ))}
     </>

--- a/app/(builder)/ycode/components/LinkSettings.tsx
+++ b/app/(builder)/ycode/components/LinkSettings.tsx
@@ -7,7 +7,7 @@
  * Can also be used in standalone mode for component variables.
  */
 
-import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -18,7 +18,7 @@ import SettingsPanel from './SettingsPanel';
 import RichTextEditor from './RichTextEditor';
 import { filterFieldGroupsByType, flattenFieldGroups, LINK_FIELD_TYPES, buildReferenceItemOptions } from '@/lib/collection-field-utils';
 import { generateLinkHref } from '@/lib/link-utils';
-import LinkItemOptions from './LinkItemOptions';
+import LinkCollectionItemPicker from './LinkCollectionItemPicker';
 import { FieldSelectDropdown, type FieldGroup, type FieldSourceType } from './CollectionFieldSelector';
 import ComponentVariableLabel, { VARIABLE_TYPE_ICONS } from './ComponentVariableLabel';
 import {
@@ -29,19 +29,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import type { Layer, CollectionField, Collection, Page, LinkSettings as LinkSettingsType, LinkType, CollectionItemWithValues, LinkSettingsValue } from '@/types';
+import type { Layer, CollectionField, Collection, Page, LinkSettings as LinkSettingsType, LinkType, LinkSettingsValue } from '@/types';
 import {
   createDynamicTextVariable,
   getDynamicTextContent,
 } from '@/lib/variable-utils';
 import { usePagesStore } from '@/stores/usePagesStore';
-import { useCollectionsStore } from '@/stores/useCollectionsStore';
 import { useAssetsStore } from '@/stores/useAssetsStore';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { useComponentsStore } from '@/stores/useComponentsStore';
 import { ASSET_CATEGORIES, getAssetIcon } from '@/lib/asset-utils';
 import { toast } from 'sonner';
-import { collectionsApi, pagesApi } from '@/lib/api';
+import { pagesApi } from '@/lib/api';
 import { canLayerHaveLink, getCollectionVariable, findLayersWithAnchorId } from '@/lib/layer-utils';
 import { getLayerIcon, getLayerName } from '@/lib/layer-display-utils';
 import { Empty, EmptyDescription, EmptyTitle } from '@/components/ui/empty';
@@ -117,9 +116,6 @@ export default function LinkSettings(props: LinkSettingsProps) {
   const standaloneOnChange = isStandaloneMode ? props.onChange : undefined;
 
   const [isOpen, setIsOpen] = useState(true);
-  const [collectionItems, setCollectionItems] = useState<CollectionItemWithValues[]>([]);
-  const [loadingItems, setLoadingItems] = useState(false);
-  const [collectionItemSearch, setCollectionItemSearch] = useState('');
 
   // Stores
   const pages = usePagesStore((state) => state.pages);
@@ -128,7 +124,6 @@ export default function LinkSettings(props: LinkSettingsProps) {
   const openFileManager = useEditorStore((state) => state.openFileManager);
   const editingComponentId = useEditorStore((state) => state.editingComponentId);
   const getAsset = useAssetsStore((state) => state.getAsset);
-  const collectionsStoreFields = useCollectionsStore((state) => state.fields);
   const getComponentById = useComponentsStore((state) => state.getComponentById);
   const addLinkVariable = useComponentsStore((state) => state.addLinkVariable);
   const updateTextVariable = useComponentsStore((state) => state.updateTextVariable);
@@ -258,29 +253,7 @@ export default function LinkSettings(props: LinkSettingsProps) {
   // Get collection ID from dynamic page settings
   const pageCollectionId = selectedPage?.settings?.cms?.collection_id || null;
 
-  // Load collection items when dynamic page is selected
-  useEffect(() => {
-    if (!pageCollectionId || !isDynamicPage) {
-      setCollectionItems([]);
-      return;
-    }
-
-    const loadItems = async () => {
-      setLoadingItems(true);
-      try {
-        const response = await collectionsApi.getItems(pageCollectionId);
-        if (response.data) {
-          setCollectionItems(response.data.items || []);
-        }
-      } catch (error) {
-        console.error('Failed to load collection items:', error);
-      } finally {
-        setLoadingItems(false);
-      }
-    };
-
-    loadItems();
-  }, [pageCollectionId, isDynamicPage]);
+  const collectionPickerId = isDynamicPage ? pageCollectionId : null;
 
   // Check if link settings should be disabled due to nesting restrictions
   const linkNestingIssue = useMemo(() => {
@@ -636,12 +609,6 @@ export default function LinkSettings(props: LinkSettingsProps) {
   // Get asset info for display
   const selectedAsset = assetId ? getAsset(assetId) : null;
 
-  // Fields for the linked page's collection (for display names)
-  const linkedPageCollectionFields = useMemo(
-    () => pageCollectionId ? collectionsStoreFields[pageCollectionId] || [] : [],
-    [pageCollectionId, collectionsStoreFields]
-  );
-
   // Layer mode requires a layer
   if (!isStandaloneMode && !layer) return null;
 
@@ -867,38 +834,16 @@ export default function LinkSettings(props: LinkSettingsProps) {
               {!useStackedLayout && <Label variant="muted">CMS item</Label>}
               {useStackedLayout && <Label variant="muted" className="mb-1.5">CMS item</Label>}
               <div className={useStackedLayout ? '' : 'col-span-2'}>
-                <Select
-                  value={collectionItemId || ''}
-                  onValueChange={(value) => {
-                    handleCollectionItemChange(value);
-                    setCollectionItemSearch('');
-                  }}
-                  onOpenChange={(open) => {
-                    if (!open) setCollectionItemSearch('');
-                  }}
-                  disabled={isLockedByOther || loadingItems}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder={loadingItems ? 'Loading...' : 'Select...'} />
-                  </SelectTrigger>
-                  <SelectContent
-                    searchable
-                    searchValue={collectionItemSearch}
-                    onSearchChange={setCollectionItemSearch}
-                    searchPlaceholder="Search items..."
-                    className="w-72"
-                  >
-                    <LinkItemOptions
-                      canUseCurrentPageItem={canUseCurrentPageItem}
-                      canUseCurrentCollectionItem={canUseCurrentCollectionItem}
-                      canUseNextPreviousItem={canUseNextPreviousItem}
-                      referenceItemOptions={referenceItemOptions}
-                      collectionItems={collectionItems}
-                      collectionFields={linkedPageCollectionFields}
-                      searchValue={collectionItemSearch}
-                    />
-                  </SelectContent>
-                </Select>
+                <LinkCollectionItemPicker
+                  collectionId={collectionPickerId}
+                  value={collectionItemId}
+                  onChange={handleCollectionItemChange}
+                  canUseCurrentPageItem={canUseCurrentPageItem}
+                  canUseCurrentCollectionItem={canUseCurrentCollectionItem}
+                  canUseNextPreviousItem={canUseNextPreviousItem}
+                  referenceItemOptions={referenceItemOptions}
+                  disabled={isLockedByOther}
+                />
               </div>
             </div>
           )}

--- a/app/(builder)/ycode/components/RichTextLinkSettings.tsx
+++ b/app/(builder)/ycode/components/RichTextLinkSettings.tsx
@@ -8,7 +8,7 @@
  * Extracted from LinkSettings to work with LinkSettings object directly.
  */
 
-import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
@@ -24,23 +24,21 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { FieldSelectDropdown, type FieldSourceType } from './CollectionFieldSelector';
-import type { Layer, CollectionField, Collection, LinkSettings, LinkType, CollectionItemWithValues } from '@/types';
+import type { Layer, CollectionField, Collection, LinkSettings, LinkType } from '@/types';
 import {
   createDynamicTextVariable,
   getDynamicTextContent,
 } from '@/lib/variable-utils';
 import { usePagesStore } from '@/stores/usePagesStore';
-import { useCollectionsStore } from '@/stores/useCollectionsStore';
 import { useAssetsStore } from '@/stores/useAssetsStore';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { getAssetIcon } from '@/lib/asset-utils';
-import { collectionsApi } from '@/lib/api';
 import { getCollectionVariable, findLayersWithAnchorId } from '@/lib/layer-utils';
 import { getLayerIcon, getLayerName } from '@/lib/layer-display-utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import PageSelector from './PageSelector';
 import { filterFieldGroupsByType, flattenFieldGroups, LINK_FIELD_TYPES, buildReferenceItemOptions, type FieldGroup } from '@/lib/collection-field-utils';
-import LinkItemOptions from './LinkItemOptions';
+import LinkCollectionItemPicker from './LinkCollectionItemPicker';
 
 export interface RichTextLinkSettingsProps {
   /** Current link settings */
@@ -77,17 +75,12 @@ export default function RichTextLinkSettings({
   excludedLinkTypes = [],
   hidePageContextOptions = false,
 }: RichTextLinkSettingsProps) {
-  const [collectionItems, setCollectionItems] = useState<CollectionItemWithValues[]>([]);
-  const [loadingItems, setLoadingItems] = useState(false);
-  const [collectionItemSearch, setCollectionItemSearch] = useState('');
-
   // Stores
   const pages = usePagesStore((state) => state.pages);
   const draftsByPageId = usePagesStore((state) => state.draftsByPageId);
   const currentPageId = useEditorStore((state) => state.currentPageId);
   const openFileManager = useEditorStore((state) => state.openFileManager);
   const getAsset = useAssetsStore((state) => state.getAsset);
-  const collectionsStoreFields = useCollectionsStore((state) => state.fields);
 
   // Get current link settings
   const linkSettings = value;
@@ -200,29 +193,7 @@ export default function RichTextLinkSettings({
   // Get collection ID from dynamic page settings
   const pageCollectionId = selectedPage?.settings?.cms?.collection_id || null;
 
-  // Load collection items when dynamic page is selected
-  useEffect(() => {
-    if (!pageCollectionId || !isDynamicPage) {
-      setCollectionItems([]);
-      return;
-    }
-
-    const loadItems = async () => {
-      setLoadingItems(true);
-      try {
-        const response = await collectionsApi.getItems(pageCollectionId);
-        if (response.data) {
-          setCollectionItems(response.data.items || []);
-        }
-      } catch (error) {
-        console.error('Failed to load collection items:', error);
-      } finally {
-        setLoadingItems(false);
-      }
-    };
-
-    loadItems();
-  }, [pageCollectionId, isDynamicPage]);
+  const collectionPickerId = isDynamicPage ? pageCollectionId : null;
 
   // Link type options for the dropdown
   const linkTypeOptions = useMemo<
@@ -482,12 +453,6 @@ export default function RichTextLinkSettings({
   // Get asset info for display
   const selectedAsset = assetId ? getAsset(assetId) : null;
 
-  // Fields for the linked page's collection (for display names)
-  const linkedPageCollectionFields = useMemo(
-    () => pageCollectionId ? collectionsStoreFields[pageCollectionId] || [] : [],
-    [pageCollectionId, collectionsStoreFields]
-  );
-
   return (
     <div className="flex flex-col gap-3">
       {/* Link Type */}
@@ -624,38 +589,15 @@ export default function RichTextLinkSettings({
             <div className="grid grid-cols-3 items-center gap-2">
               <Label className="text-xs text-muted-foreground">CMS item</Label>
               <div className="col-span-2">
-                <Select
-                  value={collectionItemId || ''}
-                  onValueChange={(value) => {
-                    handleCollectionItemChange(value);
-                    setCollectionItemSearch('');
-                  }}
-                  onOpenChange={(open) => {
-                    if (!open) setCollectionItemSearch('');
-                  }}
-                  disabled={loadingItems}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder={loadingItems ? 'Loading...' : 'Select...'} />
-                  </SelectTrigger>
-                  <SelectContent
-                    searchable
-                    searchValue={collectionItemSearch}
-                    onSearchChange={setCollectionItemSearch}
-                    searchPlaceholder="Search items..."
-                    className="w-72"
-                  >
-                    <LinkItemOptions
-                      canUseCurrentPageItem={canUseCurrentPageItem}
-                      canUseCurrentCollectionItem={canUseCurrentCollectionItem}
-                      canUseNextPreviousItem={canUseNextPreviousItem}
-                      referenceItemOptions={referenceItemOptions}
-                      collectionItems={collectionItems}
-                      collectionFields={linkedPageCollectionFields}
-                      searchValue={collectionItemSearch}
-                    />
-                  </SelectContent>
-                </Select>
+                <LinkCollectionItemPicker
+                  collectionId={collectionPickerId}
+                  value={collectionItemId}
+                  onChange={handleCollectionItemChange}
+                  canUseCurrentPageItem={canUseCurrentPageItem}
+                  canUseCurrentCollectionItem={canUseCurrentCollectionItem}
+                  canUseNextPreviousItem={canUseNextPreviousItem}
+                  referenceItemOptions={referenceItemOptions}
+                />
               </div>
             </div>
           )}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,6 +8,13 @@ interface InputProps extends Omit<React.ComponentProps<'input'>, 'size'> {
   variant?: 'default' | 'rename' | 'rename-selected';
   stepper?: boolean;
   onStepperChange?: (value: string) => void;
+  /**
+   * Disable the implicit ArrowUp/ArrowDown numeric-stepping behavior.
+   * Use for text-only inputs (e.g. search fields) where pressing arrow keys
+   * should be left to the parent for navigation/highlighting instead of
+   * incrementing the value.
+   */
+  disableKeyboardStep?: boolean;
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(function Input({
@@ -20,6 +27,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(function Input({
   onChange,
   stepper = false,
   onStepperChange,
+  disableKeyboardStep = false,
   min,
   max,
   step = '1',
@@ -34,7 +42,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(function Input({
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     // Only handle arrow keys for numeric inputs
-    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+    if (!disableKeyboardStep && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
       const currentValue = typeof value === 'string' ? value : String(value || '');
 
       // Check if the value is a valid number or empty (treat empty as 0)

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -120,6 +120,11 @@ function SelectContent({
 }) {
   const searchInputRef = React.useRef<HTMLInputElement>(null);
   const isSearchFocusedRef = React.useRef(false);
+  // Timestamp of the last keyboard-navigation key on the search input.
+  // Used to distinguish a user-initiated focus transfer to an item (arrow
+  // keys) from a programmatic one (e.g. Radix re-focusing after items
+  // re-render when search results stream in).
+  const lastNavKeyAtRef = React.useRef(0);
 
   return (
     <SelectPrimitive.Portal>
@@ -149,9 +154,34 @@ function SelectContent({
                 placeholder={searchPlaceholder || 'Search...'}
                 value={searchValue}
                 onChange={(e) => onSearchChange?.(e.target.value)}
-                onKeyDown={(e) => e.stopPropagation()}
+                disableKeyboardStep
+                onKeyDown={(e) => {
+                  // Let arrow keys / Enter / Escape bubble up so Radix can
+                  // move the highlighted item and confirm selection; stop
+                  // everything else from hijacking the Select's typeahead.
+                  if (
+                    e.key === 'ArrowUp' ||
+                    e.key === 'ArrowDown' ||
+                    e.key === 'Home' ||
+                    e.key === 'End' ||
+                    e.key === 'PageUp' ||
+                    e.key === 'PageDown'
+                  ) {
+                    lastNavKeyAtRef.current = Date.now();
+                  } else if (e.key !== 'Enter' && e.key !== 'Escape') {
+                    e.stopPropagation();
+                  }
+                }}
                 onFocus={() => { isSearchFocusedRef.current = true; }}
-                onBlur={() => {
+                onBlur={(e) => {
+                  // Only allow focus transfer to an item when the user just
+                  // pressed a navigation key. Otherwise (e.g. Radix
+                  // re-focusing after the items list updates as search
+                  // results stream in) refocus the search input so typing
+                  // is uninterrupted.
+                  const next = e.relatedTarget as HTMLElement | null;
+                  const isUserNav = Date.now() - lastNavKeyAtRef.current < 150;
+                  if (isUserNav && next?.closest('[role="option"]')) return;
                   requestAnimationFrame(() => {
                     if (isSearchFocusedRef.current) {
                       searchInputRef.current?.focus();

--- a/hooks/use-collection-item-search.ts
+++ b/hooks/use-collection-item-search.ts
@@ -1,0 +1,111 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useDebounce } from '@/hooks/use-debounce';
+import { useCollectionsStore } from '@/stores/useCollectionsStore';
+import type { CollectionField, CollectionItemWithValues } from '@/types';
+
+const SEARCH_LIMIT = 50;
+const SEARCH_DEBOUNCE_MS = 300;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface UseCollectionItemSearchResult {
+  /** Current (uncontrolled) search input value */
+  search: string;
+  setSearch: (value: string) => void;
+  /** True while a debounced server search is in flight */
+  isSearching: boolean;
+  /** Items from the store (preloaded + any merged search results) */
+  items: CollectionItemWithValues[];
+  /** Collection fields from the store */
+  fields: CollectionField[];
+  /** Resolve a human-readable label for an item using the `name` field, with fallbacks */
+  getItemLabel: (item: CollectionItemWithValues) => string;
+  /** Clear the search input */
+  resetSearch: () => void;
+}
+
+/**
+ * Provide a searchable collection-item list backed by `useCollectionsStore`.
+ * The preloaded items (first page) are returned immediately; typing triggers
+ * a debounced server search that merges results into the store so links can
+ * resolve items beyond the initial preload window.
+ *
+ * When `selectedId` is a concrete item id that isn't in the preloaded set,
+ * it is fetched and merged so the picker's trigger can display its label.
+ */
+export function useCollectionItemSearch(
+  collectionId: string | null | undefined,
+  selectedId?: string | null
+): UseCollectionItemSearchResult {
+  const itemsByCollection = useCollectionsStore((s) => s.items);
+  const fieldsByCollection = useCollectionsStore((s) => s.fields);
+  const searchAndMergeItems = useCollectionsStore((s) => s.searchAndMergeItems);
+  const ensureItemLoaded = useCollectionsStore((s) => s.ensureItemLoaded);
+
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebounce(search, SEARCH_DEBOUNCE_MS);
+  const [isSearching, setIsSearching] = useState(false);
+
+  const items = useMemo(
+    () => (collectionId ? itemsByCollection[collectionId] || [] : []),
+    [collectionId, itemsByCollection]
+  );
+  const fields = useMemo(
+    () => (collectionId ? fieldsByCollection[collectionId] || [] : []),
+    [collectionId, fieldsByCollection]
+  );
+
+  const trimmedSearch = debouncedSearch.trim();
+
+  useEffect(() => {
+    if (!collectionId || !trimmedSearch) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsSearching(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsSearching(true);
+    searchAndMergeItems(collectionId, trimmedSearch, SEARCH_LIMIT)
+      .finally(() => {
+        if (!cancelled) setIsSearching(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [collectionId, trimmedSearch, searchAndMergeItems]);
+
+  // Hydrate the selected item when it isn't part of the preloaded set so the
+  // trigger can render its label without the user opening the dropdown first.
+  // Skips dynamic-resolution keywords / reference-prefixed values, which are
+  // not concrete item ids.
+  const isConcreteItemId = !!selectedId && UUID_RE.test(selectedId);
+  const hasSelectedItemInStore = isConcreteItemId
+    && items.some((item) => item.id === selectedId);
+  useEffect(() => {
+    if (!collectionId || !isConcreteItemId || hasSelectedItemInStore) return;
+    ensureItemLoaded(collectionId, selectedId as string);
+  }, [collectionId, selectedId, isConcreteItemId, hasSelectedItemInStore, ensureItemLoaded]);
+
+  const getItemLabel = useMemo(() => {
+    const nameField = fields.find((f) => f.key === 'name');
+    return (item: CollectionItemWithValues): string => {
+      if (nameField) {
+        const nameValue = item.values?.[nameField.id];
+        if (nameValue !== null && nameValue !== undefined && String(nameValue).trim() !== '') {
+          return String(nameValue);
+        }
+      }
+      const firstValue = Object.values(item.values || {})[0];
+      return (firstValue && String(firstValue)) || `Item ${item.id.slice(0, 8)}`;
+    };
+  }, [fields]);
+
+  return {
+    search,
+    setSearch,
+    isSearching,
+    items,
+    fields,
+    getItemLabel,
+    resetSearch: () => setSearch(''),
+  };
+}

--- a/stores/useCollectionsStore.ts
+++ b/stores/useCollectionsStore.ts
@@ -54,6 +54,7 @@ interface CollectionsActions {
   loadPublishedItems: (collectionId: string) => Promise<void>;
   getDropdownItems: (collectionId: string) => Promise<Array<{ id: string; label: string }>>;
   searchAndMergeItems: (collectionId: string, query: string, limit?: number) => Promise<Array<{ id: string; label: string }>>;
+  ensureItemLoaded: (collectionId: string, itemId: string) => Promise<void>;
   createItem: (collectionId: string, values: Record<string, any>, statusAction?: StatusAction) => Promise<CollectionItemWithValues>;
   updateItem: (collectionId: string, itemId: string, values: Record<string, any>) => Promise<void>;
   deleteItem: (collectionId: string, itemId: string) => Promise<void>;
@@ -1266,6 +1267,31 @@ export const useCollectionsStore = create<CollectionsStore>((set, get) => ({
     } catch (error) {
       console.error('Failed to search collection items:', error);
       return [];
+    }
+  },
+
+  ensureItemLoaded: async (collectionId: string, itemId: string) => {
+    if (!collectionId || !itemId) return;
+    const existing = get().items[collectionId] || [];
+    if (existing.some(item => item.id === itemId)) return;
+
+    try {
+      const response = await collectionsApi.getItemById(collectionId, itemId);
+      if (response.error || !response.data) return;
+      const item = response.data;
+
+      set(state => {
+        const current = state.items[collectionId] || [];
+        if (current.some(i => i.id === item.id)) return state;
+        return {
+          items: {
+            ...state.items,
+            [collectionId]: [...current, item],
+          },
+        };
+      });
+    } catch (error) {
+      console.error('Failed to hydrate collection item:', error);
     }
   },
 }));


### PR DESCRIPTION
## Summary

Brings the CMS item picker used by link settings (layer Link, rich-text Link, and the collection Link field) on par with the canvas top-bar collection item selector: items are sourced from the store with debounced server search, the currently-selected item is lazy-hydrated so its label always renders, and keyboard/focus behavior is shared across all link surfaces.

## Changes

- Add `LinkCollectionItemPicker` so layer link settings, rich-text link settings, and the collection link field share the same picker, label resolution (dynamic-resolution keywords, reference options, slug-field fallback), search state, and empty/loading copy
- Add `useCollectionItemSearch` hook that preloads collection items, runs debounced `searchAndMergeItems`, and hydrates the currently-selected item via the new `ensureItemLoaded` store action so the trigger label persists even when the item is outside the preload window or filtered out by search
- Export `getCollectionItemDisplayName` / `resolveCollectionItemSelectLabel` helpers from `LinkItemOptions` with optional `slugFieldId` fallback for the CMS editing context
- Add `disableKeyboardStep` opt-out on `Input` and use it for the `Select` search field so ArrowUp/ArrowDown no longer step its value to `1` / `-1`
- Let `ArrowUp/Down/Home/End/PageUp/PageDown/Enter/Escape` bubble from the `Select` search input so Radix can move the highlighted option; refocus the search input on programmatic blurs (e.g. when streaming search results re-render the list) while still allowing user-driven keyboard navigation to transfer focus to items
- Render the resolved selected-item label as a sibling of `SelectValue` inside the trigger to avoid the `createRoot`/`createPortal` conflict from passing children to `SelectValue`
- Show the in-input spinner while the link picker is searching (parity with the page selector)

## Test plan

- [ ] In a collection with > 25 items, open the right-sidebar Link settings on a layer, switch the link type to a CMS item, and confirm typing surfaces items beyond the first 25
- [ ] Repeat the above for a rich-text Link (inside the rich-text editor link popover) and for the Link field on a collection item (CMS content editing)
- [ ] Select an item, then search for something that filters it out — the trigger should keep showing the selected item's label
- [ ] Hard-reload with a saved link pointing at an item outside the preload window — the trigger should still render the item's label (lazy hydrate)
- [ ] Focus the search input and press ArrowDown / ArrowUp — the highlight should move between options; the input value must stay empty (no `1` / `-1`)
- [ ] Type, then press Backspace fast — the input should keep focus while results stream in
- [ ] Press Enter on a highlighted option — selects it and closes the dropdown; Escape closes without changing the value
- [ ] While searching, the spinner appears inside the search input and disappears once results land
- [ ] Dynamic-resolution keywords (Current page item, Current collection item, Next/Previous) still appear when supported and select correctly
- [ ] Reference fields (e.g. a "Category" reference) still show their reference options at the top of the list

Made with [Cursor](https://cursor.com)