### PR TITLE
refactor(mcp): sync designSchema with DesignProperties and guard drift

### DIFF
--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import type { DesignProperties } from '@/types';
+
 export const designSchema = z.object({
   layout: z.object({
     isActive: z.boolean().optional(),
@@ -25,7 +27,13 @@ export const designSchema = z.object({
     textAlign: z.string().optional(),
     textTransform: z.string().optional(),
     textDecoration: z.string().optional(),
+    textDecorationColor: z.string().optional(),
+    textDecorationThickness: z.string().optional(),
+    underlineOffset: z.string().optional(),
+    lineClamp: z.string().optional().describe('Truncate text after N lines, e.g. "2" or "line-clamp-3"'),
+    verticalAlign: z.string().optional(),
     color: z.string().optional(),
+    placeholderColor: z.string().optional(),
   }).optional(),
   spacing: z.object({
     isActive: z.boolean().optional(),
@@ -48,12 +56,19 @@ export const designSchema = z.object({
     minHeight: z.string().optional(),
     maxWidth: z.string().optional(),
     maxHeight: z.string().optional(),
-    aspectRatio: z.string().optional(),
-    objectFit: z.string().optional(),
+    overflow: z.string().optional().describe('visible | hidden | scroll | auto'),
+    aspectRatio: z.string().nullable().optional(),
+    objectFit: z.string().nullable().optional(),
+    gridColumnSpan: z.string().nullable().optional().describe('Grid column span, e.g. "2" or "span 3"'),
+    gridRowSpan: z.string().nullable().optional().describe('Grid row span, e.g. "2" or "span 3"'),
   }).optional(),
   borders: z.object({
     isActive: z.boolean().optional(),
     borderWidth: z.string().optional(),
+    borderTopWidth: z.string().optional(),
+    borderRightWidth: z.string().optional(),
+    borderBottomWidth: z.string().optional(),
+    borderLeftWidth: z.string().optional(),
     borderStyle: z.string().optional(),
     borderColor: z.string().optional(),
     borderRadius: z.string().optional(),
@@ -61,14 +76,24 @@ export const designSchema = z.object({
     borderTopRightRadius: z.string().optional(),
     borderBottomLeftRadius: z.string().optional(),
     borderBottomRightRadius: z.string().optional(),
+    divideX: z.string().optional().describe('Horizontal divider width between children, e.g. "1px"'),
+    divideY: z.string().optional().describe('Vertical divider width between children, e.g. "1px"'),
+    divideStyle: z.string().optional(),
+    divideColor: z.string().optional(),
+    outlineWidth: z.string().optional(),
+    outlineColor: z.string().optional(),
+    outlineOffset: z.string().optional(),
   }).optional(),
   backgrounds: z.object({
     isActive: z.boolean().optional(),
     backgroundColor: z.string().optional(),
+    backgroundImage: z.string().optional().describe('CSS background-image value, e.g. "url(...)" or var reference'),
     backgroundSize: z.string().optional(),
     backgroundPosition: z.string().optional(),
     backgroundRepeat: z.string().optional(),
     backgroundClip: z.string().optional().describe('"text" for gradient text effect, "border" or "padding"'),
+    bgImageVars: z.record(z.string(), z.string()).optional()
+      .describe('Background image CSS values keyed by var name. Use "--bg-img" for desktop neutral.'),
     bgGradientVars: z.record(z.string(), z.string()).optional()
       .describe('Gradient CSS values keyed by var name. Use "--bg-img" for desktop neutral. Value is a CSS gradient like "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"'),
   }).optional(),
@@ -78,6 +103,8 @@ export const designSchema = z.object({
     boxShadow: z.string().optional(),
     blur: z.string().optional(),
     backdropBlur: z.string().optional(),
+    filter: z.string().optional().describe('CSS filter, e.g. "grayscale(1)" or "brightness(0.5)"'),
+    backdropFilter: z.string().optional().describe('CSS backdrop-filter, e.g. "saturate(180%)"'),
   }).optional(),
   positioning: z.object({
     isActive: z.boolean().optional(),
@@ -88,4 +115,64 @@ export const designSchema = z.object({
     left: z.string().optional(),
     zIndex: z.string().optional(),
   }).optional(),
+  transforms: z.object({
+    isActive: z.boolean().optional(),
+    scale: z.string().optional().describe('Uniform scale factor, e.g. "1.1" or "0.95"'),
+    rotate: z.string().optional().describe('Rotation, e.g. "45deg" or "-15deg"'),
+    translateX: z.string().optional(),
+    translateY: z.string().optional(),
+    skewX: z.string().optional(),
+    skewY: z.string().optional(),
+    transformOrigin: z.string().optional().describe('CSS transform-origin, e.g. "center" or "top left"'),
+  }).optional(),
+  transitions: z.object({
+    isActive: z.boolean().optional(),
+    transitionProperty: z.string().optional().describe('e.g. "all", "opacity", "transform, background-color"'),
+    duration: z.string().optional().describe('e.g. "200ms" or "0.3s"'),
+    easing: z.string().optional().describe('e.g. "ease-in-out", "linear", "cubic-bezier(...)"'),
+    delay: z.string().optional().describe('e.g. "100ms"'),
+  }).optional(),
 }).describe('Design properties object. Set isActive: true on any category to apply it.');
+
+// ── Drift guard ─────────────────────────────────────────────────────────────
+//
+// Compile-time assertion that every category and property of `DesignProperties`
+// is mirrored in `designSchema` above. If you add a new field to one of the
+// DesignProperties interfaces in `types/index.ts` and forget to expose it here,
+// this assertion fails to compile and the TypeScript error names every missing
+// `category.property` pair.
+//
+// Fields listed in `IntentionallyUnexposed` are deliberately omitted from MCP
+// because they store builder-only UI state (which mode toggle is shown) rather
+// than CSS that agents should set directly.
+
+type IntentionallyUnexposed = {
+  layout: 'gapMode';
+  spacing: 'marginMode' | 'paddingMode';
+  borders: 'borderWidthMode' | 'borderRadiusMode';
+};
+
+type NonUndefined<T> = Exclude<T, undefined>;
+type CategoryKeys<T> = keyof NonUndefined<T>;
+
+type ExpectedKeys<K extends keyof DesignProperties> = Exclude<
+  CategoryKeys<DesignProperties[K]>,
+  K extends keyof IntentionallyUnexposed ? IntentionallyUnexposed[K] : never
+>;
+
+type SchemaShape = z.infer<typeof designSchema>;
+
+type MissingPerCategory = {
+  [K in keyof DesignProperties]-?: K extends keyof SchemaShape
+    ? Exclude<ExpectedKeys<K>, CategoryKeys<SchemaShape[K]>>
+    : 'CATEGORY_MISSING';
+};
+
+type MissingFields = {
+  [K in keyof MissingPerCategory]: [MissingPerCategory[K]] extends [never]
+    ? never
+    : `${K & string}.${MissingPerCategory[K] & string}`;
+}[keyof MissingPerCategory];
+
+const _designSchemaDriftCheck: [MissingFields] extends [never] ? true : MissingFields = true;
+void _designSchemaDriftCheck;


### PR DESCRIPTION
## Summary

Brings `designSchema` into full parity with the `DesignProperties` type tree and locks it in with a compile-time drift guard, so future additions to design categories can't silently bypass the MCP surface. Closes audit bug B4 and folds in PR #4 (transforms/transitions) from the MCP refresh plan.

## Changes

- Add `transforms` and `transitions` categories to `designSchema`
- Add 18 previously-missing properties on existing categories:
  - `typography`: `lineClamp`, `textDecorationColor`, `textDecorationThickness`, `underlineOffset`, `verticalAlign`, `placeholderColor`
  - `sizing`: `overflow`, `gridColumnSpan`, `gridRowSpan`
  - `borders`: `borderTopWidth`/`Right`/`Bottom`/`Left`Width`, `divideX`/`Y`/`Style`/`Color`, `outlineWidth`/`Color`/`Offset`
  - `backgrounds`: `backgroundImage`, `bgImageVars`
  - `effects`: `filter`, `backdropFilter`
- Add a type-level drift guard that fails `npm run type-check` when a `DesignProperties` field is not mirrored in `designSchema`. The TypeScript error names the missing `category.property` pair (or `category.CATEGORY_MISSING` when a whole category is absent).
- Maintain an explicit `IntentionallyUnexposed` list for builder-only UI state (`gapMode`, `marginMode`, `paddingMode`, `borderWidthMode`, `borderRadiusMode`) so the guard ignores fields agents shouldn't touch.

## Test plan

- [x] `npm run type-check` passes
- [x] Verified the guard catches a removed property: temporarily dropping `typography.lineClamp` produces ``Type 'true' is not assignable to type '"typography.lineClamp"'``
- [x] Verified the guard catches a removed category: temporarily dropping the entire `transforms` block produces ``Type 'true' is not assignable to type '"transforms.CATEGORY_MISSING"'``
- [ ] In MCP, call a tool that accepts `design` (e.g. `update_layer_design`) with `transforms: { isActive: true, scale: '1.1' }` and confirm validation passes
- [ ] In MCP, call the same tool with `transitions: { isActive: true, duration: '200ms' }` and confirm validation passes
- [ ] Add a temporary field to `TypographyDesign` in `types/index.ts`, run `npm run type-check`, and confirm the error message lists `typography.<newField>`

Made with [Cursor](https://cursor.com)