### PR TITLE
feat: MCP 1.0 refresh — full feature parity with YCode

### DIFF
--- a/app/(builder)/ycode/mcp/[token]/route.ts
+++ b/app/(builder)/ycode/mcp/[token]/route.ts
@@ -28,13 +28,38 @@ function cleanupStaleSessions() {
   }
 }
 
+/**
+ * Token validation cache. AI agents make many requests per minute and each
+ * was previously hitting Supabase to revalidate the same token. Cache hits
+ * for 60s (revocations propagate within a minute, fine for agent use).
+ * Misses cache for 5s so a token flip from invalid→valid recovers quickly.
+ */
+interface TokenCacheEntry {
+  valid: boolean;
+  expires: number;
+}
+const tokenCache = new Map<string, TokenCacheEntry>();
+const TOKEN_CACHE_TTL_VALID_MS = 60_000;
+const TOKEN_CACHE_TTL_INVALID_MS = 5_000;
+
 async function authenticateToken(token: string): Promise<boolean> {
+  const now = Date.now();
+  const cached = tokenCache.get(token);
+  if (cached && cached.expires > now) {
+    return cached.valid;
+  }
+
+  let valid = false;
   try {
     const result = await validateToken(token);
-    return result !== null;
+    valid = result !== null;
   } catch {
-    return false;
+    valid = false;
   }
+
+  const ttl = valid ? TOKEN_CACHE_TTL_VALID_MS : TOKEN_CACHE_TTL_INVALID_MS;
+  tokenCache.set(token, { valid, expires: now + ttl });
+  return valid;
 }
 
 function addCorsHeaders(response: Response): Response {

--- a/lib/mcp/animation-presets.ts
+++ b/lib/mcp/animation-presets.ts
@@ -1,0 +1,465 @@
+/**
+ * Animation preset library for the MCP `add_animation` tool.
+ *
+ * Each preset produces a fully-formed `LayerInteraction` so agents can ship
+ * "fade these cards in on scroll" in one tool call instead of hand-rolling a
+ * GSAP timeline.
+ *
+ * Power users that need full control can bypass the presets and call
+ * `set_layer_interactions` with the raw shape.
+ */
+
+import type {
+  InteractionApplyStyles,
+  InteractionTimeline,
+  InteractionTween,
+  LayerInteraction,
+  TweenProperties,
+  TweenPropertyKey,
+} from '@/types';
+import { generateId } from '@/lib/utils';
+
+export const ANIMATION_PRESETS = [
+  'fade-in',
+  'fade-in-up',
+  'fade-in-down',
+  'fade-in-left',
+  'fade-in-right',
+  'scale-in',
+  'hover-lift',
+  'hover-scale',
+  'hover-fade',
+  'hover-color',
+  'click-pulse',
+  'click-shake',
+  'parallax-up',
+  'parallax-down',
+  'scroll-reveal-stagger',
+  'loop-bounce',
+  'loop-pulse',
+  'loop-spin',
+] as const;
+
+export type AnimationPreset = (typeof ANIMATION_PRESETS)[number];
+
+export type AnimationTrigger =
+  | 'click'
+  | 'hover'
+  | 'scroll-into-view'
+  | 'while-scrolling'
+  | 'load';
+
+export const ANIMATION_EASES = [
+  'none',
+  'power1.in',
+  'power1.inOut',
+  'power1.out',
+  'back.in',
+  'back.inOut',
+  'back.out',
+] as const;
+
+export type AnimationEase = (typeof ANIMATION_EASES)[number];
+
+export interface AnimationPresetOptions {
+  /** Tween duration in seconds. Preset provides a sensible default. */
+  duration?: number;
+  /** Delay before the animation starts (seconds). Defaults to 0. */
+  delay?: number;
+  /**
+   * For slide / parallax presets: how far the element travels.
+   * Accepts any CSS length (e.g. "40px", "5rem", "20%").
+   */
+  distance?: string;
+  /** Curated GSAP ease. Defaults per preset family. */
+  ease?: AnimationEase;
+  /** For scale presets: the target scale value (e.g. 1.05). */
+  scale_to?: number;
+  /** For hover-color: the background color to fade into. */
+  background_color?: string;
+  /** For scroll-reveal-stagger: seconds between consecutive targets. Defaults 0.1. */
+  stagger?: number;
+  /**
+   * For loop presets: how many times to repeat. -1 = infinite (default for loop-*),
+   * 1 = play once and reverse once (click-pulse default).
+   */
+  repeat?: number;
+}
+
+interface PresetMeta {
+  /** Default trigger if the caller doesn't override. */
+  defaultTrigger: AnimationTrigger;
+  /** Default duration in seconds. */
+  defaultDuration: number;
+  /** Default ease. */
+  defaultEase: AnimationEase;
+  /** Whether the `from` properties should be applied on load (prevents FOUC). */
+  applyFromOnLoad: boolean;
+  /** Build the tween from/to for one target. */
+  buildTween: (opts: AnimationPresetOptions) => Pick<InteractionTween, 'from' | 'to'>;
+  /** Per-property apply_styles override. */
+  applyStyles?: (opts: AnimationPresetOptions) => InteractionApplyStyles;
+  /**
+   * Optional: emit multiple tweens per target instead of one (e.g. click-shake).
+   * Each entry receives the layer_id and a position (GSAP timeline position).
+   */
+  multiStep?: (opts: AnimationPresetOptions) => Array<{
+    from: TweenProperties;
+    to: TweenProperties;
+    duration: number;
+    position: number | string;
+  }>;
+  /** Extra timeline overrides (repeat / yoyo / scrub / scrollStart). */
+  timeline?: Partial<InteractionTimeline>;
+}
+
+const REVEAL_OPACITY_FROM = '0';
+const REVEAL_OPACITY_TO = '100';
+
+const PRESETS: Record<AnimationPreset, PresetMeta> = {
+  'fade-in': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: true,
+    buildTween: () => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM },
+      to: { autoAlpha: REVEAL_OPACITY_TO },
+    }),
+  },
+  'fade-in-up': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM, y: opts.distance || '40px' },
+      to: { autoAlpha: REVEAL_OPACITY_TO, y: '0px' },
+    }),
+  },
+  'fade-in-down': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM, y: `-${stripSign(opts.distance || '40px')}` },
+      to: { autoAlpha: REVEAL_OPACITY_TO, y: '0px' },
+    }),
+  },
+  'fade-in-left': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM, x: opts.distance || '40px' },
+      to: { autoAlpha: REVEAL_OPACITY_TO, x: '0px' },
+    }),
+  },
+  'fade-in-right': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM, x: `-${stripSign(opts.distance || '40px')}` },
+      to: { autoAlpha: REVEAL_OPACITY_TO, x: '0px' },
+    }),
+  },
+  'scale-in': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'back.out',
+    applyFromOnLoad: true,
+    buildTween: () => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM, scale: '0.85' },
+      to: { autoAlpha: REVEAL_OPACITY_TO, scale: '1' },
+    }),
+  },
+  'hover-lift': {
+    defaultTrigger: 'hover',
+    defaultDuration: 0.3,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: false,
+    buildTween: (opts) => ({
+      from: { y: '0px' },
+      to: { y: `-${stripSign(opts.distance || '8px')}` },
+    }),
+  },
+  'hover-scale': {
+    defaultTrigger: 'hover',
+    defaultDuration: 0.3,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: false,
+    buildTween: (opts) => ({
+      from: { scale: '1' },
+      to: { scale: String(opts.scale_to ?? 1.05) },
+    }),
+  },
+  'hover-fade': {
+    defaultTrigger: 'hover',
+    defaultDuration: 0.3,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: false,
+    buildTween: () => ({
+      from: { autoAlpha: '100' },
+      to: { autoAlpha: '70' },
+    }),
+  },
+  'hover-color': {
+    defaultTrigger: 'hover',
+    defaultDuration: 0.3,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: false,
+    buildTween: (opts) => ({
+      from: { backgroundColor: '#ffffff' },
+      to: { backgroundColor: opts.background_color || '#000000' },
+    }),
+  },
+  'click-pulse': {
+    defaultTrigger: 'click',
+    defaultDuration: 0.15,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: false,
+    buildTween: (opts) => ({
+      from: { scale: '1' },
+      to: { scale: String(opts.scale_to ?? 1.1) },
+    }),
+    timeline: { repeat: 1, yoyo: true },
+  },
+  'click-shake': {
+    defaultTrigger: 'click',
+    defaultDuration: 0.05,
+    defaultEase: 'power1.inOut',
+    applyFromOnLoad: false,
+    buildTween: () => ({ from: { x: '0px' }, to: { x: '0px' } }),
+    multiStep: (opts) => {
+      const dist = stripSign(opts.distance || '10px');
+      const step = opts.duration ?? 0.05;
+      return [
+        { from: { x: '0px' }, to: { x: `-${dist}` }, duration: step, position: 0 },
+        { from: { x: `-${dist}` }, to: { x: dist }, duration: step, position: '>' },
+        { from: { x: dist }, to: { x: `-${dist}` }, duration: step, position: '>' },
+        { from: { x: `-${dist}` }, to: { x: dist }, duration: step, position: '>' },
+        { from: { x: dist }, to: { x: '0px' }, duration: step, position: '>' },
+      ];
+    },
+  },
+  'parallax-up': {
+    defaultTrigger: 'while-scrolling',
+    defaultDuration: 1,
+    defaultEase: 'none',
+    applyFromOnLoad: false,
+    buildTween: (opts) => ({
+      from: { y: '0px' },
+      to: { y: `-${stripSign(opts.distance || '100px')}` },
+    }),
+    timeline: { scrub: true, scrollStart: 'top bottom', scrollEnd: 'bottom top' },
+  },
+  'parallax-down': {
+    defaultTrigger: 'while-scrolling',
+    defaultDuration: 1,
+    defaultEase: 'none',
+    applyFromOnLoad: false,
+    buildTween: (opts) => ({
+      from: { y: '0px' },
+      to: { y: stripSign(opts.distance || '100px') },
+    }),
+    timeline: { scrub: true, scrollStart: 'top bottom', scrollEnd: 'bottom top' },
+  },
+  'scroll-reveal-stagger': {
+    defaultTrigger: 'scroll-into-view',
+    defaultDuration: 0.6,
+    defaultEase: 'power1.out',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { autoAlpha: REVEAL_OPACITY_FROM, y: opts.distance || '24px' },
+      to: { autoAlpha: REVEAL_OPACITY_TO, y: '0px' },
+    }),
+  },
+  'loop-bounce': {
+    defaultTrigger: 'load',
+    defaultDuration: 1.5,
+    defaultEase: 'power1.inOut',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { y: '0px' },
+      to: { y: `-${stripSign(opts.distance || '10px')}` },
+    }),
+    timeline: { repeat: -1, yoyo: true },
+  },
+  'loop-pulse': {
+    defaultTrigger: 'load',
+    defaultDuration: 1.5,
+    defaultEase: 'power1.inOut',
+    applyFromOnLoad: true,
+    buildTween: (opts) => ({
+      from: { scale: '1' },
+      to: { scale: String(opts.scale_to ?? 1.05) },
+    }),
+    timeline: { repeat: -1, yoyo: true },
+  },
+  'loop-spin': {
+    defaultTrigger: 'load',
+    defaultDuration: 4,
+    defaultEase: 'none',
+    applyFromOnLoad: true,
+    buildTween: () => ({
+      from: { rotation: '0deg' },
+      to: { rotation: '360deg' },
+    }),
+    timeline: { repeat: -1, yoyo: false },
+  },
+};
+
+export interface BuildInteractionInput {
+  preset: AnimationPreset;
+  /** Owning layer ID — used as the default tween target. */
+  ownerLayerId: string;
+  /** Override the preset's default trigger. */
+  trigger?: AnimationTrigger;
+  /** Layers the tweens act on. Defaults to [ownerLayerId]. */
+  targets?: string[];
+  options?: AnimationPresetOptions;
+}
+
+/**
+ * Build a complete `LayerInteraction` (with fresh IDs) from a preset key.
+ * Returns the interaction ready to be appended to `layer.interactions`.
+ */
+export function buildInteractionFromPreset(input: BuildInteractionInput): LayerInteraction {
+  const meta = PRESETS[input.preset];
+  if (!meta) {
+    throw new Error(`Unknown animation preset "${input.preset}"`);
+  }
+
+  const opts: AnimationPresetOptions = input.options || {};
+  const trigger: AnimationTrigger = input.trigger || meta.defaultTrigger;
+  const targets = input.targets && input.targets.length > 0 ? input.targets : [input.ownerLayerId];
+  const duration = opts.duration ?? meta.defaultDuration;
+  const ease = opts.ease ?? meta.defaultEase;
+  const stagger = opts.stagger ?? 0.1;
+  const delay = opts.delay ?? 0;
+
+  const tweens: InteractionTween[] = [];
+
+  for (let targetIdx = 0; targetIdx < targets.length; targetIdx++) {
+    const targetId = targets[targetIdx];
+    const basePosition = computeBasePosition({
+      preset: input.preset,
+      targetIdx,
+      stagger,
+      delay,
+    });
+
+    if (meta.multiStep) {
+      const steps = meta.multiStep({ ...opts, duration: opts.duration });
+      for (let stepIdx = 0; stepIdx < steps.length; stepIdx++) {
+        const step = steps[stepIdx];
+        tweens.push({
+          id: generateId('twn'),
+          layer_id: targetId,
+          position: stepIdx === 0 ? basePosition : step.position,
+          duration: step.duration,
+          ease,
+          from: step.from,
+          to: step.to,
+          apply_styles: buildApplyStyles(step.from, meta.applyFromOnLoad),
+        });
+      }
+      continue;
+    }
+
+    const { from, to } = meta.buildTween(opts);
+    tweens.push({
+      id: generateId('twn'),
+      layer_id: targetId,
+      position: basePosition,
+      duration,
+      ease,
+      from,
+      to,
+      apply_styles: meta.applyStyles ? meta.applyStyles(opts) : buildApplyStyles(from, meta.applyFromOnLoad),
+    });
+  }
+
+  const timeline: InteractionTimeline = {
+    breakpoints: ['desktop', 'tablet', 'mobile'],
+    repeat: 0,
+    yoyo: false,
+    ...(trigger === 'scroll-into-view' && { toggleActions: 'play none none none' }),
+    ...meta.timeline,
+    ...(opts.repeat !== undefined && { repeat: opts.repeat }),
+  };
+
+  return {
+    id: generateId('int'),
+    trigger,
+    timeline,
+    tweens,
+  };
+}
+
+/**
+ * Compute the GSAP position string / number for the first tween of a target.
+ * For stagger presets this offsets each target; otherwise just the delay.
+ */
+function computeBasePosition(args: {
+  preset: AnimationPreset;
+  targetIdx: number;
+  stagger: number;
+  delay: number;
+}): number | string {
+  if (args.preset === 'scroll-reveal-stagger') {
+    return args.delay + args.targetIdx * args.stagger;
+  }
+  return args.delay;
+}
+
+/** Mark every property present in `from` so the runtime knows whether to pre-apply it. */
+function buildApplyStyles(from: TweenProperties, applyOnLoad: boolean): InteractionApplyStyles {
+  const styles: InteractionApplyStyles = {};
+  const mode = applyOnLoad ? 'on-load' : 'on-trigger';
+  for (const key of Object.keys(from) as TweenPropertyKey[]) {
+    if (from[key] !== undefined && from[key] !== null) {
+      styles[key] = mode;
+    }
+  }
+  return styles;
+}
+
+/** Strip a leading "-" so callers can pass "-40px" or "40px" interchangeably for distance. */
+function stripSign(value: string): string {
+  return value.startsWith('-') ? value.slice(1) : value;
+}
+
+const PRESET_DESCRIPTIONS: Record<AnimationPreset, string> = {
+  'fade-in': 'Fades from invisible to fully opaque. Most common reveal.',
+  'fade-in-up': 'Fades in while sliding up from below (distance default 40px).',
+  'fade-in-down': 'Fades in while sliding down from above.',
+  'fade-in-left': 'Fades in while sliding left from off-screen right.',
+  'fade-in-right': 'Fades in while sliding right from off-screen left.',
+  'scale-in': 'Fades in while scaling up from 0.85. Uses back.out for a slight overshoot.',
+  'hover-lift': 'Subtle upward translation on hover (default -8px).',
+  'hover-scale': 'Scales up on hover (default 1.05).',
+  'hover-fade': 'Fades to 70% opacity on hover.',
+  'hover-color': 'Animates background color on hover (pass background_color).',
+  'click-pulse': 'Scales up then back on click (yoyo). Adjust with scale_to.',
+  'click-shake': 'Horizontal shake of 5 micro-tweens (distance default 10px).',
+  'parallax-up': 'Scroll-scrubbed upward translation. Use on hero images / decorative bg.',
+  'parallax-down': 'Scroll-scrubbed downward translation.',
+  'scroll-reveal-stagger': 'fade-in-up applied to multiple targets with a stagger offset (default 0.1s between targets).',
+  'loop-bounce': 'Infinite vertical bounce. Use on small ornamental elements.',
+  'loop-pulse': 'Infinite scale pulse.',
+  'loop-spin': 'Infinite 360° rotation. Linear ease, no yoyo.',
+};
+
+/** Public preset catalog for the reference resource. */
+export const PRESET_CATALOG = ANIMATION_PRESETS.map((key) => ({
+  key,
+  default_trigger: PRESETS[key].defaultTrigger,
+  default_duration: PRESETS[key].defaultDuration,
+  default_ease: PRESETS[key].defaultEase,
+  description: PRESET_DESCRIPTIONS[key],
+}));

--- a/lib/mcp/broadcast.ts
+++ b/lib/mcp/broadcast.ts
@@ -6,10 +6,55 @@
  * so the editor UI updates in real time when an AI agent makes changes.
  */
 
+import type { RealtimeChannel } from '@supabase/supabase-js';
+
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import type { Component, Layer, Page } from '@/types';
 
 const MCP_USER_ID = '__mcp_agent__';
