### PR TITLE
feat(mcp): tables, expanded rich-text blocks, settings parity, export_layer_html

### DIFF
--- a/lib/mcp/tools/batch.ts
+++ b/lib/mcp/tools/batch.ts
@@ -24,10 +24,22 @@ const templateEnum = z.enum(
 );
 
 const richTextBlockSchema = z.object({
-  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
-  text: z.string().optional(),
-  level: z.number().optional(),
-  items: z.array(z.string()).optional(),
+  type: z.enum([
+    'paragraph', 'heading', 'blockquote',
+    'bulletList', 'orderedList',
+    'codeBlock', 'horizontalRule',
+    'htmlEmbed', 'image', 'table', 'component',
+  ]),
+  text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
+  level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
+  items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
+  code: z.string().optional().describe('For htmlEmbed: the HTML/JS code to embed'),
+  src: z.string().optional().describe('For image: external image URL (use asset_id for uploaded assets)'),
+  alt: z.string().optional().describe('For image: alt text'),
+  asset_id: z.string().optional().describe('For image: asset ID from upload_asset'),
+  rows: z.array(z.array(z.string())).optional().describe('For table: 2D array of cell text. Inline marks (**bold** etc.) work in each cell.'),
+  header_row: z.boolean().optional().describe('For table: whether the first row should render as table headers. Defaults true.'),
+  component_id: z.string().optional().describe('For component: ID of the component to embed'),
 });
 
 const addLayerOp = z.object({

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -16,6 +16,7 @@ import {
   ELEMENT_TEMPLATES,
 } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
+import { layerToExportHtml } from '@/lib/html-layer-converter';
 import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
 import { designSchema } from './shared-schemas';
 
@@ -68,10 +69,22 @@ NESTING RULES:
       template: templateEnum.describe('Element template to create'),
       text_content: z.string().optional().describe('For text/heading/button/richText: plain display text'),
       rich_content: z.array(z.object({
-        type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
+        type: z.enum([
+          'paragraph', 'heading', 'blockquote',
+          'bulletList', 'orderedList',
+          'codeBlock', 'horizontalRule',
+          'htmlEmbed', 'image', 'table', 'component',
+        ]),
         text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
         level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
         items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
+        code: z.string().optional().describe('For htmlEmbed: the HTML/JS code to embed'),
+        src: z.string().optional().describe('For image: external image URL (use asset_id for uploaded assets)'),
+        alt: z.string().optional().describe('For image: alt text'),
+        asset_id: z.string().optional().describe('For image: asset ID from upload_asset'),
+        rows: z.array(z.array(z.string())).optional().describe('For table: 2D array of cell text'),
+        header_row: z.boolean().optional().describe('For table: whether the first row renders as headers. Defaults true.'),
+        component_id: z.string().optional().describe('For component: ID of the component to embed'),
       })).optional().describe('For richText: structured content blocks. Overrides text_content.'),
       custom_name: z.string().optional().describe('Custom display name for the layer'),
     },
@@ -446,15 +459,22 @@ LINK TYPES:
 
   server.tool(
     'update_layer_settings',
-    `Update layer settings like HTML tag, custom ID, custom attributes, embed code, and slider/lightbox configuration.
+    `Update layer settings like HTML tag, custom ID, custom attributes, embed code, visibility,
+and per-element configuration (slider, lightbox, map, select options, filter, placeholder option).
 
 COMMON USES:
 - Change heading level: tag "h1", "h2", "h3", etc.
 - Set HTML embed code: html_embed_code "<script>..."
 - Add custom attributes: custom_attributes { "data-analytics": "hero" }
 - Set custom HTML ID: html_id "my-section"
+- Hide a layer from the canvas: hidden true
 - Configure slider: slider { autoplay: true, delay: "5", loop: "loop", pagination: true }
-- Configure lightbox: lightbox { thumbnails: true, zoom: true, navigation: true }`,
+- Configure lightbox: lightbox { thumbnails: true, zoom: true, navigation: true }
+- Bind lightbox to a CMS multi-image field: lightbox { files_source: "cms", files_field_id: "<field id>" }
+- Configure map: map { provider: "mapbox", latitude: 40.7128, longitude: -74.006, zoom: 12 }
+- Bind select / checkbox / radio to a CMS collection: options_source { collection_id: "<id>", sort_field_id: "<id>", sort_order: "asc" }
+- Mark a <option> as the placeholder: is_placeholder true
+- Trigger filter element on every change: filter_on_change true`,
     {
       page_id: z.string().describe('The page ID'),
       layer_id: z.string().describe('The layer ID'),
@@ -463,32 +483,69 @@ COMMON USES:
       html_embed_code: z.string().optional().describe('For htmlEmbed layers: the HTML/CSS/JS code to embed'),
       custom_attributes: z.record(z.string(), z.string()).optional().describe('Custom HTML attributes as { name: value } pairs'),
       custom_name: z.string().optional().describe('Display name for the layer in the builder'),
+      hidden: z.boolean().optional().describe('Hide the layer on the canvas (still renders on the published site).'),
+      filter_on_change: z.boolean().optional().describe('For filter layers: trigger filtering on every input change (debounced).'),
+      is_placeholder: z.boolean().optional().describe('For <option> children of <select>: mark this option as the disabled placeholder.'),
       slider: z.object({
         navigation: z.boolean().optional().describe('Show prev/next arrows'),
         pagination: z.boolean().optional().describe('Show pagination bullets'),
-        paginationType: z.enum(['bullets', 'fraction']).optional().describe('Pagination style'),
+        pagination_type: z.enum(['bullets', 'fraction']).optional().describe('Pagination style'),
+        pagination_clickable: z.boolean().optional(),
         autoplay: z.boolean().optional().describe('Auto-advance slides'),
-        pauseOnHover: z.boolean().optional().describe('Pause autoplay on hover'),
+        pause_on_hover: z.boolean().optional().describe('Pause autoplay on hover'),
         delay: z.string().optional().describe('Autoplay delay in seconds (e.g. "3", "5")'),
         loop: z.enum(['none', 'loop', 'rewind']).optional().describe('Loop mode'),
-        animationEffect: z.enum(['slide', 'fade', 'cube', 'coverflow', 'flip', 'cards']).optional(),
+        animation_effect: z.enum(['slide', 'fade', 'cube', 'coverflow', 'flip', 'cards']).optional(),
         duration: z.string().optional().describe('Transition duration in seconds (e.g. "0.5")'),
+        easing: z.string().optional(),
         centered: z.boolean().optional().describe('Center active slide'),
         mousewheel: z.boolean().optional().describe('Navigate with scroll wheel'),
+        touch_events: z.boolean().optional(),
+        slide_to_clicked: z.boolean().optional(),
+        slides_per_group: z.number().optional(),
+        group_slide: z.number().optional(),
       }).optional().describe('Slider settings (only for slider layers)'),
       lightbox: z.object({
+        files_source: z.enum(['files', 'cms']).optional().describe('"files" for a hand-picked list, "cms" to bind to a multi-image CMS field'),
+        files: z.array(z.string()).optional().describe('For files_source "files": array of asset IDs or external URLs'),
+        files_field_id: z.string().nullable().optional().describe('For files_source "cms": the CMS field ID to read images from (must be a multi-asset field on the surrounding collection layer)'),
         thumbnails: z.boolean().optional().describe('Show thumbnails strip'),
         navigation: z.boolean().optional().describe('Show prev/next arrows'),
         pagination: z.boolean().optional().describe('Show pagination'),
         zoom: z.boolean().optional().describe('Enable pinch-to-zoom'),
-        doubleTapZoom: z.boolean().optional().describe('Enable double-tap zoom'),
+        double_tap_zoom: z.boolean().optional().describe('Enable double-tap zoom'),
         mousewheel: z.boolean().optional().describe('Navigate with scroll wheel'),
         overlay: z.enum(['light', 'dark']).optional().describe('Overlay background style'),
-        animationEffect: z.enum(['slide', 'fade', 'cube', 'coverflow', 'flip', 'cards']).optional(),
+        group_id: z.string().optional().describe('Links multiple lightboxes into one shared gallery'),
+        animation_effect: z.enum(['slide', 'fade', 'cube', 'coverflow', 'flip', 'cards']).optional(),
+        easing: z.string().optional(),
         duration: z.string().optional().describe('Transition duration in seconds'),
       }).optional().describe('Lightbox settings (only for lightbox layers)'),
+      map: z.object({
+        provider: z.enum(['mapbox', 'google']).optional(),
+        latitude: z.number().optional(),
+        longitude: z.number().optional(),
+        zoom: z.number().optional(),
+        marker_color: z.string().nullable().optional(),
+        search: z.string().optional().describe('Address / place to geocode (alternative to lat/lng)'),
+        style: z.string().optional().describe('Provider-specific style key. Sets <provider>.style.'),
+        interactive: z.boolean().optional(),
+        scroll_zoom: z.boolean().optional(),
+        show_nav_control: z.boolean().optional(),
+        show_scale_bar: z.boolean().optional(),
+      }).optional().describe('Map settings (only for map layers)'),
+      options_source: z.object({
+        collection_id: z.string().describe('Collection to source options from'),
+        default_item_id: z.string().optional().describe('Item ID to pre-select (for <select>)'),
+        default_item_ids: z.array(z.string()).optional().describe('Item IDs to pre-check (for checkbox groups)'),
+        sort_field_id: z.string().optional().describe('Field ID to sort by (omit for manual order)'),
+        sort_order: z.enum(['asc', 'desc']).optional(),
+      }).nullable().optional().describe('Bind a select / checkbox / radio element to a CMS collection. Pass null to clear.'),
     },
-    async ({ page_id, layer_id, tag, html_id, html_embed_code, custom_attributes, custom_name, slider, lightbox }) => {
+    async ({
+      page_id, layer_id, tag, html_id, html_embed_code, custom_attributes, custom_name,
+      hidden, filter_on_change, is_placeholder, slider, lightbox, map, options_source,
+    }) => {
       const layers = await getPageLayers(page_id);
       const layer = findLayerById(layers, layer_id);
       if (!layer) {
@@ -499,10 +556,85 @@ COMMON USES:
         const settings = { ...l.settings };
         if (tag) settings.tag = tag;
         if (html_id) settings.id = html_id;
+        if (hidden !== undefined) settings.hidden = hidden;
+        if (filter_on_change !== undefined) settings.filterOnChange = filter_on_change;
+        if (is_placeholder !== undefined) settings.isPlaceholder = is_placeholder;
         if (custom_attributes) settings.customAttributes = { ...settings.customAttributes, ...custom_attributes };
         if (html_embed_code !== undefined) settings.htmlEmbed = { ...settings.htmlEmbed, code: html_embed_code };
-        if (slider && settings.slider) settings.slider = { ...settings.slider, ...slider };
-        if (lightbox && settings.lightbox) settings.lightbox = { ...settings.lightbox, ...lightbox };
+        if (slider) {
+          const existing = settings.slider || {} as Record<string, unknown>;
+          settings.slider = {
+            ...existing,
+            ...(slider.navigation !== undefined && { navigation: slider.navigation }),
+            ...(slider.pagination !== undefined && { pagination: slider.pagination }),
+            ...(slider.pagination_type !== undefined && { paginationType: slider.pagination_type }),
+            ...(slider.pagination_clickable !== undefined && { paginationClickable: slider.pagination_clickable }),
+            ...(slider.autoplay !== undefined && { autoplay: slider.autoplay }),
+            ...(slider.pause_on_hover !== undefined && { pauseOnHover: slider.pause_on_hover }),
+            ...(slider.delay !== undefined && { delay: slider.delay }),
+            ...(slider.loop !== undefined && { loop: slider.loop }),
+            ...(slider.animation_effect !== undefined && { animationEffect: slider.animation_effect }),
+            ...(slider.duration !== undefined && { duration: slider.duration }),
+            ...(slider.easing !== undefined && { easing: slider.easing }),
+            ...(slider.centered !== undefined && { centered: slider.centered }),
+            ...(slider.mousewheel !== undefined && { mousewheel: slider.mousewheel }),
+            ...(slider.touch_events !== undefined && { touchEvents: slider.touch_events }),
+            ...(slider.slide_to_clicked !== undefined && { slideToClicked: slider.slide_to_clicked }),
+            ...(slider.slides_per_group !== undefined && { slidesPerGroup: slider.slides_per_group }),
+            ...(slider.group_slide !== undefined && { groupSlide: slider.group_slide }),
+          } as typeof settings.slider;
+        }
+        if (lightbox) {
+          const existing = (settings.lightbox || {}) as Record<string, unknown>;
+          const next = { ...existing } as Record<string, unknown>;
+          if (lightbox.files_source !== undefined) next.filesSource = lightbox.files_source;
+          if (lightbox.files !== undefined) next.files = lightbox.files;
+          if (lightbox.files_field_id !== undefined) {
+            next.filesField = lightbox.files_field_id
+              ? { type: 'field', data: { field_id: lightbox.files_field_id, field_type: 'image', relationships: [] } }
+              : null;
+          }
+          if (lightbox.thumbnails !== undefined) next.thumbnails = lightbox.thumbnails;
+          if (lightbox.navigation !== undefined) next.navigation = lightbox.navigation;
+          if (lightbox.pagination !== undefined) next.pagination = lightbox.pagination;
+          if (lightbox.zoom !== undefined) next.zoom = lightbox.zoom;
+          if (lightbox.double_tap_zoom !== undefined) next.doubleTapZoom = lightbox.double_tap_zoom;
+          if (lightbox.mousewheel !== undefined) next.mousewheel = lightbox.mousewheel;
+          if (lightbox.overlay !== undefined) next.overlay = lightbox.overlay;
+          if (lightbox.group_id !== undefined) next.groupId = lightbox.group_id;
+          if (lightbox.animation_effect !== undefined) next.animationEffect = lightbox.animation_effect;
+          if (lightbox.easing !== undefined) next.easing = lightbox.easing;
+          if (lightbox.duration !== undefined) next.duration = lightbox.duration;
+          settings.lightbox = next as unknown as typeof settings.lightbox;
+        }
+        if (map) {
+          const existing = (settings.map || {}) as Record<string, unknown>;
+          const next = { ...existing } as Record<string, unknown>;
+          if (map.provider !== undefined) next.provider = map.provider;
+          if (map.latitude !== undefined) next.latitude = map.latitude;
+          if (map.longitude !== undefined) next.longitude = map.longitude;
+          if (map.zoom !== undefined) next.zoom = map.zoom;
+          if (map.marker_color !== undefined) next.markerColor = map.marker_color;
+          if (map.search !== undefined) next.search = map.search;
+          const providerKey = (map.provider || existing.provider || 'mapbox') as 'mapbox' | 'google';
+          const providerSettings = { ...((existing[providerKey] as Record<string, unknown>) || {}) };
+          if (map.style !== undefined) providerSettings.style = map.style;
+          if (map.interactive !== undefined) providerSettings.interactive = map.interactive;
+          if (map.scroll_zoom !== undefined) providerSettings.scrollZoom = map.scroll_zoom;
+          if (map.show_nav_control !== undefined) providerSettings.showNavControl = map.show_nav_control;
+          if (map.show_scale_bar !== undefined) providerSettings.showScaleBar = map.show_scale_bar;
+          if (Object.keys(providerSettings).length > 0) next[providerKey] = providerSettings;
+          settings.map = next as unknown as typeof settings.map;
+        }
+        if (options_source !== undefined) {
+          settings.optionsSource = options_source === null ? undefined : {
+            collectionId: options_source.collection_id,
+            ...(options_source.default_item_id !== undefined && { defaultItemId: options_source.default_item_id }),
+            ...(options_source.default_item_ids !== undefined && { defaultItemIds: options_source.default_item_ids }),
+            ...(options_source.sort_field_id !== undefined && { sortFieldId: options_source.sort_field_id }),
+            ...(options_source.sort_order !== undefined && { sortOrder: options_source.sort_order }),
+          };
+        }
 
         return {
           ...l,
@@ -513,6 +645,26 @@ COMMON USES:
 
       await savePageLayers(page_id, updated);
       return { content: [{ type: 'text' as const, text: `Updated settings for "${layer.customName || layer.name}"` }] };
+    },
+  );
+
+  server.tool(
+    'export_layer_html',
+    `Render a layer (and its descendants) to a self-contained HTML string with Tailwind
+classes preserved. Useful for copying a section, sharing markup, or seeding another
+page via the HTML import flow.`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer ID to export'),
+    },
+    async ({ page_id, layer_id }) => {
+      const layers = await getPageLayers(page_id);
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+      const html = layerToExportHtml(layer);
+      return { content: [{ type: 'text' as const, text: html }] };
     },
   );
 

--- a/lib/mcp/utils.ts
+++ b/lib/mcp/utils.ts
@@ -131,6 +131,10 @@ export function getTiptapTextContent(text: string): TiptapDoc {
  *  - { type: "orderedList", items: ["...", "..."] }
  *  - { type: "codeBlock", text: "..." }
  *  - { type: "horizontalRule" }
+ *  - { type: "htmlEmbed", code: "<script>...</script>" }
+ *  - { type: "image", src: "...", alt?: "...", asset_id?: "..." }
+ *  - { type: "table", rows: [["cell", "cell"], ...], header_row: true }
+ *  - { type: "component", component_id: "..." }
  *
  * Text can include simple inline formatting via markdown-like syntax:
  *  - **bold**, *italic*, [link text](url)
@@ -143,10 +147,21 @@ export function buildTiptapDoc(blocks: RichTextBlock[]): TiptapDoc {
 }
 
 export interface RichTextBlock {
-  type: 'paragraph' | 'heading' | 'blockquote' | 'bulletList' | 'orderedList' | 'codeBlock' | 'horizontalRule';
+  type:
+    | 'paragraph' | 'heading' | 'blockquote'
+    | 'bulletList' | 'orderedList'
+    | 'codeBlock' | 'horizontalRule'
+    | 'htmlEmbed' | 'image' | 'table' | 'component';
   text?: string;
   level?: number;
   items?: string[];
+  code?: string;
+  src?: string;
+  alt?: string;
+  asset_id?: string;
+  rows?: string[][];
+  header_row?: boolean;
+  component_id?: string;
 }
 
 function parseInlineMarks(text: string): TiptapNode[] {
@@ -224,12 +239,48 @@ function blockToTiptapNode(block: RichTextBlock): TiptapNode {
       };
     case 'horizontalRule':
       return { type: 'horizontalRule' };
+    case 'htmlEmbed':
+      return {
+        type: 'richTextHtmlEmbed',
+        attrs: { code: block.code || '' },
+      };
+    case 'image':
+      return {
+        type: 'richTextImage',
+        attrs: {
+          src: block.src || '',
+          alt: block.alt || null,
+          assetId: block.asset_id || null,
+          link: null,
+        },
+      };
+    case 'component':
+      return {
+        type: 'richTextComponent',
+        attrs: { componentId: block.component_id || '' },
+      };
+    case 'table':
+      return buildTableNode(block.rows || [], block.header_row !== false);
     default:
       return {
         type: 'paragraph',
         content: block.text ? [{ type: 'text', text: block.text }] : [],
       };
   }
+}
+
+function buildTableNode(rows: string[][], headerRow: boolean): TiptapNode {
+  if (rows.length === 0) return { type: 'paragraph' };
+  return {
+    type: 'table',
+    content: rows.map((row, rowIdx) => ({
+      type: 'tableRow',
+      content: row.map((cellText) => ({
+        type: headerRow && rowIdx === 0 ? 'tableHeader' : 'tableCell',
+        content: [{ type: 'paragraph', content: cellText ? parseInlineMarks(cellText) : [] }],
+      })),
+    })),
+  };
 }
 
 /**
@@ -666,6 +717,36 @@ export const ELEMENT_TEMPLATES: Record<string, ElementTemplateEntry> = {
   localeSelector: {
     name: 'Locale Selector',
     description: 'Language switcher dropdown for multi-language sites.',
+    useBlocksTemplate: true,
+  },
+  table: {
+    name: 'Table',
+    description: 'Data table (renders as <table>). Pre-populated with a header row and two body rows.',
+    useBlocksTemplate: true,
+  },
+  thead: {
+    name: 'Table Header',
+    description: '<thead> with one header row. Add inside a table.',
+    useBlocksTemplate: true,
+  },
+  tbody: {
+    name: 'Table Body',
+    description: '<tbody> with one row. Add inside a table.',
+    useBlocksTemplate: true,
+  },
+  tr: {
+    name: 'Table Row',
+    description: '<tr>. Add inside thead or tbody.',
+    useBlocksTemplate: true,
+  },
+  td: {
+    name: 'Table Cell',
+    description: '<td>. Add inside a tr.',
+    useBlocksTemplate: true,
+  },
+  th: {
+    name: 'Table Header Cell',
+    description: '<th>. Add inside a thead tr.',
     useBlocksTemplate: true,
   },
 };


### PR DESCRIPTION
## Summary

Brings the canvas / element surface up to current Ycode parity. Agents can now build tables, embed rich-text images / components / html / tables, configure maps and CMS-backed lightboxes/selects, and export any layer subtree to HTML.

Closes audit items in PR 8, 9, 10, 17 (export half). PR 16 (remove individual style classes) is deferred — doing it correctly needs class-removal utilities that don't exist yet in the codebase, better as a focused follow-up. PR 17's HTML import half is deferred — depends on a server-side HTML parser dependency.

## Changes

### Element templates
- Register `table`, `thead`, `tbody`, `tr`, `td`, `th` in `ELEMENT_TEMPLATES`. Resolution flows through the existing `structureTemplates`, so they ship with the same defaults as the Ycode UI's add-element panel.

### Rich-text blocks (`RichTextBlock` + `buildTiptapDoc`)
- `htmlEmbed` → `richTextHtmlEmbed` node, takes `code`
- `image` → `richTextImage` node, takes `src` / `alt` / `asset_id`
- `table` → standard `table` / `tableRow` / `tableCell` / `tableHeader` nodes; `rows: string[][]`, `header_row: boolean`
- `component` → `richTextComponent` node, takes `component_id`
- Schemas updated in `batch.ts` and the inline `rich_content` schema on `add_layer` in `layers.ts`

### `update_layer_settings` (extended to match `LayerSettings`)
- New top-level: `hidden`, `filter_on_change`, `is_placeholder`
- `slider`: added `pagination_type` / `pagination_clickable`, `easing`, `touch_events`, `slide_to_clicked`, `slides_per_group`, `group_slide`
- `lightbox`: added `files` / `files_source` / `files_field_id` (CMS multi-image binding), `group_id`, `easing`
- `map`: full `MapSettings` surface — `provider`, `latitude` / `longitude`, `zoom`, `marker_color`, `search`, plus provider-scoped `style` / `interactive` / `scroll_zoom` / `show_nav_control` / `show_scale_bar`
- `options_source`: bind select / checkbox / radio to a CMS collection (`collection_id`, `default_item_id`(s), `sort_field_id`, `sort_order`)

### New tool `export_layer_html`
Renders any layer + descendants to a self-contained HTML string with Tailwind classes preserved. Wraps the existing `layerToExportHtml` utility — pure, server-safe.

## What's deferred

- **HTML import** (`htmlToLayers`) — requires DOMParser, browser-only. Needs a server-side HTML parser (e.g. `node-html-parser`) before we can expose it. Separate PR.
- **`clear_layer_design`** — the codebase has no class-removal utility yet. Half-baking it here would have written `null` into design objects without scrubbing the matching Tailwind classes for non-desktop breakpoints. Separate PR with proper class-removal helpers.

## Test plan

- [x] `npm run type-check` passes
- [x] `npx eslint` passes on touched files
- [ ] `add_layer` with `template: "table"` produces a 3-row table on the canvas
- [ ] `add_layer` with `template: "richText"` and `rich_content: [{ type: "table", rows: [["a","b"],["c","d"]], header_row: true }]` renders a header + body
- [ ] `add_layer` rich_content with `{ type: "htmlEmbed", code: "<iframe …></iframe>" }` renders the embed in the rich-text editor
- [ ] `add_layer` rich_content with `{ type: "image", asset_id: "<id>" }` renders the image from the asset library
- [ ] `update_layer_settings` with `map: { provider: "mapbox", latitude: 40.7128, longitude: -74.006, zoom: 12 }` repositions a map layer
- [ ] `update_layer_settings` with `lightbox: { files_source: "cms", files_field_id: "<multi-image field>" }` binds a lightbox inside a collection layer
- [ ] `update_layer_settings` with `options_source: { collection_id: "<id>", sort_field_id: "<id>", sort_order: "asc" }` populates a `<select>`
- [ ] `update_layer_settings` with `is_placeholder: true` on a `<select>` child marks it as the disabled placeholder
- [ ] `update_layer_settings` with `hidden: true` hides the layer on the canvas (still publishes)
- [ ] `export_layer_html` returns valid HTML for a section layer that round-trips through manual review

Made with [Cursor](https://cursor.com)