### PR TITLE
feat: expose layer interactions through the MCP

### DIFF
--- a/lib/mcp/animation-presets.ts
+++ b/lib/mcp/animation-presets.ts
@@ -1,0 +1,465 @@
+/**
+ * Animation preset library for the MCP `add_animation` tool.
+ *
+ * Each preset produces a fully-formed `LayerInteraction` so agents can ship
+ * "fade these cards in on scroll" in one tool call instead of hand-rolling a
+ * GSAP timeline.
+ *
+ * Power users that need full control can bypass the presets and call
+ * `set_layer_interactions` with the raw shape.
+ */
+
+import type {
+  InteractionApplyStyles,
+  InteractionTimeline,
+  InteractionTween,
+  LayerInteraction,
+  TweenProperties,
+  TweenPropertyKey,
+} from '@/types';
+import { generateId } from '@/lib/utils';
+
+export const ANIMATION_PRESETS = [
+  'fade-in',
+  'fade-in-up',
+  'fade-in-down',
+  'fade-in-left',
+  'fade-in-right',
+  'scale-in',
+  'hover-lift',
+  'hover-scale',
+  'hover-fade',
+  'hover-color',
+  'click-pulse',
+  'click-shake',
+  'parallax-up',
+  'parallax-down',
+  'scroll-reveal-stagger',
+  'loop-bounce',
+  'loop-pulse',
+  'loop-spin',
+] as const;
+
+export type AnimationPreset = (typeof ANIMATION_PRESETS)[number];
+
+export type AnimationTrigger =
+  | 'click'
+  | 'hover'
+  | 'scroll-into-view'
+  | 'while-scrolling'
+  | 'load';
+
+export const ANIMATION_EASES = [
+  'none',
+  'power1.in',
+  'power1.inOut',
+  'power1.out',
+  'back.in',
+  'back.inOut',
+  'back.out',
+] as const;
+
+export type AnimationEase = (typeof ANIMATION_EASES)[number];
+
+export interface AnimationPresetOptions {
+  /** Tween duration in seconds. Preset provides a sensible default. */
+  duration?: number;
+  /** Delay before the animation starts (seconds). Defaults to 0. */
+  delay?: number;
+  /**
+   * For slide / parallax presets: how far the element travels.
+   * Accepts any CSS length (e.g. "40px", "5rem", "20%").
+   */
+  distance?: string;
+  /** Curated GSAP ease. Defaults per preset family. */
+  ease?: AnimationEase;
+  /** For scale presets: the target scale value (e.g. 1.05). */
+  scale_to?: number;
+  /** For hover-color: the background color to fade into. */
+  background_color?: string;
+  /** For scroll-reveal-stagger: seconds between consecutive targets. Defaults 0.1. */
+  stagger?: number;
+  /**
+   * For loop presets: how many times to repeat. -1 = infinite (default for loop-*),
+   * 1 = play once and reverse once (click-pulse default).
+   */
+  repeat?: number;
+}
+
+interface PresetMeta {
+  /** Default trigger if the caller doesn't override. */
+  defaultTrigger: AnimationTrigger;
+  /** Default duration in seconds. */
+  defaultDuration: number;
+  /** Default ease. */
+  defaultEase: AnimationEase;
+  /** Whether the `from` properties should be applied on load (prevents FOUC). */
+  applyFromOnLoad: boolean;
+  /** Build the tween from/to for one target. */
+  buildTween: (opts: AnimationPresetOptions) => Pick<InteractionTween, 'from' | 'to'>;
+  /** Per-property apply_styles override. */
+  applyStyles?: (opts: AnimationPresetOptions) => InteractionApplyStyles;
+  /**
+   * Optional: emit multiple tweens per target instead of one (e.g. click-shake).
+   * Each entry receives the layer_id and a position (GSAP timeline position).
+   */
+  multiStep?: (opts: AnimationPresetOptions) => Array<{
+    from: TweenProperties;
+    to: TweenProperties;
+    duration: number;
+    position: number | string;
+  }>;
+  /** Extra timeline overrides (repeat / yoyo / scrub / scrollStart). */
+  timeline?: Partial<InteractionTimeline>;
+}
+
+const REVEAL_OPACITY_FROM = '0';
+const REVEAL_OPACITY_TO = '100';
+
+const PRESETS: Record<AnimationPreset, PresetMeta> = {
+  'fade-in': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: true,
+    buildTween: () => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM },
+      to: { autoAlpha: REVEAL_OPACITY_TO },
+    }),
+  },
+  'fade-in-up': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM, y: opts.distance || '40px' },
+      to: { autoAlpha: REVEAL_OPACITY_TO, y: '0px' },
+    }),
+  },
+  'fade-in-down': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM, y: `-${stripSign(opts.distance || '40px')}` },
+      to: { autoAlpha: REVEAL_OPACITY_TO, y: '0px' },
+    }),
+  },
+  'fade-in-left': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM, x: opts.distance || '40px' },
+      to: { autoAlpha: REVEAL_OPACITY_TO, x: '0px' },
+    }),
+  },
+  'fade-in-right': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM, x: `-${stripSign(opts.distance || '40px')}` },
+      to: { autoAlpha: REVEAL_OPACITY_TO, x: '0px' },
+    }),
+  },
+  'scale-in': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'back.out',
+    applyFromOnLoad: true,
+    buildTween: () => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM, scale: '0.85' },
+      to: { autoAlpha: REVEAL_OPACITY_TO, scale: '1' },
+    }),
+  },
+  'hover-lift': {
+    defaultTrigger: 'hover',
+    defaultDuration: 0.3,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: false,
+    buildTween: (opts) => ({
+      from: { y: '0px' },
+      to: { y: `-${stripSign(opts.distance || '8px')}` },
+    }),
+  },
+  'hover-scale': {
+    defaultTrigger: 'hover',
+    defaultDuration: 0.3,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: false,
+    buildTween: (opts) => ({
+      from: { scale: '1' },
+      to: { scale: String(opts.scale_to ?? 1.05) },
+    }),
+  },
+  'hover-fade': {
+    defaultTrigger: 'hover',
+    defaultDuration: 0.3,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: false,
+    buildTween: () => ({
+      from: { autoAlpha: '100' },
+      to: { autoAlpha: '70' },
+    }),
+  },
+  'hover-color': {
+    defaultTrigger: 'hover',
+    defaultDuration: 0.3,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: false,
+    buildTween: (opts) => ({
+      from: { backgroundColor: '#ffffff' },
+      to: { backgroundColor: opts.background_color || '#000000' },
+    }),
+  },
+  'click-pulse': {
+    defaultTrigger: 'click',
+    defaultDuration: 0.15,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: false,
+    buildTween: (opts) => ({
+      from: { scale: '1' },
+      to: { scale: String(opts.scale_to ?? 1.1) },
+    }),
+    timeline: { repeat: 1, yoyo: true },
+  },
+  'click-shake': {
+    defaultTrigger: 'click',
+    defaultDuration: 0.05,
+    defaultEase: 'power1.inOut',
+    applyFromOnLoad: false,
+    buildTween: () => ({ from: { x: '0px' }, to: { x: '0px' } }),
+    multiStep: (opts) => {
+      const dist = stripSign(opts.distance || '10px');
+      const step = opts.duration ?? 0.05;
+      return [
+        { from: { x: '0px' }, to: { x: `-${dist}` }, duration: step, position: 0 },
+        { from: { x: `-${dist}` }, to: { x: dist }, duration: step, position: '>' },
+        { from: { x: dist }, to: { x: `-${dist}` }, duration: step, position: '>' },
+        { from: { x: `-${dist}` }, to: { x: dist }, duration: step, position: '>' },
+        { from: { x: dist }, to: { x: '0px' }, duration: step, position: '>' },
+      ];
+    },
+  },
+  'parallax-up': {
+    defaultTrigger: 'while-scrolling',
+    defaultDuration: 1,
+    defaultEase: 'none',
+    applyFromOnLoad: false,
+    buildTween: (opts) => ({
+      from: { y: '0px' },
+      to: { y: `-${stripSign(opts.distance || '100px')}` },
+    }),
+    timeline: { scrub: true, scrollStart: 'top bottom', scrollEnd: 'bottom top' },
+  },
+  'parallax-down': {
+    defaultTrigger: 'while-scrolling',
+    defaultDuration: 1,
+    defaultEase: 'none',
+    applyFromOnLoad: false,
+    buildTween: (opts) => ({
+      from: { y: '0px' },
+      to: { y: stripSign(opts.distance || '100px') },
+    }),
+    timeline: { scrub: true, scrollStart: 'top bottom', scrollEnd: 'bottom top' },
+  },
+  'scroll-reveal-stagger': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM, y: opts.distance || '24px' },
+      to: { autoAlpha: REVEAL_OPACITY_TO, y: '0px' },
+    }),
+  },
+  'loop-bounce': {
+    defaultTrigger: 'load',
+    defaultDuration: 1.5,
+    defaultEase: 'power1.inOut',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { y: '0px' },
+      to: { y: `-${stripSign(opts.distance || '10px')}` },
+    }),
+    timeline: { repeat: -1, yoyo: true },
+  },
+  'loop-pulse': {
+    defaultTrigger: 'load',
+    defaultDuration: 1.5,
+    defaultEase: 'power1.inOut',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { scale: '1' },
+      to: { scale: String(opts.scale_to ?? 1.05) },
+    }),
+    timeline: { repeat: -1, yoyo: true },
+  },
+  'loop-spin': {
+    defaultTrigger: 'load',
+    defaultDuration: 4,
+    defaultEase: 'none',
+    applyFromOnLoad: true,
+    buildTween: () => ({
+      from: { rotation: '0deg' },
+      to: { rotation: '360deg' },
+    }),
+    timeline: { repeat: -1, yoyo: false },
+  },
+};
+
+export interface BuildInteractionInput {
+  preset: AnimationPreset;
+  /** Owning layer ID — used as the default tween target. */
+  ownerLayerId: string;
+  /** Override the preset's default trigger. */
+  trigger?: AnimationTrigger;
+  /** Layers the tweens act on. Defaults to [ownerLayerId]. */
+  targets?: string[];
+  options?: AnimationPresetOptions;
+}
+
+/**
+ * Build a complete `LayerInteraction` (with fresh IDs) from a preset key.
+ * Returns the interaction ready to be appended to `layer.interactions`.
+ */
+export function buildInteractionFromPreset(input: BuildInteractionInput): LayerInteraction {
+  const meta = PRESETS[input.preset];
+  if (!meta) {
+    throw new Error(`Unknown animation preset "${input.preset}"`);
+  }
+
+  const opts: AnimationPresetOptions = input.options || {};
+  const trigger: AnimationTrigger = input.trigger || meta.defaultTrigger;
+  const targets = input.targets && input.targets.length > 0 ? input.targets : [input.ownerLayerId];
+  const duration = opts.duration ?? meta.defaultDuration;
+  const ease = opts.ease ?? meta.defaultEase;
+  const stagger = opts.stagger ?? 0.1;
+  const delay = opts.delay ?? 0;
+
+  const tweens: InteractionTween[] = [];
+
+  for (let targetIdx = 0; targetIdx < targets.length; targetIdx++) {
+    const targetId = targets[targetIdx];
+    const basePosition = computeBasePosition({
+      preset: input.preset,
+      targetIdx,
+      stagger,
+      delay,
+    });
+
+    if (meta.multiStep) {
+      const steps = meta.multiStep({ ...opts, duration: opts.duration });
+      for (let stepIdx = 0; stepIdx < steps.length; stepIdx++) {
+        const step = steps[stepIdx];
+        tweens.push({
+          id: generateId('twn'),
+          layer_id: targetId,
+          position: stepIdx === 0 ? basePosition : step.position,
+          duration: step.duration,
+          ease,
+          from: step.from,
+          to: step.to,
+          apply_styles: buildApplyStyles(step.from, meta.applyFromOnLoad),
+        });
+      }
+      continue;
+    }
+
+    const { from, to } = meta.buildTween(opts);
+    tweens.push({
+      id: generateId('twn'),
+      layer_id: targetId,
+      position: basePosition,
+      duration,
+      ease,
+      from,
+      to,
+      apply_styles: meta.applyStyles ? meta.applyStyles(opts) : buildApplyStyles(from, meta.applyFromOnLoad),
+    });
+  }
+
+  const timeline: InteractionTimeline = {
+    breakpoints: ['desktop', 'tablet', 'mobile'],
+    repeat: 0,
+    yoyo: false,
+    ...(trigger === 'scroll-into-view' && { toggleActions: 'play none none none' }),
+    ...meta.timeline,
+    ...(opts.repeat !== undefined && { repeat: opts.repeat }),
+  };
+
+  return {
+    id: generateId('int'),
+    trigger,
+    timeline,
+    tweens,
+  };
+}
+
+/**
+ * Compute the GSAP position string / number for the first tween of a target.
+ * For stagger presets this offsets each target; otherwise just the delay.
+ */
+function computeBasePosition(args: {
+  preset: AnimationPreset;
+  targetIdx: number;
+  stagger: number;
+  delay: number;
+}): number | string {
+  if (args.preset === 'scroll-reveal-stagger') {
+    return args.delay + args.targetIdx * args.stagger;
+  }
+  return args.delay;
+}
+
+/** Mark every property present in `from` so the runtime knows whether to pre-apply it. */
+function buildApplyStyles(from: TweenProperties, applyOnLoad: boolean): InteractionApplyStyles {
+  const styles: InteractionApplyStyles = {};
+  const mode = applyOnLoad ? 'on-load' : 'on-trigger';
+  for (const key of Object.keys(from) as TweenPropertyKey[]) {
+    if (from[key] !== undefined && from[key] !== null) {
+      styles[key] = mode;
+    }
+  }
+  return styles;
+}
+
+/** Strip a leading "-" so callers can pass "-40px" or "40px" interchangeably for distance. */
+function stripSign(value: string): string {
+  return value.startsWith('-') ? value.slice(1) : value;
+}
+
+const PRESET_DESCRIPTIONS: Record<AnimationPreset, string> = {
+  'fade-in': 'Fades from invisible to fully opaque. Most common reveal.',
+  'fade-in-up': 'Fades in while sliding up from below (distance default 40px).',
+  'fade-in-down': 'Fades in while sliding down from above.',
+  'fade-in-left': 'Fades in while sliding left from off-screen right.',
+  'fade-in-right': 'Fades in while sliding right from off-screen left.',
+  'scale-in': 'Fades in while scaling up from 0.85. Uses back.out for a slight overshoot.',
+  'hover-lift': 'Subtle upward translation on hover (default -8px).',
+  'hover-scale': 'Scales up on hover (default 1.05).',
+  'hover-fade': 'Fades to 70% opacity on hover.',
+  'hover-color': 'Animates background color on hover (pass background_color).',
+  'click-pulse': 'Scales up then back on click (yoyo). Adjust with scale_to.',
+  'click-shake': 'Horizontal shake of 5 micro-tweens (distance default 10px).',
+  'parallax-up': 'Scroll-scrubbed upward translation. Use on hero images / decorative bg.',
+  'parallax-down': 'Scroll-scrubbed downward translation.',
+  'scroll-reveal-stagger': 'fade-in-up applied to multiple targets with a stagger offset (default 0.1s between targets).',
+  'loop-bounce': 'Infinite vertical bounce. Use on small ornamental elements.',
+  'loop-pulse': 'Infinite scale pulse.',
+  'loop-spin': 'Infinite 360° rotation. Linear ease, no yoyo.',
+};
+
+/** Public preset catalog for the reference resource. */
+export const PRESET_CATALOG = ANIMATION_PRESETS.map((key) => ({
+  key,
+  default_trigger: PRESETS[key].defaultTrigger,
+  default_duration: PRESETS[key].defaultDuration,
+  default_ease: PRESETS[key].defaultEase,
+  description: PRESET_DESCRIPTIONS[key],
+}));