+
+/**
+ * Cache subscribed realtime channels by name so successive broadcasts on the
+ * same channel skip the ~50-300ms subscribe round trip. A failed subscription
+ * removes itself from the cache so the next call retries from scratch.
+ *
+ * Stored on globalThis so the cache survives Next.js HMR in dev (same pattern
+ * as the Supabase admin client itself).
+ */
+const globalForChannels = globalThis as unknown as {
+  __mcpBroadcastChannels?: Map<string, Promise<RealtimeChannel>>;
+};
+
+const channelCache = globalForChannels.__mcpBroadcastChannels ?? new Map<string, Promise<RealtimeChannel>>();
+globalForChannels.__mcpBroadcastChannels = channelCache;
+
+async function getOrCreateChannel(channelName: string): Promise<RealtimeChannel> {
+  const cached = channelCache.get(channelName);
+  if (cached) return cached;
+
+  const promise = (async () => {
+    const client = await getSupabaseAdmin();
+    if (!client) throw new Error('Supabase not configured');
+
+    const channel = client.channel(channelName);
+
+    await new Promise<void>((resolve, reject) => {
+      channel.subscribe((status) => {
+        if (status === 'SUBSCRIBED') resolve();
+        else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
+          reject(new Error(`Realtime subscribe failed: ${status}`));
+        }
+      });
+    });
+
+    return channel;
+  })();
+
+  channelCache.set(channelName, promise);
+  promise.catch(() => channelCache.delete(channelName));
+
+  return promise;
+}
 
 async function broadcast(
   channelName: string,
@@ -17,22 +62,11 @@ async function broadcast(
   payload: Record<string, unknown>,
 ): Promise<void> {
   try {
-    const client = await getSupabaseAdmin();
-    if (!client) return;
-
-    const channel = client.channel(channelName);
-
-    await new Promise<void>((resolve, reject) => {
-      channel.subscribe((status) => {
-        if (status === 'SUBSCRIBED') resolve();
-        else if (status === 'CHANNEL_ERROR') reject(new Error('Channel error'));
-      });
-    });
-
+    const channel = await getOrCreateChannel(channelName);
     await channel.send({ type: 'broadcast', event, payload });
-    await channel.unsubscribe();
   } catch (error) {
     console.error(`[MCP-BROADCAST] Failed to broadcast ${event}:`, error);
+    channelCache.delete(channelName);
   }
 }
 

--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -40,6 +40,7 @@ Each layer has:
 - \`columns\` — 2-column flexbox layout
 - \`grid\` — 2x2 CSS Grid layout
 - \`collection\` — CMS collection list (repeats children for each item)
+- \`table\`, \`thead\`, \`tbody\`, \`tr\`, \`td\`, \`th\` — Data table elements (\`table\` ships with a header + 2 body rows)
 
 **Content** (leaf elements, no children):
 - \`text\` — Text element. Set tag via settings.tag: "h1"-"h6", "p", "span", "label"
@@ -209,8 +210,16 @@ add_layer({ template: "richText", rich_content: [
 **Updating rich text content:**
 Use \`set_rich_text_content\` or the batch \`set_rich_text\` operation.
 
-**Supported block types:** paragraph, heading (level 1-6), blockquote, bulletList, orderedList, codeBlock, horizontalRule
+**Supported block types:** paragraph, heading (level 1-6), blockquote, bulletList, orderedList, codeBlock, horizontalRule, htmlEmbed, image, table, component
 **Inline formatting:** \`**bold**\`, \`*italic*\`, \`[link text](url)\`
+
+**Extended block examples:**
+\`\`\`
+{ type: "htmlEmbed", code: "<iframe src='https://example.com' />" }
+{ type: "image", asset_id: "<asset id>", alt: "Alt text" }
+{ type: "table", header_row: true, rows: [["Name", "Age"], ["Alice", "30"], ["Bob", "25"]] }
+{ type: "component", component_id: "<component id>" }
+\`\`\`
 
 ### Layer Content & Configuration
 
@@ -226,6 +235,13 @@ update_layer_image({ layer_id: "...", asset_id: "...", alt: "Photo description" 
 update_layer_link({ layer_id: "...", link_type: "url", url: "https://example.com", target: "_blank" })
 update_layer_link({ layer_id: "...", link_type: "page", page_id_target: "<page_id>" })
 update_layer_link({ layer_id: "...", link_type: "email", email: "hello@example.com" })
+update_layer_link({ layer_id: "...", link_type: "asset", asset_id: "<asset_id>", download: true })
+
+// Anchor link to a layer on the current page
+update_layer_link({ layer_id: "...", link_type: "url", url: "", anchor_layer_id: "<target layer id>" })
+
+// Dynamic page link pinned to a specific item
+update_layer_link({ layer_id: "...", link_type: "page", page_id_target: "<dynamic page id>", collection_item_id: "<item id>" })
 \`\`\`
 
 **Setting videos:**
@@ -246,6 +262,32 @@ update_layer_settings({ layer_id: "...", tag: "h2" })
 **Configuring sliders** (after adding):
 \`\`\`
 update_layer_settings({ layer_id: "...", slider: { autoplay: true, delay: "5", loop: "loop" } })
+\`\`\`
+
+**Configuring lightboxes bound to a CMS multi-image field:**
+\`\`\`
+update_layer_settings({ layer_id: "...", lightbox: { files_source: "cms", files_field_id: "<image field id>" } })
+\`\`\`
+
+**Configuring maps:**
+\`\`\`
+update_layer_settings({ layer_id: "...", map: { provider: "mapbox", latitude: 40.7128, longitude: -74.006, zoom: 12 } })
+\`\`\`
+
+**Binding select / checkbox / radio to a CMS collection:**
+\`\`\`
+update_layer_settings({ layer_id: "...", options_source: { collection_id: "<id>", sort_field_id: "<id>", sort_order: "asc" } })
+\`\`\`
+
+**Configuring form submission behavior:**
+\`\`\`
+update_form_settings({ layer_id: "<form layer id>", success_action: "redirect", redirect_url: "/thank-you" })
+update_form_settings({ layer_id: "<form layer id>", email_notification: { enabled: true, to: "you@example.com", subject: "New lead" } })
+\`\`\`
+
+**Exporting any layer subtree to HTML:**
+\`\`\`
+export_layer_html({ page_id: "...", layer_id: "..." })  // returns the rendered HTML with Tailwind classes
 \`\`\`
 
 **Setting HTML embed code:**
@@ -275,6 +317,37 @@ update_page_settings({ page_id: "...", custom_code: { head: "<script>...</script
 update_page_settings({ page_id: "...", auth: { enabled: true, password: "secret" } })
 \`\`\`
 
+**Homepage / dynamic / error pages:**
+\`\`\`
+update_page({ page_id: "...", is_index: true })             // mark as the homepage
+update_page({ page_id: "...", is_dynamic: true })           // turn into a CMS-driven page
+update_page({ page_id: "...", error_page: 404 })            // designate as the 404 page
+\`\`\`
+
+**Binding a dynamic page to a CMS collection:**
+\`\`\`
+update_page_settings({
+  page_id: "...",
+  cms: {
+    collection_id: "<id>",
+    slug_field_id: "<id>",
+    next_previous: { sort_by: "<field id>", sort_order: "asc" }  // controls next-item / previous-item link order
+  }
+})
+\`\`\`
+
+### Redirects
+
+URL redirects are site-wide. Old paths can be literal or regex (\`.+\` / \`.*\`); exact matches take priority.
+
+\`\`\`
+list_redirects()
+add_redirect({ old_url: "/about-us", new_url: "/about", type: "301" })
+add_redirect({ old_url: "/blog/.+", new_url: "/posts/$0" })  // regex match — entire match is $0
+update_redirect({ redirect_id: "...", type: "302" })
+delete_redirect({ redirect_id: "..." })
+\`\`\`
+
 ### Components (Reusable Elements)
 
 Components are reusable layer trees that can be instanced across pages.
@@ -287,10 +360,31 @@ Each instance shares the same structure but can override specific content via **
 
 **Variables** let each instance customize content:
 - **text** — Override text content (headings, paragraphs, button labels)
+- **rich_text** — Override rich-text content (when the linked layer is a richText layer)
 - **image** — Override image source
 - **link** — Override link destination
 - **audio/video** — Override media source
 - **icon** — Override icon
+- **variant** — Override which variant of a nested component is rendered
+
+Variables support \`placeholder\` (input hint) and \`default_value\` (applied when the instance doesn't override).
+
+### Component Variants
+
+A component can have multiple named variants ("Default", "Small", "Dark", etc.) that share variables but
+have independent layer trees. Useful for design system primitives that need a few visual flavors.
+
+\`\`\`
+list_component_variants({ component_id: "..." })
+create_component_variant({ component_id: "...", name: "Small", source_variant_id: "<variant to clone>" })
+update_component_variant({ component_id: "...", variant_id: "...", name: "Compact" })
+delete_component_variant({ component_id: "...", variant_id: "..." })  // non-primary only
+
+// Target a specific variant when modifying its tree:
+update_component_layers({ component_id: "...", variant_id: "<variant id>", operations: [...] })
+\`\`\`
+
+The primary variant (variants[0]) cannot be deleted. Omit \`variant_id\` on \`update_component_layers\` to target it.
 
 EXAMPLE: Creating a "Feature Card" component with a title and description variable:
 \`\`\`
@@ -318,7 +412,22 @@ YCode has a built-in CMS. Collections are like database tables:
 - Use create_collection_item to populate with data
 - Bind collections to layers using collectionList elements
 
-Field types: text, number, boolean, date, reference, rich-text, color, asset, status
+**Field types:**
+- text, number, boolean, date (datetime), date_only
+- reference, multi_reference
+- rich_text, color, status
+- image, audio, video, document — use \`data: { multiple: true }\` for multi-asset fields
+- link, email, phone
+- option — predefined choices via \`data: { options: [{ id, name }] }\`
+- count — computed count of related items via \`data: { count_collection_id, count_field_id }\`
+
+**Sorting & ordering:**
+\`\`\`
+create_collection({ name: "Posts", sorting: { field: "<field id>", direction: "desc" } })
+update_collection({ collection_id: "...", sorting: { field: "manual_order", direction: "manual" } })
+reorder_collection_fields({ collection_id: "...", field_ids: ["...", "...", "..."] })
+set_collection_item_order({ collection_id: "...", item_id: "...", manual_order: 0 })
+\`\`\`
 
 ### Color Variables (Design Tokens)
 
@@ -343,7 +452,8 @@ Example: \`search_google_fonts({ query: "playfair" })\` → \`add_font({ family:
 Multi-language support:
 - Use list_locales to see configured languages
 - Use create_locale with ISO 639-1 code (e.g. "fr", "de", "ja")
-- Use set_translation to translate content for a locale
+- Use set_translation to translate plain-text content for a locale
+- Use set_rich_text_translation with structured blocks for richText fields (skips hand-assembling Tiptap JSON)
 - Use batch_set_translations for bulk translations
 - Each translation targets a source (page/component/cms) + content_key
 

--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -258,6 +258,74 @@ update_layer_settings({ layer_id: "...", html_embed_code: "<div>Custom HTML</div
 update_layer_iframe({ layer_id: "...", url: "https://www.youtube.com/embed/..." })
 \`\`\`
 
+### Animations & Interactions
+
+Layers can have GSAP-powered animations triggered by user events or scroll. Use the
+preset library for ~80% of cases; drop down to \`set_layer_interactions\` for full control.
+
+**Preset families** (full catalog at \`ycode://reference/animation-presets\`):
+- **Reveal** (scroll-into-view): \`fade-in\`, \`fade-in-up/down/left/right\`, \`scale-in\`
+- **Hover** (auto-yoyo on mouseleave): \`hover-lift\`, \`hover-scale\`, \`hover-fade\`, \`hover-color\`
+- **Click**: \`click-pulse\`, \`click-shake\`
+- **Scroll-scrubbed**: \`parallax-up\`, \`parallax-down\` (tween follows scroll position)
+- **Stagger**: \`scroll-reveal-stagger\` (one tween per target, offset by \`options.stagger\`)
+- **Loop** (infinite on load): \`loop-bounce\`, \`loop-pulse\`, \`loop-spin\`
+
+**Common pattern — fade hero on scroll:**
+\`\`\`
+add_animation({ page_id, layer_id: heroId, preset: "fade-in-up", options: { distance: "60px", duration: 0.8 } })
+\`\`\`
+
+**Card grid that staggers as it scrolls in:**
+\`\`\`
+add_animation({
+  page_id, layer_id: gridId,
+  preset: "scroll-reveal-stagger",
+  targets: [card1, card2, card3, card4],
+  options: { stagger: 0.12 }
+})
+\`\`\`
+
+**Hover a card to lift it AND fade in a CTA inside it** — multi-target:
+\`\`\`
+add_animation({
+  page_id, layer_id: cardId,
+  preset: "hover-lift",
+  targets: [cardId, ctaId],  // one tween per target, same trigger
+  options: { distance: "6px" }
+})
+\`\`\`
+
+**Override the preset's trigger** (rare — most presets pick the right trigger):
+\`\`\`
+add_animation({ page_id, layer_id, preset: "fade-in", trigger: "load" })
+\`\`\`
+
+**Managing animations:**
+- \`list_layer_animations({ page_id, layer_id })\` — see what's attached
+- \`remove_layer_animation({ page_id, layer_id, interaction_id })\` — drop one
+- \`clear_layer_animations({ page_id, layer_id })\` — remove all
+
+**Escape hatch — full GSAP timeline control:**
+\`set_layer_interactions\` replaces the entire \`interactions\` array with raw shapes.
+Use when presets don't fit: custom eases per-tween, exotic timeline positions ("<", ">"),
+mixed apply_styles per property, or compositions a preset can't express.
+
+Tween value formats (see the animation-presets reference for the full table):
+- \`x/y/width/height\`: CSS length string ("100px", "5rem")
+- \`scale\`: unitless string ("1.05")
+- \`rotation\`: degrees ("45deg")
+- \`autoAlpha\`: opacity 0-100 as plain string ("0", "100") — **no % suffix**
+- \`backgroundColor\`: hex/rgb ("#ffffff")
+
+**apply_styles modes** (per-property in the \`from\` state):
+- \`on-load\`: pre-apply the from state on page load. Use for reveal animations to avoid FOUC.
+- \`on-trigger\`: only apply the from state when the trigger fires. Use for hover/click
+  so the element looks normal until interacted with.
+
+The presets pick the right \`apply_styles\` mode automatically; you only need to think
+about it when using \`set_layer_interactions\`.
+
 ### Page Settings
 
 **SEO** — Set meta title, description, OG image, and noindex:

--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -89,7 +89,7 @@ Each layer's \`design\` object controls its appearance. Use update_layer_design 
 - justifyContent: "start" | "end" | "center" | "between" | "around" | "evenly"
 - alignItems: "start" | "end" | "center" | "baseline" | "stretch"
 - gap: CSS value ("16px", "1rem")
-- gridTemplateColumns: "1fr 1fr 1fr", "repeat(3, 1fr)"
+- gridTemplateColumns: "4" (bare integer count, normalized to repeat(N, 1fr)), "1fr 1fr 1fr", "repeat(3, 1fr)"
 
 **typography** — Text styling
 - fontSize: "16px", "48px", "1.25rem"

--- a/lib/mcp/page-layers.ts
+++ b/lib/mcp/page-layers.ts
@@ -1,0 +1,103 @@
+/**
+ * Cached read/write helpers for page layers used by MCP tools.
+ *
+ * Agents typically make 10-50 sequential tool calls against the same page. The
+ * naive `getDraftLayers` → `upsertDraftLayers` pattern hits Supabase twice per
+ * call (once for the tool's read, once inside the repo's write). This module
+ * collapses both:
+ *
+ *   1. Reads are cached per page on `globalThis` with a short TTL. Subsequent
+ *      reads inside a burst skip the DB entirely. The TTL is short enough that
+ *      builder-side edits resync within a few seconds.
+ *
+ *   2. Writes pass the cached `PageLayers` row to `upsertDraftLayers` via its
+ *      `existingDraft` parameter, so the repo skips its own internal read.
+ *      The repo's translation diff still runs against the cached snapshot.
+ *
+ * On any write error we evict the page from the cache so the next read pulls
+ * fresh data from the DB.
+ */
+
+import type { Layer, PageLayers } from '@/types';
+import {
+  getDraftLayers,
+  upsertDraftLayers,
+} from '@/lib/repositories/pageLayersRepository';
+import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
+
+interface CacheEntry {
+  pageLayers: PageLayers;
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5_000;
+
+const globalForPageCache = globalThis as unknown as {
+  __mcpPageLayersCache?: Map<string, CacheEntry>;
+};
+
+const cache = globalForPageCache.__mcpPageLayersCache ?? new Map<string, CacheEntry>();
+globalForPageCache.__mcpPageLayersCache = cache;
+
+function isFresh(entry: CacheEntry | undefined): entry is CacheEntry {
+  return entry !== undefined && entry.expiresAt > Date.now();
+}
+
+/**
+ * Fetch the draft `PageLayers` row for a page, served from the in-memory cache
+ * when fresh. Returns `null` if no draft exists.
+ */
+export async function getCachedDraft(pageId: string): Promise<PageLayers | null> {
+  const cached = cache.get(pageId);
+  if (isFresh(cached)) {
+    return cached.pageLayers;
+  }
+
+  const draft = await getDraftLayers(pageId);
+  if (draft) {
+    cache.set(pageId, { pageLayers: draft, expiresAt: Date.now() + CACHE_TTL_MS });
+  } else {
+    cache.delete(pageId);
+  }
+  return draft;
+}
+
+/**
+ * Convenience: return just the layer tree (or `[]` if no draft).
+ */
+export async function getCachedLayers(pageId: string): Promise<Layer[]> {
+  const draft = await getCachedDraft(pageId);
+  return (draft?.layers as Layer[]) || [];
+}
+
+/**
+ * Save layers for a page and update the cache. Passes the cached `PageLayers`
+ * snapshot to `upsertDraftLayers` so the repo skips its own pre-read.
+ *
+ * On error the cache entry is invalidated so the next read is forced to hit
+ * the database.
+ */
+export async function saveCachedLayers(pageId: string, layers: Layer[]): Promise<PageLayers> {
+  const cached = cache.get(pageId);
+  const existingDraft = isFresh(cached) ? cached.pageLayers : undefined;
+
+  let saved: PageLayers;
+  try {
+    saved = await upsertDraftLayers(pageId, layers, undefined, existingDraft);
+  } catch (error) {
+    cache.delete(pageId);
+    throw error;
+  }
+
+  cache.set(pageId, { pageLayers: saved, expiresAt: Date.now() + CACHE_TTL_MS });
+  broadcastLayersChanged(pageId, layers).catch(() => {});
+  return saved;
+}
+
+/**
+ * Drop the cached entry for a page. Use after operations that change the page
+ * outside this module's awareness (e.g. publishing, deleting).
+ */
+export function invalidateCachedPage(pageId: string): void {
+  cache.delete(pageId);
+}

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -44,6 +44,11 @@ const EXAMPLE_PROMPTS = {
     'Set design inline with add_layer to reduce the number of operations',
     'Use add_font + search_google_fonts to add custom fonts before using them',
     'Always publish after completing changes',
+    'For repeating UI primitives, build a component and use create_component_variant for visual flavors',
+    'For tabular data, add_layer template "table" gives a ready-made structure to populate',
+    'For tables inside rich text, use rich_content { type: "table", rows: [[...]], header_row: true }',
+    'For dynamic pages, update_page is_dynamic + update_page_settings.cms is the canonical wiring path',
+    'For lightbox galleries fed by a CMS image field, set lightbox.files_source "cms" + files_field_id',
   ],
 };
 
@@ -81,6 +86,12 @@ export function registerReferenceResources(server: McpServer) {
               grid: '2x2 CSS Grid layout.',
               collection: 'CMS collection list (repeats children for each item).',
               hr: 'Horizontal divider line.',
+              table: 'Data table (<table>). Ships with header + 2 body rows.',
+              thead: '<thead> — add inside a table.',
+              tbody: '<tbody> — add inside a table.',
+              tr: '<tr> — add inside thead or tbody.',
+              td: '<td> — add inside a tr.',
+              th: '<th> — add inside a thead tr.',
             },
             content: {
               heading: 'Heading text (h1). 48px bold.',
@@ -176,6 +187,21 @@ export function registerReferenceResources(server: McpServer) {
             positioning: {
               position: { type: 'enum', values: ['relative', 'absolute', 'fixed', 'sticky'] },
               zIndex: { type: 'string' },
+            },
+            transforms: {
+              translateX: { type: 'css_value', examples: ['10px', '50%'] },
+              translateY: { type: 'css_value', examples: ['10px', '50%'] },
+              scale: { type: 'css_value', examples: ['1', '1.05', '0.95'] },
+              rotate: { type: 'css_value', examples: ['0deg', '45deg', '-90deg'] },
+              skewX: { type: 'css_value', examples: ['0deg', '10deg'] },
+              skewY: { type: 'css_value', examples: ['0deg', '10deg'] },
+              transformOrigin: { type: 'string', examples: ['center', 'top left'] },
+            },
+            transitions: {
+              transitionProperty: { type: 'string', examples: ['all', 'colors', 'transform'] },
+              transitionDuration: { type: 'css_value', examples: ['150ms', '300ms'] },
+              transitionTimingFunction: { type: 'enum', values: ['linear', 'in', 'out', 'in-out'] },
+              transitionDelay: { type: 'css_value', examples: ['0ms', '100ms'] },
             },
           },
         }, null, 2),

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -150,7 +150,7 @@ export function registerReferenceResources(server: McpServer) {
               justifyContent: { type: 'enum', values: ['start', 'end', 'center', 'between', 'around', 'evenly'] },
               alignItems: { type: 'enum', values: ['start', 'end', 'center', 'baseline', 'stretch'] },
               gap: { type: 'css_value', examples: ['16px', '1rem'] },
-              gridTemplateColumns: { type: 'string', examples: ['1fr 1fr 1fr', 'repeat(3, 1fr)'] },
+              gridTemplateColumns: { type: 'string', examples: ['4', '1fr 1fr 1fr', 'repeat(3, 1fr)'], description: 'A bare integer is accepted and normalized to repeat(N, 1fr).' },
             },
             typography: {
               fontSize: { type: 'css_value', examples: ['16px', '48px'] },

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -53,6 +53,190 @@ const EXAMPLE_PROMPTS = {
   ],
 };
 
+// Reference resources are fully static — their content is derived from compile-time
+// imports (ELEMENT_TEMPLATES, PRESET_CATALOG, ANIMATION_EASES) and inline constants.
+// Stringify them once at module load so every resource read just hands back the
+// cached string instead of re-serializing on every fetch.
+const ELEMENTS_REFERENCE_JSON = JSON.stringify({
+  templates: getAvailableTemplates(),
+  nesting_rules: {
+    cannot_have_children: [
+      'icon', 'image', 'audio', 'video', 'iframe',
+      'text', 'span', 'label', 'hr',
+      'input', 'textarea', 'select', 'checkbox', 'radio',
+      'htmlEmbed',
+    ],
+    section_cannot_contain_section: true,
+    links_cannot_nest: true,
+    component_instances_are_readonly: true,
+  },
+  element_types: {
+    structure: {
+      section: 'Full-width page section.',
+      div: 'Generic container.',
+      container: 'Max-width container (1280px) with padding.',
+      columns: '2-column flexbox layout.',
+      grid: '2x2 CSS Grid layout.',
+      collection: 'CMS collection list (repeats children for each item).',
+      hr: 'Horizontal divider line.',
+      table: 'Data table (<table>). Ships with header + 2 body rows.',
+      thead: '<thead> — add inside a table.',
+      tbody: '<tbody> — add inside a table.',
+      tr: '<tr> — add inside thead or tbody.',
+      td: '<td> — add inside a tr.',
+      th: '<th> — add inside a thead tr.',
+    },
+    content: {
+      heading: 'Heading text (h1). 48px bold.',
+      text: 'Paragraph text (p). 16px.',
+      richText: 'Rich text block. Use set_rich_text_content or rich_content in add_layer.',
+    },
+    media: {
+      image: 'Image element. Use update_layer_image to set asset.',
+      video: 'Video player. Use update_layer_video to set source.',
+      audio: 'Audio player.',
+      icon: 'SVG icon. 24x24px.',
+      iframe: 'Iframe embed. Use update_layer_iframe to set URL.',
+    },
+    interactive: {
+      button: 'Button with text child. Use update_layer_link to set destination.',
+      form: 'Form container.',
+      input: 'Text input.',
+      textarea: 'Multi-line text area.',
+      select: 'Dropdown select input.',
+      checkbox: 'Checkbox input.',
+      radio: 'Radio button input.',
+      filter: 'Collection filter input.',
+      label: 'Form label element.',
+    },
+    utility: {
+      htmlEmbed: 'Custom HTML/CSS/JS code. Set via update_layer_settings.',
+      slider: 'Carousel with navigation, pagination, autoplay. Configure via update_layer_settings.',
+      lightbox: 'Fullscreen gallery with thumbnails, navigation, zoom.',
+      map: 'Interactive map element.',
+      localeSelector: 'Language switcher for multi-language sites.',
+    },
+  },
+});
+
+const DESIGN_REFERENCE_JSON = JSON.stringify({
+  instructions: 'Set isActive: true on any category for it to take effect. Use ui_state parameter for hover/focus/active styles. Use bgGradientVars for gradient backgrounds.',
+  categories: {
+    layout: {
+      display: { type: 'enum', values: ['Flex', 'block', 'inline-block', 'grid', 'hidden'] },
+      flexDirection: { type: 'enum', values: ['row', 'column', 'row-reverse', 'column-reverse'] },
+      justifyContent: { type: 'enum', values: ['start', 'end', 'center', 'between', 'around', 'evenly'] },
+      alignItems: { type: 'enum', values: ['start', 'end', 'center', 'baseline', 'stretch'] },
+      gap: { type: 'css_value', examples: ['16px', '1rem'] },
+      gridTemplateColumns: { type: 'string', examples: ['4', '1fr 1fr 1fr', 'repeat(3, 1fr)'], description: 'A bare integer is accepted and normalized to repeat(N, 1fr).' },
+    },
+    typography: {
+      fontSize: { type: 'css_value', examples: ['16px', '48px'] },
+      fontWeight: { type: 'string', examples: ['400', '600', '700'] },
+      fontFamily: { type: 'string', examples: ['DM Sans', 'Plus Jakarta Sans'] },
+      lineHeight: { type: 'css_value', examples: ['1.1', '1.5'] },
+      letterSpacing: { type: 'css_value', examples: ['-0.03em', '0'] },
+      textAlign: { type: 'enum', values: ['left', 'center', 'right'] },
+      color: { type: 'color', examples: ['#171717', '#ffffff'] },
+    },
+    spacing: { padding: { type: 'css_value' }, margin: { type: 'css_value' } },
+    sizing: {
+      width: { type: 'css_value', examples: ['100%', 'auto'] },
+      maxWidth: { type: 'css_value', examples: ['1280px'] },
+      aspectRatio: { type: 'string', examples: ['16/9', '1/1'] },
+    },
+    borders: {
+      borderRadius: { type: 'css_value', examples: ['12px', '9999px'] },
+      borderWidth: { type: 'css_value' },
+      borderColor: { type: 'color' },
+    },
+    backgrounds: {
+      backgroundColor: { type: 'color', examples: ['#ffffff', '#0a0a0a'] },
+      backgroundClip: { type: 'enum', values: ['text', 'border', 'padding'] },
+      bgGradientVars: {
+        type: 'record',
+        description: 'CSS gradient values keyed by var name. "--bg-img" for desktop neutral.',
+        examples: [{ '--bg-img': 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)' }],
+      },
+    },
+    effects: {
+      opacity: { type: 'string' },
+      boxShadow: { type: 'string' },
+    },
+    positioning: {
+      position: { type: 'enum', values: ['relative', 'absolute', 'fixed', 'sticky'] },
+      zIndex: { type: 'string' },
+    },
+    transforms: {
+      translateX: { type: 'css_value', examples: ['10px', '50%'] },
+      translateY: { type: 'css_value', examples: ['10px', '50%'] },
+      scale: { type: 'css_value', examples: ['1', '1.05', '0.95'] },
+      rotate: { type: 'css_value', examples: ['0deg', '45deg', '-90deg'] },
+      skewX: { type: 'css_value', examples: ['0deg', '10deg'] },
+      skewY: { type: 'css_value', examples: ['0deg', '10deg'] },
+      transformOrigin: { type: 'string', examples: ['center', 'top left'] },
+    },
+    transitions: {
+      transitionProperty: { type: 'string', examples: ['all', 'colors', 'transform'] },
+      transitionDuration: { type: 'css_value', examples: ['150ms', '300ms'] },
+      transitionTimingFunction: { type: 'enum', values: ['linear', 'in', 'out', 'in-out'] },
+      transitionDelay: { type: 'css_value', examples: ['0ms', '100ms'] },
+    },
+  },
+});
+
+const ANIMATION_PRESETS_REFERENCE_JSON = JSON.stringify({
+  instructions: 'Use add_animation with a preset key for the common cases. Drop down to set_layer_interactions only when you need full GSAP control.',
+  presets: PRESET_CATALOG,
+  triggers: {
+    click: 'Fires on user click. Use for affordances (pulse, shake).',
+    hover: 'Fires on mouseenter, reverses on mouseleave. Auto-yoyos so you only define the "to" state.',
+    'scroll-into-view': 'Fires once when the element enters the viewport. Default for reveal presets.',
+    'while-scrolling': 'Tween is scrubbed by scroll position. Set timeline.scrub. Use for parallax / progress effects.',
+    load: 'Fires on page load. Use for loops or on-load entrance choreography.',
+  },
+  eases: ANIMATION_EASES,
+  tween_value_formats: {
+    'x | y | width | height': 'CSS length string with unit ("100px", "50%", "5rem").',
+    scale: 'Unitless number string ("1", "1.05").',
+    'rotation | skewX | skewY': 'Degrees with suffix ("45deg", "-90deg").',
+    autoAlpha: 'Opacity 0-100 as plain string ("0", "100") — no % suffix.',
+    backgroundColor: 'Hex or rgb() string ("#ffffff").',
+    display: '"visible" or "hidden".',
+  },
+  tween_position: {
+    number: 'Absolute time in seconds from timeline start.',
+    '">"': 'Start after the previous tween ends.',
+    '"<"': 'Start with the previous tween (overlap).',
+  },
+  apply_styles_modes: {
+    'on-load': 'Apply the "from" value immediately on page load. Use for reveal animations to avoid FOUC.',
+    'on-trigger': 'Apply the "from" value only when the trigger fires. Use for hover/click (element looks normal until interacted with).',
+  },
+  interaction_shape_example: {
+    id: 'int_xxx (auto-generated if omitted)',
+    trigger: 'scroll-into-view',
+    timeline: {
+      breakpoints: ['desktop', 'tablet', 'mobile'],
+      repeat: 0,
+      yoyo: false,
+      toggleActions: 'play none none none',
+    },
+    tweens: [{
+      id: 'twn_xxx (auto-generated if omitted)',
+      layer_id: 'lyr_xxx',
+      position: 0,
+      duration: 0.6,
+      ease: 'power1.out',
+      from: { autoAlpha: '0', y: '40px' },
+      to: { autoAlpha: '100', y: '0px' },
+      apply_styles: { autoAlpha: 'on-load', y: 'on-load' },
+    }],
+  },
+});
+
+const PROMPTS_REFERENCE_JSON = JSON.stringify(EXAMPLE_PROMPTS);
+
 export function registerReferenceResources(server: McpServer) {
   server.resource(
     'elements-reference',
@@ -65,67 +249,7 @@ export function registerReferenceResources(server: McpServer) {
       contents: [{
         uri: 'ycode://reference/elements',
         mimeType: 'application/json',
-        text: JSON.stringify({
-          templates: getAvailableTemplates(),
-          nesting_rules: {
-            cannot_have_children: [
-              'icon', 'image', 'audio', 'video', 'iframe',
-              'text', 'span', 'label', 'hr',
-              'input', 'textarea', 'select', 'checkbox', 'radio',
-              'htmlEmbed',
-            ],
-            section_cannot_contain_section: true,
-            links_cannot_nest: true,
-            component_instances_are_readonly: true,
-          },
-          element_types: {
-            structure: {
-              section: 'Full-width page section.',
-              div: 'Generic container.',
-              container: 'Max-width container (1280px) with padding.',
-              columns: '2-column flexbox layout.',
-              grid: '2x2 CSS Grid layout.',
-              collection: 'CMS collection list (repeats children for each item).',
-              hr: 'Horizontal divider line.',
-              table: 'Data table (<table>). Ships with header + 2 body rows.',
-              thead: '<thead> — add inside a table.',
-              tbody: '<tbody> — add inside a table.',
-              tr: '<tr> — add inside thead or tbody.',
-              td: '<td> — add inside a tr.',
-              th: '<th> — add inside a thead tr.',
-            },
-            content: {
-              heading: 'Heading text (h1). 48px bold.',
-              text: 'Paragraph text (p). 16px.',
-              richText: 'Rich text block. Use set_rich_text_content or rich_content in add_layer.',
-            },
-            media: {
-              image: 'Image element. Use update_layer_image to set asset.',
-              video: 'Video player. Use update_layer_video to set source.',
-              audio: 'Audio player.',
-              icon: 'SVG icon. 24x24px.',
-              iframe: 'Iframe embed. Use update_layer_iframe to set URL.',
-            },
-            interactive: {
-              button: 'Button with text child. Use update_layer_link to set destination.',
-              form: 'Form container.',
-              input: 'Text input.',
-              textarea: 'Multi-line text area.',
-              select: 'Dropdown select input.',
-              checkbox: 'Checkbox input.',
-              radio: 'Radio button input.',
-              filter: 'Collection filter input.',
-              label: 'Form label element.',
-            },
-            utility: {
-              htmlEmbed: 'Custom HTML/CSS/JS code. Set via update_layer_settings.',
-              slider: 'Carousel with navigation, pagination, autoplay. Configure via update_layer_settings.',
-              lightbox: 'Fullscreen gallery with thumbnails, navigation, zoom.',
-              map: 'Interactive map element.',
-              localeSelector: 'Language switcher for multi-language sites.',
-            },
-          },
-        }),
+        text: ELEMENTS_REFERENCE_JSON,
       }],
     }),
   );
@@ -141,71 +265,7 @@ export function registerReferenceResources(server: McpServer) {
       contents: [{
         uri: 'ycode://reference/design-properties',
         mimeType: 'application/json',
-        text: JSON.stringify({
-          instructions: 'Set isActive: true on any category for it to take effect. Use ui_state parameter for hover/focus/active styles. Use bgGradientVars for gradient backgrounds.',
-          categories: {
-            layout: {
-              display: { type: 'enum', values: ['Flex', 'block', 'inline-block', 'grid', 'hidden'] },
-              flexDirection: { type: 'enum', values: ['row', 'column', 'row-reverse', 'column-reverse'] },
-              justifyContent: { type: 'enum', values: ['start', 'end', 'center', 'between', 'around', 'evenly'] },
-              alignItems: { type: 'enum', values: ['start', 'end', 'center', 'baseline', 'stretch'] },
-              gap: { type: 'css_value', examples: ['16px', '1rem'] },
-              gridTemplateColumns: { type: 'string', examples: ['4', '1fr 1fr 1fr', 'repeat(3, 1fr)'], description: 'A bare integer is accepted and normalized to repeat(N, 1fr).' },
-            },
-            typography: {
-              fontSize: { type: 'css_value', examples: ['16px', '48px'] },
-              fontWeight: { type: 'string', examples: ['400', '600', '700'] },
-              fontFamily: { type: 'string', examples: ['DM Sans', 'Plus Jakarta Sans'] },
-              lineHeight: { type: 'css_value', examples: ['1.1', '1.5'] },
-              letterSpacing: { type: 'css_value', examples: ['-0.03em', '0'] },
-              textAlign: { type: 'enum', values: ['left', 'center', 'right'] },
-              color: { type: 'color', examples: ['#171717', '#ffffff'] },
-            },
-            spacing: { padding: { type: 'css_value' }, margin: { type: 'css_value' } },
-            sizing: {
-              width: { type: 'css_value', examples: ['100%', 'auto'] },
-              maxWidth: { type: 'css_value', examples: ['1280px'] },
-              aspectRatio: { type: 'string', examples: ['16/9', '1/1'] },
-            },
-            borders: {
-              borderRadius: { type: 'css_value', examples: ['12px', '9999px'] },
-              borderWidth: { type: 'css_value' },
-              borderColor: { type: 'color' },
-            },
-            backgrounds: {
-              backgroundColor: { type: 'color', examples: ['#ffffff', '#0a0a0a'] },
-              backgroundClip: { type: 'enum', values: ['text', 'border', 'padding'] },
-              bgGradientVars: {
-                type: 'record',
-                description: 'CSS gradient values keyed by var name. "--bg-img" for desktop neutral.',
-                examples: [{ '--bg-img': 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)' }],
-              },
-            },
-            effects: {
-              opacity: { type: 'string' },
-              boxShadow: { type: 'string' },
-            },
-            positioning: {
-              position: { type: 'enum', values: ['relative', 'absolute', 'fixed', 'sticky'] },
-              zIndex: { type: 'string' },
-            },
-            transforms: {
-              translateX: { type: 'css_value', examples: ['10px', '50%'] },
-              translateY: { type: 'css_value', examples: ['10px', '50%'] },
-              scale: { type: 'css_value', examples: ['1', '1.05', '0.95'] },
-              rotate: { type: 'css_value', examples: ['0deg', '45deg', '-90deg'] },
-              skewX: { type: 'css_value', examples: ['0deg', '10deg'] },
-              skewY: { type: 'css_value', examples: ['0deg', '10deg'] },
-              transformOrigin: { type: 'string', examples: ['center', 'top left'] },
-            },
-            transitions: {
-              transitionProperty: { type: 'string', examples: ['all', 'colors', 'transform'] },
-              transitionDuration: { type: 'css_value', examples: ['150ms', '300ms'] },
-              transitionTimingFunction: { type: 'enum', values: ['linear', 'in', 'out', 'in-out'] },
-              transitionDelay: { type: 'css_value', examples: ['0ms', '100ms'] },
-            },
-          },
-        }),
+        text: DESIGN_REFERENCE_JSON,
       }],
     }),
   );
@@ -221,55 +281,7 @@ export function registerReferenceResources(server: McpServer) {
       contents: [{
         uri: 'ycode://reference/animation-presets',
         mimeType: 'application/json',
-        text: JSON.stringify({
-          instructions: 'Use add_animation with a preset key for the common cases. Drop down to set_layer_interactions only when you need full GSAP control.',
-          presets: PRESET_CATALOG,
-          triggers: {
-            click: 'Fires on user click. Use for affordances (pulse, shake).',
-            hover: 'Fires on mouseenter, reverses on mouseleave. Auto-yoyos so you only define the "to" state.',
-            'scroll-into-view': 'Fires once when the element enters the viewport. Default for reveal presets.',
-            'while-scrolling': 'Tween is scrubbed by scroll position. Set timeline.scrub. Use for parallax / progress effects.',
-            load: 'Fires on page load. Use for loops or on-load entrance choreography.',
-          },
-          eases: ANIMATION_EASES,
-          tween_value_formats: {
-            'x | y | width | height': 'CSS length string with unit ("100px", "50%", "5rem").',
-            scale: 'Unitless number string ("1", "1.05").',
-            'rotation | skewX | skewY': 'Degrees with suffix ("45deg", "-90deg").',
-            autoAlpha: 'Opacity 0-100 as plain string ("0", "100") — no % suffix.',
-            backgroundColor: 'Hex or rgb() string ("#ffffff").',
-            display: '"visible" or "hidden".',
-          },
-          tween_position: {
-            number: 'Absolute time in seconds from timeline start.',
-            '">"': 'Start after the previous tween ends.',
-            '"<"': 'Start with the previous tween (overlap).',
-          },
-          apply_styles_modes: {
-            'on-load': 'Apply the "from" value immediately on page load. Use for reveal animations to avoid FOUC.',
-            'on-trigger': 'Apply the "from" value only when the trigger fires. Use for hover/click (element looks normal until interacted with).',
-          },
-          interaction_shape_example: {
-            id: 'int_xxx (auto-generated if omitted)',
-            trigger: 'scroll-into-view',
-            timeline: {
-              breakpoints: ['desktop', 'tablet', 'mobile'],
-              repeat: 0,
-              yoyo: false,
-              toggleActions: 'play none none none',
-            },
-            tweens: [{
-              id: 'twn_xxx (auto-generated if omitted)',
-              layer_id: 'lyr_xxx',
-              position: 0,
-              duration: 0.6,
-              ease: 'power1.out',
-              from: { autoAlpha: '0', y: '40px' },
-              to: { autoAlpha: '100', y: '0px' },
-              apply_styles: { autoAlpha: 'on-load', y: 'on-load' },
-            }],
-          },
-        }),
+        text: ANIMATION_PRESETS_REFERENCE_JSON,
       }],
     }),
   );
@@ -285,7 +297,7 @@ export function registerReferenceResources(server: McpServer) {
       contents: [{
         uri: 'ycode://reference/prompts',
         mimeType: 'application/json',
-        text: JSON.stringify(EXAMPLE_PROMPTS),
+        text: PROMPTS_REFERENCE_JSON,
       }],
     }),
   );

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ELEMENT_TEMPLATES } from '@/lib/mcp/utils';
+import { ANIMATION_EASES, PRESET_CATALOG } from '@/lib/mcp/animation-presets';
 
 function getAvailableTemplates() {
   return Object.entries(ELEMENT_TEMPLATES).map(([key, t]) => ({
@@ -177,6 +178,70 @@ export function registerReferenceResources(server: McpServer) {
               position: { type: 'enum', values: ['relative', 'absolute', 'fixed', 'sticky'] },
               zIndex: { type: 'string' },
             },
+          },
+        }, null, 2),
+      }],
+    }),
+  );
+
+  server.resource(
+    'animation-presets-reference',
+    'ycode://reference/animation-presets',
+    {
+      description: 'Animation preset catalog: keys, default triggers/durations/eases, plus the raw LayerInteraction shape for set_layer_interactions',
+      mimeType: 'application/json',
+    },
+    async () => ({
+      contents: [{
+        uri: 'ycode://reference/animation-presets',
+        mimeType: 'application/json',
+        text: JSON.stringify({
+          instructions: 'Use add_animation with a preset key for the common cases. Drop down to set_layer_interactions only when you need full GSAP control.',
+          presets: PRESET_CATALOG,
+          triggers: {
+            click: 'Fires on user click. Use for affordances (pulse, shake).',
+            hover: 'Fires on mouseenter, reverses on mouseleave. Auto-yoyos so you only define the "to" state.',
+            'scroll-into-view': 'Fires once when the element enters the viewport. Default for reveal presets.',
+            'while-scrolling': 'Tween is scrubbed by scroll position. Set timeline.scrub. Use for parallax / progress effects.',
+            load: 'Fires on page load. Use for loops or on-load entrance choreography.',
+          },
+          eases: ANIMATION_EASES,
+          tween_value_formats: {
+            'x | y | width | height': 'CSS length string with unit ("100px", "50%", "5rem").',
+            scale: 'Unitless number string ("1", "1.05").',
+            'rotation | skewX | skewY': 'Degrees with suffix ("45deg", "-90deg").',
+            autoAlpha: 'Opacity 0-100 as plain string ("0", "100") — no % suffix.',
+            backgroundColor: 'Hex or rgb() string ("#ffffff").',
+            display: '"visible" or "hidden".',
+          },
+          tween_position: {
+            number: 'Absolute time in seconds from timeline start.',
+            '">"': 'Start after the previous tween ends.',
+            '"<"': 'Start with the previous tween (overlap).',
+          },
+          apply_styles_modes: {
+            'on-load': 'Apply the "from" value immediately on page load. Use for reveal animations to avoid FOUC.',
+            'on-trigger': 'Apply the "from" value only when the trigger fires. Use for hover/click (element looks normal until interacted with).',
+          },
+          interaction_shape_example: {
+            id: 'int_xxx (auto-generated if omitted)',
+            trigger: 'scroll-into-view',
+            timeline: {
+              breakpoints: ['desktop', 'tablet', 'mobile'],
+              repeat: 0,
+              yoyo: false,
+              toggleActions: 'play none none none',
+            },
+            tweens: [{
+              id: 'twn_xxx (auto-generated if omitted)',
+              layer_id: 'lyr_xxx',
+              position: 0,
+              duration: 0.6,
+              ease: 'power1.out',
+              from: { autoAlpha: '0', y: '40px' },
+              to: { autoAlpha: '100', y: '0px' },
+              apply_styles: { autoAlpha: 'on-load', y: 'on-load' },
+            }],
           },
         }, null, 2),
       }],

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -125,7 +125,7 @@ export function registerReferenceResources(server: McpServer) {
               localeSelector: 'Language switcher for multi-language sites.',
             },
           },
-        }, null, 2),
+        }),
       }],
     }),
   );
@@ -205,7 +205,7 @@ export function registerReferenceResources(server: McpServer) {
               transitionDelay: { type: 'css_value', examples: ['0ms', '100ms'] },
             },
           },
-        }, null, 2),
+        }),
       }],
     }),
   );
@@ -269,7 +269,7 @@ export function registerReferenceResources(server: McpServer) {
               apply_styles: { autoAlpha: 'on-load', y: 'on-load' },
             }],
           },
-        }, null, 2),
+        }),
       }],
     }),
   );
@@ -285,7 +285,7 @@ export function registerReferenceResources(server: McpServer) {
       contents: [{
         uri: 'ycode://reference/prompts',
         mimeType: 'application/json',
-        text: JSON.stringify(EXAMPLE_PROMPTS, null, 2),
+        text: JSON.stringify(EXAMPLE_PROMPTS),
       }],
     }),
   );

--- a/lib/mcp/resources/site.ts
+++ b/lib/mcp/resources/site.ts
@@ -39,7 +39,7 @@ export function registerSiteResources(server: McpServer) {
               name: f.name,
               parent_id: f.page_folder_id,
             })),
-          }, null, 2),
+          }),
         }],
       };
     },
@@ -77,7 +77,7 @@ export function registerSiteResources(server: McpServer) {
         contents: [{
           uri: 'ycode://site/collections',
           mimeType: 'application/json',
-          text: JSON.stringify(schema, null, 2),
+          text: JSON.stringify(schema),
         }],
       };
     },
@@ -121,7 +121,7 @@ export function registerSiteResources(server: McpServer) {
               label: l.label,
               is_default: l.is_default,
             })),
-          }, null, 2),
+          }),
         }],
       };
     },

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -28,7 +28,7 @@ import { registerSiteResources } from '@/lib/mcp/resources/site';
 
 export function createMcpServer(): McpServer {
   const server = new McpServer(
-    { name: 'ycode', version: '0.4.0' },
+    { name: 'ycode', version: '0.5.0' },
     { instructions: SYSTEM_INSTRUCTIONS },
   );
 

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -28,7 +28,7 @@ import { registerSiteResources } from '@/lib/mcp/resources/site';
 
 export function createMcpServer(): McpServer {
   const server = new McpServer(
-    { name: 'ycode', version: '0.4.0' },
+    { name: 'ycode', version: '1.0.0' },
     { instructions: SYSTEM_INSTRUCTIONS },
   );
 

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -23,6 +23,7 @@ import { registerLocaleTools } from '@/lib/mcp/tools/locales';
 import { registerFormTools } from '@/lib/mcp/tools/forms';
 import { registerSettingsTools } from '@/lib/mcp/tools/settings';
 import { registerPublishingTools } from '@/lib/mcp/tools/publishing';
+import { registerAnimationTools } from '@/lib/mcp/tools/animations';
 import { registerReferenceResources } from '@/lib/mcp/resources/reference';
 import { registerSiteResources } from '@/lib/mcp/resources/site';
 
@@ -48,6 +49,7 @@ export function createMcpServer(): McpServer {
   registerFormTools(server);
   registerSettingsTools(server);
   registerPublishingTools(server);
+  registerAnimationTools(server);
 
   registerReferenceResources(server);
   registerSiteResources(server);

--- a/lib/mcp/tools/animations.ts
+++ b/lib/mcp/tools/animations.ts
@@ -1,0 +1,304 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { Layer, LayerInteraction } from '@/types';
+import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
+import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
+import { findLayerById, updateLayerById, generateId } from '@/lib/mcp/utils';
+import {
+  ANIMATION_EASES,
+  ANIMATION_PRESETS,
+  buildInteractionFromPreset,
+} from '@/lib/mcp/animation-presets';
+
+async function getPageLayers(pageId: string): Promise<Layer[]> {
+  const pageLayers = await getDraftLayers(pageId);
+  return (pageLayers?.layers as Layer[]) || [];
+}
+
+async function savePageLayers(pageId: string, layers: Layer[]): Promise<void> {
+  await upsertDraftLayers(pageId, layers);
+  broadcastLayersChanged(pageId, layers).catch(() => {});
+}
+
+const presetEnum = z.enum(ANIMATION_PRESETS);
+const triggerEnum = z.enum(['click', 'hover', 'scroll-into-view', 'while-scrolling', 'load']);
+const easeEnum = z.enum(ANIMATION_EASES);
+const breakpointEnum = z.enum(['desktop', 'tablet', 'mobile']);
+
+const tweenPropertyKeyEnum = z.enum([
+  'x', 'y', 'rotation', 'scale', 'skewX', 'skewY',
+  'autoAlpha', 'display', 'width', 'height', 'backgroundColor',
+]);
+
+const tweenPropertiesSchema = z.object({
+  x: z.string().nullable().optional(),
+  y: z.string().nullable().optional(),
+  rotation: z.string().nullable().optional(),
+  scale: z.string().nullable().optional(),
+  skewX: z.string().nullable().optional(),
+  skewY: z.string().nullable().optional(),
+  autoAlpha: z.string().nullable().optional().describe('Opacity 0-100 as a string (e.g. "0", "100"). Stored without unit.'),
+  display: z.string().nullable().optional().describe('"visible" or "hidden".'),
+  width: z.string().nullable().optional(),
+  height: z.string().nullable().optional(),
+  backgroundColor: z.string().nullable().optional().describe('Hex / rgb color.'),
+});
+
+const tweenSchema = z.object({
+  id: z.string().optional().describe('Leave blank to auto-generate.'),
+  layer_id: z.string().describe('Layer the tween animates. Can differ from the interaction owner.'),
+  position: z.union([z.number(), z.string()])
+    .describe('GSAP timeline position. Number = seconds, ">" = after previous, "<" = with previous.'),
+  duration: z.number().describe('Tween duration in seconds.'),
+  ease: easeEnum.describe('GSAP ease.'),
+  from: tweenPropertiesSchema,
+  to: tweenPropertiesSchema,
+  apply_styles: z.record(tweenPropertyKeyEnum, z.enum(['on-load', 'on-trigger']))
+    .optional()
+    .describe('Per-property: "on-load" pre-applies the from state immediately (prevents FOUC on reveals). "on-trigger" defers until the trigger fires.'),
+});
+
+const interactionSchema = z.object({
+  id: z.string().optional().describe('Leave blank to auto-generate.'),
+  trigger: triggerEnum,
+  timeline: z.object({
+    breakpoints: z.array(breakpointEnum).describe('Which breakpoints the animation runs on.'),
+    repeat: z.number().describe('-1 = infinite, 0 = none, n = repeat n times.'),
+    yoyo: z.boolean().describe('Reverse direction on each repeat.'),
+    scrollStart: z.string().optional().describe('Scroll trigger start (e.g. "top 80%"). For scroll-into-view / while-scrolling.'),
+    scrollEnd: z.string().optional().describe('Scroll trigger end (e.g. "bottom top"). For while-scrolling.'),
+    scrub: z.union([z.boolean(), z.number()]).optional().describe('while-scrolling: true for direct link, number for smoothing seconds.'),
+    toggleActions: z.string().optional().describe('scroll-into-view: GSAP toggleActions (default "play none none none").'),
+  }),
+  tweens: z.array(tweenSchema).min(1),
+});
+
+function ensureIds(interaction: z.infer<typeof interactionSchema>): LayerInteraction {
+  return {
+    id: interaction.id || generateId('int'),
+    trigger: interaction.trigger,
+    timeline: interaction.timeline,
+    tweens: interaction.tweens.map((t) => ({
+      id: t.id || generateId('twn'),
+      layer_id: t.layer_id,
+      position: t.position,
+      duration: t.duration,
+      ease: t.ease,
+      from: t.from,
+      to: t.to,
+      apply_styles: t.apply_styles || {},
+    })),
+  };
+}
+
+export function registerAnimationTools(server: McpServer) {
+  server.tool(
+    'add_animation',
+    `Add a curated animation to a layer using one of YCode's preset patterns.
+
+Presets cover ~80% of animation needs. Use set_layer_interactions for full GSAP control.
+
+PRESETS:
+- Reveal (default trigger scroll-into-view): fade-in, fade-in-up, fade-in-down,
+  fade-in-left, fade-in-right, scale-in
+- Hover (forced trigger hover): hover-lift, hover-scale, hover-fade, hover-color
+- Click (forced trigger click): click-pulse, click-shake
+- Scroll (forced trigger while-scrolling, scrubbed by scroll position): parallax-up, parallax-down
+- Stagger (default trigger scroll-into-view): scroll-reveal-stagger (one tween per target,
+  offset by options.stagger seconds — pass multiple targets!)
+- Loop (default trigger load, infinite): loop-bounce, loop-pulse, loop-spin
+
+The animation is owned by layer_id but each tween can target a different layer via targets[].
+This enables card-hover patterns where hovering one element animates several.
+
+Options vary by preset:
+- duration / delay / ease — work on every preset
+- distance — fade-in-*, parallax-*, click-shake, loop-bounce, hover-lift (e.g. "40px", "5rem")
+- scale_to — hover-scale, click-pulse, loop-pulse (e.g. 1.05)
+- background_color — hover-color (hex / rgb)
+- stagger — scroll-reveal-stagger (seconds between targets, default 0.1)
+- repeat — override the preset's default repeat (e.g. force loop-spin to play 3 times)`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('Layer that owns the animation (and the default target)'),
+      preset: presetEnum,
+      trigger: triggerEnum.optional()
+        .describe('Override the preset\'s default trigger. Rare — most presets have the right trigger baked in.'),
+      targets: z.array(z.string()).optional()
+        .describe('Layers the tweens animate. Defaults to [layer_id]. Pass multiple for card-hover patterns or scroll-reveal-stagger.'),
+      options: z.object({
+        duration: z.number().optional(),
+        delay: z.number().optional(),
+        distance: z.string().optional().describe('CSS length (e.g. "40px", "5rem", "20%")'),
+        ease: easeEnum.optional(),
+        scale_to: z.number().optional(),
+        background_color: z.string().optional(),
+        stagger: z.number().optional(),
+        repeat: z.number().optional(),
+      }).optional(),
+    },
+    async ({ page_id, layer_id, preset, trigger, targets, options }) => {
+      const layers = await getPageLayers(page_id);
+      const owner = findLayerById(layers, layer_id);
+      if (!owner) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+
+      if (targets && targets.length > 0) {
+        for (const targetId of targets) {
+          if (!findLayerById(layers, targetId)) {
+            return { content: [{ type: 'text' as const, text: `Error: Target layer "${targetId}" not found.` }], isError: true };
+          }
+        }
+      }
+
+      const interaction = buildInteractionFromPreset({
+        preset,
+        ownerLayerId: layer_id,
+        trigger,
+        targets,
+        options,
+      });
+
+      const updated = updateLayerById(layers, layer_id, (l) => ({
+        ...l,
+        interactions: [...(l.interactions || []), interaction],
+      }));
+
+      await savePageLayers(page_id, updated);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            message: `Added "${preset}" animation to "${owner.customName || owner.name}"`,
+            interaction_id: interaction.id,
+            tween_count: interaction.tweens.length,
+          }, null, 2),
+        }],
+      };
+    },
+  );
+
+  server.tool(
+    'list_layer_animations',
+    'List all animations attached to a layer with their triggers and tween summaries.',
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer ID'),
+    },
+    async ({ page_id, layer_id }) => {
+      const layers = await getPageLayers(page_id);
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+      const interactions = (layer.interactions || []).map((i) => ({
+        id: i.id,
+        trigger: i.trigger,
+        timeline: i.timeline,
+        tween_count: i.tweens.length,
+        targets: Array.from(new Set(i.tweens.map((t) => t.layer_id))),
+      }));
+      return { content: [{ type: 'text' as const, text: JSON.stringify(interactions, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'remove_layer_animation',
+    'Remove a single animation from a layer by its interaction ID.',
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer ID'),
+      interaction_id: z.string().describe('The interaction ID to remove'),
+    },
+    async ({ page_id, layer_id, interaction_id }) => {
+      const layers = await getPageLayers(page_id);
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+      const existing = layer.interactions || [];
+      const next = existing.filter((i) => i.id !== interaction_id);
+      if (next.length === existing.length) {
+        return { content: [{ type: 'text' as const, text: `Error: Interaction "${interaction_id}" not found on this layer.` }], isError: true };
+      }
+
+      const updated = updateLayerById(layers, layer_id, (l) => ({ ...l, interactions: next }));
+      await savePageLayers(page_id, updated);
+      return { content: [{ type: 'text' as const, text: `Removed interaction "${interaction_id}"` }] };
+    },
+  );
+
+  server.tool(
+    'clear_layer_animations',
+    'Remove all animations from a layer.',
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer ID'),
+    },
+    async ({ page_id, layer_id }) => {
+      const layers = await getPageLayers(page_id);
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+      const removed = (layer.interactions || []).length;
+      const updated = updateLayerById(layers, layer_id, (l) => ({ ...l, interactions: [] }));
+      await savePageLayers(page_id, updated);
+      return { content: [{ type: 'text' as const, text: `Cleared ${removed} animation(s) from "${layer.customName || layer.name}"` }] };
+    },
+  );
+
+  server.tool(
+    'set_layer_interactions',
+    `Raw escape hatch: replace a layer's entire \`interactions\` array with the full LayerInteraction
+shape. Use when add_animation's presets aren't expressive enough — custom timelines,
+exotic eases, per-property apply_styles, multi-target stagger compositions, etc.
+
+Refer to ycode://reference/animation-presets for the preset catalog and trigger semantics.
+
+Each interaction has:
+- trigger: click | hover | scroll-into-view | while-scrolling | load
+- timeline: { breakpoints, repeat, yoyo, scrollStart?, scrollEnd?, scrub?, toggleActions? }
+- tweens: [{ layer_id, position, duration, ease, from, to, apply_styles? }]
+
+Tween value formats:
+- x/y/width/height/distance: "100px", "50%", "5rem"
+- scale: "1", "1.05" (no unit)
+- rotation/skewX/skewY: "45deg", "-90deg"
+- autoAlpha (opacity): "0" to "100" (no % suffix)
+- backgroundColor: "#ffffff" or "rgb(0,0,0)"
+- display: "visible" | "hidden"
+
+position can be a number (seconds), ">" (after previous), or "<" (with previous).`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer ID'),
+      interactions: z.array(interactionSchema)
+        .describe('Replaces the entire interactions array. Pass [] to clear (or use clear_layer_animations).'),
+    },
+    async ({ page_id, layer_id, interactions }) => {
+      const layers = await getPageLayers(page_id);
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+
+      const normalized = interactions.map(ensureIds);
+
+      const updated = updateLayerById(layers, layer_id, (l) => ({ ...l, interactions: normalized }));
+      await savePageLayers(page_id, updated);
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            message: `Set ${normalized.length} interaction(s) on "${layer.customName || layer.name}"`,
+            interaction_ids: normalized.map((i) => i.id),
+          }, null, 2),
+        }],
+      };
+    },
+  );
+}

