### PR TITLE
fix(publish): dispatch site.published webhook event

### DIFF
--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -14,6 +14,7 @@ import {
   invalidateForLocalisationChanges,
 } from '@/lib/services/cacheService';
 import { findAffectedPages } from '@/lib/repositories/pageLayersRepository';
+import { dispatchSitePublishedEvent } from '@/lib/services/webhookService';
 import { getAllDraftPages, hardDeleteSoftDeletedPages } from '@/lib/repositories/pageRepository';
 import { publishComponents, getUnpublishedComponents, hardDeleteSoftDeletedComponents } from '@/lib/repositories/componentRepository';
 import { publishLayerStyles, getUnpublishedLayerStyles, hardDeleteSoftDeletedLayerStyles } from '@/lib/repositories/layerStyleRepository';
@@ -729,6 +730,20 @@ export async function POST(request: NextRequest) {
       result.published_at_setting = await savePublishedAt(publishedAt);
     } catch {
       // Silently handle - non-fatal
+    }
+
+    // Dispatch the site.published webhook event. The dispatcher is the only
+    // path that delivers to user-configured webhooks for this event type
+    // (advertised in the Integrations → Webhooks UI), so without this call
+    // any "Site Published" subscription silently never fires. Wrapped so
+    // webhook failures never block the publish response.
+    try {
+      await dispatchSitePublishedEvent({
+        pages_count: result.changes.pages,
+        collections_count: result.changes.collectionItems,
+      });
+    } catch {
+      // Silently handle — webhook failures must not break a successful publish
     }
 
     // Calculate total duration


### PR DESCRIPTION
The `site.published` event is advertised in **Integrations → Webhooks** ([app/(builder)/ycode/integrations/webhooks/page.tsx](https://github.com/ycode/ycode/blob/main/app/%28builder%29/ycode/integrations/webhooks/page.tsx)) and the `dispatchSitePublishedEvent` helper exists in [lib/services/webhookService.ts](https://github.com/ycode/ycode/blob/main/lib/services/webhookService.ts), but the dispatcher was never called from the publish route handler. Any user-configured webhook for that event has been silently never firing.

This PR wires the dispatch inside the POST publish handler, just after `savePublishedAt`. Wrapped in a try/catch so webhook delivery failures never block a successful publish response.

Payload mirrors the other dispatchers in `webhookService.ts`: `pages_count` and `collections_count` derived from the publish result.

## Why a separate PR

Split out per @liamwalder's review on #225 — this is a self-contained bug fix that should land independently of the static-export integration.

## Verified

- `npm run type-check` clean
- `npm run lint:fix` clean on the touched file

🤖 Co-authored with [Claude Code](https://claude.com/claude-code). Disclosure for review transparency.