--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -258,6 +258,74 @@ update_layer_settings({ layer_id: "...", html_embed_code: "<div>Custom HTML</div
 update_layer_iframe({ layer_id: "...", url: "https://www.youtube.com/embed/..." })
 \`\`\`
 
+### Animations & Interactions
+
+Layers can have GSAP-powered animations triggered by user events or scroll. Use the
+preset library for ~80% of cases; drop down to \`set_layer_interactions\` for full control.
+
+**Preset families** (full catalog at \`ycode://reference/animation-presets\`):
+- **Reveal** (scroll-into-view): \`fade-in\`, \`fade-in-up/down/left/right\`, \`scale-in\`
+- **Hover** (auto-yoyo on mouseleave): \`hover-lift\`, \`hover-scale\`, \`hover-fade\`, \`hover-color\`
+- **Click**: \`click-pulse\`, \`click-shake\`
+- **Scroll-scrubbed**: \`parallax-up\`, \`parallax-down\` (tween follows scroll position)
+- **Stagger**: \`scroll-reveal-stagger\` (one tween per target, offset by \`options.stagger\`)
+- **Loop** (infinite on load): \`loop-bounce\`, \`loop-pulse\`, \`loop-spin\`
+
+**Common pattern — fade hero on scroll:**
+\`\`\`
+add_animation({ page_id, layer_id: heroId, preset: "fade-in-up", options: { distance: "60px", duration: 0.8 } })
+\`\`\`
+
+**Card grid that staggers as it scrolls in:**
+\`\`\`
+add_animation({
+  page_id, layer_id: gridId,
+  preset: "scroll-reveal-stagger",
+  targets: [card1, card2, card3, card4],
+  options: { stagger: 0.12 }
+})
+\`\`\`
+
+**Hover a card to lift it AND fade in a CTA inside it** — multi-target:
+\`\`\`
+add_animation({
+  page_id, layer_id: cardId,
+  preset: "hover-lift",
+  targets: [cardId, ctaId],  // one tween per target, same trigger
+  options: { distance: "6px" }
+})
+\`\`\`
+
+**Override the preset's trigger** (rare — most presets pick the right trigger):
+\`\`\`
+add_animation({ page_id, layer_id, preset: "fade-in", trigger: "load" })
+\`\`\`
+
+**Managing animations:**
+- \`list_layer_animations({ page_id, layer_id })\` — see what's attached
+- \`remove_layer_animation({ page_id, layer_id, interaction_id })\` — drop one
+- \`clear_layer_animations({ page_id, layer_id })\` — remove all
+
+**Escape hatch — full GSAP timeline control:**
+\`set_layer_interactions\` replaces the entire \`interactions\` array with raw shapes.
+Use when presets don't fit: custom eases per-tween, exotic timeline positions ("<", ">"),
+mixed apply_styles per property, or compositions a preset can't express.
+
+Tween value formats (see the animation-presets reference for the full table):
+- \`x/y/width/height\`: CSS length string ("100px", "5rem")
+- \`scale\`: unitless string ("1.05")
+- \`rotation\`: degrees ("45deg")
+- \`autoAlpha\`: opacity 0-100 as plain string ("0", "100") — **no % suffix**
+- \`backgroundColor\`: hex/rgb ("#ffffff")
+
+**apply_styles modes** (per-property in the \`from\` state):
+- \`on-load\`: pre-apply the from state on page load. Use for reveal animations to avoid FOUC.
+- \`on-trigger\`: only apply the from state when the trigger fires. Use for hover/click
+  so the element looks normal until interacted with.
+
+The presets pick the right \`apply_styles\` mode automatically; you only need to think
+about it when using \`set_layer_interactions\`.
+
 ### Page Settings
 
 **SEO** — Set meta title, description, OG image, and noindex:

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ELEMENT_TEMPLATES } from '@/lib/mcp/utils';
+import { ANIMATION_EASES, PRESET_CATALOG } from '@/lib/mcp/animation-presets';
 
 function getAvailableTemplates() {
   return Object.entries(ELEMENT_TEMPLATES).map(([key, t]) => ({
@@ -177,6 +178,70 @@ export function registerReferenceResources(server: McpServer) {
               position: { type: 'enum', values: ['relative', 'absolute', 'fixed', 'sticky'] },
               zIndex: { type: 'string' },
             },
+          },
+        }, null, 2),
+      }],
+    }),
+  );
+
+  server.resource(
+    'animation-presets-reference',
+    'ycode://reference/animation-presets',
+    {
+      description: 'Animation preset catalog: keys, default triggers/durations/eases, plus the raw LayerInteraction shape for set_layer_interactions',
+      mimeType: 'application/json',
+    },
+    async () => ({
+      contents: [{
+        uri: 'ycode://reference/animation-presets',
+        mimeType: 'application/json',
+        text: JSON.stringify({
+          instructions: 'Use add_animation with a preset key for the common cases. Drop down to set_layer_interactions only when you need full GSAP control.',
+          presets: PRESET_CATALOG,
+          triggers: {
+            click: 'Fires on user click. Use for affordances (pulse, shake).',
+            hover: 'Fires on mouseenter, reverses on mouseleave. Auto-yoyos so you only define the "to" state.',
+            'scroll-into-view': 'Fires once when the element enters the viewport. Default for reveal presets.',
+            'while-scrolling': 'Tween is scrubbed by scroll position. Set timeline.scrub. Use for parallax / progress effects.',
+            load: 'Fires on page load. Use for loops or on-load entrance choreography.',
+          },
+          eases: ANIMATION_EASES,
+          tween_value_formats: {
+            'x | y | width | height': 'CSS length string with unit ("100px", "50%", "5rem").',
+            scale: 'Unitless number string ("1", "1.05").',
+            'rotation | skewX | skewY': 'Degrees with suffix ("45deg", "-90deg").',
+            autoAlpha: 'Opacity 0-100 as plain string ("0", "100") — no % suffix.',
+            backgroundColor: 'Hex or rgb() string ("#ffffff").',
+            display: '"visible" or "hidden".',
+          },
+          tween_position: {
+            number: 'Absolute time in seconds from timeline start.',
+            '">"': 'Start after the previous tween ends.',
+            '"<"': 'Start with the previous tween (overlap).',
+          },
+          apply_styles_modes: {
+            'on-load': 'Apply the "from" value immediately on page load. Use for reveal animations to avoid FOUC.',
+            'on-trigger': 'Apply the "from" value only when the trigger fires. Use for hover/click (element looks normal until interacted with).',
+          },
+          interaction_shape_example: {
+            id: 'int_xxx (auto-generated if omitted)',
+            trigger: 'scroll-into-view',
+            timeline: {
+              breakpoints: ['desktop', 'tablet', 'mobile'],
+              repeat: 0,
+              yoyo: false,
+              toggleActions: 'play none none none',
+            },
+            tweens: [{
+              id: 'twn_xxx (auto-generated if omitted)',
+              layer_id: 'lyr_xxx',
+              position: 0,
+              duration: 0.6,
+              ease: 'power1.out',
+              from: { autoAlpha: '0', y: '40px' },
+              to: { autoAlpha: '100', y: '0px' },
+              apply_styles: { autoAlpha: 'on-load', y: 'on-load' },
+            }],
           },
         }, null, 2),
       }],

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -23,6 +23,7 @@ import { registerLocaleTools } from '@/lib/mcp/tools/locales';
 import { registerFormTools } from '@/lib/mcp/tools/forms';
 import { registerSettingsTools } from '@/lib/mcp/tools/settings';
 import { registerPublishingTools } from '@/lib/mcp/tools/publishing';
+import { registerAnimationTools } from '@/lib/mcp/tools/animations';
 import { registerReferenceResources } from '@/lib/mcp/resources/reference';
 import { registerSiteResources } from '@/lib/mcp/resources/site';
 
@@ -48,6 +49,7 @@ export function createMcpServer(): McpServer {
   registerFormTools(server);
   registerSettingsTools(server);
   registerPublishingTools(server);
+  registerAnimationTools(server);
 
   registerReferenceResources(server);
   registerSiteResources(server);

--- a/lib/mcp/tools/animations.ts
+++ b/lib/mcp/tools/animations.ts
@@ -1,0 +1,304 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { Layer, LayerInteraction } from '@/types';
+import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
+import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
+import { findLayerById, updateLayerById, generateId } from '@/lib/mcp/utils';
+import {
+  ANIMATION_EASES,
+  ANIMATION_PRESETS,
+  buildInteractionFromPreset,
+} from '@/lib/mcp/animation-presets';
+
+async function getPageLayers(pageId: string): Promise<Layer[]> {
+  const pageLayers = await getDraftLayers(pageId);
+  return (pageLayers?.layers as Layer[]) || [];
+}
+
+async function savePageLayers(pageId: string, layers: Layer[]): Promise<void> {
+  await upsertDraftLayers(pageId, layers);
+  broadcastLayersChanged(pageId, layers).catch(() => {});
+}
+
+const presetEnum = z.enum(ANIMATION_PRESETS);
+const triggerEnum = z.enum(['click', 'hover', 'scroll-into-view', 'while-scrolling', 'load']);
+const easeEnum = z.enum(ANIMATION_EASES);
+const breakpointEnum = z.enum(['desktop', 'tablet', 'mobile']);
+
+const tweenPropertyKeyEnum = z.enum([
+  'x', 'y', 'rotation', 'scale', 'skewX', 'skewY',
+  'autoAlpha', 'display', 'width', 'height', 'backgroundColor',
+]);
+
+const tweenPropertiesSchema = z.object({
+  x: z.string().nullable().optional(),
+  y: z.string().nullable().optional(),
+  rotation: z.string().nullable().optional(),
+  scale: z.string().nullable().optional(),
+  skewX: z.string().nullable().optional(),
+  skewY: z.string().nullable().optional(),
+  autoAlpha: z.string().nullable().optional().describe('Opacity 0-100 as a string (e.g. "0", "100"). Stored without unit.'),
+  display: z.string().nullable().optional().describe('"visible" or "hidden".'),
+  width: z.string().nullable().optional(),
+  height: z.string().nullable().optional(),
+  backgroundColor: z.string().nullable().optional().describe('Hex / rgb color.'),
+});
+
+const tweenSchema = z.object({
+  id: z.string().optional().describe('Leave blank to auto-generate.'),
+  layer_id: z.string().describe('Layer the tween animates. Can differ from the interaction owner.'),
+  position: z.union([z.number(), z.string()])
+    .describe('GSAP timeline position. Number = seconds, ">" = after previous, "<" = with previous.'),
+  duration: z.number().describe('Tween duration in seconds.'),
+  ease: easeEnum.describe('GSAP ease.'),
+  from: tweenPropertiesSchema,
+  to: tweenPropertiesSchema,
+  apply_styles: z.record(tweenPropertyKeyEnum, z.enum(['on-load', 'on-trigger']))
+    .optional()
+    .describe('Per-property: "on-load" pre-applies the from state immediately (prevents FOUC on reveals). "on-trigger" defers until the trigger fires.'),
+});
+
+const interactionSchema = z.object({
+  id: z.string().optional().describe('Leave blank to auto-generate.'),
+  trigger: triggerEnum,
+  timeline: z.object({
+    breakpoints: z.array(breakpointEnum).describe('Which breakpoints the animation runs on.'),
+    repeat: z.number().describe('-1 = infinite, 0 = none, n = repeat n times.'),
+    yoyo: z.boolean().describe('Reverse direction on each repeat.'),
+    scrollStart: z.string().optional().describe('Scroll trigger start (e.g. "top 80%"). For scroll-into-view / while-scrolling.'),
+    scrollEnd: z.string().optional().describe('Scroll trigger end (e.g. "bottom top"). For while-scrolling.'),
+    scrub: z.union([z.boolean(), z.number()]).optional().describe('while-scrolling: true for direct link, number for smoothing seconds.'),
+    toggleActions: z.string().optional().describe('scroll-into-view: GSAP toggleActions (default "play none none none").'),
+  }),
+  tweens: z.array(tweenSchema).min(1),
+});
+
+function ensureIds(interaction: z.infer<typeof interactionSchema>): LayerInteraction {
+  return {
+    id: interaction.id || generateId('int'),
+    trigger: interaction.trigger,
+    timeline: interaction.timeline,
+    tweens: interaction.tweens.map((t) => ({
+      id: t.id || generateId('twn'),
+      layer_id: t.layer_id,
+      position: t.position,
+      duration: t.duration,
+      ease: t.ease,
+      from: t.from,
+      to: t.to,
+      apply_styles: t.apply_styles || {},
+    })),
+  };
+}
+
+export function registerAnimationTools(server: McpServer) {
+  server.tool(
+    'add_animation',
+    `Add a curated animation to a layer using one of YCode's preset patterns.
+
+Presets cover ~80% of animation needs. Use set_layer_interactions for full GSAP control.
+
+PRESETS:
+- Reveal (default trigger scroll-into-view): fade-in, fade-in-up, fade-in-down,
+  fade-in-left, fade-in-right, scale-in
+- Hover (forced trigger hover): hover-lift, hover-scale, hover-fade, hover-color
+- Click (forced trigger click): click-pulse, click-shake
+- Scroll (forced trigger while-scrolling, scrubbed by scroll position): parallax-up, parallax-down
+- Stagger (default trigger scroll-into-view): scroll-reveal-stagger (one tween per target,
+  offset by options.stagger seconds — pass multiple targets!)
+- Loop (default trigger load, infinite): loop-bounce, loop-pulse, loop-spin
+
+The animation is owned by layer_id but each tween can target a different layer via targets[].
+This enables card-hover patterns where hovering one element animates several.
+
+Options vary by preset:
+- duration / delay / ease — work on every preset
+- distance — fade-in-*, parallax-*, click-shake, loop-bounce, hover-lift (e.g. "40px", "5rem")
+- scale_to — hover-scale, click-pulse, loop-pulse (e.g. 1.05)
+- background_color — hover-color (hex / rgb)
+- stagger — scroll-reveal-stagger (seconds between targets, default 0.1)
+- repeat — override the preset's default repeat (e.g. force loop-spin to play 3 times)`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('Layer that owns the animation (and the default target)'),
+      preset: presetEnum,
+      trigger: triggerEnum.optional()
+        .describe('Override the preset\'s default trigger. Rare — most presets have the right trigger baked in.'),
+      targets: z.array(z.string()).optional()
+        .describe('Layers the tweens animate. Defaults to [layer_id]. Pass multiple for card-hover patterns or scroll-reveal-stagger.'),
+      options: z.object({
+        duration: z.number().optional(),
+        delay: z.number().optional(),
+        distance: z.string().optional().describe('CSS length (e.g. "40px", "5rem", "20%")'),
+        ease: easeEnum.optional(),
+        scale_to: z.number().optional(),
+        background_color: z.string().optional(),
+        stagger: z.number().optional(),
+        repeat: z.number().optional(),
+      }).optional(),
+    },
+    async ({ page_id, layer_id, preset, trigger, targets, options }) => {
+      const layers = await getPageLayers(page_id);
+      const owner = findLayerById(layers, layer_id);
+      if (!owner) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+
+      if (targets && targets.length > 0) {
+        for (const targetId of targets) {
+          if (!findLayerById(layers, targetId)) {
+            return { content: [{ type: 'text' as const, text: `Error: Target layer "${targetId}" not found.` }], isError: true };
+          }
+        }
+      }
+
+      const interaction = buildInteractionFromPreset({
+        preset,
+        ownerLayerId: layer_id,
+        trigger,
+        targets,
+        options,
+      });
+
+      const updated = updateLayerById(layers, layer_id, (l) => ({
+        ...l,
+        interactions: [...(l.interactions || []), interaction],
+      }));
+
+      await savePageLayers(page_id, updated);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            message: `Added "${preset}" animation to "${owner.customName || owner.name}"`,
+            interaction_id: interaction.id,
+            tween_count: interaction.tweens.length,
+          }, null, 2),
+        }],
+      };
+    },
+  );
+
+  server.tool(
+    'list_layer_animations',
+    'List all animations attached to a layer with their triggers and tween summaries.',
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer ID'),
+    },
+    async ({ page_id, layer_id }) => {
+      const layers = await getPageLayers(page_id);
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+      const interactions = (layer.interactions || []).map((i) => ({
+        id: i.id,
+        trigger: i.trigger,
+        timeline: i.timeline,
+        tween_count: i.tweens.length,
+        targets: Array.from(new Set(i.tweens.map((t) => t.layer_id))),
+      }));
+      return { content: [{ type: 'text' as const, text: JSON.stringify(interactions, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'remove_layer_animation',
+    'Remove a single animation from a layer by its interaction ID.',
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer ID'),
+      interaction_id: z.string().describe('The interaction ID to remove'),
+    },
+    async ({ page_id, layer_id, interaction_id }) => {
+      const layers = await getPageLayers(page_id);
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+      const existing = layer.interactions || [];
+      const next = existing.filter((i) => i.id !== interaction_id);
+      if (next.length === existing.length) {
+        return { content: [{ type: 'text' as const, text: `Error: Interaction "${interaction_id}" not found on this layer.` }], isError: true };
+      }
+
+      const updated = updateLayerById(layers, layer_id, (l) => ({ ...l, interactions: next }));
+      await savePageLayers(page_id, updated);
+      return { content: [{ type: 'text' as const, text: `Removed interaction "${interaction_id}"` }] };
+    },
+  );
+
+  server.tool(
+    'clear_layer_animations',
+    'Remove all animations from a layer.',
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer ID'),
+    },
+    async ({ page_id, layer_id }) => {
+      const layers = await getPageLayers(page_id);
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+      const removed = (layer.interactions || []).length;
+      const updated = updateLayerById(layers, layer_id, (l) => ({ ...l, interactions: [] }));
+      await savePageLayers(page_id, updated);
+      return { content: [{ type: 'text' as const, text: `Cleared ${removed} animation(s) from "${layer.customName || layer.name}"` }] };
+    },
+  );
+
+  server.tool(
+    'set_layer_interactions',
+    `Raw escape hatch: replace a layer's entire \`interactions\` array with the full LayerInteraction
+shape. Use when add_animation's presets aren't expressive enough — custom timelines,
+exotic eases, per-property apply_styles, multi-target stagger compositions, etc.
+
+Refer to ycode://reference/animation-presets for the preset catalog and trigger semantics.
+
+Each interaction has:
+- trigger: click | hover | scroll-into-view | while-scrolling | load
+- timeline: { breakpoints, repeat, yoyo, scrollStart?, scrollEnd?, scrub?, toggleActions? }
+- tweens: [{ layer_id, position, duration, ease, from, to, apply_styles? }]
+
+Tween value formats:
+- x/y/width/height/distance: "100px", "50%", "5rem"
+- scale: "1", "1.05" (no unit)
+- rotation/skewX/skewY: "45deg", "-90deg"
+- autoAlpha (opacity): "0" to "100" (no % suffix)
+- backgroundColor: "#ffffff" or "rgb(0,0,0)"
+- display: "visible" | "hidden"
+
+position can be a number (seconds), ">" (after previous), or "<" (with previous).`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer ID'),
+      interactions: z.array(interactionSchema)
+        .describe('Replaces the entire interactions array. Pass [] to clear (or use clear_layer_animations).'),
+    },
+    async ({ page_id, layer_id, interactions }) => {
+      const layers = await getPageLayers(page_id);
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+
+      const normalized = interactions.map(ensureIds);
+
+      const updated = updateLayerById(layers, layer_id, (l) => ({ ...l, interactions: normalized }));
+      await savePageLayers(page_id, updated);
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            message: `Set ${normalized.length} interaction(s) on "${layer.customName || layer.name}"`,
+            interaction_ids: normalized.map((i) => i.id),
+          }, null, 2),
+        }],
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Adds a preset-first animations surface to the MCP so agents can ship "fade these cards in on scroll" or "lift on hover" in a single tool call instead of hand-rolling GSAP timelines. Power users keep full control via a raw escape hatch that exposes the entire `LayerInteraction` shape.