--- a/lib/mcp/tools/animations.ts
+++ b/lib/mcp/tools/animations.ts
@@ -2,8 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { Layer, LayerInteraction } from '@/types';
-import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
-import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
+import { getCachedLayers as getPageLayers, saveCachedLayers } from '@/lib/mcp/page-layers';
 import { findLayerById, updateLayerById, generateId } from '@/lib/mcp/utils';
 import {
   ANIMATION_EASES,
@@ -11,14 +10,8 @@ import {
   buildInteractionFromPreset,
 } from '@/lib/mcp/animation-presets';
 
-async function getPageLayers(pageId: string): Promise<Layer[]> {
-  const pageLayers = await getDraftLayers(pageId);
-  return (pageLayers?.layers as Layer[]) || [];
-}
-
 async function savePageLayers(pageId: string, layers: Layer[]): Promise<void> {
-  await upsertDraftLayers(pageId, layers);
-  broadcastLayersChanged(pageId, layers).catch(() => {});
+  await saveCachedLayers(pageId, layers);
 }
 
 const presetEnum = z.enum(ANIMATION_PRESETS);

--- a/lib/mcp/tools/animations.ts
+++ b/lib/mcp/tools/animations.ts
@@ -174,7 +174,7 @@ Options vary by preset:
             message: `Added "${preset}" animation to "${owner.customName || owner.name}"`,
             interaction_id: interaction.id,
             tween_count: interaction.tweens.length,
-          }, null, 2),
+          }),
         }],
       };
     },
