### PR TITLE
fix: resolve page links inside rich-text embedded components

### DIFF
--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -38,7 +38,8 @@ const getCachedPublishedFolders = unstable_cache(
   { tags: ['all-pages'], revalidate: false }
 );
 
-/** Recursively collect all page link refs ({collection_item_id, page_id}) from a Tiptap JSON node */
+/** Recursively collect all page link refs ({collection_item_id, page_id}) from a Tiptap JSON node.
+ * Also descends into pre-resolved layers stored on embedded richTextComponent nodes. */
 function collectTiptapPageLinks(node: any): PageLinkRef[] {
   if (!node || typeof node !== 'object') return [];
   const results: PageLinkRef[] = [];
@@ -49,6 +50,10 @@ function collectTiptapPageLinks(node: any): PageLinkRef[] {
         results.push({ collection_item_id: mark.attrs.page.collection_item_id, page_id: mark.attrs.page.id });
       }
     }
+  }
+  // Pre-resolved layers from rich-text-embedded components (set by resolveTiptapComponentCollections)
+  if (node.type === 'richTextComponent' && Array.isArray(node.attrs?._resolvedLayers)) {
+    results.push(...collectLayerPageLinks(node.attrs._resolvedLayers as Layer[]));
   }
   if (node.content && Array.isArray(node.content)) {
     for (const child of node.content) results.push(...collectTiptapPageLinks(child));
@@ -87,15 +92,34 @@ function collectLayerPageLinks(layers: Layer[]): PageLinkRef[] {
   return results;
 }
 
+/** Recursively scan a Tiptap JSON node for richTextComponent nodes and harvest
+ * slugs from their pre-resolved layers (populated by resolveTiptapComponentCollections). */
+function extractTiptapCollectionItemSlugs(node: any, slugs: Record<string, string>): void {
+  if (!node || typeof node !== 'object') return;
+  if (node.type === 'richTextComponent' && Array.isArray(node.attrs?._resolvedLayers)) {
+    const nested = extractCollectionItemSlugs(node.attrs._resolvedLayers as Layer[]);
+    Object.assign(slugs, nested);
+  }
+  if (Array.isArray(node.content)) {
+    for (const child of node.content) extractTiptapCollectionItemSlugs(child, slugs);
+  }
+}
+
 /**
  * Extract collection item slugs from resolved collection layers.
  * These are populated by resolveCollectionLayers with `_collectionItemId` / `_collectionItemSlug`.
+ * Also descends into pre-resolved layers of rich-text-embedded components so links inside
+ * those components (e.g. "current-collection") can be resolved at render time.
  */
 function extractCollectionItemSlugs(layers: Layer[]): Record<string, string> {
   const slugs: Record<string, string> = {};
   const scan = (layer: Layer) => {
     if (layer._collectionItemId && layer._collectionItemSlug) {
       slugs[layer._collectionItemId] = layer._collectionItemSlug;
+    }
+    const textVar = layer.variables?.text as any;
+    if (textVar?.type === 'dynamic_rich_text' && textVar.data?.content) {
+      extractTiptapCollectionItemSlugs(textVar.data.content, slugs);
     }
     if (layer.children) layer.children.forEach(scan);
   };


### PR DESCRIPTION
## Summary

Page links inside components embedded in CMS rich-text fields (e.g. a "Bio" button using the `current-collection` keyword) rendered with the literal `{slug}` placeholder instead of the actual item slug. The renderer was building the collection-item slug map by walking only `layer.children`, but rich-text-embedded components store their pre-resolved layers on `attrs._resolvedLayers` of the Tiptap `richTextComponent` node — they were never visited.

## Changes

- Descend into `attrs._resolvedLayers` of `richTextComponent` Tiptap nodes when collecting page link refs, so specific item ID and `ref-*` links contribute to `referencedItemIds`
- Descend into the same node attribute when extracting collection-item slugs, so `current-collection`, `next-item` and `previous-item` keywords resolve for layers inside embedded components
- Mirrors the existing pattern already used in `lib/asset-utils.ts`

## Test plan

- [ ] Embed a component containing a collection layer inside a CMS `rich_text` field on a dynamic page
- [ ] Add a layer-level page link inside that component using `current-collection`
- [ ] Publish and visit the generated page — the link should resolve to the actual item URL (no `{slug}` placeholder)
- [ ] Verify `next-item` / `previous-item` keywords still work for non-embedded usage
- [ ] Verify links pointing to a specific collection item ID inside the embedded component also resolve correctly

Made with [Cursor](https://cursor.com)