### PR TITLE
feat(mcp): page extensions, redirects, form settings, rich-text translations

### DIFF
--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -517,6 +517,50 @@ COMMON USES:
   );
 
   server.tool(
+    'update_form_settings',
+    `Configure how a form layer handles submissions.
+
+success_action: "message" (default) shows the form's alert child; "redirect" sends the visitor to redirect_url.
+email_notification: when enabled, each submission emails the configured address. Requires SMTP set up in site settings.
+redirect_url: used when success_action is "redirect". Accepts an internal path "/thank-you" or an external URL.`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The form layer ID'),
+      success_action: z.enum(['message', 'redirect']).optional(),
+      redirect_url: z.string().optional()
+        .describe('For success_action "redirect": the URL to send the user to.'),
+      email_notification: z.object({
+        enabled: z.boolean(),
+        to: z.string().describe('Email address that receives a notification on each submission'),
+        subject: z.string().optional().describe('Subject line of the notification email'),
+      }).optional(),
+    },
+    async ({ page_id, layer_id, success_action, redirect_url, email_notification }) => {
+      const layers = await getPageLayers(page_id);
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+
+      const updated = updateLayerById(layers, layer_id, (l) => {
+        const settings = { ...l.settings };
+        const existingForm = (settings.form || {}) as Record<string, unknown>;
+        const nextForm: Record<string, unknown> = { ...existingForm };
+        if (success_action !== undefined) nextForm.success_action = success_action;
+        if (email_notification !== undefined) nextForm.email_notification = email_notification;
+        if (redirect_url !== undefined) {
+          nextForm.redirect_url = { type: 'dynamic_text', data: { content: redirect_url } };
+        }
+        settings.form = nextForm as typeof settings.form;
+        return { ...l, settings };
+      });
+
+      await savePageLayers(page_id, updated);
+      return { content: [{ type: 'text' as const, text: `Updated form settings for "${layer.customName || layer.name}"` }] };
+    },
+  );
+
+  server.tool(
     'update_layer_iframe',
     'Set the source URL for an iframe layer.',
     {

--- a/lib/mcp/tools/locales.ts
+++ b/lib/mcp/tools/locales.ts
@@ -14,6 +14,15 @@ import {
   deleteTranslation,
   upsertTranslations,
 } from '@/lib/repositories/translationRepository';
+import { buildTiptapDoc } from '@/lib/mcp/utils';
+import type { RichTextBlock } from '@/lib/mcp/utils';
+
+const richTextBlockSchema = z.object({
+  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
+  text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
+  level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
+  items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
+});
 
 export function registerLocaleTools(server: McpServer) {
   server.tool(
@@ -232,6 +241,43 @@ export function registerLocaleTools(server: McpServer) {
       await deleteTranslation(translation_id);
       return {
         content: [{ type: 'text' as const, text: `Translation ${translation_id} deleted successfully.` }],
+      };
+    },
+  );
+
+  server.tool(
+    'set_rich_text_translation',
+    `Translate a rich-text content key by passing structured blocks. The blocks are converted
+to the Tiptap JSON shape that Ycode expects for richtext translations and stored as
+content_value. Equivalent to calling set_translation with content_type "richtext" but the
+agent doesn't have to assemble the JSON by hand.
+
+Block types match add_layer's rich_content: paragraph, heading, blockquote, bulletList,
+orderedList, codeBlock, horizontalRule. Text supports **bold**, *italic*, [link](url).`,
+    {
+      locale_id: z.string().describe('The locale ID'),
+      source_type: z.enum(['page', 'folder', 'component', 'cms']).describe('Type of source being translated'),
+      source_id: z.string().describe('ID of the source (page ID, component ID, etc.)'),
+      content_key: z.string().describe('Content key identifying the rich-text field (e.g. layer ID or "richtext:<field id>")'),
+      blocks: z.array(richTextBlockSchema).min(1).describe('Rich-text blocks describing the translated content'),
+      is_completed: z.boolean().optional().describe('Mark translation as complete. Defaults to false.'),
+    },
+    async ({ locale_id, source_type, source_id, content_key, blocks, is_completed }) => {
+      const doc = buildTiptapDoc(blocks as RichTextBlock[]);
+      const translation = await createTranslation({
+        locale_id,
+        source_type,
+        source_id,
+        content_key,
+        content_type: 'richtext',
+        content_value: JSON.stringify(doc),
+        is_completed,
+      });
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({ message: 'Rich-text translation saved', translation }, null, 2),
+        }],
       };
     },
   );

