### PR TITLE
docs(mcp): refresh instructions + reference for 1.0 surface

### DIFF
--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -40,6 +40,7 @@ Each layer has:
 - \`columns\` — 2-column flexbox layout
 - \`grid\` — 2x2 CSS Grid layout
 - \`collection\` — CMS collection list (repeats children for each item)
+- \`table\`, \`thead\`, \`tbody\`, \`tr\`, \`td\`, \`th\` — Data table elements (\`table\` ships with a header + 2 body rows)
 
 **Content** (leaf elements, no children):
 - \`text\` — Text element. Set tag via settings.tag: "h1"-"h6", "p", "span", "label"
@@ -209,8 +210,16 @@ add_layer({ template: "richText", rich_content: [
 **Updating rich text content:**
 Use \`set_rich_text_content\` or the batch \`set_rich_text\` operation.
 
-**Supported block types:** paragraph, heading (level 1-6), blockquote, bulletList, orderedList, codeBlock, horizontalRule
+**Supported block types:** paragraph, heading (level 1-6), blockquote, bulletList, orderedList, codeBlock, horizontalRule, htmlEmbed, image, table, component
 **Inline formatting:** \`**bold**\`, \`*italic*\`, \`[link text](url)\`
+
+**Extended block examples:**
+\`\`\`
+{ type: "htmlEmbed", code: "<iframe src='https://example.com' />" }
+{ type: "image", asset_id: "<asset id>", alt: "Alt text" }
+{ type: "table", header_row: true, rows: [["Name", "Age"], ["Alice", "30"], ["Bob", "25"]] }
+{ type: "component", component_id: "<component id>" }
+\`\`\`
 
 ### Layer Content & Configuration
 
@@ -226,6 +235,13 @@ update_layer_image({ layer_id: "...", asset_id: "...", alt: "Photo description" 
 update_layer_link({ layer_id: "...", link_type: "url", url: "https://example.com", target: "_blank" })
 update_layer_link({ layer_id: "...", link_type: "page", page_id_target: "<page_id>" })
 update_layer_link({ layer_id: "...", link_type: "email", email: "hello@example.com" })
+update_layer_link({ layer_id: "...", link_type: "asset", asset_id: "<asset_id>", download: true })
+
+// Anchor link to a layer on the current page
+update_layer_link({ layer_id: "...", link_type: "url", url: "", anchor_layer_id: "<target layer id>" })
+
+// Dynamic page link pinned to a specific item
+update_layer_link({ layer_id: "...", link_type: "page", page_id_target: "<dynamic page id>", collection_item_id: "<item id>" })
 \`\`\`
 
 **Setting videos:**
@@ -246,6 +262,32 @@ update_layer_settings({ layer_id: "...", tag: "h2" })
 **Configuring sliders** (after adding):
 \`\`\`
 update_layer_settings({ layer_id: "...", slider: { autoplay: true, delay: "5", loop: "loop" } })
+\`\`\`
+
+**Configuring lightboxes bound to a CMS multi-image field:**
+\`\`\`
+update_layer_settings({ layer_id: "...", lightbox: { files_source: "cms", files_field_id: "<image field id>" } })
+\`\`\`
+
+**Configuring maps:**
+\`\`\`
+update_layer_settings({ layer_id: "...", map: { provider: "mapbox", latitude: 40.7128, longitude: -74.006, zoom: 12 } })
+\`\`\`
+
+**Binding select / checkbox / radio to a CMS collection:**
+\`\`\`
+update_layer_settings({ layer_id: "...", options_source: { collection_id: "<id>", sort_field_id: "<id>", sort_order: "asc" } })
+\`\`\`
+
+**Configuring form submission behavior:**
+\`\`\`
+update_form_settings({ layer_id: "<form layer id>", success_action: "redirect", redirect_url: "/thank-you" })
+update_form_settings({ layer_id: "<form layer id>", email_notification: { enabled: true, to: "you@example.com", subject: "New lead" } })
+\`\`\`
+
+**Exporting any layer subtree to HTML:**
+\`\`\`
+export_layer_html({ page_id: "...", layer_id: "..." })  // returns the rendered HTML with Tailwind classes
 \`\`\`
 
 **Setting HTML embed code:**
@@ -275,6 +317,37 @@ update_page_settings({ page_id: "...", custom_code: { head: "<script>...</script
 update_page_settings({ page_id: "...", auth: { enabled: true, password: "secret" } })
 \`\`\`
 
+**Homepage / dynamic / error pages:**
+\`\`\`
+update_page({ page_id: "...", is_index: true })             // mark as the homepage
+update_page({ page_id: "...", is_dynamic: true })           // turn into a CMS-driven page
+update_page({ page_id: "...", error_page: 404 })            // designate as the 404 page
+\`\`\`
+
+**Binding a dynamic page to a CMS collection:**
+\`\`\`
+update_page_settings({
+  page_id: "...",
+  cms: {
+    collection_id: "<id>",
+    slug_field_id: "<id>",
+    next_previous: { sort_by: "<field id>", sort_order: "asc" }  // controls next-item / previous-item link order
+  }
+})
+\`\`\`
+
+### Redirects
+
+URL redirects are site-wide. Old paths can be literal or regex (\`.+\` / \`.*\`); exact matches take priority.
+
+\`\`\`
+list_redirects()
+add_redirect({ old_url: "/about-us", new_url: "/about", type: "301" })
+add_redirect({ old_url: "/blog/.+", new_url: "/posts/$0" })  // regex match — entire match is $0
+update_redirect({ redirect_id: "...", type: "302" })
+delete_redirect({ redirect_id: "..." })
+\`\`\`
+
 ### Components (Reusable Elements)
 
 Components are reusable layer trees that can be instanced across pages.
@@ -287,10 +360,31 @@ Each instance shares the same structure but can override specific content via **
 
 **Variables** let each instance customize content:
 - **text** — Override text content (headings, paragraphs, button labels)
+- **rich_text** — Override rich-text content (when the linked layer is a richText layer)
 - **image** — Override image source
 - **link** — Override link destination
 - **audio/video** — Override media source
 - **icon** — Override icon
+- **variant** — Override which variant of a nested component is rendered
+
+Variables support \`placeholder\` (input hint) and \`default_value\` (applied when the instance doesn't override).
+
+### Component Variants
+
+A component can have multiple named variants ("Default", "Small", "Dark", etc.) that share variables but
+have independent layer trees. Useful for design system primitives that need a few visual flavors.
+
+\`\`\`
+list_component_variants({ component_id: "..." })
+create_component_variant({ component_id: "...", name: "Small", source_variant_id: "<variant to clone>" })
+update_component_variant({ component_id: "...", variant_id: "...", name: "Compact" })
+delete_component_variant({ component_id: "...", variant_id: "..." })  // non-primary only
+
+// Target a specific variant when modifying its tree:
+update_component_layers({ component_id: "...", variant_id: "<variant id>", operations: [...] })
+\`\`\`
+
+The primary variant (variants[0]) cannot be deleted. Omit \`variant_id\` on \`update_component_layers\` to target it.
 
 EXAMPLE: Creating a "Feature Card" component with a title and description variable:
 \`\`\`
@@ -318,7 +412,22 @@ YCode has a built-in CMS. Collections are like database tables:
 - Use create_collection_item to populate with data
 - Bind collections to layers using collectionList elements
 
-Field types: text, number, boolean, date, reference, rich-text, color, asset, status
+**Field types:**
+- text, number, boolean, date (datetime), date_only
+- reference, multi_reference
+- rich_text, color, status
+- image, audio, video, document — use \`data: { multiple: true }\` for multi-asset fields
+- link, email, phone
+- option — predefined choices via \`data: { options: [{ id, name }] }\`
+- count — computed count of related items via \`data: { count_collection_id, count_field_id }\`
+
+**Sorting & ordering:**
+\`\`\`
+create_collection({ name: "Posts", sorting: { field: "<field id>", direction: "desc" } })
+update_collection({ collection_id: "...", sorting: { field: "manual_order", direction: "manual" } })
+reorder_collection_fields({ collection_id: "...", field_ids: ["...", "...", "..."] })
+set_collection_item_order({ collection_id: "...", item_id: "...", manual_order: 0 })
+\`\`\`
 
 ### Color Variables (Design Tokens)
 
@@ -343,7 +452,8 @@ Example: \`search_google_fonts({ query: "playfair" })\` → \`add_font({ family:
 Multi-language support:
 - Use list_locales to see configured languages
 - Use create_locale with ISO 639-1 code (e.g. "fr", "de", "ja")
-- Use set_translation to translate content for a locale
+- Use set_translation to translate plain-text content for a locale
+- Use set_rich_text_translation with structured blocks for richText fields (skips hand-assembling Tiptap JSON)
 - Use batch_set_translations for bulk translations
 - Each translation targets a source (page/component/cms) + content_key
 

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -44,6 +44,11 @@ const EXAMPLE_PROMPTS = {
     'Set design inline with add_layer to reduce the number of operations',
     'Use add_font + search_google_fonts to add custom fonts before using them',
     'Always publish after completing changes',
+    'For repeating UI primitives, build a component and use create_component_variant for visual flavors',
+    'For tabular data, add_layer template "table" gives a ready-made structure to populate',
+    'For tables inside rich text, use rich_content { type: "table", rows: [[...]], header_row: true }',
+    'For dynamic pages, update_page is_dynamic + update_page_settings.cms is the canonical wiring path',
+    'For lightbox galleries fed by a CMS image field, set lightbox.files_source "cms" + files_field_id',
   ],
 };
 
@@ -81,6 +86,12 @@ export function registerReferenceResources(server: McpServer) {
               grid: '2x2 CSS Grid layout.',
               collection: 'CMS collection list (repeats children for each item).',
               hr: 'Horizontal divider line.',
+              table: 'Data table (<table>). Ships with header + 2 body rows.',
+              thead: '<thead> — add inside a table.',
+              tbody: '<tbody> — add inside a table.',
+              tr: '<tr> — add inside thead or tbody.',
+              td: '<td> — add inside a tr.',
+              th: '<th> — add inside a thead tr.',
             },
             content: {
               heading: 'Heading text (h1). 48px bold.',
@@ -176,6 +187,21 @@ export function registerReferenceResources(server: McpServer) {
             positioning: {
               position: { type: 'enum', values: ['relative', 'absolute', 'fixed', 'sticky'] },
               zIndex: { type: 'string' },
+            },
+            transforms: {
+              translateX: { type: 'css_value', examples: ['10px', '50%'] },
+              translateY: { type: 'css_value', examples: ['10px', '50%'] },
+              scale: { type: 'css_value', examples: ['1', '1.05', '0.95'] },
+              rotate: { type: 'css_value', examples: ['0deg', '45deg', '-90deg'] },
+              skewX: { type: 'css_value', examples: ['0deg', '10deg'] },
+              skewY: { type: 'css_value', examples: ['0deg', '10deg'] },
+              transformOrigin: { type: 'string', examples: ['center', 'top left'] },
+            },
+            transitions: {
+              transitionProperty: { type: 'string', examples: ['all', 'colors', 'transform'] },
+              transitionDuration: { type: 'css_value', examples: ['150ms', '300ms'] },
+              transitionTimingFunction: { type: 'enum', values: ['linear', 'in', 'out', 'in-out'] },
+              transitionDelay: { type: 'css_value', examples: ['0ms', '100ms'] },
             },
           },
         }, null, 2),

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -28,7 +28,7 @@ import { registerSiteResources } from '@/lib/mcp/resources/site';
 
 export function createMcpServer(): McpServer {
   const server = new McpServer(
-    { name: 'ycode', version: '0.4.0' },
+    { name: 'ycode', version: '1.0.0' },
     { instructions: SYSTEM_INSTRUCTIONS },
   );
 


### PR DESCRIPTION
## Summary

Closes out the MCP foundation refresh and feature catch-up by documenting everything the agent can now do, and bumps the protocol version to **1.0.0** to signal the major surface shift.

This is the final PR in the audit sequence. Should land **after** #252, #253, #254, #255, #256 so the docs match the shipped surface.

## Changes

### \`instructions.ts\`
- Add \`table\` / \`thead\` / \`tbody\` / \`tr\` / \`td\` / \`th\` to the structure list
- Add \`htmlEmbed\` / \`image\` / \`table\` / \`component\` to the rich-text block catalog with examples
- Document anchor links, dynamic-item links, \`rel\` / \`download\` / \`asset\` paths on \`update_layer_link\`
- Document the \`update_layer_settings\` additions: lightbox CMS binding, map, options_source, plus the dedicated \`update_form_settings\` tool
- Document \`export_layer_html\`
- Add \`update_page\` \`is_index\` / \`is_dynamic\` / \`error_page\` and the CMS binding block on \`update_page_settings\`
- Add the new redirects tool family (\`list_redirects\`, \`add_redirect\`, \`update_redirect\`, \`delete_redirect\`)
- Document \`rich_text\` and \`variant\` component variable types, \`placeholder\` / \`default_value\`, and the full variant CRUD surface (\`list_component_variants\`, \`create_component_variant\` with optional \`source_variant_id\`, \`update_component_variant\`, \`delete_component_variant\`, and \`variant_id\` on \`update_component_layers\`)
- Document the new collection field types (\`option\`, \`count\`), the \`data\` shape for multi-asset fields, sorting + reorder + manual item ordering
- Document \`set_rich_text_translation\`

### \`resources/reference.ts\`
- Add table elements to the structure type catalog
- Add \`transforms\` and \`transitions\` design categories to the design-properties reference (previously only the 8 original categories were listed)
- Add closing tips covering components/variants, tables, dynamic pages, and CMS-bound lightboxes

### \`server.ts\`
- Bump server version \`0.4.0\` → \`1.0.0\`

## What's NOT documented (deferred surfaces)

- HTML import (\`htmlToLayers\`) — needs server DOM parser
- \`clear_layer_design\` — needs class-removal utility
- Layer interactions (full LayerInteraction surface) — pending design analysis
- Integrations (Airtable / Webflow / static export) — cloud-only
- Presigned URL uploads — needs storage signing plumbing

These will be documented as they ship.

## Test plan

- [x] \`npm run type-check\` passes
- [x] \`npx eslint\` clean on touched files
- [ ] After merge, hit the MCP server's instructions endpoint and verify the agent receives the new content
- [ ] Connect a client (Claude Desktop, etc.) and confirm \`name: "ycode", version: "1.0.0"\` in the server handshake
- [ ] Pull the \`ycode://reference/design-properties\` resource and verify transforms / transitions appear
- [ ] Pull the \`ycode://reference/elements\` resource and verify table elements appear
- [ ] Run a smoke prompt referencing one of the new docs sections (e.g. "set a hover transform scale on this button") and confirm the agent doesn't hallucinate a tool

Made with [Cursor](https://cursor.com)