### PR TITLE
fix: prevent double-append of resize params and unblock seo image preview

### DIFF
--- a/app/(builder)/ycode/components/PageSettingsPanel.tsx
+++ b/app/(builder)/ycode/components/PageSettingsPanel.tsx
@@ -1666,6 +1666,11 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
                             <div className="bg-input rounded-lg w-full aspect-[1.91/1] flex items-center justify-center overflow-hidden relative">
                               {isSeoImageFieldVariable(seoImage) ? null : (() => {
                                 const imageUrl = seoImageAsset?.public_url;
+                                // `unoptimized`: the assets store already
+                                // rewrites `public_url` to our `/a/...` proxy
+                                // URL with resize params, so we don't want
+                                // Next's optimizer (and its `localPatterns`
+                                // gate) to re-process it.
                                 return imageUrl ? (
                                   <Image
                                     className="object-cover"
@@ -1673,6 +1678,7 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
                                     alt="Social preview"
                                     fill
                                     sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                                    unoptimized
                                   />
                                 ) : null;
                               })()}

--- a/lib/asset-utils.ts
+++ b/lib/asset-utils.ts
@@ -385,8 +385,14 @@ export function getOptimizedImageUrl(
 
   try {
     if (isProxyUrl(url)) {
-      const separator = url.includes('?') ? '&' : '?';
-      return `${url}${separator}width=${width}&quality=${quality}`;
+      // Use URL parsing against a dummy base so we can `.set()` rather than
+      // append — the store may have already rewritten `public_url` to include
+      // its own `width`/`quality`, and naive concatenation would emit them
+      // twice (e.g. `?width=1920&quality=80&width=200&quality=80`).
+      const proxyUrl = new URL(url, 'http://localhost');
+      proxyUrl.searchParams.set('width', width.toString());
+      proxyUrl.searchParams.set('quality', quality.toString());
+      return `${proxyUrl.pathname}${proxyUrl.search}`;
     }
 
     const urlObj = new URL(url);


### PR DESCRIPTION
## Summary

Two related image-rendering bugs in the builder:

1. `getOptimizedImageUrl` appended `?width=&quality=` via string concat, so when the assets store had already rewritten `public_url` to the proxy URL with resize params, callers got URLs like `/a/{hash}/foo.webp?width=1920&quality=80&width=200&quality=80`. The proxy then resolved to the wrong size.
2. The SEO social preview in `PageSettingsPanel` rendered the same proxy URL through `next/image`. Next 15's `localPatterns` gate rejects local URLs with query strings, breaking the preview.

## Changes

- Parse the URL in `getOptimizedImageUrl` and call `searchParams.set()` so resize params are replaced rather than duplicated.
- Mark the SEO social preview `<Image>` as `unoptimized` — the proxy already returns a resized image, so Next's optimizer would be a no-op layer on top anyway.

## Test plan

- [ ] Open the file manager: thumbnail URLs contain a single `width=`/`quality=` pair (200/80), not two
- [ ] Open Page Settings → SEO: the social preview thumbnail renders for a static asset image
- [ ] Open Page Settings → SEO: the social preview area stays empty (no error) when the image is a dynamic field variable
- [ ] No `next/image` `localPatterns` errors in the dev console

Made with [Cursor](https://cursor.com)