--- a/lib/mcp/tools/pages.ts
+++ b/lib/mcp/tools/pages.ts
@@ -3,7 +3,20 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getAllPages, getPageById, getPagesByFolder, createPage, updatePage, deletePage, duplicatePage } from '@/lib/repositories/pageRepository';
 import { getAllPageFolders } from '@/lib/repositories/pageFolderRepository';
 import { upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
+import { getSettingByKey, setSetting } from '@/lib/repositories/settingsRepository';
 import { broadcastPageCreated, broadcastPageUpdated, broadcastPageDeleted, broadcastLayersChanged } from '@/lib/mcp/broadcast';
+import type { Redirect } from '@/types';
+
+const REDIRECTS_KEY = 'redirects';
+
+async function getRedirects(): Promise<Redirect[]> {
+  const value = await getSettingByKey(REDIRECTS_KEY);
+  return Array.isArray(value) ? value : [];
+}
+
+function generateRedirectId(): string {
+  return `redirect_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
 
 export function registerPageTools(server: McpServer) {
   server.tool(
@@ -80,12 +93,19 @@ export function registerPageTools(server: McpServer) {
 
   server.tool(
     'update_page',
-    "Update a page's name, slug, or folder.",
+    `Update a page's metadata: name, slug, folder, homepage flag, dynamic flag, and error-page assignment.
+
+ERROR PAGES: Set error_page to 401, 404, or 500 to designate this as the auth-required / not-found / server-error page for the site. Pass null to clear.
+DYNAMIC PAGES: Set is_dynamic true to turn this into a CMS-driven page (then use update_page_settings.cms to bind it to a collection).`,
     {
       page_id: z.string().describe('The page ID to update'),
       name: z.string().optional().describe('New page title'),
       slug: z.string().optional().describe('New URL slug'),
       page_folder_id: z.string().nullable().optional().describe('Move to folder ID, or null for root'),
+      is_index: z.boolean().optional().describe('Mark as the homepage (only one page can be the index)'),
+      is_dynamic: z.boolean().optional().describe('Turn into a CMS dynamic page'),
+      error_page: z.union([z.literal(401), z.literal(404), z.literal(500)]).nullable().optional()
+        .describe('Designate as 401 / 404 / 500 error page. Pass null to clear.'),
     },
     async ({ page_id, ...data }) => {
       const page = await updatePage(page_id, data);
@@ -96,11 +116,13 @@ export function registerPageTools(server: McpServer) {
 
   server.tool(
     'update_page_settings',
-    `Update page SEO, custom code, or password protection settings.
+    `Update page SEO, custom code, password protection, or CMS binding (dynamic pages).
 
 SEO: Set title, description, noindex, and OG image (asset ID).
 Custom code: Inject HTML into <head> or before </body>.
-Password protection: Enable/disable with a password.`,
+Password protection: Enable/disable with a password.
+CMS binding: For dynamic pages — bind to a collection, pick the slug field, and configure
+how next-item / previous-item links traverse the collection.`,
     {
       page_id: z.string().describe('The page ID'),
       seo: z.object({
@@ -117,8 +139,16 @@ Password protection: Enable/disable with a password.`,
         enabled: z.boolean().describe('Enable or disable password protection'),
         password: z.string().optional().describe('Password for accessing the page'),
       }).optional(),
+      cms: z.object({
+        collection_id: z.string().describe('Collection to drive this dynamic page'),
+        slug_field_id: z.string().describe('Field whose value provides each item\'s URL slug'),
+        next_previous: z.object({
+          sort_by: z.string().optional().describe('"manual" (default) or a collection field ID'),
+          sort_order: z.enum(['asc', 'desc']).optional(),
+        }).optional().describe('Controls how next-item / previous-item link keywords traverse this page\'s collection.'),
+      }).nullable().optional().describe('CMS binding for dynamic pages. Pass null to clear.'),
     },