@@ -200,7 +200,7 @@ Options vary by preset:
         tween_count: i.tweens.length,
         targets: Array.from(new Set(i.tweens.map((t) => t.layer_id))),
       }));
-      return { content: [{ type: 'text' as const, text: JSON.stringify(interactions, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(interactions) }] };
     },
   );
 
@@ -296,7 +296,7 @@ position can be a number (seconds), ">" (after previous), or "<" (with previous)
           text: JSON.stringify({
             message: `Set ${normalized.length} interaction(s) on "${layer.customName || layer.name}"`,
             interaction_ids: normalized.map((i) => i.id),
-          }, null, 2),
+          }),
         }],
       };
     },

--- a/lib/mcp/tools/assets.ts
+++ b/lib/mcp/tools/assets.ts
@@ -19,7 +19,7 @@ export function registerAssetTools(server: McpServer) {
         height: a.height,
       }));
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(summary) }],
       };
     },
   );
@@ -85,7 +85,7 @@ Use base64_data for images generated locally (e.g. AI-generated images in a sand
               public_url: asset.public_url,
               width: asset.width,
               height: asset.height,
-            }, null, 2),
+            }),
           }],
         };
       } catch (err) {
@@ -105,7 +105,7 @@ Use base64_data for images generated locally (e.g. AI-generated images in a sand
       if (!asset) {
         return { content: [{ type: 'text' as const, text: `Error: Asset "${asset_id}" not found.` }], isError: true };
       }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(asset, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(asset) }] };
     },
   );
 
@@ -123,7 +123,7 @@ Use base64_data for images generated locally (e.g. AI-generated images in a sand
       if (folder_id !== undefined) updates.asset_folder_id = folder_id;
 
       const asset = await updateAsset(asset_id, updates);
-      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: `Updated asset "${asset.filename}"`, asset }, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: `Updated asset "${asset.filename}"`, asset }) }] };
     },
   );
 

--- a/lib/mcp/tools/batch.ts
+++ b/lib/mcp/tools/batch.ts
@@ -13,22 +13,10 @@ import {
   getTiptapTextContent,
   buildTiptapDoc,
   applyDesignToLayer,
-  ELEMENT_TEMPLATES,
 } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
 import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
-import { designSchema } from './shared-schemas';
-
-const templateEnum = z.enum(
-  Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
-);
-
-const richTextBlockSchema = z.object({
-  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
-  text: z.string().optional(),
-  level: z.number().optional(),
-  items: z.array(z.string()).optional(),
-});
+import { designSchema, richTextBlockSchema, templateEnum } from './shared-schemas';
 
 const addLayerOp = z.object({
   type: z.literal('add_layer'),

--- a/lib/mcp/tools/batch.ts
+++ b/lib/mcp/tools/batch.ts
@@ -24,10 +24,22 @@ const templateEnum = z.enum(
 );
 
 const richTextBlockSchema = z.object({
-  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
-  text: z.string().optional(),
-  level: z.number().optional(),
-  items: z.array(z.string()).optional(),
+  type: z.enum([
+    'paragraph', 'heading', 'blockquote',
+    'bulletList', 'orderedList',
+    'codeBlock', 'horizontalRule',
+    'htmlEmbed', 'image', 'table', 'component',
+  ]),
+  text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
+  level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
+  items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
+  code: z.string().optional().describe('For htmlEmbed: the HTML/JS code to embed'),
+  src: z.string().optional().describe('For image: external image URL (use asset_id for uploaded assets)'),
+  alt: z.string().optional().describe('For image: alt text'),
+  asset_id: z.string().optional().describe('For image: asset ID from upload_asset'),
+  rows: z.array(z.array(z.string())).optional().describe('For table: 2D array of cell text. Inline marks (**bold** etc.) work in each cell.'),
+  header_row: z.boolean().optional().describe('For table: whether the first row should render as table headers. Defaults true.'),
+  component_id: z.string().optional().describe('For component: ID of the component to embed'),
 });
 
 const addLayerOp = z.object({

--- a/lib/mcp/tools/batch.ts
+++ b/lib/mcp/tools/batch.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Layer, Breakpoint, UIState } from '@/types';
-import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
 import {
   findLayerById,
   updateLayerById,
@@ -15,7 +14,7 @@ import {
   applyDesignToLayer,
 } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
-import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
+import { getCachedLayers, saveCachedLayers } from '@/lib/mcp/page-layers';
 import { designSchema, richTextBlockSchema, templateEnum } from './shared-schemas';
 
 const addLayerOp = z.object({
@@ -106,8 +105,7 @@ EXAMPLE:
       operations: z.array(operationSchema).min(1).max(50).describe('Array of operations to execute in order'),
     },
     async ({ page_id, operations }) => {
-      const pageLayers = await getDraftLayers(page_id);
-      let layers = (pageLayers?.layers as Layer[]) || [];
+      let layers = await getCachedLayers(page_id);
 
       const refMap = new Map<string, string>();
       const results: Array<{ op: number; status: string; detail: string }> = [];
@@ -241,11 +239,10 @@ EXAMPLE:
 
       const errors = results.filter((r) => r.status === 'error');
       if (errors.length === operations.length) {
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'All operations failed', results }, null, 2) }], isError: true };
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'All operations failed', results }) }], isError: true };
       }
 
-      await upsertDraftLayers(page_id, layers);
-      broadcastLayersChanged(page_id, layers).catch(() => {});
+      await saveCachedLayers(page_id, layers);
 
       const refEntries = Object.fromEntries(refMap);
       return {
@@ -255,7 +252,7 @@ EXAMPLE:
             message: `Executed ${results.filter((r) => r.status === 'ok').length}/${operations.length} operations`,
             ref_ids: Object.keys(refEntries).length > 0 ? refEntries : undefined,
             results,
-          }, null, 2),
+          }),
         }],
       };
     },

--- a/lib/mcp/tools/collections.ts
+++ b/lib/mcp/tools/collections.ts
@@ -1,14 +1,77 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { CollectionFieldData, CollectionFieldType, CollectionSorting } from '@/types';
 import { getAllCollections, createCollection, updateCollection, deleteCollection } from '@/lib/repositories/collectionRepository';
-import { getFieldsByCollectionId, createField, updateField, deleteField } from '@/lib/repositories/collectionFieldRepository';
-import { getItemsByCollectionId, getItemsWithValues, createItem, deleteItem } from '@/lib/repositories/collectionItemRepository';
+import {
+  getFieldsByCollectionId,
+  createField,
+  updateField,
+  deleteField,
+  reorderFields,
+} from '@/lib/repositories/collectionFieldRepository';
+import {
+  getItemsByCollectionId,
+  getItemsWithValues,
+  createItem,
+  updateItem,
+  deleteItem,
+} from '@/lib/repositories/collectionItemRepository';
 import { setValuesByFieldName } from '@/lib/repositories/collectionItemValueRepository';
+
+const fieldTypeEnum = z.enum([
+  'text', 'number', 'boolean', 'date', 'date_only',
+  'reference', 'multi_reference',
+  'rich_text', 'image', 'audio', 'video', 'document',
+  'link', 'email', 'phone',
+  'color', 'status',
+  'option', 'count',
+]).describe('Field type (date = datetime, date_only = date without time)');
+
+const optionEntrySchema = z.object({
+  id: z.string().describe('Stable option ID (use the same ID when setting this option as a value on items)'),
+  name: z.string().describe('Display name shown to editors'),
+});
+
+const fieldDataSchema = z.object({
+  multiple: z.boolean().optional()
+    .describe('For asset fields (image/audio/video/document): allow multiple files per item'),
+  options: z.array(optionEntrySchema).optional()
+    .describe('For "option" field type: the selectable values'),
+  count_collection_id: z.string().optional()
+    .describe('For "count" field type: the child collection whose items will be counted'),
+  count_field_id: z.string().optional()
+    .describe('For "count" field type: the reference field on the child collection that points back here'),
+}).describe('Type-specific field configuration');
+
+const sortDirectionEnum = z.enum(['asc', 'desc', 'manual'])
+  .describe('"manual" uses the item manual_order; otherwise sorts by the field value');
+
+const sortingSchema = z.object({
+  field: z.string().describe('Field ID to sort by, or the literal "manual_order"'),
+  direction: sortDirectionEnum,
+}).describe('Default sort order for items in this collection');
+
+/**
+ * Translate the MCP-facing `data` schema (with flat count_collection_id /
+ * count_field_id keys for ergonomics) into the storage shape used by
+ * CollectionFieldData.
+ */
+function buildFieldData(input: z.infer<typeof fieldDataSchema> | undefined): CollectionFieldData | undefined {
+  if (!input) return undefined;
+  const data: CollectionFieldData = {};
+  if (input.multiple !== undefined) data.multiple = input.multiple;
+  if (input.options !== undefined) data.options = input.options;
+  if (input.count_collection_id && input.count_field_id) {
+    data.count = { collectionId: input.count_collection_id, fieldId: input.count_field_id };
+  }
+  return data;
+}
 
 export function registerCollectionTools(server: McpServer) {
   server.tool(
     'list_collections',
-    "List all CMS collections with their IDs, names, and slugs. Collections are YCode's CMS — each collection is like a database table.",
+    "List all CMS collections with their IDs, names, slugs, and default sorting. Collections are YCode's CMS — each collection is like a database table.",
     {},
     async () => {
       const collections = await getAllCollections();
@@ -19,9 +82,12 @@ export function registerCollectionTools(server: McpServer) {
   server.tool(
     'create_collection',
     'Create a new CMS collection. After creating, use add_collection_field to define its schema.',
-    { name: z.string().describe('Collection name (e.g. "Blog Posts", "Team Members")') },
-    async ({ name }) => {
-      const collection = await createCollection({ name });
+    {
+      name: z.string().describe('Collection name (e.g. "Blog Posts", "Team Members")'),
+      sorting: sortingSchema.optional(),
+    },
+    async ({ name, sorting }) => {
+      const collection = await createCollection({ name, sorting: sorting as CollectionSorting | undefined });
       return { content: [{ type: 'text' as const, text: JSON.stringify(collection, null, 2) }] };
     },
   );
@@ -31,18 +97,35 @@ export function registerCollectionTools(server: McpServer) {
     `Add a field to a collection's schema.
 
 FIELD TYPES:
-- text, number, boolean, date (datetime), date_only (date without time), reference, rich-text, color, asset, status`,
+- text, number, boolean, date (datetime), date_only (date without time)
+- reference (single link to one item), multi_reference (link to multiple items)
+- rich_text, color, status
+- image, audio, video, document (use data.multiple: true for multi-asset fields)
+- link, email, phone
+- option (predefined choices — pass data.options)
+- count (computed count of related items — pass data.count_collection_id + data.count_field_id)`,
     {
       collection_id: z.string().describe('The collection ID'),
       name: z.string().describe('Field display name'),
-      type: z.enum(['text', 'number', 'boolean', 'date', 'date_only', 'reference', 'multi_reference', 'rich_text', 'image', 'audio', 'video', 'document', 'link', 'email', 'phone', 'color', 'status']).describe('Field data type (date = datetime, date_only = date without time)'),
+      type: fieldTypeEnum,
       key: z.string().optional().describe('Unique field key (auto-generated from name if omitted)'),
-      reference_collection_id: z.string().optional().describe('For reference fields: the target collection ID'),
+      reference_collection_id: z.string().optional().describe('For reference / multi_reference fields: the target collection ID'),
+      default: z.string().optional().describe('Default value applied to new items'),
+      fillable: z.boolean().optional().describe('Whether this field can be set via the API / form submissions. Defaults true.'),
+      hidden: z.boolean().optional().describe('Hide this field from the CMS UI. Useful for internal computed fields.'),
+      is_computed: z.boolean().optional().describe('Whether the value is computed automatically (e.g. count fields).'),
+      data: fieldDataSchema.optional(),
     },
-    async ({ collection_id, ...fieldData }) => {
+    async ({ collection_id, data, ...fieldData }) => {
       const existingFields = await getFieldsByCollectionId(collection_id);
       const order = existingFields.length;
-      const field = await createField({ collection_id, order, ...fieldData });
+      const field = await createField({
+        collection_id,
+        order,
+        ...fieldData,
+        type: fieldData.type as CollectionFieldType,
+        data: buildFieldData(data),
+      });
       return { content: [{ type: 'text' as const, text: JSON.stringify(field, null, 2) }] };
     },
   );
@@ -61,7 +144,7 @@ FIELD TYPES:
         content: [{
           type: 'text' as const,
           text: JSON.stringify({
-            fields: fields.map((f) => ({ id: f.id, name: f.name, type: f.type, key: f.key })),
+            fields: fields.map((f) => ({ id: f.id, name: f.name, type: f.type, key: f.key, data: f.data })),
             items,
             total,
           }, null, 2),
@@ -76,18 +159,18 @@ FIELD TYPES:
     {
       collection_id: z.string().describe('The collection ID'),
       values: z.record(z.string(), z.unknown()).optional()
-        .describe('Field values as { fieldId: value } pairs'),
+        .describe('Field values as { fieldId: value } pairs. For "option" fields, value is the option ID. For multi-asset fields, value is a JSON array of asset IDs.'),
     },
     async ({ collection_id, values }) => {
       const item = await createItem({ collection_id });
 
       if (values && Object.keys(values).length > 0) {
         const fields = await getFieldsByCollectionId(collection_id);
-        const fieldType: Record<string, string> = {};
+        const fieldType: Record<string, CollectionFieldType> = {};
         for (const f of fields) {
           fieldType[f.id] = f.type;
         }
-        await setValuesByFieldName(item.id, collection_id, values, fieldType as any);
+        await setValuesByFieldName(item.id, collection_id, values as Record<string, unknown>, fieldType);
       }
 
       const { items: itemWithValues } = await getItemsWithValues(collection_id);
@@ -107,11 +190,11 @@ FIELD TYPES:
     },
     async ({ collection_id, item_id, values }) => {
       const fields = await getFieldsByCollectionId(collection_id);
-      const fieldType: Record<string, string> = {};
+      const fieldType: Record<string, CollectionFieldType> = {};
       for (const f of fields) {
         fieldType[f.id] = f.type;
       }
-      await setValuesByFieldName(item_id, collection_id, values, fieldType as any);
+      await setValuesByFieldName(item_id, collection_id, values as Record<string, unknown>, fieldType);
       return { content: [{ type: 'text' as const, text: `Updated item ${item_id}` }] };
     },
   );
@@ -130,14 +213,33 @@ FIELD TYPES:
   );
 
   server.tool(
+    'set_collection_item_order',
+    'Set the manual ordering position of an item within its collection. Only takes effect when the collection sorting is "manual".',
+    {
+      collection_id: z.string().describe('The collection ID (for permission scoping)'),
+      item_id: z.string().describe('The item ID to reorder'),
+      manual_order: z.number().int().describe('New position. Lower values appear first.'),
+    },
+    async ({ item_id, manual_order }) => {
+      const item = await updateItem(item_id, { manual_order });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(item, null, 2) }] };
+    },
+  );
+
+  server.tool(
     'update_collection',
-    'Rename a collection',
+    'Rename a collection or update its default sorting.',
     {
       collection_id: z.string().describe('The collection ID'),
-      name: z.string().describe('New collection name'),
+      name: z.string().optional().describe('New collection name'),
+      sorting: sortingSchema.nullable().optional()
+        .describe('Default sort applied in the CMS list view and on the canvas. Pass null to clear.'),
     },
-    async ({ collection_id, name }) => {
-      const collection = await updateCollection(collection_id, { name });
+    async ({ collection_id, name, sorting }) => {
+      const updates: { name?: string; sorting?: CollectionSorting | null } = {};
+      if (name !== undefined) updates.name = name;
+      if (sorting !== undefined) updates.sorting = sorting as CollectionSorting | null;
+      const collection = await updateCollection(collection_id, updates);
       return { content: [{ type: 'text' as const, text: JSON.stringify(collection, null, 2) }] };
     },
   );
@@ -154,15 +256,23 @@ FIELD TYPES:
 
   server.tool(
     'update_collection_field',
-    'Update a collection field (rename, change type, update reference)',
+    'Update a collection field (rename, change type, update reference, change metadata, update type-specific data).',
     {
       field_id: z.string().describe('The field ID to update'),
       name: z.string().optional().describe('New field name'),
-      type: z.enum(['text', 'number', 'boolean', 'date', 'date_only', 'reference', 'multi_reference', 'rich_text', 'image', 'audio', 'video', 'document', 'link', 'email', 'phone', 'color', 'status']).optional().describe('New field type (date = datetime, date_only = date without time)'),
-      reference_collection_id: z.string().optional().describe('For reference fields: target collection ID'),
+      type: fieldTypeEnum.optional(),
+      reference_collection_id: z.string().nullable().optional().describe('For reference fields: target collection ID. Pass null to clear.'),
+      default: z.string().nullable().optional().describe('Default value applied to new items. Pass null to clear.'),
+      fillable: z.boolean().optional(),
+      hidden: z.boolean().optional(),
+      data: fieldDataSchema.optional().describe('Replaces the entire field data object. Pass options[] to add/remove option values, data.multiple to toggle multi-asset, etc.'),
     },
-    async ({ field_id, ...updates }) => {
-      const field = await updateField(field_id, updates);
+    async ({ field_id, data, ...updates }) => {
+      const field = await updateField(field_id, {
+        ...updates,
+        type: updates.type as CollectionFieldType | undefined,
+        data: buildFieldData(data),
+      });
       return { content: [{ type: 'text' as const, text: JSON.stringify(field, null, 2) }] };
     },
   );
@@ -174,6 +284,19 @@ FIELD TYPES:
     async ({ field_id }) => {
       await deleteField(field_id);
       return { content: [{ type: 'text' as const, text: `Deleted field ${field_id}` }] };
+    },
+  );
+
+  server.tool(
+    'reorder_collection_fields',
+    'Reorder the fields of a collection. Pass the field IDs in the desired display order.',
+    {
+      collection_id: z.string().describe('The collection ID'),
+      field_ids: z.array(z.string()).min(1).describe('All field IDs in the desired order'),
+    },
+    async ({ collection_id, field_ids }) => {
+      await reorderFields(collection_id, false, field_ids);
+      return { content: [{ type: 'text' as const, text: `Reordered ${field_ids.length} fields in collection ${collection_id}` }] };
     },
   );
 }

--- a/lib/mcp/tools/collections.ts
+++ b/lib/mcp/tools/collections.ts
@@ -75,7 +75,7 @@ export function registerCollectionTools(server: McpServer) {
     {},
     async () => {
       const collections = await getAllCollections();
-      return { content: [{ type: 'text' as const, text: JSON.stringify(collections, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(collections) }] };
     },
   );
 
@@ -88,7 +88,7 @@ export function registerCollectionTools(server: McpServer) {
     },
     async ({ name, sorting }) => {
       const collection = await createCollection({ name, sorting: sorting as CollectionSorting | undefined });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(collection, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(collection) }] };
     },
   );
 
@@ -126,7 +126,7 @@ FIELD TYPES:
         type: fieldData.type as CollectionFieldType,
         data: buildFieldData(data),
       });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(field, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(field) }] };
     },
   );
 
@@ -147,7 +147,7 @@ FIELD TYPES:
             fields: fields.map((f) => ({ id: f.id, name: f.name, type: f.type, key: f.key, data: f.data })),
             items,
             total,
-          }, null, 2),
+          }),
         }],
       };
     },
@@ -176,7 +176,7 @@ FIELD TYPES:
       const { items: itemWithValues } = await getItemsWithValues(collection_id);
       const created = itemWithValues.find((i) => i.id === item.id);
 
-      return { content: [{ type: 'text' as const, text: JSON.stringify(created || item, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(created || item) }] };
     },
   );
 
@@ -222,7 +222,7 @@ FIELD TYPES:
     },
     async ({ item_id, manual_order }) => {
       const item = await updateItem(item_id, { manual_order });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(item, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(item) }] };
     },
   );
 
@@ -240,7 +240,7 @@ FIELD TYPES:
       if (name !== undefined) updates.name = name;
       if (sorting !== undefined) updates.sorting = sorting as CollectionSorting | null;
       const collection = await updateCollection(collection_id, updates);
-      return { content: [{ type: 'text' as const, text: JSON.stringify(collection, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(collection) }] };
     },
   );
 
@@ -273,7 +273,7 @@ FIELD TYPES:
         type: updates.type as CollectionFieldType | undefined,
         data: buildFieldData(data),
       });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(field, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(field) }] };
     },
   );
 

--- a/lib/mcp/tools/components.ts
+++ b/lib/mcp/tools/components.ts
@@ -19,7 +19,6 @@ import {
   getTiptapTextContent,
   applyDesignToLayer,
   generateId,
-  ELEMENT_TEMPLATES,
 } from '@/lib/mcp/utils';
 import {
   broadcastComponentCreated,
@@ -27,11 +26,7 @@ import {
   broadcastComponentDeleted,
   broadcastComponentLayersUpdated,
 } from '@/lib/mcp/broadcast';
-import { designSchema } from './shared-schemas';
-
-const templateEnum = z.enum(
-  Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
-);
+import { designSchema, templateEnum } from './shared-schemas';
 
 const variableSchema = z.object({
   name: z.string().describe('Display name (e.g. "Button label", "Hero image")'),

--- a/lib/mcp/tools/components.ts
+++ b/lib/mcp/tools/components.ts
@@ -28,14 +28,7 @@ import {
   broadcastComponentDeleted,
   broadcastComponentLayersUpdated,
 } from '@/lib/mcp/broadcast';
-import { designSchema, templateEnum } from './shared-schemas';
-
-const richTextBlockSchema = z.object({
-  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
-  text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
-  level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
-  items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
-});
+import { designSchema, richTextBlockSchema, templateEnum } from './shared-schemas';
 
 const variableSchema = z.object({
   name: z.string().describe('Display name (e.g. "Button label", "Hero image")'),

--- a/lib/mcp/tools/components.ts
+++ b/lib/mcp/tools/components.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { Layer } from '@/types';
+import type { Breakpoint, Layer, UIState } from '@/types';
 import {
   getAllComponents,
   getComponentById,
@@ -17,9 +17,11 @@ import {
   canHaveChildren,
   createLayerFromTemplate,
   getTiptapTextContent,
+  buildTiptapDoc,
   applyDesignToLayer,
   generateId,
 } from '@/lib/mcp/utils';
+import type { RichTextBlock } from '@/lib/mcp/utils';
 import {
   broadcastComponentCreated,
   broadcastComponentUpdated,
@@ -27,6 +29,13 @@ import {
   broadcastComponentLayersUpdated,
 } from '@/lib/mcp/broadcast';
 import { designSchema, templateEnum } from './shared-schemas';
+
+const richTextBlockSchema = z.object({
+  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
+  text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
+  level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
+  items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
+});
 
 const variableSchema = z.object({
   name: z.string().describe('Display name (e.g. "Button label", "Hero image")'),
@@ -168,7 +177,11 @@ EXAMPLE: A "Card" component with a title variable:
   server.tool(
     'update_component_layers',
     `Modify a component's layer tree. Works like batch_operations but for component layers.
-Use ref_id in add_layer to name layers, then reference them in later operations.`,
+Use ref_id in add_layer to name layers, then reference them in later operations.
+
+Supports the same ops as batch_operations (add_layer, update_design, update_text,
+update_image, set_rich_text, apply_style, delete_layer, move_layer) plus
+link_variable for wiring component variables to layers.`,
     {
       component_id: z.string().describe('The component ID'),
       operations: z.array(z.discriminatedUnion('type', [
@@ -178,9 +191,12 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
           position: z.number().optional(),
           template: templateEnum,
           text_content: z.string().optional(),
+          rich_content: z.array(richTextBlockSchema).optional()
+            .describe('For richText: structured content blocks. Overrides text_content.'),
           custom_name: z.string().optional(),
           ref_id: z.string().optional().describe('Reference ID for later operations'),
           design: designSchema.optional(),
+          image_asset_id: z.string().optional().describe('For image layers: asset ID to display'),
           variable_id: z.string().optional()
             .describe('Component variable ID to link to this layer\'s primary content (text/image/link)'),
         }),
@@ -188,11 +204,30 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
           type: z.literal('update_design'),
           layer_id: z.string().describe('Layer ID or ref_id'),
           design: designSchema,
+          breakpoint: z.enum(['desktop', 'tablet', 'mobile']).default('desktop').optional(),
+          ui_state: z.enum(['neutral', 'hover', 'focus', 'active', 'disabled']).default('neutral').optional()
+            .describe('UI state: "hover" for hover styles, "focus" for focus, etc.'),
         }),
         z.object({
           type: z.literal('update_text'),
           layer_id: z.string().describe('Layer ID or ref_id'),
           text: z.string(),
+        }),
+        z.object({
+          type: z.literal('update_image'),
+          layer_id: z.string().describe('Layer ID or ref_id'),
+          asset_id: z.string().describe('Asset ID from upload_asset'),
+        }),
+        z.object({
+          type: z.literal('set_rich_text'),
+          layer_id: z.string().describe('RichText layer ID or ref_id'),
+          blocks: z.array(richTextBlockSchema).min(1)
+            .describe('Content blocks (paragraph, heading, list, etc.)'),
+        }),
+        z.object({
+          type: z.literal('apply_style'),
+          layer_id: z.string(),
+          style_id: z.string().describe('Layer style ID to apply'),
         }),
         z.object({
           type: z.literal('delete_layer'),
@@ -238,11 +273,19 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
               let newLayer = createLayerFromTemplate(op.template, {
                 customName: op.custom_name,
                 textContent: op.text_content,
+                richContent: op.rich_content as RichTextBlock[] | undefined,
               });
               if (!newLayer) { results.push({ op: i, status: 'error', detail: `Unknown template "${op.template}"` }); continue; }
 
               if (op.design) {
                 newLayer = applyDesignToLayer(newLayer, op.design as Record<string, Record<string, unknown>>);
+              }
+
+              if (op.image_asset_id && newLayer.variables?.image) {
+                newLayer.variables = {
+                  ...newLayer.variables,
+                  image: { ...newLayer.variables.image, src: { type: 'asset', data: { asset_id: op.image_asset_id } } },
+                };
               }
 
               if (op.variable_id) {
@@ -259,8 +302,10 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
               const layerId = refMap.get(op.layer_id) || op.layer_id;
               const layer = findLayerById(layers, layerId);
               if (!layer) { results.push({ op: i, status: 'error', detail: `Layer "${op.layer_id}" not found` }); continue; }
+              const bp = (op.breakpoint ?? 'desktop') as Breakpoint;
+              const state = (op.ui_state ?? 'neutral') as UIState;
               layers = updateLayerById(layers, layerId, (l) =>
-                applyDesignToLayer(l, op.design as Record<string, Record<string, unknown>>),
+                applyDesignToLayer(l, op.design as Record<string, Record<string, unknown>>, bp, state),
               );
               results.push({ op: i, status: 'ok', detail: `Styled "${layer.customName || layer.name}"` });
               break;
@@ -278,6 +323,50 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
                 },
               }));
               results.push({ op: i, status: 'ok', detail: `Set text on "${layer.customName || layer.name}"` });
+              break;
+            }
+
+            case 'update_image': {
+              const layerId = refMap.get(op.layer_id) || op.layer_id;
+              const layer = findLayerById(layers, layerId);
+              if (!layer) { results.push({ op: i, status: 'error', detail: `Layer "${op.layer_id}" not found` }); continue; }
+              layers = updateLayerById(layers, layerId, (l) => {
+                const existing = (l.variables?.image || {}) as Record<string, unknown>;
+                return {
+                  ...l,
+                  variables: {
+                    ...l.variables,
+                    image: {
+                      ...existing,
+                      src: { type: 'asset' as const, data: { asset_id: op.asset_id } },
+                      alt: (existing.alt || { type: 'dynamic_text' as const, data: { content: '' } }) as { type: 'dynamic_text'; data: { content: string } },
+                    },
+                  },
+                };
+              });
+              results.push({ op: i, status: 'ok', detail: `Set image on "${layer.customName || layer.name}"` });
+              break;
+            }
+
+            case 'set_rich_text': {
+              const layerId = refMap.get(op.layer_id) || op.layer_id;
+              const layer = findLayerById(layers, layerId);
+              if (!layer) { results.push({ op: i, status: 'error', detail: `Layer "${op.layer_id}" not found` }); continue; }
+              const tiptapDoc = buildTiptapDoc(op.blocks as RichTextBlock[]);
+              layers = updateLayerById(layers, layerId, (l) => ({
+                ...l,
+                variables: { ...l.variables, text: { type: 'dynamic_rich_text', data: { content: tiptapDoc } } },
+              }));
+              results.push({ op: i, status: 'ok', detail: `Set rich text on "${layer.customName || layer.name}" (${op.blocks.length} blocks)` });
+              break;
+            }
+
+            case 'apply_style': {
+              const layerId = refMap.get(op.layer_id) || op.layer_id;
+              const layer = findLayerById(layers, layerId);
+              if (!layer) { results.push({ op: i, status: 'error', detail: `Layer "${op.layer_id}" not found` }); continue; }
+              layers = updateLayerById(layers, layerId, (l) => ({ ...l, styleId: op.style_id }));
+              results.push({ op: i, status: 'ok', detail: `Applied style to "${layer.customName || layer.name}"` });
               break;
             }
 

--- a/lib/mcp/tools/components.ts
+++ b/lib/mcp/tools/components.ts
@@ -75,7 +75,7 @@ export function registerComponentTools(server: McpServer) {
         is_published: c.is_published,
       }));
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(summary) }],
       };
     },
   );