This is the last feature PR in the MCP refresh series, closing out the audit gap for layer interactions.

## Changes

- Add `lib/mcp/animation-presets.ts` with 18 curated presets across reveal, hover, click, parallax, stagger, and loop families. Each preset bakes in sensible defaults for trigger, duration, ease, and `apply_styles` mode (avoiding FOUC on reveals, deferring on hover/click)
- Add `lib/mcp/tools/animations.ts` registering 5 tools:
  - `add_animation` — preset + options, with multi-target tweens via an explicit `targets` array
  - `list_layer_animations`, `remove_layer_animation`, `clear_layer_animations`
  - `set_layer_interactions` — raw `LayerInteraction` shape for cases presets can't express (custom eases per tween, mixed `apply_styles`, exotic timeline positions)
- Add `ycode://reference/animation-presets` resource documenting the catalog, trigger semantics, tween value formats, `apply_styles` modes, and the raw interaction shape with a worked example
- Register the new tools in `lib/mcp/server.ts`
- Document the surface in `lib/mcp/instructions.ts` (Animations & Interactions section) with realistic examples (scroll reveal, staggered grid, multi-target hover)

## Test plan

- [ ] `npm run type-check` passes
- [ ] In Cursor / Claude Desktop, list MCP tools — confirm `add_animation`, `list_layer_animations`, `remove_layer_animation`, `clear_layer_animations`, and `set_layer_interactions` appear
- [ ] Read `ycode://reference/animation-presets` and confirm the catalog is well-formed
- [ ] `add_animation` with preset `fade-in-up` on a layer — open the builder, the layer fades in and slides up when scrolled into view
- [ ] `add_animation` with preset `scroll-reveal-stagger` and 3 `targets` — each card reveals with the expected stagger
- [ ] `add_animation` with preset `hover-lift` and `targets: [cardId, ctaId]` — hovering the card moves both elements together
- [ ] `add_animation` with preset `loop-spin` on an icon — icon spins continuously
- [ ] `add_animation` with preset `parallax-up` — element moves with scroll, scrubbed
- [ ] `list_layer_animations` returns the expected interaction summaries
- [ ] `remove_layer_animation` removes the targeted interaction; `clear_layer_animations` removes all
- [ ] `set_layer_interactions` with a hand-crafted shape produces a working animation in the builder

Made with [Cursor](https://cursor.com)