### PR TITLE
fix(mcp): broadcast layout insertions and bump server version

### DIFF
--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -28,7 +28,7 @@ import { registerSiteResources } from '@/lib/mcp/resources/site';
 
 export function createMcpServer(): McpServer {
   const server = new McpServer(
-    { name: 'ycode', version: '0.4.0' },
+    { name: 'ycode', version: '0.5.0' },
     { instructions: SYSTEM_INSTRUCTIONS },
   );
 

--- a/lib/mcp/tools/layouts.ts
+++ b/lib/mcp/tools/layouts.ts
@@ -4,6 +4,7 @@ import type { Layer } from '@/types';
 import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
 import { getLayoutTemplate } from '@/lib/templates/blocks';
 import { findLayerById, insertLayer, canHaveChildren, generateId } from '@/lib/mcp/utils';
+import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
 
 const LAYOUT_CATALOG = [
   { key: 'hero-001', category: 'Hero', description: 'Two-column hero with heading, text, and image' },
@@ -149,6 +150,7 @@ Use list_layouts to see available layouts.`,
       }
 
       await upsertDraftLayers(page_id, layers);
+      broadcastLayersChanged(page_id, layers).catch(() => {});
 
       return {
         content: [{


### PR DESCRIPTION
## Summary

Two small cleanup items from the MCP audit. Together they close the remaining "pre-existing bugs" tracked in the audit doc (B7 and B8).

## Changes

- **B8 — `fix(mcp): broadcast layer changes after add_layout`**: Without the broadcast, layouts inserted via the MCP only appear in the builder after a manual refresh. Now mirrors the broadcast call every other layer-mutating tool makes (`add_layer`, `batch_operations`, etc.).
- **B7 — `chore(mcp): bump server version to 0.5.0`**: The `0.4.0` string was set when the `date_only` collection field was added back in March. Since then the MCP surface has gained the auto-derived layout catalog, deduped template enum, design schema in sync with `DesignProperties` (transforms, transitions, line-clamp, +15 fields) backed by a compile-time drift guard, and full op parity between `update_component_layers` and `batch_operations` — a minor bump is overdue.

## Test plan

- [x] `npm run type-check` passes
- [ ] In the builder, open a page in two tabs. From tab A, call `add_layout` via MCP. Confirm tab B updates without a manual refresh.
- [ ] Connect any MCP client and confirm it reports the server as `ycode v0.5.0`.

Made with [Cursor](https://cursor.com)