@@ -93,7 +93,7 @@ export function registerComponentTools(server: McpServer) {
         };
       }
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(component, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(component) }],
       };
     },
   );
@@ -142,7 +142,7 @@ EXAMPLE: A "Card" component with a title variable:
             id: component.id,
             root_layer_id: rootLayer.id,
             variables: component.variables || [],
-          }, null, 2),
+          }),
         }],
       };
     },
@@ -171,7 +171,7 @@ EXAMPLE: A "Card" component with a title variable:
           text: JSON.stringify({
             message: `Component "${component.name}" updated`,
             variables: component.variables || [],
-          }, null, 2),
+          }),
         }],
       };
     },
@@ -200,7 +200,7 @@ EXAMPLE: A "Card" component with a title variable:
         layer_count: countLayers(v.layers),
         is_primary: v === variants[0],
       }));
-      return { content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(summary) }] };
     },
   );
 
@@ -259,7 +259,7 @@ EXAMPLE: A "Card" component with a title variable:
             message: `Variant "${name}" created`,
             id: newVariant.id,
             root_layer_id: layers[0]?.id,
-          }, null, 2),
+          }),
         }],
       };
     },
@@ -590,7 +590,7 @@ Pass variant_id to target a specific named variant; omit it to update the primar
       const errors = results.filter((r) => r.status === 'error');
       if (errors.length === operations.length) {
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ message: 'All operations failed', results }, null, 2) }],
+          content: [{ type: 'text' as const, text: JSON.stringify({ message: 'All operations failed', results }) }],
           isError: true,
         };
       }
@@ -607,7 +607,7 @@ Pass variant_id to target a specific named variant; omit it to update the primar
             message: `Executed ${results.filter((r) => r.status === 'ok').length}/${operations.length} operations`,
             ref_ids: Object.keys(refEntries).length > 0 ? refEntries : undefined,
             results,
-          }, null, 2),
+          }),
         }],
       };
     },
@@ -630,7 +630,7 @@ Pass variant_id to target a specific named variant; omit it to update the primar
               type: e.type,
               name: e.name,
             })),
-          }, null, 2),
+          }),
         }],
       };
     },

