### PR TITLE
feat(mcp): expand CMS surface — option/count fields, sorting, link extensions

### DIFF
--- a/lib/mcp/tools/collections.ts
+++ b/lib/mcp/tools/collections.ts
@@ -1,14 +1,77 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { CollectionFieldData, CollectionFieldType, CollectionSorting } from '@/types';
 import { getAllCollections, createCollection, updateCollection, deleteCollection } from '@/lib/repositories/collectionRepository';
-import { getFieldsByCollectionId, createField, updateField, deleteField } from '@/lib/repositories/collectionFieldRepository';
-import { getItemsByCollectionId, getItemsWithValues, createItem, deleteItem } from '@/lib/repositories/collectionItemRepository';
+import {
+  getFieldsByCollectionId,
+  createField,
+  updateField,
+  deleteField,
+  reorderFields,
+} from '@/lib/repositories/collectionFieldRepository';
+import {
+  getItemsByCollectionId,
+  getItemsWithValues,
+  createItem,
+  updateItem,
+  deleteItem,
+} from '@/lib/repositories/collectionItemRepository';
 import { setValuesByFieldName } from '@/lib/repositories/collectionItemValueRepository';
+
+const fieldTypeEnum = z.enum([
+  'text', 'number', 'boolean', 'date', 'date_only',
+  'reference', 'multi_reference',
+  'rich_text', 'image', 'audio', 'video', 'document',
+  'link', 'email', 'phone',
+  'color', 'status',
+  'option', 'count',
+]).describe('Field type (date = datetime, date_only = date without time)');
+
+const optionEntrySchema = z.object({
+  id: z.string().describe('Stable option ID (use the same ID when setting this option as a value on items)'),
+  name: z.string().describe('Display name shown to editors'),
+});
+
+const fieldDataSchema = z.object({
+  multiple: z.boolean().optional()
+    .describe('For asset fields (image/audio/video/document): allow multiple files per item'),
+  options: z.array(optionEntrySchema).optional()
+    .describe('For "option" field type: the selectable values'),
+  count_collection_id: z.string().optional()
+    .describe('For "count" field type: the child collection whose items will be counted'),
+  count_field_id: z.string().optional()
+    .describe('For "count" field type: the reference field on the child collection that points back here'),
+}).describe('Type-specific field configuration');
+
+const sortDirectionEnum = z.enum(['asc', 'desc', 'manual'])
+  .describe('"manual" uses the item manual_order; otherwise sorts by the field value');
+
+const sortingSchema = z.object({
+  field: z.string().describe('Field ID to sort by, or the literal "manual_order"'),
+  direction: sortDirectionEnum,
+}).describe('Default sort order for items in this collection');
+
+/**
+ * Translate the MCP-facing `data` schema (with flat count_collection_id /
+ * count_field_id keys for ergonomics) into the storage shape used by
+ * CollectionFieldData.
+ */
+function buildFieldData(input: z.infer<typeof fieldDataSchema> | undefined): CollectionFieldData | undefined {
+  if (!input) return undefined;
+  const data: CollectionFieldData = {};
+  if (input.multiple !== undefined) data.multiple = input.multiple;
+  if (input.options !== undefined) data.options = input.options;
+  if (input.count_collection_id && input.count_field_id) {
+    data.count = { collectionId: input.count_collection_id, fieldId: input.count_field_id };
+  }
+  return data;
+}
 
 export function registerCollectionTools(server: McpServer) {
   server.tool(
     'list_collections',
-    "List all CMS collections with their IDs, names, and slugs. Collections are YCode's CMS — each collection is like a database table.",
+    "List all CMS collections with their IDs, names, slugs, and default sorting. Collections are YCode's CMS — each collection is like a database table.",
     {},
     async () => {
       const collections = await getAllCollections();
@@ -19,9 +82,12 @@ export function registerCollectionTools(server: McpServer) {
   server.tool(
     'create_collection',
     'Create a new CMS collection. After creating, use add_collection_field to define its schema.',
-    { name: z.string().describe('Collection name (e.g. "Blog Posts", "Team Members")') },
-    async ({ name }) => {
-      const collection = await createCollection({ name });
+    {
+      name: z.string().describe('Collection name (e.g. "Blog Posts", "Team Members")'),
+      sorting: sortingSchema.optional(),
+    },
+    async ({ name, sorting }) => {
+      const collection = await createCollection({ name, sorting: sorting as CollectionSorting | undefined });
       return { content: [{ type: 'text' as const, text: JSON.stringify(collection, null, 2) }] };
     },
   );
@@ -31,18 +97,35 @@ export function registerCollectionTools(server: McpServer) {
     `Add a field to a collection's schema.
 
 FIELD TYPES:
-- text, number, boolean, date (datetime), date_only (date without time), reference, rich-text, color, asset, status`,
+- text, number, boolean, date (datetime), date_only (date without time)
+- reference (single link to one item), multi_reference (link to multiple items)
+- rich_text, color, status
+- image, audio, video, document (use data.multiple: true for multi-asset fields)
+- link, email, phone
+- option (predefined choices — pass data.options)
+- count (computed count of related items — pass data.count_collection_id + data.count_field_id)`,
     {
       collection_id: z.string().describe('The collection ID'),
       name: z.string().describe('Field display name'),
-      type: z.enum(['text', 'number', 'boolean', 'date', 'date_only', 'reference', 'multi_reference', 'rich_text', 'image', 'audio', 'video', 'document', 'link', 'email', 'phone', 'color', 'status']).describe('Field data type (date = datetime, date_only = date without time)'),
+      type: fieldTypeEnum,
       key: z.string().optional().describe('Unique field key (auto-generated from name if omitted)'),
-      reference_collection_id: z.string().optional().describe('For reference fields: the target collection ID'),
+      reference_collection_id: z.string().optional().describe('For reference / multi_reference fields: the target collection ID'),
+      default: z.string().optional().describe('Default value applied to new items'),
+      fillable: z.boolean().optional().describe('Whether this field can be set via the API / form submissions. Defaults true.'),
+      hidden: z.boolean().optional().describe('Hide this field from the CMS UI. Useful for internal computed fields.'),
+      is_computed: z.boolean().optional().describe('Whether the value is computed automatically (e.g. count fields).'),
+      data: fieldDataSchema.optional(),
     },
-    async ({ collection_id, ...fieldData }) => {
+    async ({ collection_id, data, ...fieldData }) => {
       const existingFields = await getFieldsByCollectionId(collection_id);
       const order = existingFields.length;
-      const field = await createField({ collection_id, order, ...fieldData });
+      const field = await createField({
+        collection_id,
+        order,
+        ...fieldData,
+        type: fieldData.type as CollectionFieldType,
+        data: buildFieldData(data),
+      });
       return { content: [{ type: 'text' as const, text: JSON.stringify(field, null, 2) }] };
     },
   );
@@ -61,7 +144,7 @@ FIELD TYPES:
         content: [{
           type: 'text' as const,
           text: JSON.stringify({
-            fields: fields.map((f) => ({ id: f.id, name: f.name, type: f.type, key: f.key })),
+            fields: fields.map((f) => ({ id: f.id, name: f.name, type: f.type, key: f.key, data: f.data })),
             items,
             total,
           }, null, 2),
@@ -76,18 +159,18 @@ FIELD TYPES:
     {
       collection_id: z.string().describe('The collection ID'),
       values: z.record(z.string(), z.unknown()).optional()
-        .describe('Field values as { fieldId: value } pairs'),
+        .describe('Field values as { fieldId: value } pairs. For "option" fields, value is the option ID. For multi-asset fields, value is a JSON array of asset IDs.'),
     },
     async ({ collection_id, values }) => {
       const item = await createItem({ collection_id });
 
       if (values && Object.keys(values).length > 0) {
         const fields = await getFieldsByCollectionId(collection_id);
-        const fieldType: Record<string, string> = {};
+        const fieldType: Record<string, CollectionFieldType> = {};
         for (const f of fields) {
           fieldType[f.id] = f.type;
         }
-        await setValuesByFieldName(item.id, collection_id, values, fieldType as any);
+        await setValuesByFieldName(item.id, collection_id, values as Record<string, unknown>, fieldType);
       }
 
       const { items: itemWithValues } = await getItemsWithValues(collection_id);
@@ -107,11 +190,11 @@ FIELD TYPES:
     },
     async ({ collection_id, item_id, values }) => {
       const fields = await getFieldsByCollectionId(collection_id);
-      const fieldType: Record<string, string> = {};
+      const fieldType: Record<string, CollectionFieldType> = {};
       for (const f of fields) {
         fieldType[f.id] = f.type;
       }
-      await setValuesByFieldName(item_id, collection_id, values, fieldType as any);
+      await setValuesByFieldName(item_id, collection_id, values as Record<string, unknown>, fieldType);
       return { content: [{ type: 'text' as const, text: `Updated item ${item_id}` }] };
     },
   );
@@ -130,14 +213,33 @@ FIELD TYPES:
   );
 
   server.tool(
+    'set_collection_item_order',
+    'Set the manual ordering position of an item within its collection. Only takes effect when the collection sorting is "manual".',
+    {
+      collection_id: z.string().describe('The collection ID (for permission scoping)'),
+      item_id: z.string().describe('The item ID to reorder'),
+      manual_order: z.number().int().describe('New position. Lower values appear first.'),
+    },
+    async ({ item_id, manual_order }) => {
+      const item = await updateItem(item_id, { manual_order });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(item, null, 2) }] };
+    },
+  );
+
+  server.tool(
     'update_collection',
-    'Rename a collection',
+    'Rename a collection or update its default sorting.',
     {
       collection_id: z.string().describe('The collection ID'),
-      name: z.string().describe('New collection name'),
+      name: z.string().optional().describe('New collection name'),
+      sorting: sortingSchema.nullable().optional()
+        .describe('Default sort applied in the CMS list view and on the canvas. Pass null to clear.'),
     },
-    async ({ collection_id, name }) => {
-      const collection = await updateCollection(collection_id, { name });
+    async ({ collection_id, name, sorting }) => {
+      const updates: { name?: string; sorting?: CollectionSorting | null } = {};
+      if (name !== undefined) updates.name = name;
+      if (sorting !== undefined) updates.sorting = sorting as CollectionSorting | null;
+      const collection = await updateCollection(collection_id, updates);
       return { content: [{ type: 'text' as const, text: JSON.stringify(collection, null, 2) }] };
     },
   );
@@ -154,15 +256,23 @@ FIELD TYPES:
 
   server.tool(
     'update_collection_field',
-    'Update a collection field (rename, change type, update reference)',
+    'Update a collection field (rename, change type, update reference, change metadata, update type-specific data).',
     {
       field_id: z.string().describe('The field ID to update'),
       name: z.string().optional().describe('New field name'),
-      type: z.enum(['text', 'number', 'boolean', 'date', 'date_only', 'reference', 'multi_reference', 'rich_text', 'image', 'audio', 'video', 'document', 'link', 'email', 'phone', 'color', 'status']).optional().describe('New field type (date = datetime, date_only = date without time)'),
-      reference_collection_id: z.string().optional().describe('For reference fields: target collection ID'),
+      type: fieldTypeEnum.optional(),
+      reference_collection_id: z.string().nullable().optional().describe('For reference fields: target collection ID. Pass null to clear.'),
+      default: z.string().nullable().optional().describe('Default value applied to new items. Pass null to clear.'),
+      fillable: z.boolean().optional(),
+      hidden: z.boolean().optional(),
+      data: fieldDataSchema.optional().describe('Replaces the entire field data object. Pass options[] to add/remove option values, data.multiple to toggle multi-asset, etc.'),
     },
-    async ({ field_id, ...updates }) => {
-      const field = await updateField(field_id, updates);
+    async ({ field_id, data, ...updates }) => {
+      const field = await updateField(field_id, {
+        ...updates,
+        type: updates.type as CollectionFieldType | undefined,
+        data: buildFieldData(data),
+      });
       return { content: [{ type: 'text' as const, text: JSON.stringify(field, null, 2) }] };
     },
   );
@@ -174,6 +284,19 @@ FIELD TYPES:
     async ({ field_id }) => {
       await deleteField(field_id);
       return { content: [{ type: 'text' as const, text: `Deleted field ${field_id}` }] };
+    },
+  );
+
+  server.tool(
+    'reorder_collection_fields',
+    'Reorder the fields of a collection. Pass the field IDs in the desired display order.',
+    {
+      collection_id: z.string().describe('The collection ID'),
+      field_ids: z.array(z.string()).min(1).describe('All field IDs in the desired order'),
+    },
+    async ({ collection_id, field_ids }) => {
+      await reorderFields(collection_id, false, field_ids);
+      return { content: [{ type: 'text' as const, text: `Reordered ${field_ids.length} fields in collection ${collection_id}` }] };
     },
   );
 }

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -333,22 +333,27 @@ For gradient text: also set backgroundClip: "text" and color to "transparent".`,
 
 LINK TYPES:
 - url: External URL (e.g. "https://example.com")
-- page: Link to another page in the site
+- page: Link to another page in the site. Pass collection_item_id alongside page_id_target to link to a specific dynamic-page item.
 - email: Mailto link
 - phone: Tel link
-- asset: Download link to an asset`,
+- asset: Download link to an asset
+- anchor: Set anchor_layer_id (and optionally page_id_target) to jump to a specific layer on the same or another page.`,
     {
       page_id: z.string().describe('The page ID'),
       layer_id: z.string().describe('The layer ID'),
       link_type: z.enum(['url', 'email', 'phone', 'asset', 'page']).describe('Type of link'),
       url: z.string().optional().describe('For url type: the target URL'),
       page_id_target: z.string().optional().describe('For page type: the target page ID'),
+      collection_item_id: z.string().optional().describe('For dynamic page links: the specific collection item the link should resolve to. Omit to use the current item at runtime.'),
       email: z.string().optional().describe('For email type: the email address'),
       phone: z.string().optional().describe('For phone type: the phone number'),
       asset_id: z.string().optional().describe('For asset type: the asset ID to download'),
-      target: z.enum(['_blank', '_self']).optional().describe('Link target. _blank opens new tab.'),
+      anchor_layer_id: z.string().optional().describe('Layer ID to scroll to as an in-page anchor. Combine with link_type "url" to link to "#layer" on the same page, or with link_type "page" to link to "#layer" on another page.'),
+      target: z.enum(['_blank', '_self', '_parent', '_top']).optional().describe('Link target. _blank opens new tab.'),
+      rel: z.string().optional().describe('rel attribute, e.g. "noopener noreferrer", "nofollow", "sponsored", "ugc"'),
+      download: z.boolean().optional().describe('When true, instruct the browser to download the linked resource instead of navigating.'),
     },
-    async ({ page_id, layer_id, link_type, url, page_id_target, email, phone, asset_id, target }) => {
+    async ({ page_id, layer_id, link_type, url, page_id_target, collection_item_id, email, phone, asset_id, anchor_layer_id, target, rel, download }) => {
       const layers = await getPageLayers(page_id);
       const layer = findLayerById(layers, layer_id);
       if (!layer) {
@@ -360,8 +365,15 @@ LINK TYPES:
       if (link_type === 'email' && email) link.email = { type: 'dynamic_text', data: { content: email } };
       if (link_type === 'phone' && phone) link.phone = { type: 'dynamic_text', data: { content: phone } };
       if (link_type === 'asset' && asset_id) link.asset = { id: asset_id };
-      if (link_type === 'page' && page_id_target) link.page = { id: page_id_target };
+      if (link_type === 'page' && page_id_target) {
+        link.page = collection_item_id
+          ? { id: page_id_target, collection_item_id }
+          : { id: page_id_target };
+      }
+      if (anchor_layer_id) link.anchor_layer_id = anchor_layer_id;
       if (target) link.target = target;
+      if (rel !== undefined) link.rel = rel;
+      if (download !== undefined) link.download = download;
 
       const updated = updateLayerById(layers, layer_id, (l) => ({
         ...l,


### PR DESCRIPTION
## Summary

Brings the MCP collection / link surface up to current Ycode parity. Agents previously could not create the `option` or `count` field types, configure multi-asset fields, set field metadata (default / fillable / hidden / is_computed), define a default sort, reorder fields, reposition items, or build anchor / dynamic-item / rel-bearing links. They can now.

Closes audit items in PR 6, 7, 15 (excluding the `field` link type, which needs collection-layer context and is better delivered alongside the collection-layer / loop work).

## Changes

### `lib/mcp/tools/collections.ts`
- Extract a shared `fieldTypeEnum` (was hand-rewritten on both add and update — drift waiting to happen)
- Add `option` and `count` to the field type enum
- New `data` parameter (`fieldDataSchema`) on add / update covering:
  - `multiple` — for asset fields (image / audio / video / document)
  - `options[]` — for `option` fields
  - `count_collection_id` + `count_field_id` — for `count` fields, flattened from the storage shape `{ collectionId, fieldId }` for ergonomics
- Add `default`, `fillable`, `hidden`, `is_computed` to `add_collection_field` and `update_collection_field`
- Add `sorting` to `create_collection` and `update_collection` (`{ field, direction }` where direction is `asc | desc | manual`)
- New tool `reorder_collection_fields(collection_id, field_ids[])`
- New tool `set_collection_item_order(item_id, manual_order)`
- `list_collection_items` now includes each field's `data` blob so agents can see existing option choices / count config

### `lib/mcp/tools/layers.ts` — `update_layer_link`
- `anchor_layer_id` — in-page or cross-page anchor jumps
- `collection_item_id` — pin a dynamic page link to a specific item (the runtime previously had to guess from context)
- `rel` and `download` — both already supported by `LinkSettings`, just never exposed
- Widen `target` enum to include `_parent` / `_top` (matches the type)

## What's deferred

The `field` link type (href resolved from a CMS field) needs the surrounding collection-layer context and item resolution. Better delivered as part of the collection-loop work in a follow-up.

## Test plan

- [x] `npm run type-check` passes
- [x] `npx eslint lib/mcp/tools/{collections,layers}.ts` passes
- [ ] `add_collection_field` with `type: 'option'` and `data: { options: [{ id: 'red', name: 'Red' }, { id: 'blue', name: 'Blue' }] }` then `create_collection_item` with `{ values: { '<field_id>': 'red' } }` — value persists and renders as "Red" in the CMS UI
- [ ] `add_collection_field` with `type: 'count'`, `data: { count_collection_id: '<child>', count_field_id: '<ref>' }` — items show a computed count
- [ ] `update_collection` with `sorting: { field: '<field_id>', direction: 'desc' }` — list view sorts accordingly
- [ ] `reorder_collection_fields` reorders the schema panel
- [ ] `set_collection_item_order(item, 0)` on a manually-sorted collection promotes the item to the top
- [ ] `update_layer_link` with `link_type: 'url'` and `anchor_layer_id: '<id>'` writes `#layer` in the rendered href
- [ ] `update_layer_link` with `link_type: 'page'`, `page_id_target: '<dyn page>'`, `collection_item_id: '<id>'` links to the specific dynamic item
- [ ] `update_layer_link` with `download: true, rel: 'nofollow'` reflects in the rendered `<a>` attributes

Made with [Cursor](https://cursor.com)