### PR TITLE
refactor(mcp): centralize templateEnum and richTextBlockSchema

### DIFF
--- a/lib/mcp/tools/batch.ts
+++ b/lib/mcp/tools/batch.ts
@@ -13,22 +13,10 @@ import {
   getTiptapTextContent,
   buildTiptapDoc,
   applyDesignToLayer,
-  ELEMENT_TEMPLATES,
 } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
 import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
-import { designSchema } from './shared-schemas';
-
-const templateEnum = z.enum(
-  Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
-);
-
-const richTextBlockSchema = z.object({
-  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
-  text: z.string().optional(),
-  level: z.number().optional(),
-  items: z.array(z.string()).optional(),
-});
+import { designSchema, richTextBlockSchema, templateEnum } from './shared-schemas';
 
 const addLayerOp = z.object({
   type: z.literal('add_layer'),

--- a/lib/mcp/tools/components.ts
+++ b/lib/mcp/tools/components.ts
@@ -19,7 +19,6 @@ import {
   getTiptapTextContent,
   applyDesignToLayer,
   generateId,
-  ELEMENT_TEMPLATES,
 } from '@/lib/mcp/utils';
 import {
   broadcastComponentCreated,
@@ -27,11 +26,7 @@ import {
   broadcastComponentDeleted,
   broadcastComponentLayersUpdated,
 } from '@/lib/mcp/broadcast';
-import { designSchema } from './shared-schemas';
-
-const templateEnum = z.enum(
-  Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
-);
+import { designSchema, templateEnum } from './shared-schemas';
 
 const variableSchema = z.object({
   name: z.string().describe('Display name (e.g. "Button label", "Hero image")'),

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -13,15 +13,10 @@ import {
   getTiptapTextContent,
   buildTiptapDoc,
   applyDesignToLayer,
-  ELEMENT_TEMPLATES,
 } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
 import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
-import { designSchema } from './shared-schemas';
-
-const templateEnum = z.enum(
-  Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
-);
+import { designSchema, richTextBlockSchema, templateEnum } from './shared-schemas';
 
 async function getPageLayers(pageId: string): Promise<Layer[]> {
   const pageLayers = await getDraftLayers(pageId);
@@ -67,12 +62,8 @@ NESTING RULES:
       position: z.number().optional().describe('Index within parent children. Omit to append at end.'),
       template: templateEnum.describe('Element template to create'),
       text_content: z.string().optional().describe('For text/heading/button/richText: plain display text'),
-      rich_content: z.array(z.object({
-        type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
-        text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
-        level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
-        items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
-      })).optional().describe('For richText: structured content blocks. Overrides text_content.'),
+      rich_content: z.array(richTextBlockSchema).optional()
+        .describe('For richText: structured content blocks. Overrides text_content.'),
       custom_name: z.string().optional().describe('Custom display name for the layer'),
     },
     async ({ page_id, parent_layer_id, position, template, text_content, rich_content, custom_name }) => {

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -1,4 +1,25 @@
 import { z } from 'zod';
+import { ELEMENT_TEMPLATES } from '@/lib/mcp/utils';
+
+/**
+ * Enum of every element template key the MCP can create. Derived from
+ * ELEMENT_TEMPLATES so the three add-layer surfaces (single, batch,
+ * component) cannot drift apart when a new template is added.
+ */
+export const templateEnum = z.enum(
+  Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
+);
+
+/**
+ * Structured rich-text block accepted by add_layer (rich_content) and the
+ * batch set_rich_text operation. Mirrors the RichTextBlock type in utils.ts.
+ */
+export const richTextBlockSchema = z.object({
+  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
+  text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
+  level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
+  items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
+});
 
 export const designSchema = z.object({
   layout: z.object({


### PR DESCRIPTION
## Summary

The element-template enum and the rich-text block schema were each duplicated across `layers.ts`, `batch.ts`, and (for the enum) `components.ts`. Three independent copies meant a new template or new rich-text block type had to be remembered in every file, with no compile-time guard forcing them to stay aligned.

This change moves both schemas into `lib/mcp/tools/shared-schemas.ts` so all add-layer surfaces share one source of truth. No behavior change for current callers — the accepted values are byte-for-byte the same.

## Changes

- Add `templateEnum` and `richTextBlockSchema` to \`lib/mcp/tools/shared-schemas.ts\`, both derived from / aligned with \`lib/mcp/utils.ts\` (\`ELEMENT_TEMPLATES\`, \`RichTextBlock\`)
- Remove the duplicate \`templateEnum\` definitions from \`layers.ts\`, \`batch.ts\`, \`components.ts\`
- Remove the duplicate \`richTextBlockSchema\` definitions from \`layers.ts\` (inline) and \`batch.ts\` (named)
- Update imports in all three consumers to pull from \`shared-schemas\`
- Add brief JSDoc on each shared schema explaining intent and what they mirror

Net diff: -31 / +26 lines.

## Test plan

- [ ] Call \`add_layer\` via MCP with a template like \`hr\` or \`button\` — verify it still works
- [ ] Call \`batch_operations\` with an \`add_layer\` operation — verify same template list works
- [ ] Call \`update_component_layers\` with an \`add_layer\` operation — verify same template list works
- [ ] Call \`add_layer\` with \`rich_content\` blocks (paragraph, heading, bulletList) — verify rich-text creation still works
- [ ] Call \`batch_operations\` with a \`set_rich_text\` operation — verify same block types accepted
- [ ] Verify that adding a new key to \`ELEMENT_TEMPLATES\` in \`lib/mcp/utils.ts\` automatically makes it valid in all three add-layer surfaces with no other code change

Made with [Cursor](https://cursor.com)