--- a/lib/mcp/tools/components.ts
+++ b/lib/mcp/tools/components.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { Layer } from '@/types';
+import type { ComponentVariable, ComponentVariableValue, ComponentVariant, Layer } from '@/types';
 import {
   getAllComponents,
   getComponentById,
@@ -33,11 +33,35 @@ const templateEnum = z.enum(
   Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
 );
 
+const variableTypeEnum = z.enum(['text', 'rich_text', 'image', 'link', 'audio', 'video', 'icon', 'variant'])
+  .describe('Variable type. "variant" lets instances pick which variant of a nested component is rendered.');
+
 const variableSchema = z.object({
   name: z.string().describe('Display name (e.g. "Button label", "Hero image")'),
-  type: z.enum(['text', 'image', 'link', 'audio', 'video', 'icon']).default('text')
-    .describe('Variable type'),
+  type: variableTypeEnum.default('text'),
+  placeholder: z.string().optional()
+    .describe('Placeholder text shown in the override input on each instance.'),
+  default_value: z.unknown().optional()
+    .describe('Default value applied when an instance does not override the variable. Shape matches the variable type (e.g. { type: "dynamic_text", data: { content: "Click me" } } for text).'),
 });
+
+const variableUpdateSchema = z.object({
+  id: z.string().optional().describe('Existing variable ID to update, or omit to create new'),
+  name: z.string().describe('Variable display name'),
+  type: variableTypeEnum.default('text'),
+  placeholder: z.string().optional(),
+  default_value: z.unknown().optional(),
+});
+
+function normalizeVariables(input: Array<z.infer<typeof variableUpdateSchema>>): ComponentVariable[] {
+  return input.map((v) => ({
+    id: v.id || generateId(),
+    name: v.name,
+    type: v.type,
+    ...(v.placeholder !== undefined && { placeholder: v.placeholder }),
+    ...(v.default_value !== undefined && { default_value: v.default_value as ComponentVariableValue }),
+  }));
+}
 
 export function registerComponentTools(server: McpServer) {
   server.tool(
@@ -103,11 +127,7 @@ EXAMPLE: A "Card" component with a title variable:
         children: [],
       };
 
-      const componentVariables = variables?.map((v) => ({
-        id: generateId(),
-        name: v.name,
-        type: v.type,
-      }));
+      const componentVariables = variables ? normalizeVariables(variables) : undefined;
 
       const component = await createComponent({
         name,
@@ -133,27 +153,17 @@ EXAMPLE: A "Card" component with a title variable:
 
   server.tool(
     'update_component',
-    'Update a component\'s name and/or variables. Use update_component_layers to modify the layer tree.',
+    'Update a component\'s name and/or variables. Use update_component_layers to modify the layer tree, or the variant tools for variant management.',
     {
       component_id: z.string().describe('The component ID'),
       name: z.string().optional().describe('New component name'),
-      variables: z.array(z.object({
-        id: z.string().optional().describe('Existing variable ID to update, or omit to create new'),
-        name: z.string().describe('Variable display name'),
-        type: z.enum(['text', 'image', 'link', 'audio', 'video', 'icon']).default('text'),
-      })).optional().describe('Full list of variables (replaces existing). Include existing IDs to preserve them.'),
+      variables: z.array(variableUpdateSchema).optional()
+        .describe('Full list of variables (replaces existing). Include existing IDs to preserve them; new entries get fresh IDs.'),
     },
     async ({ component_id, name, variables }) => {
-      const updates: Record<string, unknown> = {};
+      const updates: { name?: string; variables?: ComponentVariable[] } = {};
       if (name !== undefined) updates.name = name;
-
-      if (variables !== undefined) {
-        updates.variables = variables.map((v) => ({
-          id: v.id || generateId(),
-          name: v.name,
-          type: v.type,
-        }));
-      }
+      if (variables !== undefined) updates.variables = normalizeVariables(variables);
 
       const component = await updateComponent(component_id, updates);
       broadcastComponentUpdated(component_id, updates).catch(() => {});
@@ -171,11 +181,181 @@ EXAMPLE: A "Card" component with a title variable:
   );
 
   server.tool(
-    'update_component_layers',
-    `Modify a component's layer tree. Works like batch_operations but for component layers.
-Use ref_id in add_layer to name layers, then reference them in later operations.`,
+    'list_component_variants',
+    'List the named variants of a component. Every component has at least one ("Default"). Variants share the component\'s variables.',
     {
       component_id: z.string().describe('The component ID'),
+    },
+    async ({ component_id }) => {
+      const component = await getComponentById(component_id);
+      if (!component) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: Component "${component_id}" not found.` }],
+          isError: true,
+        };
+      }
+      const variants = (component.variants && component.variants.length > 0)
+        ? component.variants
+        : [{ id: generateId(), name: 'Default', layers: component.layers || [] }];
+      const summary = variants.map((v) => ({
+        id: v.id,
+        name: v.name,
+        layer_count: countLayers(v.layers),
+        is_primary: v === variants[0],
+      }));
+      return { content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'create_component_variant',
+    `Add a new named variant to a component. Pass source_variant_id to clone an existing variant
+(new layer IDs are generated). Omit it to start from an empty root div.`,
+    {
+      component_id: z.string().describe('The component ID'),
+      name: z.string().describe('Variant name (e.g. "Small", "Dark", "Compact")'),
+      source_variant_id: z.string().optional()
+        .describe('Variant to clone. Omit for an empty starting tree.'),
+    },
+    async ({ component_id, name, source_variant_id }) => {
+      const component = await getComponentById(component_id);
+      if (!component) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: Component "${component_id}" not found.` }],
+          isError: true,
+        };
+      }
+      const existing: ComponentVariant[] = (component.variants && component.variants.length > 0)
+        ? component.variants
+        : [{ id: generateId(), name: 'Default', layers: component.layers || [] }];
+
+      let layers: Layer[];
+      if (source_variant_id) {
+        const source = existing.find((v) => v.id === source_variant_id);
+        if (!source) {
+          return {
+            content: [{ type: 'text' as const, text: `Error: Source variant "${source_variant_id}" not found.` }],
+            isError: true,
+          };
+        }
+        layers = source.layers.map(cloneLayerWithNewIds);
+      } else {
+        layers = [{
+          id: generateId(),
+          name: 'div',
+          customName: name,
+          classes: '',
+          children: [],
+        }];
+      }
+
+      const newVariant: ComponentVariant = { id: generateId(), name, layers };
+      const updatedVariants = [...existing, newVariant];
+
+      await updateComponent(component_id, { variants: updatedVariants });
+      broadcastComponentUpdated(component_id, { variants: updatedVariants }).catch(() => {});
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            message: `Variant "${name}" created`,
+            id: newVariant.id,
+            root_layer_id: layers[0]?.id,
+          }, null, 2),
+        }],
+      };
+    },
+  );
+
+  server.tool(
+    'update_component_variant',
+    'Rename a component variant. Use update_component_layers with variant_id to modify its tree.',
+    {
+      component_id: z.string().describe('The component ID'),
+      variant_id: z.string().describe('The variant ID'),
+      name: z.string().describe('New variant name'),
+    },
+    async ({ component_id, variant_id, name }) => {
+      const component = await getComponentById(component_id);
+      if (!component) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: Component "${component_id}" not found.` }],
+          isError: true,
+        };
+      }
+      const variants = component.variants || [];
+      const idx = variants.findIndex((v) => v.id === variant_id);
+      if (idx === -1) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: Variant "${variant_id}" not found.` }],
+          isError: true,
+        };
+      }
+      const updatedVariants = [...variants];
+      updatedVariants[idx] = { ...updatedVariants[idx], name };
+
+      await updateComponent(component_id, { variants: updatedVariants });
+      broadcastComponentUpdated(component_id, { variants: updatedVariants }).catch(() => {});
+
+      return { content: [{ type: 'text' as const, text: `Variant "${variant_id}" renamed to "${name}"` }] };
+    },
+  );
+
+  server.tool(
+    'delete_component_variant',
+    'Delete a named variant. The component must keep at least one variant — the primary cannot be deleted.',
+    {
+      component_id: z.string().describe('The component ID'),
+      variant_id: z.string().describe('The variant ID to delete'),
+    },
+    async ({ component_id, variant_id }) => {
+      const component = await getComponentById(component_id);
+      if (!component) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: Component "${component_id}" not found.` }],
+          isError: true,
+        };
+      }
+      const variants = component.variants || [];
+      if (variants.length <= 1) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: A component must keep at least one variant.' }],
+          isError: true,
+        };
+      }
+      if (variants[0]?.id === variant_id) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: The primary variant cannot be deleted. Reorder variants or delete a non-primary one.' }],
+          isError: true,
+        };
+      }
+      const updatedVariants = variants.filter((v) => v.id !== variant_id);
+      if (updatedVariants.length === variants.length) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: Variant "${variant_id}" not found.` }],
+          isError: true,
+        };
+      }
+
+      await updateComponent(component_id, { variants: updatedVariants });
+      broadcastComponentUpdated(component_id, { variants: updatedVariants }).catch(() => {});
+
+      return { content: [{ type: 'text' as const, text: `Variant "${variant_id}" deleted` }] };
+    },
+  );
+
+  server.tool(
+    'update_component_layers',
+    `Modify a component's layer tree. Works like batch_operations but for component layers.
+Use ref_id in add_layer to name layers, then reference them in later operations.
+
+Pass variant_id to target a specific named variant; omit it to update the primary variant
+(variants[0]), which is what most components have.`,
+    {
+      component_id: z.string().describe('The component ID'),
+      variant_id: z.string().optional()
+        .describe('Variant to modify. Omit to target the primary variant.'),
       operations: z.array(z.discriminatedUnion('type', [
         z.object({
           type: z.literal('add_layer'),
@@ -213,11 +393,11 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
           type: z.literal('link_variable'),
           layer_id: z.string().describe('Layer ID or ref_id'),
           variable_id: z.string().describe('Component variable ID to link'),
-          variable_type: z.enum(['text', 'image', 'link', 'audio', 'video', 'icon']).default('text'),
+          variable_type: variableTypeEnum.default('text'),
         }),
       ])).min(1).max(50),
     },
-    async ({ component_id, operations }) => {
+    async ({ component_id, variant_id, operations }) => {
       const component = await getComponentById(component_id);
       if (!component) {
         return {
@@ -226,7 +406,20 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
         };
       }
 
-      let layers = component.layers || [];
+      const variants: ComponentVariant[] = (component.variants && component.variants.length > 0)
+        ? component.variants
+        : [{ id: generateId(), name: 'Default', layers: component.layers || [] }];
+      const targetIdx = variant_id
+        ? variants.findIndex((v) => v.id === variant_id)
+        : 0;
+      if (targetIdx === -1) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: Variant "${variant_id}" not found.` }],
+          isError: true,
+        };
+      }
+
+      let layers = variants[targetIdx].layers || [];
       const refMap = new Map<string, string>();
       const results: Array<{ op: number; status: string; detail: string }> = [];
 
@@ -329,8 +522,9 @@ Use ref_id in add_layer to name layers, then reference them in later operations.
         };
       }
 
-      await updateComponent(component_id, { layers });
-      broadcastComponentLayersUpdated(component_id, layers).catch(() => {});
+      const updatedVariants = variants.map((v, i) => (i === targetIdx ? { ...v, layers } : v));
+      await updateComponent(component_id, { variants: updatedVariants });
+      broadcastComponentLayersUpdated(component_id, updatedVariants[0].layers).catch(() => {});
 
       const refEntries = Object.fromEntries(refMap);
       return {
@@ -380,6 +574,20 @@ function countLayers(layers: Layer[]): number {
 }
 
 /**
+ * Deep-clone a layer, regenerating IDs for the whole subtree.
+ * Used when cloning a variant so the new variant has fresh layer IDs.
+ */
+function cloneLayerWithNewIds(layer: Layer): Layer {
+  return {
+    ...layer,
+    id: generateId('lyr'),
+    ...(layer.children && Array.isArray(layer.children) && {
+      children: layer.children.map(cloneLayerWithNewIds),
+    }),
+  };
+}
+
+/**
  * Link a component variable to a layer's primary content slot.
  * Sets the variable's `id` field so the component system resolves overrides.
  */
@@ -388,6 +596,7 @@ function linkVariableToLayer(layer: Layer, variableId: string, variableType: str
 
   switch (variableType) {
     case 'text':
+    case 'rich_text':
       if (vars.text) {
         vars.text = { ...vars.text, id: variableId };
       } else {
@@ -432,6 +641,23 @@ function linkVariableToLayer(layer: Layer, variableId: string, variableType: str
         };
       }
       break;
+
+    case 'icon':
+      if (vars.icon) {
+        vars.icon = {
+          ...vars.icon,
+          src: { ...(vars.icon.src || { type: 'asset', data: { asset_id: null } }), id: variableId },
+        };
+      }
+      break;
+
+    case 'variant': {
+      // Variant variables target the layer's nested-component variant override.
+      // The runtime reads componentVariantId; the variable_id wires up the override slot.
+      const next = { ...layer } as Layer & { componentVariantVariableId?: string };
+      next.componentVariantVariableId = variableId;
+      return { ...next, variables: vars };
+    }
   }
 
   return { ...layer, variables: vars };

--- a/lib/mcp/tools/forms.ts
+++ b/lib/mcp/tools/forms.ts
@@ -19,7 +19,7 @@ export function registerFormTools(server: McpServer) {
       return {
         content: [{
           type: 'text' as const,
-          text: JSON.stringify(summaries, null, 2),
+          text: JSON.stringify(summaries),
         }],
       };
     },
@@ -43,7 +43,7 @@ export function registerFormTools(server: McpServer) {
             payload: s.payload,
             status: s.status,
             created_at: s.created_at,
-          })), null, 2),
+          }))),
         }],
       };
     },
@@ -61,7 +61,7 @@ export function registerFormTools(server: McpServer) {
         return { content: [{ type: 'text' as const, text: `Error: Submission "${submission_id}" not found.` }], isError: true };
       }
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(submission, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(submission) }],
       };
     },
   );
@@ -78,7 +78,7 @@ export function registerFormTools(server: McpServer) {
       return {
         content: [{
           type: 'text' as const,
-          text: JSON.stringify({ message: `Submission marked as "${status}"`, submission }, null, 2),
+          text: JSON.stringify({ message: `Submission marked as "${status}"`, submission }),
         }],
       };
     },

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -13,15 +13,10 @@ import {
   getTiptapTextContent,
   buildTiptapDoc,
   applyDesignToLayer,
-  ELEMENT_TEMPLATES,
 } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
 import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
-import { designSchema } from './shared-schemas';
-
-const templateEnum = z.enum(
-  Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
-);
+import { designSchema, richTextBlockSchema, templateEnum } from './shared-schemas';
 
 async function getPageLayers(pageId: string): Promise<Layer[]> {
   const pageLayers = await getDraftLayers(pageId);
@@ -67,12 +62,8 @@ NESTING RULES:
       position: z.number().optional().describe('Index within parent children. Omit to append at end.'),
       template: templateEnum.describe('Element template to create'),
       text_content: z.string().optional().describe('For text/heading/button/richText: plain display text'),
-      rich_content: z.array(z.object({
-        type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
-        text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
-        level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
-        items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
-      })).optional().describe('For richText: structured content blocks. Overrides text_content.'),
+      rich_content: z.array(richTextBlockSchema).optional()
+        .describe('For richText: structured content blocks. Overrides text_content.'),
       custom_name: z.string().optional().describe('Custom display name for the layer'),
     },
     async ({ page_id, parent_layer_id, position, template, text_content, rich_content, custom_name }) => {

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -517,6 +517,50 @@ COMMON USES:
   );
 
   server.tool(
+    'update_form_settings',
+    `Configure how a form layer handles submissions.
+
+success_action: "message" (default) shows the form's alert child; "redirect" sends the visitor to redirect_url.
+email_notification: when enabled, each submission emails the configured address. Requires SMTP set up in site settings.
+redirect_url: used when success_action is "redirect". Accepts an internal path "/thank-you" or an external URL.`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The form layer ID'),
+      success_action: z.enum(['message', 'redirect']).optional(),
+      redirect_url: z.string().optional()
+        .describe('For success_action "redirect": the URL to send the user to.'),
+      email_notification: z.object({
+        enabled: z.boolean(),
+        to: z.string().describe('Email address that receives a notification on each submission'),
+        subject: z.string().optional().describe('Subject line of the notification email'),
+      }).optional(),
+    },
+    async ({ page_id, layer_id, success_action, redirect_url, email_notification }) => {
+      const layers = await getPageLayers(page_id);
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+
+      const updated = updateLayerById(layers, layer_id, (l) => {
+        const settings = { ...l.settings };
+        const existingForm = (settings.form || {}) as Record<string, unknown>;
+        const nextForm: Record<string, unknown> = { ...existingForm };
+        if (success_action !== undefined) nextForm.success_action = success_action;
+        if (email_notification !== undefined) nextForm.email_notification = email_notification;
+        if (redirect_url !== undefined) {
+          nextForm.redirect_url = { type: 'dynamic_text', data: { content: redirect_url } };
+        }
+        settings.form = nextForm as typeof settings.form;
+        return { ...l, settings };
+      });
+
+      await savePageLayers(page_id, updated);
+      return { content: [{ type: 'text' as const, text: `Updated form settings for "${layer.customName || layer.name}"` }] };
+    },
+  );
+
+  server.tool(
     'update_layer_iframe',
     'Set the source URL for an iframe layer.',
     {

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -16,6 +16,7 @@ import {
   ELEMENT_TEMPLATES,
 } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
+import { layerToExportHtml } from '@/lib/html-layer-converter';
 import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
 import { designSchema } from './shared-schemas';
 
@@ -68,10 +69,22 @@ NESTING RULES:
       template: templateEnum.describe('Element template to create'),
       text_content: z.string().optional().describe('For text/heading/button/richText: plain display text'),
       rich_content: z.array(z.object({
-        type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
+        type: z.enum([
+          'paragraph', 'heading', 'blockquote',
+          'bulletList', 'orderedList',
+          'codeBlock', 'horizontalRule',
+          'htmlEmbed', 'image', 'table', 'component',
+        ]),
         text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
         level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
         items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
+        code: z.string().optional().describe('For htmlEmbed: the HTML/JS code to embed'),
+        src: z.string().optional().describe('For image: external image URL (use asset_id for uploaded assets)'),
+        alt: z.string().optional().describe('For image: alt text'),
+        asset_id: z.string().optional().describe('For image: asset ID from upload_asset'),
+        rows: z.array(z.array(z.string())).optional().describe('For table: 2D array of cell text'),
+        header_row: z.boolean().optional().describe('For table: whether the first row renders as headers. Defaults true.'),
+        component_id: z.string().optional().describe('For component: ID of the component to embed'),
       })).optional().describe('For richText: structured content blocks. Overrides text_content.'),
       custom_name: z.string().optional().describe('Custom display name for the layer'),
     },
@@ -446,15 +459,22 @@ LINK TYPES:
 
   server.tool(
     'update_layer_settings',
-    `Update layer settings like HTML tag, custom ID, custom attributes, embed code, and slider/lightbox configuration.
+    `Update layer settings like HTML tag, custom ID, custom attributes, embed code, visibility,
+and per-element configuration (slider, lightbox, map, select options, filter, placeholder option).
 
 COMMON USES:
 - Change heading level: tag "h1", "h2", "h3", etc.
 - Set HTML embed code: html_embed_code "<script>..."
 - Add custom attributes: custom_attributes { "data-analytics": "hero" }
 - Set custom HTML ID: html_id "my-section"
+- Hide a layer from the canvas: hidden true
 - Configure slider: slider { autoplay: true, delay: "5", loop: "loop", pagination: true }
-- Configure lightbox: lightbox { thumbnails: true, zoom: true, navigation: true }`,
+- Configure lightbox: lightbox { thumbnails: true, zoom: true, navigation: true }
+- Bind lightbox to a CMS multi-image field: lightbox { files_source: "cms", files_field_id: "<field id>" }
+- Configure map: map { provider: "mapbox", latitude: 40.7128, longitude: -74.006, zoom: 12 }
+- Bind select / checkbox / radio to a CMS collection: options_source { collection_id: "<id>", sort_field_id: "<id>", sort_order: "asc" }
+- Mark a <option> as the placeholder: is_placeholder true
+- Trigger filter element on every change: filter_on_change true`,
     {
       page_id: z.string().describe('The page ID'),
       layer_id: z.string().describe('The layer ID'),
@@ -463,32 +483,69 @@ COMMON USES:
       html_embed_code: z.string().optional().describe('For htmlEmbed layers: the HTML/CSS/JS code to embed'),
       custom_attributes: z.record(z.string(), z.string()).optional().describe('Custom HTML attributes as { name: value } pairs'),
       custom_name: z.string().optional().describe('Display name for the layer in the builder'),
+      hidden: z.boolean().optional().describe('Hide the layer on the canvas (still renders on the published site).'),
+      filter_on_change: z.boolean().optional().describe('For filter layers: trigger filtering on every input change (debounced).'),
+      is_placeholder: z.boolean().optional().describe('For <option> children of <select>: mark this option as the disabled placeholder.'),
       slider: z.object({
         navigation: z.boolean().optional().describe('Show prev/next arrows'),
         pagination: z.boolean().optional().describe('Show pagination bullets'),
-        paginationType: z.enum(['bullets', 'fraction']).optional().describe('Pagination style'),
+        pagination_type: z.enum(['bullets', 'fraction']).optional().describe('Pagination style'),
+        pagination_clickable: z.boolean().optional(),
         autoplay: z.boolean().optional().describe('Auto-advance slides'),
-        pauseOnHover: z.boolean().optional().describe('Pause autoplay on hover'),
+        pause_on_hover: z.boolean().optional().describe('Pause autoplay on hover'),
         delay: z.string().optional().describe('Autoplay delay in seconds (e.g. "3", "5")'),
         loop: z.enum(['none', 'loop', 'rewind']).optional().describe('Loop mode'),
-        animationEffect: z.enum(['slide', 'fade', 'cube', 'coverflow', 'flip', 'cards']).optional(),
+        animation_effect: z.enum(['slide', 'fade', 'cube', 'coverflow', 'flip', 'cards']).optional(),
         duration: z.string().optional().describe('Transition duration in seconds (e.g. "0.5")'),
+        easing: z.string().optional(),
         centered: z.boolean().optional().describe('Center active slide'),
         mousewheel: z.boolean().optional().describe('Navigate with scroll wheel'),
+        touch_events: z.boolean().optional(),
+        slide_to_clicked: z.boolean().optional(),
+        slides_per_group: z.number().optional(),
+        group_slide: z.number().optional(),
       }).optional().describe('Slider settings (only for slider layers)'),
       lightbox: z.object({
+        files_source: z.enum(['files', 'cms']).optional().describe('"files" for a hand-picked list, "cms" to bind to a multi-image CMS field'),
+        files: z.array(z.string()).optional().describe('For files_source "files": array of asset IDs or external URLs'),
+        files_field_id: z.string().nullable().optional().describe('For files_source "cms": the CMS field ID to read images from (must be a multi-asset field on the surrounding collection layer)'),
         thumbnails: z.boolean().optional().describe('Show thumbnails strip'),
         navigation: z.boolean().optional().describe('Show prev/next arrows'),
         pagination: z.boolean().optional().describe('Show pagination'),
         zoom: z.boolean().optional().describe('Enable pinch-to-zoom'),
-        doubleTapZoom: z.boolean().optional().describe('Enable double-tap zoom'),
+        double_tap_zoom: z.boolean().optional().describe('Enable double-tap zoom'),
         mousewheel: z.boolean().optional().describe('Navigate with scroll wheel'),
         overlay: z.enum(['light', 'dark']).optional().describe('Overlay background style'),
-        animationEffect: z.enum(['slide', 'fade', 'cube', 'coverflow', 'flip', 'cards']).optional(),
+        group_id: z.string().optional().describe('Links multiple lightboxes into one shared gallery'),
+        animation_effect: z.enum(['slide', 'fade', 'cube', 'coverflow', 'flip', 'cards']).optional(),
+        easing: z.string().optional(),
         duration: z.string().optional().describe('Transition duration in seconds'),
       }).optional().describe('Lightbox settings (only for lightbox layers)'),
+      map: z.object({
+        provider: z.enum(['mapbox', 'google']).optional(),
+        latitude: z.number().optional(),
+        longitude: z.number().optional(),
+        zoom: z.number().optional(),
+        marker_color: z.string().nullable().optional(),
+        search: z.string().optional().describe('Address / place to geocode (alternative to lat/lng)'),
+        style: z.string().optional().describe('Provider-specific style key. Sets <provider>.style.'),
+        interactive: z.boolean().optional(),
+        scroll_zoom: z.boolean().optional(),
+        show_nav_control: z.boolean().optional(),
+        show_scale_bar: z.boolean().optional(),
+      }).optional().describe('Map settings (only for map layers)'),
+      options_source: z.object({
+        collection_id: z.string().describe('Collection to source options from'),
+        default_item_id: z.string().optional().describe('Item ID to pre-select (for <select>)'),
+        default_item_ids: z.array(z.string()).optional().describe('Item IDs to pre-check (for checkbox groups)'),
+        sort_field_id: z.string().optional().describe('Field ID to sort by (omit for manual order)'),
+        sort_order: z.enum(['asc', 'desc']).optional(),
+      }).nullable().optional().describe('Bind a select / checkbox / radio element to a CMS collection. Pass null to clear.'),
     },
-    async ({ page_id, layer_id, tag, html_id, html_embed_code, custom_attributes, custom_name, slider, lightbox }) => {
+    async ({
+      page_id, layer_id, tag, html_id, html_embed_code, custom_attributes, custom_name,
+      hidden, filter_on_change, is_placeholder, slider, lightbox, map, options_source,
+    }) => {
       const layers = await getPageLayers(page_id);
       const layer = findLayerById(layers, layer_id);
       if (!layer) {
@@ -499,10 +556,85 @@ COMMON USES:
         const settings = { ...l.settings };
         if (tag) settings.tag = tag;
         if (html_id) settings.id = html_id;
+        if (hidden !== undefined) settings.hidden = hidden;
+        if (filter_on_change !== undefined) settings.filterOnChange = filter_on_change;
+        if (is_placeholder !== undefined) settings.isPlaceholder = is_placeholder;
         if (custom_attributes) settings.customAttributes = { ...settings.customAttributes, ...custom_attributes };
         if (html_embed_code !== undefined) settings.htmlEmbed = { ...settings.htmlEmbed, code: html_embed_code };
-        if (slider && settings.slider) settings.slider = { ...settings.slider, ...slider };
-        if (lightbox && settings.lightbox) settings.lightbox = { ...settings.lightbox, ...lightbox };
+        if (slider) {
+          const existing = settings.slider || {} as Record<string, unknown>;
+          settings.slider = {
+            ...existing,
+            ...(slider.navigation !== undefined && { navigation: slider.navigation }),
+            ...(slider.pagination !== undefined && { pagination: slider.pagination }),
+            ...(slider.pagination_type !== undefined && { paginationType: slider.pagination_type }),
+            ...(slider.pagination_clickable !== undefined && { paginationClickable: slider.pagination_clickable }),
+            ...(slider.autoplay !== undefined && { autoplay: slider.autoplay }),
+            ...(slider.pause_on_hover !== undefined && { pauseOnHover: slider.pause_on_hover }),
+            ...(slider.delay !== undefined && { delay: slider.delay }),
+            ...(slider.loop !== undefined && { loop: slider.loop }),
+            ...(slider.animation_effect !== undefined && { animationEffect: slider.animation_effect }),
+            ...(slider.duration !== undefined && { duration: slider.duration }),
+            ...(slider.easing !== undefined && { easing: slider.easing }),
+            ...(slider.centered !== undefined && { centered: slider.centered }),
+            ...(slider.mousewheel !== undefined && { mousewheel: slider.mousewheel }),
+            ...(slider.touch_events !== undefined && { touchEvents: slider.touch_events }),
+            ...(slider.slide_to_clicked !== undefined && { slideToClicked: slider.slide_to_clicked }),
+            ...(slider.slides_per_group !== undefined && { slidesPerGroup: slider.slides_per_group }),
+            ...(slider.group_slide !== undefined && { groupSlide: slider.group_slide }),
+          } as typeof settings.slider;
+        }
+        if (lightbox) {
+          const existing = (settings.lightbox || {}) as Record<string, unknown>;
+          const next = { ...existing } as Record<string, unknown>;
+          if (lightbox.files_source !== undefined) next.filesSource = lightbox.files_source;
+          if (lightbox.files !== undefined) next.files = lightbox.files;
+          if (lightbox.files_field_id !== undefined) {
+            next.filesField = lightbox.files_field_id
+              ? { type: 'field', data: { field_id: lightbox.files_field_id, field_type: 'image', relationships: [] } }
+              : null;
+          }
+          if (lightbox.thumbnails !== undefined) next.thumbnails = lightbox.thumbnails;
+          if (lightbox.navigation !== undefined) next.navigation = lightbox.navigation;
+          if (lightbox.pagination !== undefined) next.pagination = lightbox.pagination;
+          if (lightbox.zoom !== undefined) next.zoom = lightbox.zoom;
+          if (lightbox.double_tap_zoom !== undefined) next.doubleTapZoom = lightbox.double_tap_zoom;
+          if (lightbox.mousewheel !== undefined) next.mousewheel = lightbox.mousewheel;
+          if (lightbox.overlay !== undefined) next.overlay = lightbox.overlay;
+          if (lightbox.group_id !== undefined) next.groupId = lightbox.group_id;
+          if (lightbox.animation_effect !== undefined) next.animationEffect = lightbox.animation_effect;
+          if (lightbox.easing !== undefined) next.easing = lightbox.easing;
+          if (lightbox.duration !== undefined) next.duration = lightbox.duration;
+          settings.lightbox = next as unknown as typeof settings.lightbox;
+        }
+        if (map) {
+          const existing = (settings.map || {}) as Record<string, unknown>;
+          const next = { ...existing } as Record<string, unknown>;
+          if (map.provider !== undefined) next.provider = map.provider;
+          if (map.latitude !== undefined) next.latitude = map.latitude;
+          if (map.longitude !== undefined) next.longitude = map.longitude;
+          if (map.zoom !== undefined) next.zoom = map.zoom;
+          if (map.marker_color !== undefined) next.markerColor = map.marker_color;
+          if (map.search !== undefined) next.search = map.search;
+          const providerKey = (map.provider || existing.provider || 'mapbox') as 'mapbox' | 'google';
+          const providerSettings = { ...((existing[providerKey] as Record<string, unknown>) || {}) };
+          if (map.style !== undefined) providerSettings.style = map.style;
+          if (map.interactive !== undefined) providerSettings.interactive = map.interactive;
+          if (map.scroll_zoom !== undefined) providerSettings.scrollZoom = map.scroll_zoom;
+          if (map.show_nav_control !== undefined) providerSettings.showNavControl = map.show_nav_control;
+          if (map.show_scale_bar !== undefined) providerSettings.showScaleBar = map.show_scale_bar;
+          if (Object.keys(providerSettings).length > 0) next[providerKey] = providerSettings;
+          settings.map = next as unknown as typeof settings.map;
+        }
+        if (options_source !== undefined) {
+          settings.optionsSource = options_source === null ? undefined : {
+            collectionId: options_source.collection_id,
+            ...(options_source.default_item_id !== undefined && { defaultItemId: options_source.default_item_id }),
+            ...(options_source.default_item_ids !== undefined && { defaultItemIds: options_source.default_item_ids }),
+            ...(options_source.sort_field_id !== undefined && { sortFieldId: options_source.sort_field_id }),
+            ...(options_source.sort_order !== undefined && { sortOrder: options_source.sort_order }),
+          };
+        }
 
         return {
           ...l,
@@ -513,6 +645,26 @@ COMMON USES:
 
       await savePageLayers(page_id, updated);
       return { content: [{ type: 'text' as const, text: `Updated settings for "${layer.customName || layer.name}"` }] };
+    },
+  );
+
+  server.tool(
+    'export_layer_html',
+    `Render a layer (and its descendants) to a self-contained HTML string with Tailwind
+classes preserved. Useful for copying a section, sharing markup, or seeding another
+page via the HTML import flow.`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer ID to export'),
+    },
+    async ({ page_id, layer_id }) => {
+      const layers = await getPageLayers(page_id);
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+      const html = layerToExportHtml(layer);
+      return { content: [{ type: 'text' as const, text: html }] };
     },
   );
 

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DesignProperties, Layer, LinkSettings } from '@/types';
-import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
 import {
   findLayerById,
   updateLayerById,
@@ -16,17 +15,11 @@ import {
 } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
 import { layerToExportHtml } from '@/lib/html-layer-converter';
-import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
+import { getCachedLayers as getPageLayers, saveCachedLayers } from '@/lib/mcp/page-layers';
 import { designSchema, richTextBlockSchema, templateEnum } from './shared-schemas';
 
-async function getPageLayers(pageId: string): Promise<Layer[]> {
-  const pageLayers = await getDraftLayers(pageId);
-  return (pageLayers?.layers as Layer[]) || [];
-}
-
 async function savePageLayers(pageId: string, layers: Layer[]): Promise<void> {
-  await upsertDraftLayers(pageId, layers);
-  broadcastLayersChanged(pageId, layers).catch(() => {});
+  await saveCachedLayers(pageId, layers);
 }
 
 export function registerLayerTools(server: McpServer) {

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -333,22 +333,27 @@ For gradient text: also set backgroundClip: "text" and color to "transparent".`,
 
 LINK TYPES:
 - url: External URL (e.g. "https://example.com")
-- page: Link to another page in the site
+- page: Link to another page in the site. Pass collection_item_id alongside page_id_target to link to a specific dynamic-page item.
 - email: Mailto link
 - phone: Tel link
-- asset: Download link to an asset`,
+- asset: Download link to an asset
+- anchor: Set anchor_layer_id (and optionally page_id_target) to jump to a specific layer on the same or another page.`,
     {
       page_id: z.string().describe('The page ID'),
       layer_id: z.string().describe('The layer ID'),
       link_type: z.enum(['url', 'email', 'phone', 'asset', 'page']).describe('Type of link'),
       url: z.string().optional().describe('For url type: the target URL'),
       page_id_target: z.string().optional().describe('For page type: the target page ID'),
+      collection_item_id: z.string().optional().describe('For dynamic page links: the specific collection item the link should resolve to. Omit to use the current item at runtime.'),
       email: z.string().optional().describe('For email type: the email address'),
       phone: z.string().optional().describe('For phone type: the phone number'),
       asset_id: z.string().optional().describe('For asset type: the asset ID to download'),
-      target: z.enum(['_blank', '_self']).optional().describe('Link target. _blank opens new tab.'),
+      anchor_layer_id: z.string().optional().describe('Layer ID to scroll to as an in-page anchor. Combine with link_type "url" to link to "#layer" on the same page, or with link_type "page" to link to "#layer" on another page.'),
+      target: z.enum(['_blank', '_self', '_parent', '_top']).optional().describe('Link target. _blank opens new tab.'),
+      rel: z.string().optional().describe('rel attribute, e.g. "noopener noreferrer", "nofollow", "sponsored", "ugc"'),
+      download: z.boolean().optional().describe('When true, instruct the browser to download the linked resource instead of navigating.'),
     },
-    async ({ page_id, layer_id, link_type, url, page_id_target, email, phone, asset_id, target }) => {
+    async ({ page_id, layer_id, link_type, url, page_id_target, collection_item_id, email, phone, asset_id, anchor_layer_id, target, rel, download }) => {
       const layers = await getPageLayers(page_id);
       const layer = findLayerById(layers, layer_id);
       if (!layer) {
@@ -360,8 +365,15 @@ LINK TYPES:
       if (link_type === 'email' && email) link.email = { type: 'dynamic_text', data: { content: email } };
       if (link_type === 'phone' && phone) link.phone = { type: 'dynamic_text', data: { content: phone } };
       if (link_type === 'asset' && asset_id) link.asset = { id: asset_id };
-      if (link_type === 'page' && page_id_target) link.page = { id: page_id_target };
+      if (link_type === 'page' && page_id_target) {
+        link.page = collection_item_id
+          ? { id: page_id_target, collection_item_id }
+          : { id: page_id_target };
+      }
+      if (anchor_layer_id) link.anchor_layer_id = anchor_layer_id;
       if (target) link.target = target;
+      if (rel !== undefined) link.rel = rel;
+      if (download !== undefined) link.download = download;
 
       const updated = updateLayerById(layers, layer_id, (l) => ({
         ...l,

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -38,7 +38,7 @@ before making changes.`,
     { page_id: z.string().describe('The page ID') },
     async ({ page_id }) => {
       const layers = await getPageLayers(page_id);
-      return { content: [{ type: 'text' as const, text: JSON.stringify(layers, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(layers) }] };
     },
   );
 
@@ -100,7 +100,7 @@ NESTING RULES:
             message: `Added ${template} "${custom_name || newLayer.customName || template}" to page`,
             layer_id: newLayer.id,
             parent_layer_id,
-          }, null, 2),
+          }),
         }],
       };
     },
@@ -154,7 +154,7 @@ For gradient text: also set backgroundClip: "text" and color to "transparent".`,
             layer_id,
             classes: updatedLayer?.classes,
             design: updatedLayer?.design,
-          }, null, 2),
+          }),
         }],
       };
     },
@@ -227,7 +227,7 @@ For gradient text: also set backgroundClip: "text" and color to "transparent".`,
           text: JSON.stringify({
             message: `Set rich text content for "${layer.customName || layer.name}" (${blocks.length} blocks)`,
             layer_id,
-          }, null, 2),
+          }),
         }],
       };
     },

--- a/lib/mcp/tools/layouts.ts
+++ b/lib/mcp/tools/layouts.ts
@@ -9,6 +9,7 @@ import {
   getLayoutsByCategory,
 } from '@/lib/templates/blocks';
 import { findLayerById, insertLayer, canHaveChildren } from '@/lib/mcp/utils';
+import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
 
 interface CatalogEntry {
   key: string;
@@ -104,6 +105,7 @@ Use list_layouts to see available layouts.`,
       }
 
       await upsertDraftLayers(page_id, layers);
