### PR TITLE
fix: replay click animations from current values

### DIFF
--- a/components/AnimationInitializer.tsx
+++ b/components/AnimationInitializer.tsx
@@ -410,7 +410,7 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
               }
               isForward = !isForward;
             } else {
-              timeline.restart();
+              timeline.invalidate().restart();
             }
           };
 


### PR DESCRIPTION
## Summary

Click-triggered timelines call `timeline.restart()`, which rewinds to the start values GSAP recorded on the first play. For `to()`-only tweens (no explicit `from`), this means repeated clicks re-run the same animation even when the element is already in the end state — e.g. clicking an accordion section that's already open re-animates its image from `0` to `auto` every time.

Invalidating the timeline before restart re-reads current DOM values, which matches state-toggling UI expectations without affecting `fromTo` or explicit-`from` tweens.

## Changes

- Replace `timeline.restart()` with `timeline.invalidate().restart()` on click triggers (non-yoyo, non-looped path)

## Test plan

- [ ] Accordion-style click interaction: clicking the same trigger repeatedly while it's open does not re-animate
- [ ] Clicking a different trigger still animates correctly between states
- [ ] `fromTo` tweens with explicit start/end values still play as expected on every click
- [ ] Yoyo click interactions still toggle play/reverse correctly
- [ ] Looped click interactions still toggle play/pause correctly
- [ ] Hover, scroll-into-view, while-scrolling, and load triggers behave unchanged

Made with [Cursor](https://cursor.com)