### PR TITLE
refactor(mcp): foundation refresh — close audit bugs B1–B5, B7, B8

### DIFF
--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -28,7 +28,7 @@ import { registerSiteResources } from '@/lib/mcp/resources/site';
 
 export function createMcpServer(): McpServer {
   const server = new McpServer(
-    { name: 'ycode', version: '0.4.0' },
+    { name: 'ycode', version: '0.5.0' },
     { instructions: SYSTEM_INSTRUCTIONS },
   );
 

--- a/lib/mcp/tools/batch.ts
+++ b/lib/mcp/tools/batch.ts
@@ -13,22 +13,10 @@ import {
   getTiptapTextContent,
   buildTiptapDoc,
   applyDesignToLayer,
-  ELEMENT_TEMPLATES,
 } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
 import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
-import { designSchema } from './shared-schemas';
-
-const templateEnum = z.enum(
-  Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
-);
-
-const richTextBlockSchema = z.object({
-  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
-  text: z.string().optional(),
-  level: z.number().optional(),
-  items: z.array(z.string()).optional(),
-});
+import { designSchema, richTextBlockSchema, templateEnum } from './shared-schemas';
 
 const addLayerOp = z.object({
   type: z.literal('add_layer'),

--- a/lib/mcp/tools/components.ts
+++ b/lib/mcp/tools/components.ts
@@ -19,7 +19,6 @@ import {
   getTiptapTextContent,
   applyDesignToLayer,
   generateId,
-  ELEMENT_TEMPLATES,
 } from '@/lib/mcp/utils';
 import {
   broadcastComponentCreated,
@@ -27,11 +26,7 @@ import {
   broadcastComponentDeleted,
   broadcastComponentLayersUpdated,
 } from '@/lib/mcp/broadcast';
-import { designSchema } from './shared-schemas';
-
-const templateEnum = z.enum(
-  Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
-);
+import { designSchema, templateEnum } from './shared-schemas';
 
 const variableSchema = z.object({
   name: z.string().describe('Display name (e.g. "Button label", "Hero image")'),

--- a/lib/mcp/tools/components.ts
+++ b/lib/mcp/tools/components.ts
@@ -28,14 +28,7 @@ import {
   broadcastComponentDeleted,
   broadcastComponentLayersUpdated,
 } from '@/lib/mcp/broadcast';
-import { designSchema, templateEnum } from './shared-schemas';
-
-const richTextBlockSchema = z.object({
-  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
-  text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
-  level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
-  items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
-});
+import { designSchema, richTextBlockSchema, templateEnum } from './shared-schemas';
 
 const variableSchema = z.object({
   name: z.string().describe('Display name (e.g. "Button label", "Hero image")'),

--- a/lib/mcp/tools/components.ts
+++ b/lib/mcp/tools/components.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { Layer } from '@/types';
+import type { Breakpoint, Layer, UIState } from '@/types';
 import {
   getAllComponents,
   getComponentById,
@@ -17,9 +17,11 @@ import {
   canHaveChildren,
   createLayerFromTemplate,
   getTiptapTextContent,
+  buildTiptapDoc,
   applyDesignToLayer,
   generateId,
 } from '@/lib/mcp/utils';
+import type { RichTextBlock } from '@/lib/mcp/utils';
 import {
   broadcastComponentCreated,
   broadcastComponentUpdated,
@@ -27,6 +29,13 @@ import {
   broadcastComponentLayersUpdated,
 } from '@/lib/mcp/broadcast';
 import { designSchema, templateEnum } from './shared-schemas';
+
+const richTextBlockSchema = z.object({
+  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
+  text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
+  level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
+  items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
+});
 
 const variableSchema = z.object({
   name: z.string().describe('Display name (e.g. "Button label", "Hero image")'),
@@ -168,7 +177,11 @@ EXAMPLE: A "Card" component with a title variable:
   server.tool(
     'update_component_layers',
     `Modify a component's layer tree. Works like batch_operations but for component layers.
-Use ref_id in add_layer to name layers, then reference them in later operations.`,
+Use ref_id in add_layer to name layers, then reference them in later operations.
+
+Supports the same ops as batch_operations (add_layer, update_design, update_text,
+update_image, set_rich_text, apply_style, delete_layer, move_layer) plus
+link_variable for wiring component variables to layers.`,
     {
       component_id: z.string().describe('The component ID'),
       operations: z.array(z.discriminatedUnion('type', [
@@ -178,9 +191,12 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
           position: z.number().optional(),
           template: templateEnum,
           text_content: z.string().optional(),
+          rich_content: z.array(richTextBlockSchema).optional()
+            .describe('For richText: structured content blocks. Overrides text_content.'),
           custom_name: z.string().optional(),
           ref_id: z.string().optional().describe('Reference ID for later operations'),
           design: designSchema.optional(),
+          image_asset_id: z.string().optional().describe('For image layers: asset ID to display'),
           variable_id: z.string().optional()
             .describe('Component variable ID to link to this layer\'s primary content (text/image/link)'),
         }),
@@ -188,11 +204,30 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
           type: z.literal('update_design'),
           layer_id: z.string().describe('Layer ID or ref_id'),
           design: designSchema,
+          breakpoint: z.enum(['desktop', 'tablet', 'mobile']).default('desktop').optional(),
+          ui_state: z.enum(['neutral', 'hover', 'focus', 'active', 'disabled']).default('neutral').optional()
+            .describe('UI state: "hover" for hover styles, "focus" for focus, etc.'),
         }),
         z.object({
           type: z.literal('update_text'),
           layer_id: z.string().describe('Layer ID or ref_id'),
           text: z.string(),
+        }),
+        z.object({
+          type: z.literal('update_image'),
+          layer_id: z.string().describe('Layer ID or ref_id'),
+          asset_id: z.string().describe('Asset ID from upload_asset'),
+        }),
+        z.object({
+          type: z.literal('set_rich_text'),
+          layer_id: z.string().describe('RichText layer ID or ref_id'),
+          blocks: z.array(richTextBlockSchema).min(1)
+            .describe('Content blocks (paragraph, heading, list, etc.)'),
+        }),
+        z.object({
+          type: z.literal('apply_style'),
+          layer_id: z.string(),
+          style_id: z.string().describe('Layer style ID to apply'),
         }),
         z.object({
           type: z.literal('delete_layer'),
@@ -238,11 +273,19 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
               let newLayer = createLayerFromTemplate(op.template, {
                 customName: op.custom_name,
                 textContent: op.text_content,
+                richContent: op.rich_content as RichTextBlock[] | undefined,
               });
               if (!newLayer) { results.push({ op: i, status: 'error', detail: `Unknown template "${op.template}"` }); continue; }
 
               if (op.design) {
                 newLayer = applyDesignToLayer(newLayer, op.design as Record<string, Record<string, unknown>>);
+              }
+
+              if (op.image_asset_id && newLayer.variables?.image) {
+                newLayer.variables = {
+                  ...newLayer.variables,
+                  image: { ...newLayer.variables.image, src: { type: 'asset', data: { asset_id: op.image_asset_id } } },
+                };
               }
 
               if (op.variable_id) {
@@ -259,8 +302,10 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
               const layerId = refMap.get(op.layer_id) || op.layer_id;
               const layer = findLayerById(layers, layerId);
               if (!layer) { results.push({ op: i, status: 'error', detail: `Layer "${op.layer_id}" not found` }); continue; }
+              const bp = (op.breakpoint ?? 'desktop') as Breakpoint;
+              const state = (op.ui_state ?? 'neutral') as UIState;
               layers = updateLayerById(layers, layerId, (l) =>
-                applyDesignToLayer(l, op.design as Record<string, Record<string, unknown>>),
+                applyDesignToLayer(l, op.design as Record<string, Record<string, unknown>>, bp, state),
               );
               results.push({ op: i, status: 'ok', detail: `Styled "${layer.customName || layer.name}"` });
               break;
@@ -278,6 +323,50 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
                 },
               }));
               results.push({ op: i, status: 'ok', detail: `Set text on "${layer.customName || layer.name}"` });
+              break;
+            }
+
+            case 'update_image': {
+              const layerId = refMap.get(op.layer_id) || op.layer_id;
+              const layer = findLayerById(layers, layerId);
+              if (!layer) { results.push({ op: i, status: 'error', detail: `Layer "${op.layer_id}" not found` }); continue; }
+              layers = updateLayerById(layers, layerId, (l) => {
+                const existing = (l.variables?.image || {}) as Record<string, unknown>;
+                return {
+                  ...l,
+                  variables: {
+                    ...l.variables,
+                    image: {
+                      ...existing,
+                      src: { type: 'asset' as const, data: { asset_id: op.asset_id } },
+                      alt: (existing.alt || { type: 'dynamic_text' as const, data: { content: '' } }) as { type: 'dynamic_text'; data: { content: string } },
+                    },
+                  },
+                };
+              });
+              results.push({ op: i, status: 'ok', detail: `Set image on "${layer.customName || layer.name}"` });
+              break;
+            }
+
+            case 'set_rich_text': {
+              const layerId = refMap.get(op.layer_id) || op.layer_id;
+              const layer = findLayerById(layers, layerId);
+              if (!layer) { results.push({ op: i, status: 'error', detail: `Layer "${op.layer_id}" not found` }); continue; }
+              const tiptapDoc = buildTiptapDoc(op.blocks as RichTextBlock[]);
+              layers = updateLayerById(layers, layerId, (l) => ({
+                ...l,
+                variables: { ...l.variables, text: { type: 'dynamic_rich_text', data: { content: tiptapDoc } } },
+              }));
+              results.push({ op: i, status: 'ok', detail: `Set rich text on "${layer.customName || layer.name}" (${op.blocks.length} blocks)` });
+              break;
+            }
+
+            case 'apply_style': {
+              const layerId = refMap.get(op.layer_id) || op.layer_id;
+              const layer = findLayerById(layers, layerId);
+              if (!layer) { results.push({ op: i, status: 'error', detail: `Layer "${op.layer_id}" not found` }); continue; }
+              layers = updateLayerById(layers, layerId, (l) => ({ ...l, styleId: op.style_id }));
+              results.push({ op: i, status: 'ok', detail: `Applied style to "${layer.customName || layer.name}"` });
               break;
             }
 

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -13,15 +13,10 @@ import {
   getTiptapTextContent,
   buildTiptapDoc,
   applyDesignToLayer,
-  ELEMENT_TEMPLATES,
 } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
 import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
-import { designSchema } from './shared-schemas';
-
-const templateEnum = z.enum(
-  Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
-);
+import { designSchema, richTextBlockSchema, templateEnum } from './shared-schemas';
 
 async function getPageLayers(pageId: string): Promise<Layer[]> {
   const pageLayers = await getDraftLayers(pageId);
@@ -67,12 +62,8 @@ NESTING RULES:
       position: z.number().optional().describe('Index within parent children. Omit to append at end.'),
       template: templateEnum.describe('Element template to create'),
       text_content: z.string().optional().describe('For text/heading/button/richText: plain display text'),
-      rich_content: z.array(z.object({
-        type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
-        text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
-        level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
-        items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
-      })).optional().describe('For richText: structured content blocks. Overrides text_content.'),
+      rich_content: z.array(richTextBlockSchema).optional()
+        .describe('For richText: structured content blocks. Overrides text_content.'),
       custom_name: z.string().optional().describe('Custom display name for the layer'),
     },
     async ({ page_id, parent_layer_id, position, template, text_content, rich_content, custom_name }) => {

--- a/lib/mcp/tools/layouts.ts
+++ b/lib/mcp/tools/layouts.ts
@@ -9,6 +9,7 @@ import {
   getLayoutsByCategory,
 } from '@/lib/templates/blocks';
 import { findLayerById, insertLayer, canHaveChildren } from '@/lib/mcp/utils';
+import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
 
 interface CatalogEntry {
   key: string;
@@ -104,6 +105,7 @@ Use list_layouts to see available layouts.`,
       }
 
       await upsertDraftLayers(page_id, layers);
+      broadcastLayersChanged(page_id, layers).catch(() => {});
 
       return {
         content: [{

--- a/lib/mcp/tools/layouts.ts
+++ b/lib/mcp/tools/layouts.ts
@@ -2,76 +2,49 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Layer } from '@/types';
 import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
-import { getLayoutTemplate } from '@/lib/templates/blocks';
-import { findLayerById, insertLayer, canHaveChildren, generateId } from '@/lib/mcp/utils';
+import {
+  getLayoutTemplate,
+  getLayoutCategory,
+  getLayoutPreviewImage,
+  getLayoutsByCategory,
+} from '@/lib/templates/blocks';
+import { findLayerById, insertLayer, canHaveChildren } from '@/lib/mcp/utils';
 
-const LAYOUT_CATALOG = [
-  { key: 'hero-001', category: 'Hero', description: 'Two-column hero with heading, text, and image' },
-  { key: 'hero-002', category: 'Hero', description: 'Centered hero with large heading and CTA buttons' },
-  { key: 'hero-003', category: 'Hero', description: 'Hero with background image and overlay text' },
-  { key: 'hero-004', category: 'Hero', description: 'Minimal hero with heading and subtext' },
-  { key: 'hero-005', category: 'Hero', description: 'Hero with features grid below' },
-  { key: 'header-001', category: 'Header', description: 'Navigation bar with logo and links' },
-  { key: 'header-002', category: 'Header', description: 'Centered navigation with logo' },
-  { key: 'header-003', category: 'Header', description: 'Minimal header with logo and CTA' },
-  { key: 'header-004', category: 'Header', description: 'Header with logo, links, and button' },
-  { key: 'features-001', category: 'Features', description: 'Three-column feature cards with icons' },
-  { key: 'features-002', category: 'Features', description: 'Two-column features with image' },
-  { key: 'features-003', category: 'Features', description: 'Feature grid with 4 cards' },
-  { key: 'features-004', category: 'Features', description: 'Alternating feature rows with images' },
-  { key: 'features-005', category: 'Features', description: 'Feature list with large numbers' },
-  { key: 'features-006', category: 'Features', description: 'Bento grid features layout' },
-  { key: 'features-007', category: 'Features', description: 'Features with icon circles' },
-  { key: 'features-008', category: 'Features', description: 'Three features side by side' },
-  { key: 'features-009', category: 'Features', description: 'Feature showcase with tabs' },
-  { key: 'features-010', category: 'Features', description: 'Large feature card grid' },
-  { key: 'features-011', category: 'Features', description: 'Minimal two-column features' },
-  { key: 'features-012', category: 'Features', description: 'Features with colored backgrounds' },
-  { key: 'blog-001', category: 'Blog posts', description: 'Three-column blog post cards' },
-  { key: 'blog-002', category: 'Blog posts', description: 'Blog list with featured image' },
-  { key: 'blog-003', category: 'Blog posts', description: 'Two-column blog cards' },
-  { key: 'blog-004', category: 'Blog posts', description: 'Blog grid with categories' },
-  { key: 'blog-005', category: 'Blog posts', description: 'Blog cards with author info' },
-  { key: 'blog-006', category: 'Blog posts', description: 'Minimal blog list' },
-  { key: 'blog-header-001', category: 'Blog header', description: 'Blog post header with title and meta' },
-  { key: 'blog-header-002', category: 'Blog header', description: 'Blog header with cover image' },
-  { key: 'blog-header-003', category: 'Blog header', description: 'Minimal blog header' },
-  { key: 'blog-header-004', category: 'Blog header', description: 'Blog header with breadcrumbs' },
-  { key: 'stats-001', category: 'Stats', description: 'Statistics row with large numbers' },
-  { key: 'stats-002', category: 'Stats', description: 'Stats grid with descriptions' },
-  { key: 'stats-003', category: 'Stats', description: 'Stats with progress indicators' },
-  { key: 'pricing-001', category: 'Pricing', description: 'Three-tier pricing cards' },
-  { key: 'team-001', category: 'Team', description: 'Team member cards with photos' },
-  { key: 'team-002', category: 'Team', description: 'Team grid with roles' },
-  { key: 'testimonials-001', category: 'Testimonials', description: 'Single centered testimonial quote' },
-  { key: 'testimonials-002', category: 'Testimonials', description: 'Testimonial cards grid' },
-  { key: 'testimonials-003', category: 'Testimonials', description: 'Testimonial with avatar and rating' },
-  { key: 'testimonials-004', category: 'Testimonials', description: 'Full-width testimonial slider' },
-  { key: 'testimonials-005', category: 'Testimonials', description: 'Testimonial wall' },
-  { key: 'faq-001', category: 'FAQ', description: 'Frequently asked questions accordion' },
-  { key: 'navigation-001', category: 'Navigation', description: 'Top navigation bar' },
-  { key: 'navigation-002', category: 'Navigation', description: 'Side navigation menu' },
-  { key: 'footer-001', category: 'Footer', description: 'Multi-column footer with links' },
-  { key: 'footer-002', category: 'Footer', description: 'Simple footer with logo and copyright' },
-  { key: 'footer-003', category: 'Footer', description: 'Footer with newsletter signup' },
-];
+interface CatalogEntry {
+  key: string;
+  preview_image_url?: string;
+}
+
+/**
+ * Auto-derive the layout catalog from `layoutTemplates` so it can never
+ * drift from the source of truth (previously caused `blog-header-*` and
+ * `blog-001..006` keys to be advertised but unusable).
+ */
+function buildLayoutCatalog(): Record<string, CatalogEntry[]> {
+  const byCategory = getLayoutsByCategory();
+  const result: Record<string, CatalogEntry[]> = {};
+
+  for (const [category, keys] of Object.entries(byCategory)) {
+    result[category] = keys.map((key) => {
+      const preview = getLayoutPreviewImage(key);
+      return preview ? { key, preview_image_url: preview } : { key };
+    });
+  }
+
+  return result;
+}
 
 export function registerLayoutTools(server: McpServer) {
   server.tool(
     'list_layouts',
     `List all available pre-built layout templates organized by category.
-Use add_layout to insert any of these into a page.
-
-Categories: Hero, Header, Features, Blog posts, Blog header, Stats, Pricing,
-Team, Testimonials, FAQ, Navigation, Footer`,
+Use add_layout to insert any of these into a page.`,
     {},
     async () => {
-      const byCategory: Record<string, typeof LAYOUT_CATALOG> = {};
-      for (const layout of LAYOUT_CATALOG) {
-        if (!byCategory[layout.category]) byCategory[layout.category] = [];
-        byCategory[layout.category].push(layout);
-      }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(byCategory, null, 2) }] };
+      const catalog = buildLayoutCatalog();
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(catalog, null, 2) }],
+      };
     },
   );
 
@@ -86,66 +59,48 @@ Use list_layouts to see available layouts.`,
       position: z.number().optional().describe('Position within parent. Omit to append at end.'),
     },
     async ({ page_id, layout_key, parent_layer_id, position }) => {
-      const found = LAYOUT_CATALOG.find((l) => l.key === layout_key);
-      if (!found) {
-        return { content: [{ type: 'text' as const, text: `Error: Unknown layout "${layout_key}". Use list_layouts to see available layouts.` }], isError: true };
+      const layoutLayer = getLayoutTemplate(layout_key);
+      if (!layoutLayer) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error: Unknown layout "${layout_key}". Use list_layouts to see available layouts.`,
+          }],
+          isError: true,
+        };
       }
+
+      const category = getLayoutCategory(layout_key);
 
       const pageLayers = await getDraftLayers(page_id);
       let layers = (pageLayers?.layers as Layer[]) || [];
 
-      // Try the main project's layout template system
-      let layoutLayer: Layer | null = null;
-      try {
-        layoutLayer = getLayoutTemplate(layout_key);
-      } catch {
-        // Layout template not available
-      }
-
-      if (!layoutLayer) {
-        // Fallback: create a basic section scaffold
-        const section: Layer = {
-          id: generateId('lyr'),
-          name: 'section',
-          customName: `${found.category}: ${found.description}`,
-          classes: ['flex', 'flex-col', 'w-[100%]', 'pt-[80px]', 'pb-[80px]', 'items-center'],
-          design: {
-            layout: { isActive: true, display: 'Flex', flexDirection: 'column', alignItems: 'center' },
-            sizing: { isActive: true, width: '100%' },
-            spacing: { isActive: true, paddingTop: '80px', paddingBottom: '80px' },
-          },
-          children: [{
-            id: generateId('lyr'),
-            name: 'div',
-            customName: 'Container',
-            classes: ['flex', 'flex-col', 'max-w-[1280px]', 'w-[100%]', 'pl-[32px]', 'pr-[32px]'],
-            design: {
-              layout: { isActive: true, display: 'Flex', flexDirection: 'column' },
-              sizing: { isActive: true, width: '100%', maxWidth: '1280px' },
-              spacing: { isActive: true, paddingLeft: '32px', paddingRight: '32px' },
-            },
-            children: [],
-          }],
-        };
-        layoutLayer = section;
-      }
-
       if (parent_layer_id) {
         const parent = findLayerById(layers, parent_layer_id);
         if (!parent) {
-          return { content: [{ type: 'text' as const, text: `Error: Parent "${parent_layer_id}" not found.` }], isError: true };
+          return {
+            content: [{
+              type: 'text' as const,
+              text: `Error: Parent "${parent_layer_id}" not found.`,
+            }],
+            isError: true,
+          };
         }
         if (!canHaveChildren(parent)) {
-          return { content: [{ type: 'text' as const, text: `Error: "${parent.customName || parent.name}" cannot have children.` }], isError: true };
+          return {
+            content: [{
+              type: 'text' as const,
+              text: `Error: "${parent.customName || parent.name}" cannot have children.`,
+            }],
+            isError: true,
+          };
         }
         layers = insertLayer(layers, parent_layer_id, layoutLayer, position);
+      } else if (position !== undefined) {
+        layers = [...layers];
+        layers.splice(position, 0, layoutLayer);
       } else {
-        if (position !== undefined) {
-          layers = [...layers];
-          layers.splice(position, 0, layoutLayer);
-        } else {
-          layers = [...layers, layoutLayer];
-        }
+        layers = [...layers, layoutLayer];
       }
 
       await upsertDraftLayers(page_id, layers);
@@ -154,10 +109,11 @@ Use list_layouts to see available layouts.`,
         content: [{
           type: 'text' as const,
           text: JSON.stringify({
-            message: `Added ${found.category} section to page`,
+            message: `Added ${category || 'layout'} section to page`,
             section_id: layoutLayer.id,
             container_id: layoutLayer.children?.[0]?.id,
-            layout: found,
+            layout_key,
+            category,
           }, null, 2),
         }],
       };

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -1,4 +1,25 @@
 import { z } from 'zod';
+import { ELEMENT_TEMPLATES } from '@/lib/mcp/utils';
+
+/**
+ * Enum of every element template key the MCP can create. Derived from
+ * ELEMENT_TEMPLATES so the three add-layer surfaces (single, batch,
+ * component) cannot drift apart when a new template is added.
+ */
+export const templateEnum = z.enum(
+  Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
+);
+
+/**
+ * Structured rich-text block accepted by add_layer (rich_content) and the
+ * batch set_rich_text operation. Mirrors the RichTextBlock type in utils.ts.
+ */
+export const richTextBlockSchema = z.object({
+  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
+  text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
+  level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
+  items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
+});
 
 export const designSchema = z.object({
   layout: z.object({

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
+
+import type { DesignProperties } from '@/types';
 import { ELEMENT_TEMPLATES } from '@/lib/mcp/utils';
 
 /**
@@ -20,8 +22,6 @@ export const richTextBlockSchema = z.object({
   level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
   items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
 });
-
-import type { DesignProperties } from '@/types';
 
 export const designSchema = z.object({
   layout: z.object({

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -21,6 +21,8 @@ export const richTextBlockSchema = z.object({
   items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
 });
 
+import type { DesignProperties } from '@/types';
+
 export const designSchema = z.object({
   layout: z.object({
     isActive: z.boolean().optional(),
@@ -46,7 +48,13 @@ export const designSchema = z.object({
     textAlign: z.string().optional(),
     textTransform: z.string().optional(),
     textDecoration: z.string().optional(),
+    textDecorationColor: z.string().optional(),
+    textDecorationThickness: z.string().optional(),
+    underlineOffset: z.string().optional(),
+    lineClamp: z.string().optional().describe('Truncate text after N lines, e.g. "2" or "line-clamp-3"'),
+    verticalAlign: z.string().optional(),
     color: z.string().optional(),
+    placeholderColor: z.string().optional(),
   }).optional(),
   spacing: z.object({
     isActive: z.boolean().optional(),
@@ -69,12 +77,19 @@ export const designSchema = z.object({
     minHeight: z.string().optional(),
     maxWidth: z.string().optional(),
     maxHeight: z.string().optional(),
-    aspectRatio: z.string().optional(),
-    objectFit: z.string().optional(),
+    overflow: z.string().optional().describe('visible | hidden | scroll | auto'),
+    aspectRatio: z.string().nullable().optional(),
+    objectFit: z.string().nullable().optional(),
+    gridColumnSpan: z.string().nullable().optional().describe('Grid column span, e.g. "2" or "span 3"'),
+    gridRowSpan: z.string().nullable().optional().describe('Grid row span, e.g. "2" or "span 3"'),
   }).optional(),
   borders: z.object({
     isActive: z.boolean().optional(),
     borderWidth: z.string().optional(),
+    borderTopWidth: z.string().optional(),
+    borderRightWidth: z.string().optional(),
+    borderBottomWidth: z.string().optional(),
+    borderLeftWidth: z.string().optional(),
     borderStyle: z.string().optional(),
     borderColor: z.string().optional(),
     borderRadius: z.string().optional(),
@@ -82,14 +97,24 @@ export const designSchema = z.object({
     borderTopRightRadius: z.string().optional(),
     borderBottomLeftRadius: z.string().optional(),
     borderBottomRightRadius: z.string().optional(),
+    divideX: z.string().optional().describe('Horizontal divider width between children, e.g. "1px"'),
+    divideY: z.string().optional().describe('Vertical divider width between children, e.g. "1px"'),
+    divideStyle: z.string().optional(),
+    divideColor: z.string().optional(),
+    outlineWidth: z.string().optional(),
+    outlineColor: z.string().optional(),
+    outlineOffset: z.string().optional(),
   }).optional(),
   backgrounds: z.object({
     isActive: z.boolean().optional(),
     backgroundColor: z.string().optional(),
+    backgroundImage: z.string().optional().describe('CSS background-image value, e.g. "url(...)" or var reference'),
     backgroundSize: z.string().optional(),
     backgroundPosition: z.string().optional(),
     backgroundRepeat: z.string().optional(),
     backgroundClip: z.string().optional().describe('"text" for gradient text effect, "border" or "padding"'),
+    bgImageVars: z.record(z.string(), z.string()).optional()
+      .describe('Background image CSS values keyed by var name. Use "--bg-img" for desktop neutral.'),
     bgGradientVars: z.record(z.string(), z.string()).optional()
       .describe('Gradient CSS values keyed by var name. Use "--bg-img" for desktop neutral. Value is a CSS gradient like "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"'),
   }).optional(),
@@ -99,6 +124,8 @@ export const designSchema = z.object({
     boxShadow: z.string().optional(),
     blur: z.string().optional(),
     backdropBlur: z.string().optional(),
+    filter: z.string().optional().describe('CSS filter, e.g. "grayscale(1)" or "brightness(0.5)"'),
+    backdropFilter: z.string().optional().describe('CSS backdrop-filter, e.g. "saturate(180%)"'),
   }).optional(),
   positioning: z.object({
     isActive: z.boolean().optional(),
@@ -109,4 +136,64 @@ export const designSchema = z.object({
     left: z.string().optional(),
     zIndex: z.string().optional(),
   }).optional(),
+  transforms: z.object({
+    isActive: z.boolean().optional(),
+    scale: z.string().optional().describe('Uniform scale factor, e.g. "1.1" or "0.95"'),
+    rotate: z.string().optional().describe('Rotation, e.g. "45deg" or "-15deg"'),
+    translateX: z.string().optional(),
+    translateY: z.string().optional(),
+    skewX: z.string().optional(),
+    skewY: z.string().optional(),
+    transformOrigin: z.string().optional().describe('CSS transform-origin, e.g. "center" or "top left"'),
+  }).optional(),
+  transitions: z.object({
+    isActive: z.boolean().optional(),
+    transitionProperty: z.string().optional().describe('e.g. "all", "opacity", "transform, background-color"'),
+    duration: z.string().optional().describe('e.g. "200ms" or "0.3s"'),
+    easing: z.string().optional().describe('e.g. "ease-in-out", "linear", "cubic-bezier(...)"'),
+    delay: z.string().optional().describe('e.g. "100ms"'),
+  }).optional(),
 }).describe('Design properties object. Set isActive: true on any category to apply it.');
+
+// ── Drift guard ─────────────────────────────────────────────────────────────
+//
+// Compile-time assertion that every category and property of `DesignProperties`
+// is mirrored in `designSchema` above. If you add a new field to one of the
+// DesignProperties interfaces in `types/index.ts` and forget to expose it here,
+// this assertion fails to compile and the TypeScript error names every missing
+// `category.property` pair.
+//
+// Fields listed in `IntentionallyUnexposed` are deliberately omitted from MCP
+// because they store builder-only UI state (which mode toggle is shown) rather
+// than CSS that agents should set directly.
+
+type IntentionallyUnexposed = {
+  layout: 'gapMode';
+  spacing: 'marginMode' | 'paddingMode';
+  borders: 'borderWidthMode' | 'borderRadiusMode';
+};
+
+type NonUndefined<T> = Exclude<T, undefined>;
+type CategoryKeys<T> = keyof NonUndefined<T>;
+
+type ExpectedKeys<K extends keyof DesignProperties> = Exclude<
+  CategoryKeys<DesignProperties[K]>,
+  K extends keyof IntentionallyUnexposed ? IntentionallyUnexposed[K] : never
+>;
+
+type SchemaShape = z.infer<typeof designSchema>;
+
+type MissingPerCategory = {
+  [K in keyof DesignProperties]-?: K extends keyof SchemaShape
+    ? Exclude<ExpectedKeys<K>, CategoryKeys<SchemaShape[K]>>
+    : 'CATEGORY_MISSING';
+};
+
+type MissingFields = {
+  [K in keyof MissingPerCategory]: [MissingPerCategory[K]] extends [never]
+    ? never
+    : `${K & string}.${MissingPerCategory[K] & string}`;
+}[keyof MissingPerCategory];
+
+const _designSchemaDriftCheck: [MissingFields] extends [never] ? true : MissingFields = true;
+void _designSchemaDriftCheck;


### PR DESCRIPTION
## Summary

Consolidates the five small MCP cleanup PRs (#247, #248, #249, #250, #251) into a single foundation-refresh PR. Closes all seven pre-existing MCP audit bugs and bumps the server version accordingly. Pure cleanup — no new feature surface for agents beyond making the existing surface accurate, complete, and drift-proof.

## Changes

Grouped by audit bug (commit history preserved for blame / bisect):

- **B1, B2 — layout catalog drift** (`refactor(mcp): auto-derive layout catalog from layoutTemplates`)
  - Removed the hand-typed `LAYOUT_CATALOG` constant and the section-scaffold fallback
  - `list_layouts` and `add_layout` now read directly from `layoutTemplates` via `getLayoutsByCategory()` / `getLayoutTemplate()`, so the broken `blog-header-001..004` and `blog-001..006` keys (which existed in the catalog but not the templates) can no longer happen
- **B3 — duplicated `templateEnum` / `richTextBlockSchema`** (`refactor(mcp): centralize templateEnum and richTextBlockSchema`)
  - Single source in `shared-schemas.ts`; `layers.ts`, `batch.ts`, `components.ts` all import from it
- **B4 — `designSchema` drift from `DesignProperties`** (`refactor(mcp): sync designSchema with DesignProperties and guard drift`)
  - Added `transforms` and `transitions` categories plus 18 missing properties (`typography.lineClamp`, `textDecorationColor`/`Thickness`, `underlineOffset`, `verticalAlign`, `placeholderColor`; `sizing.overflow`, `gridColumnSpan`/`RowSpan`; all four directional `border*Width`, `divide*`, `outline*`; `backgrounds.backgroundImage`, `bgImageVars`; `effects.filter`, `backdropFilter`)
  - Added a compile-time drift guard that fails `npm run type-check` with a message naming the missing `category.property` pair if a future `DesignProperties` field is not mirrored in `designSchema`. Builder-only UI state (`gapMode`, `marginMode`, `paddingMode`, `borderWidthMode`, `borderRadiusMode`) is explicitly opted out
- **B5 — `update_component_layers` < `batch_operations`** (`feat(mcp): bring update_component_layers to batch_operations parity`)
  - Added `update_image`, `set_rich_text`, `apply_style` ops
  - Added `rich_content` and `image_asset_id` to `add_layer`
  - Added `breakpoint` and `ui_state` to `update_design` (component layers are now responsive / state-aware via batch)
- **B7 — server version** (`chore(mcp): bump server version to 0.5.0`)
  - `0.4.0` → `0.5.0`
- **B8 — silent layout insertions** (`fix(mcp): broadcast layer changes after add_layout`)
  - Added the `broadcastLayersChanged` call so MCP-inserted layouts show up in live builder sessions without a manual refresh
- Reconciliation commit at the tip (`refactor(mcp): tidy imports after consolidating cherry-picks`) deduplicates `richTextBlockSchema` in `components.ts` and lifts the `DesignProperties` import in `shared-schemas.ts` to the top of the file

## Why one PR instead of five

The five PRs were all in the same area (`lib/mcp/**`) and all tagged the same audit cleanup work. Reviewing them in one place is easier than chasing five branches, and shipping them as one unit lines up cleanly with the `0.5.0` version bump.

## Supersedes

Closes #247, #248, #249, #250, #251.

## Test plan

- [x] `npm run type-check` passes
- [x] `npx eslint lib/mcp/` passes
- [x] Cherry-pick + reconciliation produces a tree identical (modulo commit metadata) to applying the five PRs in sequence
- [ ] `list_layouts` returns every category in `layoutTemplates` including the previously-broken `Blog header` and `Blog posts` keys
- [ ] `add_layout` succeeds for `blog-headers-001` and `blog-posts-001`
- [ ] After `add_layout` in the builder, the live canvas updates without manual refresh
- [ ] `update_component_layers` accepts `{ type: 'update_image' }`, `{ type: 'apply_style' }`, `{ type: 'set_rich_text' }`
- [ ] `update_component_layers` `update_design` with `breakpoint: 'mobile', ui_state: 'hover'` produces the expected `mobile:hover:` classes
- [ ] Adding a new property to a `DesignProperties` interface in `types/index.ts` and re-running `npm run type-check` produces an error naming the missing `category.property`
- [ ] MCP clients report the server as `ycode v0.5.0`

Made with [Cursor](https://cursor.com)