+      broadcastLayersChanged(page_id, layers).catch(() => {});
 
       return {
         content: [{

--- a/lib/mcp/tools/layouts.ts
+++ b/lib/mcp/tools/layouts.ts
@@ -2,76 +2,49 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Layer } from '@/types';
 import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
-import { getLayoutTemplate } from '@/lib/templates/blocks';
-import { findLayerById, insertLayer, canHaveChildren, generateId } from '@/lib/mcp/utils';
+import {
+  getLayoutTemplate,
+  getLayoutCategory,
+  getLayoutPreviewImage,
+  getLayoutsByCategory,
+} from '@/lib/templates/blocks';
+import { findLayerById, insertLayer, canHaveChildren } from '@/lib/mcp/utils';
 
-const LAYOUT_CATALOG = [
-  { key: 'hero-001', category: 'Hero', description: 'Two-column hero with heading, text, and image' },
-  { key: 'hero-002', category: 'Hero', description: 'Centered hero with large heading and CTA buttons' },
-  { key: 'hero-003', category: 'Hero', description: 'Hero with background image and overlay text' },
-  { key: 'hero-004', category: 'Hero', description: 'Minimal hero with heading and subtext' },
-  { key: 'hero-005', category: 'Hero', description: 'Hero with features grid below' },
-  { key: 'header-001', category: 'Header', description: 'Navigation bar with logo and links' },
-  { key: 'header-002', category: 'Header', description: 'Centered navigation with logo' },
-  { key: 'header-003', category: 'Header', description: 'Minimal header with logo and CTA' },
-  { key: 'header-004', category: 'Header', description: 'Header with logo, links, and button' },
-  { key: 'features-001', category: 'Features', description: 'Three-column feature cards with icons' },
-  { key: 'features-002', category: 'Features', description: 'Two-column features with image' },
-  { key: 'features-003', category: 'Features', description: 'Feature grid with 4 cards' },
-  { key: 'features-004', category: 'Features', description: 'Alternating feature rows with images' },
-  { key: 'features-005', category: 'Features', description: 'Feature list with large numbers' },
-  { key: 'features-006', category: 'Features', description: 'Bento grid features layout' },
-  { key: 'features-007', category: 'Features', description: 'Features with icon circles' },
-  { key: 'features-008', category: 'Features', description: 'Three features side by side' },
-  { key: 'features-009', category: 'Features', description: 'Feature showcase with tabs' },
-  { key: 'features-010', category: 'Features', description: 'Large feature card grid' },
-  { key: 'features-011', category: 'Features', description: 'Minimal two-column features' },
-  { key: 'features-012', category: 'Features', description: 'Features with colored backgrounds' },
-  { key: 'blog-001', category: 'Blog posts', description: 'Three-column blog post cards' },
-  { key: 'blog-002', category: 'Blog posts', description: 'Blog list with featured image' },
-  { key: 'blog-003', category: 'Blog posts', description: 'Two-column blog cards' },
-  { key: 'blog-004', category: 'Blog posts', description: 'Blog grid with categories' },
-  { key: 'blog-005', category: 'Blog posts', description: 'Blog cards with author info' },
-  { key: 'blog-006', category: 'Blog posts', description: 'Minimal blog list' },
-  { key: 'blog-header-001', category: 'Blog header', description: 'Blog post header with title and meta' },
-  { key: 'blog-header-002', category: 'Blog header', description: 'Blog header with cover image' },
-  { key: 'blog-header-003', category: 'Blog header', description: 'Minimal blog header' },
-  { key: 'blog-header-004', category: 'Blog header', description: 'Blog header with breadcrumbs' },
-  { key: 'stats-001', category: 'Stats', description: 'Statistics row with large numbers' },
-  { key: 'stats-002', category: 'Stats', description: 'Stats grid with descriptions' },
-  { key: 'stats-003', category: 'Stats', description: 'Stats with progress indicators' },
-  { key: 'pricing-001', category: 'Pricing', description: 'Three-tier pricing cards' },
-  { key: 'team-001', category: 'Team', description: 'Team member cards with photos' },
-  { key: 'team-002', category: 'Team', description: 'Team grid with roles' },
-  { key: 'testimonials-001', category: 'Testimonials', description: 'Single centered testimonial quote' },
-  { key: 'testimonials-002', category: 'Testimonials', description: 'Testimonial cards grid' },
-  { key: 'testimonials-003', category: 'Testimonials', description: 'Testimonial with avatar and rating' },
-  { key: 'testimonials-004', category: 'Testimonials', description: 'Full-width testimonial slider' },
-  { key: 'testimonials-005', category: 'Testimonials', description: 'Testimonial wall' },
-  { key: 'faq-001', category: 'FAQ', description: 'Frequently asked questions accordion' },
-  { key: 'navigation-001', category: 'Navigation', description: 'Top navigation bar' },
-  { key: 'navigation-002', category: 'Navigation', description: 'Side navigation menu' },
-  { key: 'footer-001', category: 'Footer', description: 'Multi-column footer with links' },
-  { key: 'footer-002', category: 'Footer', description: 'Simple footer with logo and copyright' },
-  { key: 'footer-003', category: 'Footer', description: 'Footer with newsletter signup' },
-];
+interface CatalogEntry {
+  key: string;
+  preview_image_url?: string;
+}
+
+/**
+ * Auto-derive the layout catalog from `layoutTemplates` so it can never
+ * drift from the source of truth (previously caused `blog-header-*` and
+ * `blog-001..006` keys to be advertised but unusable).
+ */
+function buildLayoutCatalog(): Record<string, CatalogEntry[]> {
+  const byCategory = getLayoutsByCategory();
+  const result: Record<string, CatalogEntry[]> = {};
+
+  for (const [category, keys] of Object.entries(byCategory)) {
+    result[category] = keys.map((key) => {
+      const preview = getLayoutPreviewImage(key);
+      return preview ? { key, preview_image_url: preview } : { key };
+    });
+  }
+
+  return result;
+}
 
 export function registerLayoutTools(server: McpServer) {
   server.tool(
     'list_layouts',
     `List all available pre-built layout templates organized by category.
-Use add_layout to insert any of these into a page.
-
-Categories: Hero, Header, Features, Blog posts, Blog header, Stats, Pricing,
-Team, Testimonials, FAQ, Navigation, Footer`,
+Use add_layout to insert any of these into a page.`,
     {},
     async () => {
-      const byCategory: Record<string, typeof LAYOUT_CATALOG> = {};
-      for (const layout of LAYOUT_CATALOG) {
-        if (!byCategory[layout.category]) byCategory[layout.category] = [];
-        byCategory[layout.category].push(layout);
-      }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(byCategory, null, 2) }] };
+      const catalog = buildLayoutCatalog();
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(catalog, null, 2) }],
+      };
     },
   );
 
@@ -86,66 +59,48 @@ Use list_layouts to see available layouts.`,
       position: z.number().optional().describe('Position within parent. Omit to append at end.'),
     },
     async ({ page_id, layout_key, parent_layer_id, position }) => {
-      const found = LAYOUT_CATALOG.find((l) => l.key === layout_key);
-      if (!found) {
-        return { content: [{ type: 'text' as const, text: `Error: Unknown layout "${layout_key}". Use list_layouts to see available layouts.` }], isError: true };
+      const layoutLayer = getLayoutTemplate(layout_key);
+      if (!layoutLayer) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error: Unknown layout "${layout_key}". Use list_layouts to see available layouts.`,
+          }],
+          isError: true,
+        };
       }
+
+      const category = getLayoutCategory(layout_key);
 
       const pageLayers = await getDraftLayers(page_id);
       let layers = (pageLayers?.layers as Layer[]) || [];
 
-      // Try the main project's layout template system
-      let layoutLayer: Layer | null = null;
-      try {
-        layoutLayer = getLayoutTemplate(layout_key);
-      } catch {
-        // Layout template not available
-      }
-
-      if (!layoutLayer) {
-        // Fallback: create a basic section scaffold
-        const section: Layer = {
-          id: generateId('lyr'),
-          name: 'section',
-          customName: `${found.category}: ${found.description}`,
-          classes: ['flex', 'flex-col', 'w-[100%]', 'pt-[80px]', 'pb-[80px]', 'items-center'],
-          design: {
-            layout: { isActive: true, display: 'Flex', flexDirection: 'column', alignItems: 'center' },
-            sizing: { isActive: true, width: '100%' },
-            spacing: { isActive: true, paddingTop: '80px', paddingBottom: '80px' },
-          },
-          children: [{
-            id: generateId('lyr'),
-            name: 'div',
-            customName: 'Container',
-            classes: ['flex', 'flex-col', 'max-w-[1280px]', 'w-[100%]', 'pl-[32px]', 'pr-[32px]'],
-            design: {
-              layout: { isActive: true, display: 'Flex', flexDirection: 'column' },
-              sizing: { isActive: true, width: '100%', maxWidth: '1280px' },
-              spacing: { isActive: true, paddingLeft: '32px', paddingRight: '32px' },
-            },
-            children: [],
-          }],
-        };
-        layoutLayer = section;
-      }
-
       if (parent_layer_id) {
         const parent = findLayerById(layers, parent_layer_id);
         if (!parent) {
-          return { content: [{ type: 'text' as const, text: `Error: Parent "${parent_layer_id}" not found.` }], isError: true };
+          return {
+            content: [{
+              type: 'text' as const,
+              text: `Error: Parent "${parent_layer_id}" not found.`,
+            }],
+            isError: true,
+          };
         }
         if (!canHaveChildren(parent)) {
-          return { content: [{ type: 'text' as const, text: `Error: "${parent.customName || parent.name}" cannot have children.` }], isError: true };
+          return {
+            content: [{
+              type: 'text' as const,
+              text: `Error: "${parent.customName || parent.name}" cannot have children.`,
+            }],
+            isError: true,
+          };
         }
         layers = insertLayer(layers, parent_layer_id, layoutLayer, position);
+      } else if (position !== undefined) {
+        layers = [...layers];
+        layers.splice(position, 0, layoutLayer);
       } else {
-        if (position !== undefined) {
-          layers = [...layers];
-          layers.splice(position, 0, layoutLayer);
-        } else {
-          layers = [...layers, layoutLayer];
-        }
+        layers = [...layers, layoutLayer];
       }
 
       await upsertDraftLayers(page_id, layers);
@@ -154,10 +109,11 @@ Use list_layouts to see available layouts.`,
         content: [{
           type: 'text' as const,
           text: JSON.stringify({
-            message: `Added ${found.category} section to page`,
+            message: `Added ${category || 'layout'} section to page`,
             section_id: layoutLayer.id,
             container_id: layoutLayer.children?.[0]?.id,
-            layout: found,
+            layout_key,
+            category,
           }, null, 2),
         }],
       };

--- a/lib/mcp/tools/layouts.ts
+++ b/lib/mcp/tools/layouts.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Layer } from '@/types';
-import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
+import { getCachedLayers, saveCachedLayers } from '@/lib/mcp/page-layers';
 import {
   getLayoutTemplate,
   getLayoutCategory,
@@ -9,7 +9,6 @@ import {
   getLayoutsByCategory,
 } from '@/lib/templates/blocks';
 import { findLayerById, insertLayer, canHaveChildren } from '@/lib/mcp/utils';
-import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
 
 interface CatalogEntry {
   key: string;
@@ -73,8 +72,7 @@ Use list_layouts to see available layouts.`,
 
       const category = getLayoutCategory(layout_key);
 
-      const pageLayers = await getDraftLayers(page_id);
-      let layers = (pageLayers?.layers as Layer[]) || [];
+      let layers: Layer[] = await getCachedLayers(page_id);
 
       if (parent_layer_id) {
         const parent = findLayerById(layers, parent_layer_id);
@@ -104,8 +102,7 @@ Use list_layouts to see available layouts.`,
         layers = [...layers, layoutLayer];
       }
 
-      await upsertDraftLayers(page_id, layers);
-      broadcastLayersChanged(page_id, layers).catch(() => {});
+      await saveCachedLayers(page_id, layers);
 
       return {
         content: [{

--- a/lib/mcp/tools/layouts.ts
+++ b/lib/mcp/tools/layouts.ts
@@ -44,7 +44,7 @@ Use add_layout to insert any of these into a page.`,
     async () => {
       const catalog = buildLayoutCatalog();
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(catalog, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(catalog) }],
       };
     },
   );
@@ -116,7 +116,7 @@ Use list_layouts to see available layouts.`,
             container_id: layoutLayer.children?.[0]?.id,
             layout_key,
             category,
-          }, null, 2),
+          }),
         }],
       };
     },

--- a/lib/mcp/tools/locales.ts
+++ b/lib/mcp/tools/locales.ts
@@ -14,6 +14,15 @@ import {
   deleteTranslation,
   upsertTranslations,
 } from '@/lib/repositories/translationRepository';
+import { buildTiptapDoc } from '@/lib/mcp/utils';
+import type { RichTextBlock } from '@/lib/mcp/utils';
+
+const richTextBlockSchema = z.object({
+  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
+  text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
+  level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
+  items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
+});
 
 export function registerLocaleTools(server: McpServer) {
   server.tool(
@@ -232,6 +241,43 @@ export function registerLocaleTools(server: McpServer) {
       await deleteTranslation(translation_id);
       return {
         content: [{ type: 'text' as const, text: `Translation ${translation_id} deleted successfully.` }],
+      };
+    },
+  );
+
+  server.tool(
+    'set_rich_text_translation',
+    `Translate a rich-text content key by passing structured blocks. The blocks are converted
+to the Tiptap JSON shape that Ycode expects for richtext translations and stored as
+content_value. Equivalent to calling set_translation with content_type "richtext" but the
+agent doesn't have to assemble the JSON by hand.
+
+Block types match add_layer's rich_content: paragraph, heading, blockquote, bulletList,
+orderedList, codeBlock, horizontalRule. Text supports **bold**, *italic*, [link](url).`,
+    {
+      locale_id: z.string().describe('The locale ID'),
+      source_type: z.enum(['page', 'folder', 'component', 'cms']).describe('Type of source being translated'),
+      source_id: z.string().describe('ID of the source (page ID, component ID, etc.)'),
+      content_key: z.string().describe('Content key identifying the rich-text field (e.g. layer ID or "richtext:<field id>")'),
+      blocks: z.array(richTextBlockSchema).min(1).describe('Rich-text blocks describing the translated content'),
+      is_completed: z.boolean().optional().describe('Mark translation as complete. Defaults to false.'),
+    },
+    async ({ locale_id, source_type, source_id, content_key, blocks, is_completed }) => {
+      const doc = buildTiptapDoc(blocks as RichTextBlock[]);
+      const translation = await createTranslation({
+        locale_id,
+        source_type,
+        source_id,
+        content_key,
+        content_type: 'richtext',
+        content_value: JSON.stringify(doc),
+        is_completed,
+      });
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({ message: 'Rich-text translation saved', translation }, null, 2),
+        }],
       };
     },
   );

--- a/lib/mcp/tools/pages.ts
+++ b/lib/mcp/tools/pages.ts
@@ -3,7 +3,20 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getAllPages, getPageById, getPagesByFolder, createPage, updatePage, deletePage, duplicatePage } from '@/lib/repositories/pageRepository';
 import { getAllPageFolders } from '@/lib/repositories/pageFolderRepository';
 import { upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
+import { getSettingByKey, setSetting } from '@/lib/repositories/settingsRepository';
 import { broadcastPageCreated, broadcastPageUpdated, broadcastPageDeleted, broadcastLayersChanged } from '@/lib/mcp/broadcast';
+import type { Redirect } from '@/types';
+
+const REDIRECTS_KEY = 'redirects';
+
+async function getRedirects(): Promise<Redirect[]> {
+  const value = await getSettingByKey(REDIRECTS_KEY);
+  return Array.isArray(value) ? value : [];
+}
+
+function generateRedirectId(): string {
+  return `redirect_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
 
 export function registerPageTools(server: McpServer) {
   server.tool(
@@ -80,12 +93,19 @@ export function registerPageTools(server: McpServer) {
 
   server.tool(
     'update_page',
-    "Update a page's name, slug, or folder.",
+    `Update a page's metadata: name, slug, folder, homepage flag, dynamic flag, and error-page assignment.
+
+ERROR PAGES: Set error_page to 401, 404, or 500 to designate this as the auth-required / not-found / server-error page for the site. Pass null to clear.
+DYNAMIC PAGES: Set is_dynamic true to turn this into a CMS-driven page (then use update_page_settings.cms to bind it to a collection).`,
     {
       page_id: z.string().describe('The page ID to update'),
       name: z.string().optional().describe('New page title'),
       slug: z.string().optional().describe('New URL slug'),
       page_folder_id: z.string().nullable().optional().describe('Move to folder ID, or null for root'),
+      is_index: z.boolean().optional().describe('Mark as the homepage (only one page can be the index)'),
+      is_dynamic: z.boolean().optional().describe('Turn into a CMS dynamic page'),
+      error_page: z.union([z.literal(401), z.literal(404), z.literal(500)]).nullable().optional()
+        .describe('Designate as 401 / 404 / 500 error page. Pass null to clear.'),
     },
     async ({ page_id, ...data }) => {
       const page = await updatePage(page_id, data);
@@ -96,11 +116,13 @@ export function registerPageTools(server: McpServer) {
 
   server.tool(
     'update_page_settings',
-    `Update page SEO, custom code, or password protection settings.
+    `Update page SEO, custom code, password protection, or CMS binding (dynamic pages).
 
 SEO: Set title, description, noindex, and OG image (asset ID).
 Custom code: Inject HTML into <head> or before </body>.
-Password protection: Enable/disable with a password.`,
+Password protection: Enable/disable with a password.
+CMS binding: For dynamic pages — bind to a collection, pick the slug field, and configure
+how next-item / previous-item links traverse the collection.`,
     {
       page_id: z.string().describe('The page ID'),
       seo: z.object({
@@ -117,8 +139,16 @@ Password protection: Enable/disable with a password.`,
         enabled: z.boolean().describe('Enable or disable password protection'),
         password: z.string().optional().describe('Password for accessing the page'),
       }).optional(),
+      cms: z.object({
+        collection_id: z.string().describe('Collection to drive this dynamic page'),
+        slug_field_id: z.string().describe('Field whose value provides each item\'s URL slug'),
+        next_previous: z.object({
+          sort_by: z.string().optional().describe('"manual" (default) or a collection field ID'),
+          sort_order: z.enum(['asc', 'desc']).optional(),
+        }).optional().describe('Controls how next-item / previous-item link keywords traverse this page\'s collection.'),
+      }).nullable().optional().describe('CMS binding for dynamic pages. Pass null to clear.'),
     },
-    async ({ page_id, seo, custom_code, auth }) => {
+    async ({ page_id, seo, custom_code, auth, cms }) => {
       const existing = await getPageById(page_id);
       if (!existing) {
         return { content: [{ type: 'text' as const, text: `Error: Page "${page_id}" not found.` }], isError: true };
@@ -151,6 +181,23 @@ Password protection: Enable/disable with a password.`,
         };
       }
 
+      if (cms !== undefined) {
+        if (cms === null) {
+          delete settings.cms;
+        } else {
+          settings.cms = {
+            collection_id: cms.collection_id,
+            slug_field_id: cms.slug_field_id,
+            ...(cms.next_previous && {
+              next_previous: {
+                ...(cms.next_previous.sort_by !== undefined && { sort_by: cms.next_previous.sort_by as 'manual' | string }),
+                ...(cms.next_previous.sort_order !== undefined && { sort_order: cms.next_previous.sort_order }),
+              },
+            }),
+          };
+        }
+      }
+
       const page = await updatePage(page_id, { settings });
       broadcastPageUpdated(page_id, { settings }).catch(() => {});
       return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'Updated page settings', settings: page.settings }, null, 2) }] };
@@ -176,6 +223,89 @@ Password protection: Enable/disable with a password.`,
       await deletePage(page_id);
       broadcastPageDeleted(page_id).catch(() => {});
       return { content: [{ type: 'text' as const, text: `Page ${page_id} deleted successfully.` }] };
+    },
+  );
+
+  server.tool(
+    'list_redirects',
+    `List all configured URL redirects. Redirects map an old path to a new URL (internal path
+or external URL), with optional 301 (permanent) or 302 (temporary) semantics. Paths containing
+".+" or ".*" are treated as regex patterns; exact matches take priority.`,
+    {},
+    async () => {
+      const redirects = await getRedirects();
+      return { content: [{ type: 'text' as const, text: JSON.stringify(redirects, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'add_redirect',
+    `Add a new URL redirect.
+
+Examples:
+- { old_url: "/about-us", new_url: "/about", type: "301" }
+- { old_url: "/blog/.+", new_url: "/posts/$0" } (regex — entire match is $0)
+- { old_url: "/", new_url: "/welcome" } (root / homepage redirect)`,
+    {
+      old_url: z.string().describe('The old internal path (must start with /). Use ".+" or ".*" for regex patterns.'),
+      new_url: z.string().describe('The new destination — internal path "/about" or external URL "https://example.com"'),
+      type: z.enum(['301', '302']).optional().describe('301 = permanent, 302 = temporary. Defaults to 301.'),
+    },
+    async ({ old_url, new_url, type }) => {
+      const redirects = await getRedirects();
+      const newRedirect: Redirect = {
+        id: generateRedirectId(),
+        oldUrl: old_url,
+        newUrl: new_url,
+        ...(type && { type }),
+      };
+      await setSetting(REDIRECTS_KEY, [...redirects, newRedirect]);
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'Redirect added', redirect: newRedirect }, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'update_redirect',
+    'Update an existing redirect by ID.',
+    {
+      redirect_id: z.string().describe('The redirect ID'),
+      old_url: z.string().optional(),
+      new_url: z.string().optional(),
+      type: z.enum(['301', '302']).optional(),
+    },
+    async ({ redirect_id, old_url, new_url, type }) => {
+      const redirects = await getRedirects();
+      const idx = redirects.findIndex((r) => r.id === redirect_id);
+      if (idx === -1) {
+        return { content: [{ type: 'text' as const, text: `Error: Redirect "${redirect_id}" not found.` }], isError: true };
+      }
+      const updated: Redirect = {
+        ...redirects[idx],
+        ...(old_url !== undefined && { oldUrl: old_url }),
+        ...(new_url !== undefined && { newUrl: new_url }),
+        ...(type !== undefined && { type }),
+      };
+      const next = [...redirects];
+      next[idx] = updated;
+      await setSetting(REDIRECTS_KEY, next);
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'Redirect updated', redirect: updated }, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'delete_redirect',
+    'Delete a redirect by ID.',
+    {
+      redirect_id: z.string().describe('The redirect ID'),
+    },
+    async ({ redirect_id }) => {
+      const redirects = await getRedirects();
+      const next = redirects.filter((r) => r.id !== redirect_id);
+      if (next.length === redirects.length) {
+        return { content: [{ type: 'text' as const, text: `Error: Redirect "${redirect_id}" not found.` }], isError: true };
+      }
+      await setSetting(REDIRECTS_KEY, next);
+      return { content: [{ type: 'text' as const, text: `Redirect ${redirect_id} deleted` }] };
     },
   );
 }

--- a/lib/mcp/tools/pages.ts
+++ b/lib/mcp/tools/pages.ts
@@ -82,7 +82,8 @@ export function registerPageTools(server: McpServer) {
         classes: '',
         children: [],
       }];
-      await upsertDraftLayers(page.id, initialLayers);
+      // Brand-new page guarantees no existing draft — assert it to skip the repo's pre-read.
+      await upsertDraftLayers(page.id, initialLayers, undefined, null);
 
       broadcastPageCreated(page).catch(() => {});
       broadcastLayersChanged(page.id, initialLayers).catch(() => {});

--- a/lib/mcp/tools/pages.ts
+++ b/lib/mcp/tools/pages.ts
@@ -27,7 +27,7 @@ export function registerPageTools(server: McpServer) {
       const pages = await getAllPages();
       const folders = await getAllPageFolders();
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ pages, folders }, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify({ pages, folders }) }],
       };
     },
   );
@@ -41,7 +41,7 @@ export function registerPageTools(server: McpServer) {
       if (!page) {
         return { content: [{ type: 'text' as const, text: `Error: Page "${page_id}" not found.` }], isError: true };
       }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(page, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(page) }] };
     },
   );
 