-    async ({ page_id, seo, custom_code, auth }) => {
+    async ({ page_id, seo, custom_code, auth, cms }) => {
       const existing = await getPageById(page_id);
       if (!existing) {
         return { content: [{ type: 'text' as const, text: `Error: Page "${page_id}" not found.` }], isError: true };
@@ -151,6 +181,23 @@ Password protection: Enable/disable with a password.`,
         };
       }
 
+      if (cms !== undefined) {
+        if (cms === null) {
+          delete settings.cms;
+        } else {
+          settings.cms = {
+            collection_id: cms.collection_id,
+            slug_field_id: cms.slug_field_id,
+            ...(cms.next_previous && {
+              next_previous: {
+                ...(cms.next_previous.sort_by !== undefined && { sort_by: cms.next_previous.sort_by as 'manual' | string }),
+                ...(cms.next_previous.sort_order !== undefined && { sort_order: cms.next_previous.sort_order }),
+              },
+            }),
+          };
+        }
+      }
+
       const page = await updatePage(page_id, { settings });
       broadcastPageUpdated(page_id, { settings }).catch(() => {});
       return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'Updated page settings', settings: page.settings }, null, 2) }] };
@@ -176,6 +223,89 @@ Password protection: Enable/disable with a password.`,
       await deletePage(page_id);
       broadcastPageDeleted(page_id).catch(() => {});
       return { content: [{ type: 'text' as const, text: `Page ${page_id} deleted successfully.` }] };
+    },
+  );
+
+  server.tool(
+    'list_redirects',
+    `List all configured URL redirects. Redirects map an old path to a new URL (internal path
+or external URL), with optional 301 (permanent) or 302 (temporary) semantics. Paths containing
+".+" or ".*" are treated as regex patterns; exact matches take priority.`,
+    {},
+    async () => {
+      const redirects = await getRedirects();
+      return { content: [{ type: 'text' as const, text: JSON.stringify(redirects, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'add_redirect',
+    `Add a new URL redirect.
+
+Examples:
+- { old_url: "/about-us", new_url: "/about", type: "301" }
+- { old_url: "/blog/.+", new_url: "/posts/$0" } (regex — entire match is $0)
+- { old_url: "/", new_url: "/welcome" } (root / homepage redirect)`,
+    {
+      old_url: z.string().describe('The old internal path (must start with /). Use ".+" or ".*" for regex patterns.'),
+      new_url: z.string().describe('The new destination — internal path "/about" or external URL "https://example.com"'),
+      type: z.enum(['301', '302']).optional().describe('301 = permanent, 302 = temporary. Defaults to 301.'),
+    },
+    async ({ old_url, new_url, type }) => {
+      const redirects = await getRedirects();
+      const newRedirect: Redirect = {
+        id: generateRedirectId(),
+        oldUrl: old_url,
+        newUrl: new_url,
+        ...(type && { type }),
+      };
+      await setSetting(REDIRECTS_KEY, [...redirects, newRedirect]);
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'Redirect added', redirect: newRedirect }, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'update_redirect',
+    'Update an existing redirect by ID.',
+    {
+      redirect_id: z.string().describe('The redirect ID'),
+      old_url: z.string().optional(),
+      new_url: z.string().optional(),
+      type: z.enum(['301', '302']).optional(),
+    },
+    async ({ redirect_id, old_url, new_url, type }) => {
+      const redirects = await getRedirects();
+      const idx = redirects.findIndex((r) => r.id === redirect_id);
+      if (idx === -1) {
+        return { content: [{ type: 'text' as const, text: `Error: Redirect "${redirect_id}" not found.` }], isError: true };
+      }
+      const updated: Redirect = {
+        ...redirects[idx],
+        ...(old_url !== undefined && { oldUrl: old_url }),
+        ...(new_url !== undefined && { newUrl: new_url }),
+        ...(type !== undefined && { type }),
+      };
+      const next = [...redirects];
+      next[idx] = updated;
+      await setSetting(REDIRECTS_KEY, next);
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'Redirect updated', redirect: updated }, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'delete_redirect',
+    'Delete a redirect by ID.',
+    {
+      redirect_id: z.string().describe('The redirect ID'),
+    },
+    async ({ redirect_id }) => {
+      const redirects = await getRedirects();
+      const next = redirects.filter((r) => r.id !== redirect_id);
+      if (next.length === redirects.length) {
+        return { content: [{ type: 'text' as const, text: `Error: Redirect "${redirect_id}" not found.` }], isError: true };
+      }
+      await setSetting(REDIRECTS_KEY, next);
+      return { content: [{ type: 'text' as const, text: `Redirect ${redirect_id} deleted` }] };
     },
   );
 }


### PR DESCRIPTION
## Summary

Brings the page / forms / i18n MCP surface up to current Ycode parity. Agents can now mark pages as homepage / dynamic / error pages, bind dynamic pages to CMS collections, manage URL redirects, configure form submission behavior, and write rich-text translations without hand-assembling Tiptap JSON.

Closes audit PR 13, 14, 18, 19.

## Changes

### Pages (`PageSettings` parity)
- `update_page` accepts `is_index`, `is_dynamic`, `error_page` (`401` / `404` / `500` or `null`)
- `update_page_settings` accepts a `cms` block:
  - `collection_id` — collection that drives the page
  - `slug_field_id` — which field provides each item's slug
  - `next_previous: { sort_by?, sort_order? }` — controls how `next-item` / `previous-item` link keywords traverse the collection. Defaults match the runtime (`manual_order` asc)
  - Pass `cms: null` to detach a dynamic page from its collection

### Redirects (`Redirect[]` parity, stored under the `redirects` site setting)
- `list_redirects`
- `add_redirect` — `old_url`, `new_url`, `type` (`301` default / `302`). Regex patterns (`.+` / `.*`) work the same way `matchRedirect` expects.
- `update_redirect` — modify by ID
- `delete_redirect` — remove by ID

### Forms (`FormSettings` parity)
- New `update_form_settings(page_id, layer_id, …)` tool covers:
  - `success_action`: `"message"` (default) shows the form's alert child, `"redirect"` sends visitors to `redirect_url`
  - `redirect_url`: stored as a `dynamic_text` link value
  - `email_notification: { enabled, to, subject }`

> Deliberately added as a separate tool (not folded into `update_layer_settings`) to avoid conflicting with the parallel PR #254 that already rewrites `update_layer_settings` for slider / lightbox / map / options_source.

### Translations
- New `set_rich_text_translation` — pass `blocks[]` (same shape as `add_layer`'s `rich_content`), the tool builds the Tiptap JSON via `buildTiptapDoc` and stores it as `content_value` with `content_type: "richtext"`. Saves agents from assembling the doc shape by hand.

## What's deferred

- **Integrations** (Airtable, Webflow, static export) — cloud-only, big optional surface. Separate PR.
- **Presigned URL uploads** for assets ≤ 50MB — needs storage-signing infrastructure decisions. Separate PR.

## Test plan

- [x] `npm run type-check` passes
- [x] `npx eslint` clean on touched files

### Pages
- [ ] `update_page` with `is_dynamic: true`, then `update_page_settings` with `cms: { collection_id, slug_field_id }` — dynamic page resolves to the first collection item
- [ ] `update_page_settings` with `cms.next_previous: { sort_by: "<field>", sort_order: "desc" }` — `next-item` links jump in the configured order
- [ ] `update_page` with `error_page: 404` — visiting an unknown URL renders this page
- [ ] `update_page_settings` with `cms: null` — clears the binding

### Redirects
- [ ] `add_redirect` with `old_url: "/about-us"`, `new_url: "/about"` — visiting `/about-us` 301s to `/about`
- [ ] `add_redirect` with `old_url: "/blog/.+"`, `new_url: "/posts/\$0"` — regex match preserves the path
- [ ] `update_redirect` changes `type` to `302` — verify in the redirects panel
- [ ] `delete_redirect` removes it from the list

### Forms
- [ ] `update_form_settings` with `success_action: "redirect"` and `redirect_url: "/thank-you"` — successful submission redirects
- [ ] `update_form_settings` with `email_notification: { enabled: true, to: "you@example.com", subject: "New lead" }` — submission triggers an email (requires SMTP set up)

### Translations
- [ ] `set_rich_text_translation` with `blocks: [{ type: "heading", level: 2, text: "Bonjour" }, { type: "paragraph", text: "Salut **monde**" }]` — translation list shows the formatted output

Made with [Cursor](https://cursor.com)