@@ -87,7 +87,7 @@ export function registerPageTools(server: McpServer) {
       broadcastPageCreated(page).catch(() => {});
       broadcastLayersChanged(page.id, initialLayers).catch(() => {});
 
-      return { content: [{ type: 'text' as const, text: JSON.stringify(page, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(page) }] };
     },
   );
 
@@ -110,7 +110,7 @@ DYNAMIC PAGES: Set is_dynamic true to turn this into a CMS-driven page (then use
     async ({ page_id, ...data }) => {
       const page = await updatePage(page_id, data);
       broadcastPageUpdated(page_id, data).catch(() => {});
-      return { content: [{ type: 'text' as const, text: JSON.stringify(page, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(page) }] };
     },
   );
 
@@ -200,7 +200,7 @@ how next-item / previous-item links traverse the collection.`,
 
       const page = await updatePage(page_id, { settings });
       broadcastPageUpdated(page_id, { settings }).catch(() => {});
-      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'Updated page settings', settings: page.settings }, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'Updated page settings', settings: page.settings }) }] };
     },
   );
 
@@ -211,7 +211,7 @@ how next-item / previous-item links traverse the collection.`,
     async ({ page_id }) => {
       const page = await duplicatePage(page_id);
       broadcastPageCreated(page).catch(() => {});
-      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: `Duplicated page as "${page.name}"`, page }, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: `Duplicated page as "${page.name}"`, page }) }] };
     },
   );
 
@@ -234,7 +234,7 @@ or external URL), with optional 301 (permanent) or 302 (temporary) semantics. Pa
     {},
     async () => {
       const redirects = await getRedirects();
-      return { content: [{ type: 'text' as const, text: JSON.stringify(redirects, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(redirects) }] };
     },
   );
 
@@ -260,7 +260,7 @@ Examples:
         ...(type && { type }),
       };
       await setSetting(REDIRECTS_KEY, [...redirects, newRedirect]);
-      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'Redirect added', redirect: newRedirect }, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'Redirect added', redirect: newRedirect }) }] };
     },
   );
 
@@ -288,7 +288,7 @@ Examples:
       const next = [...redirects];
       next[idx] = updated;
       await setSetting(REDIRECTS_KEY, next);
-      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'Redirect updated', redirect: updated }, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'Redirect updated', redirect: updated }) }] };
     },
   );
 

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -1,4 +1,25 @@
 import { z } from 'zod';
+import { ELEMENT_TEMPLATES } from '@/lib/mcp/utils';
+
+/**
+ * Enum of every element template key the MCP can create. Derived from
+ * ELEMENT_TEMPLATES so the three add-layer surfaces (single, batch,
+ * component) cannot drift apart when a new template is added.
+ */
+export const templateEnum = z.enum(
+  Object.keys(ELEMENT_TEMPLATES) as [string, ...string[]],
+);
+
+/**
+ * Structured rich-text block accepted by add_layer (rich_content) and the
+ * batch set_rich_text operation. Mirrors the RichTextBlock type in utils.ts.
+ */
+export const richTextBlockSchema = z.object({
+  type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
+  text: z.string().optional().describe('Text content. Supports **bold**, *italic*, [link](url).'),
+  level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
+  items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
+});
 
 export const designSchema = z.object({
   layout: z.object({

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
+
+import type { DesignProperties } from '@/types';
 import { ELEMENT_TEMPLATES } from '@/lib/mcp/utils';
 
 /**
@@ -20,8 +22,6 @@ export const richTextBlockSchema = z.object({
   level: z.number().optional().describe('Heading level 1-6 (for heading type)'),
   items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
 });
-
-import type { DesignProperties } from '@/types';
 
 export const designSchema = z.object({
   layout: z.object({

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -21,6 +21,8 @@ export const richTextBlockSchema = z.object({
   items: z.array(z.string()).optional().describe('List items (for bulletList/orderedList)'),
 });
 
+import type { DesignProperties } from '@/types';
+
 export const designSchema = z.object({
   layout: z.object({
     isActive: z.boolean().optional(),
@@ -46,7 +48,13 @@ export const designSchema = z.object({
     textAlign: z.string().optional(),
     textTransform: z.string().optional(),
     textDecoration: z.string().optional(),
+    textDecorationColor: z.string().optional(),
+    textDecorationThickness: z.string().optional(),
+    underlineOffset: z.string().optional(),
+    lineClamp: z.string().optional().describe('Truncate text after N lines, e.g. "2" or "line-clamp-3"'),
+    verticalAlign: z.string().optional(),
     color: z.string().optional(),
+    placeholderColor: z.string().optional(),
   }).optional(),
   spacing: z.object({
     isActive: z.boolean().optional(),
@@ -69,12 +77,19 @@ export const designSchema = z.object({
     minHeight: z.string().optional(),
     maxWidth: z.string().optional(),
     maxHeight: z.string().optional(),
-    aspectRatio: z.string().optional(),
-    objectFit: z.string().optional(),
+    overflow: z.string().optional().describe('visible | hidden | scroll | auto'),
+    aspectRatio: z.string().nullable().optional(),
+    objectFit: z.string().nullable().optional(),
+    gridColumnSpan: z.string().nullable().optional().describe('Grid column span, e.g. "2" or "span 3"'),
+    gridRowSpan: z.string().nullable().optional().describe('Grid row span, e.g. "2" or "span 3"'),
   }).optional(),
   borders: z.object({
     isActive: z.boolean().optional(),
     borderWidth: z.string().optional(),
+    borderTopWidth: z.string().optional(),
+    borderRightWidth: z.string().optional(),
+    borderBottomWidth: z.string().optional(),
+    borderLeftWidth: z.string().optional(),
     borderStyle: z.string().optional(),
     borderColor: z.string().optional(),
     borderRadius: z.string().optional(),
@@ -82,14 +97,24 @@ export const designSchema = z.object({
     borderTopRightRadius: z.string().optional(),
     borderBottomLeftRadius: z.string().optional(),
     borderBottomRightRadius: z.string().optional(),
+    divideX: z.string().optional().describe('Horizontal divider width between children, e.g. "1px"'),
+    divideY: z.string().optional().describe('Vertical divider width between children, e.g. "1px"'),
+    divideStyle: z.string().optional(),
+    divideColor: z.string().optional(),
+    outlineWidth: z.string().optional(),
+    outlineColor: z.string().optional(),
+    outlineOffset: z.string().optional(),
   }).optional(),
   backgrounds: z.object({
     isActive: z.boolean().optional(),
     backgroundColor: z.string().optional(),
+    backgroundImage: z.string().optional().describe('CSS background-image value, e.g. "url(...)" or var reference'),
     backgroundSize: z.string().optional(),
     backgroundPosition: z.string().optional(),
     backgroundRepeat: z.string().optional(),
     backgroundClip: z.string().optional().describe('"text" for gradient text effect, "border" or "padding"'),
+    bgImageVars: z.record(z.string(), z.string()).optional()
+      .describe('Background image CSS values keyed by var name. Use "--bg-img" for desktop neutral.'),
     bgGradientVars: z.record(z.string(), z.string()).optional()
       .describe('Gradient CSS values keyed by var name. Use "--bg-img" for desktop neutral. Value is a CSS gradient like "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"'),
   }).optional(),
@@ -99,6 +124,8 @@ export const designSchema = z.object({
     boxShadow: z.string().optional(),
     blur: z.string().optional(),
     backdropBlur: z.string().optional(),
+    filter: z.string().optional().describe('CSS filter, e.g. "grayscale(1)" or "brightness(0.5)"'),
+    backdropFilter: z.string().optional().describe('CSS backdrop-filter, e.g. "saturate(180%)"'),
   }).optional(),
   positioning: z.object({
     isActive: z.boolean().optional(),
@@ -109,4 +136,64 @@ export const designSchema = z.object({
     left: z.string().optional(),
     zIndex: z.string().optional(),
   }).optional(),
+  transforms: z.object({
+    isActive: z.boolean().optional(),
+    scale: z.string().optional().describe('Uniform scale factor, e.g. "1.1" or "0.95"'),
+    rotate: z.string().optional().describe('Rotation, e.g. "45deg" or "-15deg"'),
+    translateX: z.string().optional(),
+    translateY: z.string().optional(),
+    skewX: z.string().optional(),
+    skewY: z.string().optional(),
+    transformOrigin: z.string().optional().describe('CSS transform-origin, e.g. "center" or "top left"'),
+  }).optional(),
+  transitions: z.object({
+    isActive: z.boolean().optional(),
+    transitionProperty: z.string().optional().describe('e.g. "all", "opacity", "transform, background-color"'),
+    duration: z.string().optional().describe('e.g. "200ms" or "0.3s"'),
+    easing: z.string().optional().describe('e.g. "ease-in-out", "linear", "cubic-bezier(...)"'),
+    delay: z.string().optional().describe('e.g. "100ms"'),
+  }).optional(),
 }).describe('Design properties object. Set isActive: true on any category to apply it.');
+
+// ── Drift guard ─────────────────────────────────────────────────────────────
+//
+// Compile-time assertion that every category and property of `DesignProperties`
+// is mirrored in `designSchema` above. If you add a new field to one of the
+// DesignProperties interfaces in `types/index.ts` and forget to expose it here,
+// this assertion fails to compile and the TypeScript error names every missing
+// `category.property` pair.
+//
+// Fields listed in `IntentionallyUnexposed` are deliberately omitted from MCP
+// because they store builder-only UI state (which mode toggle is shown) rather
+// than CSS that agents should set directly.
+
+type IntentionallyUnexposed = {
+  layout: 'gapMode';
+  spacing: 'marginMode' | 'paddingMode';
+  borders: 'borderWidthMode' | 'borderRadiusMode';
+};
+
+type NonUndefined<T> = Exclude<T, undefined>;
+type CategoryKeys<T> = keyof NonUndefined<T>;
+
+type ExpectedKeys<K extends keyof DesignProperties> = Exclude<
+  CategoryKeys<DesignProperties[K]>,
+  K extends keyof IntentionallyUnexposed ? IntentionallyUnexposed[K] : never
+>;
+
+type SchemaShape = z.infer<typeof designSchema>;
+
+type MissingPerCategory = {
+  [K in keyof DesignProperties]-?: K extends keyof SchemaShape
+    ? Exclude<ExpectedKeys<K>, CategoryKeys<SchemaShape[K]>>
+    : 'CATEGORY_MISSING';
+};
+
+type MissingFields = {
+  [K in keyof MissingPerCategory]: [MissingPerCategory[K]] extends [never]
+    ? never
+    : `${K & string}.${MissingPerCategory[K] & string}`;
+}[keyof MissingPerCategory];
+
+const _designSchemaDriftCheck: [MissingFields] extends [never] ? true : MissingFields = true;
+void _designSchemaDriftCheck;

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -35,6 +35,16 @@ export const richTextBlockSchema = z.object({
   component_id: z.string().optional().describe('For component: ID of the component to embed'),
 });
 
+// Accept a bare integer column/row count (e.g. "4") and normalize it to the
+// canonical `repeat(N, 1fr)` form used by the visual editor's LayoutControls.
+// Without this, `grid-cols-[4]` is emitted, which Tailwind treats as invalid CSS.
+const gridTracksSchema = z.preprocess(
+  (value) => (typeof value === 'string' && /^\d+$/.test(value.trim())
+    ? `repeat(${value.trim()}, 1fr)`
+    : value),
+  z.string(),
+).optional();
+
 export const designSchema = z.object({
   layout: z.object({
     isActive: z.boolean().optional(),
@@ -46,8 +56,8 @@ export const designSchema = z.object({
     gap: z.string().optional(),
     columnGap: z.string().optional(),
     rowGap: z.string().optional(),
-    gridTemplateColumns: z.string().optional(),
-    gridTemplateRows: z.string().optional(),
+    gridTemplateColumns: gridTracksSchema,
+    gridTemplateRows: gridTracksSchema,
   }).optional(),
   typography: z.object({
     isActive: z.boolean().optional(),

--- a/lib/mcp/tools/styles.ts
+++ b/lib/mcp/tools/styles.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DesignProperties, Layer } from '@/types';
 import { getAllStyles, createStyle, updateStyle, deleteStyle } from '@/lib/repositories/layerStyleRepository';
-import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
+import { getCachedDraft, saveCachedLayers } from '@/lib/mcp/page-layers';
 import { findLayerById, updateLayerById, designToClassString } from '@/lib/mcp/utils';
 import { designSchema } from './shared-schemas';
 
@@ -45,7 +45,7 @@ export function registerStyleTools(server: McpServer) {
       style_id: z.string().describe('The style ID'),
     },
     async ({ page_id, layer_id, style_id }) => {
-      const pageLayers = await getDraftLayers(page_id);
+      const pageLayers = await getCachedDraft(page_id);
       if (!pageLayers) {
         return { content: [{ type: 'text' as const, text: `Error: Page "${page_id}" has no layers.` }], isError: true };
       }
@@ -57,7 +57,7 @@ export function registerStyleTools(server: McpServer) {
       }
 
       const updated = updateLayerById(layers, layer_id, (l) => ({ ...l, styleId: style_id }));
-      await upsertDraftLayers(page_id, updated);
+      await saveCachedLayers(page_id, updated);
 
       return { content: [{ type: 'text' as const, text: `Applied style "${style_id}" to "${layer.customName || layer.name}"` }] };
     },

--- a/lib/mcp/tools/styles.ts
+++ b/lib/mcp/tools/styles.ts
@@ -13,7 +13,7 @@ export function registerStyleTools(server: McpServer) {
     {},
     async () => {
       const styles = await getAllStyles();
-      return { content: [{ type: 'text' as const, text: JSON.stringify(styles, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(styles) }] };
     },
   );
 
@@ -30,7 +30,7 @@ export function registerStyleTools(server: McpServer) {
       return {
         content: [{
           type: 'text' as const,
-          text: JSON.stringify({ message: `Created style "${name}"`, style_id: style.id, classes }, null, 2),
+          text: JSON.stringify({ message: `Created style "${name}"`, style_id: style.id, classes }),
         }],
       };
     },
@@ -79,7 +79,7 @@ export function registerStyleTools(server: McpServer) {
         updates.classes = designToClassString(design as DesignProperties);
       }
       const style = await updateStyle(style_id, updates);
-      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: `Updated style "${style.name}"`, style }, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ message: `Updated style "${style.name}"`, style }) }] };
     },
   );
 

--- a/lib/mcp/utils.ts
+++ b/lib/mcp/utils.ts
@@ -131,6 +131,10 @@ export function getTiptapTextContent(text: string): TiptapDoc {
  *  - { type: "orderedList", items: ["...", "..."] }
  *  - { type: "codeBlock", text: "..." }
  *  - { type: "horizontalRule" }
+ *  - { type: "htmlEmbed", code: "<script>...</script>" }
+ *  - { type: "image", src: "...", alt?: "...", asset_id?: "..." }
+ *  - { type: "table", rows: [["cell", "cell"], ...], header_row: true }
+ *  - { type: "component", component_id: "..." }
  *
  * Text can include simple inline formatting via markdown-like syntax:
  *  - **bold**, *italic*, [link text](url)
@@ -143,10 +147,21 @@ export function buildTiptapDoc(blocks: RichTextBlock[]): TiptapDoc {
 }
 
 export interface RichTextBlock {
-  type: 'paragraph' | 'heading' | 'blockquote' | 'bulletList' | 'orderedList' | 'codeBlock' | 'horizontalRule';
+  type:
+    | 'paragraph' | 'heading' | 'blockquote'
+    | 'bulletList' | 'orderedList'
+    | 'codeBlock' | 'horizontalRule'
+    | 'htmlEmbed' | 'image' | 'table' | 'component';
   text?: string;
   level?: number;
   items?: string[];
+  code?: string;
+  src?: string;
+  alt?: string;
+  asset_id?: string;
+  rows?: string[][];
+  header_row?: boolean;
+  component_id?: string;
 }
 
 function parseInlineMarks(text: string): TiptapNode[] {
@@ -224,12 +239,48 @@ function blockToTiptapNode(block: RichTextBlock): TiptapNode {
       };
     case 'horizontalRule':
       return { type: 'horizontalRule' };
+    case 'htmlEmbed':
+      return {
+        type: 'richTextHtmlEmbed',
+        attrs: { code: block.code || '' },
+      };
+    case 'image':
+      return {
+        type: 'richTextImage',
+        attrs: {
+          src: block.src || '',
+          alt: block.alt || null,
+          assetId: block.asset_id || null,
+          link: null,
+        },
+      };
+    case 'component':
+      return {
+        type: 'richTextComponent',
+        attrs: { componentId: block.component_id || '' },
+      };
+    case 'table':
+      return buildTableNode(block.rows || [], block.header_row !== false);
     default:
       return {
         type: 'paragraph',
         content: block.text ? [{ type: 'text', text: block.text }] : [],
       };
   }
+}
+
+function buildTableNode(rows: string[][], headerRow: boolean): TiptapNode {
+  if (rows.length === 0) return { type: 'paragraph' };
+  return {
+    type: 'table',
+    content: rows.map((row, rowIdx) => ({
+      type: 'tableRow',
+      content: row.map((cellText) => ({
+        type: headerRow && rowIdx === 0 ? 'tableHeader' : 'tableCell',
+        content: [{ type: 'paragraph', content: cellText ? parseInlineMarks(cellText) : [] }],
+      })),
+    })),
+  };
 }
 
 /**
@@ -666,6 +717,36 @@ export const ELEMENT_TEMPLATES: Record<string, ElementTemplateEntry> = {
   localeSelector: {
     name: 'Locale Selector',
     description: 'Language switcher dropdown for multi-language sites.',
+    useBlocksTemplate: true,
+  },
+  table: {
+    name: 'Table',
+    description: 'Data table (renders as <table>). Pre-populated with a header row and two body rows.',
+    useBlocksTemplate: true,
+  },
+  thead: {
+    name: 'Table Header',
+    description: '<thead> with one header row. Add inside a table.',
+    useBlocksTemplate: true,
+  },
+  tbody: {
+    name: 'Table Body',
+    description: '<tbody> with one row. Add inside a table.',
+    useBlocksTemplate: true,
+  },
+  tr: {
+    name: 'Table Row',
+    description: '<tr>. Add inside thead or tbody.',
+    useBlocksTemplate: true,
+  },
+  td: {
+    name: 'Table Cell',
+    description: '<td>. Add inside a tr.',
+    useBlocksTemplate: true,
+  },
+  th: {
+    name: 'Table Header Cell',
+    description: '<th>. Add inside a thead tr.',
     useBlocksTemplate: true,
   },
 };

--- a/lib/repositories/pageLayersRepository.ts
+++ b/lib/repositories/pageLayersRepository.ts
@@ -108,11 +108,17 @@ export async function getPublishedLayers(pageId: string): Promise<PageLayers | n
  * @param pageId - Page ID
  * @param layers - Page layers
  * @param additionalData - Optional additional fields (e.g., metadata)
+ * @param existingDraft - Optional pre-fetched draft to skip the internal
+ *   `getDraftLayers` read. Callers that already have the row (e.g. the MCP
+ *   page-layers cache) can pass it through to avoid a redundant DB round trip.
+ *   Pass `null` to assert "no draft exists" without re-checking. Omit (or
+ *   pass `undefined`) to preserve the original fetch-then-decide behavior.
  */
 export async function upsertDraftLayers(
   pageId: string,
   layers: Layer[],
-  additionalData?: Record<string, any>
+  additionalData?: Record<string, any>,
+  existingDraft?: PageLayers | null,
 ): Promise<PageLayers> {
   const client = await getSupabaseAdmin();
 
@@ -120,12 +126,14 @@ export async function upsertDraftLayers(
     throw new Error('Supabase not configured');
   }
 
-  // Check if draft exists
-  const existingDraft = await getDraftLayers(pageId);
+  // Use the caller-provided draft when available, otherwise fall back to a fresh read.
+  const resolvedDraft = existingDraft !== undefined
+    ? existingDraft
+    : await getDraftLayers(pageId);
 
   // Detect removed and changed layer content, update translations accordingly
-  if (existingDraft && existingDraft.layers) {
-    const oldContentMap = extractLayerContentMap(existingDraft.layers, 'page', pageId);
+  if (resolvedDraft && resolvedDraft.layers) {
+    const oldContentMap = extractLayerContentMap(resolvedDraft.layers, 'page', pageId);
     const newContentMap = extractLayerContentMap(layers, 'page', pageId);
 
     // Find removed keys (exist in old but not in new)
@@ -150,7 +158,7 @@ export async function upsertDraftLayers(
   // Use provided generated_css, or preserve the existing value for hash consistency
   const cssForHash = additionalData?.generated_css !== undefined
     ? (additionalData.generated_css as string) || null
-    : existingDraft?.generated_css || null;
+    : resolvedDraft?.generated_css || null;
 
   const contentHash = generatePageLayersHash({
     layers,
@@ -168,12 +176,12 @@ export async function upsertDraftLayers(
     Object.assign(updateData, additionalData);
   }
 
-  if (existingDraft) {
+  if (resolvedDraft) {
     // Update existing draft
     const { data, error } = await client
       .from('page_layers')
       .update(updateData)
-      .eq('id', existingDraft.id)
+      .eq('id', resolvedDraft.id)
       .eq('is_published', false)
       .select()
       .single();


### PR DESCRIPTION
## Summary

Brings the embedded MCP server up to **MCP 1.0** by closing the gap between what YCode has shipped over the last several months and what AI agents can do through the protocol. Consolidates seven thematic PRs (#252–#258) into a single atomic delivery so the refresh either lands fully or not at all.

Bumps MCP version `0.4.0` → `1.0.0`.

## Sub-PRs (already reviewed, merged into this branch)

| | Theme | |
|---|---|---|
| #252 | Foundation refresh — `shared-schemas.ts`, import cleanup, `update_component_layers` parity | merged |
| #253 | **PR-A** CMS surface — option/count fields, sorting, reorder, expanded link types | merged |
| #255 | **PR-C** Components & variants — variant CRUD, `rich_text`/`variant` variable types | merged |
| #254 | **PR-B** Elements & settings — tables, expanded rich-text blocks, map/lightbox/select settings, `export_layer_html` | merged |
| #256 | **PR-D** Pages / forms / i18n — redirects, dynamic pages, error pages, `update_form_settings`, `set_rich_text_translation` | merged |
| #258 | **PR-E** Interactions — 18 animation presets + raw `set_layer_interactions` escape hatch | merged |
| #257 | **PR-F** Docs refresh + 1.0 version bump | merged |

## Changes

- **CMS** — `option` and `count` field types, multi-asset toggle, per-field sorting, cross-collection references, `set_collection_item_order`, `reorder_collection_fields`
- **Elements** — table primitives (`table`/`thead`/`tbody`/`tr`/`td`/`th`), rich-text blocks for HTML embeds, images, tables, components
- **Layer settings** — expanded `update_layer_settings` (hidden, filter_on_change, slider/lightbox/map/options_source), `export_layer_html`
- **Components** — variant CRUD (`list_component_variants`, `create_component_variant`, `update_component_variant`, `delete_component_variant`), `update_component_layers` variant targeting, new variable types (`rich_text`, `variant`), variable `placeholder`/`default_value`
- **Pages** — `is_index` / `is_dynamic` / `error_page`, CMS binding for dynamic pages, site-wide redirects (`list_redirects`, `add_redirect`, `update_redirect`, `delete_redirect`)
- **Forms** — `update_form_settings` (success_action, redirect_url, email_notification)
- **i18n** — `set_rich_text_translation` for structured rich-text translations
- **Animations** — `add_animation` with 18 curated presets (reveal/hover/click/parallax/stagger/loop), multi-target tweens via `targets`, `list_layer_animations` / `remove_layer_animation` / `clear_layer_animations`, and `set_layer_interactions` as the raw GSAP escape hatch
- **Reference resources** — new `ycode://reference/animation-presets`, expanded `elements-reference` and `design-reference`
- **Instructions** — comprehensive rewrite covering every new surface

## Test plan

- [ ] `npm run type-check` passes on the integration branch
- [ ] In Cursor / Claude Desktop, list MCP tools — confirm all new tools are present
- [ ] Read `ycode://reference/animation-presets`, `ycode://reference/elements`, `ycode://reference/design-properties`, `ycode://reference/prompts` — all well-formed
- [ ] Spot-check one tool from each sub-PR:
  - PR-A: `add_collection_field` with type `option` and entries
  - PR-B: `add_layer` with template `table`
  - PR-C: `create_component_variant` cloning the default
  - PR-D: `add_redirect` and confirm it lands in site settings; `update_form_settings` with `success_action: "redirect"`
  - PR-E: `add_animation` with preset `fade-in-up`, then `list_layer_animations`
- [ ] Confirm the builder loads pages with the consolidated tool changes (no regressions)

## Rollback

Reverting this PR cleanly removes the entire MCP 1.0 refresh in one commit.

Made with [Cursor](https://cursor.com)