### PR TITLE
fix: translate component instance overrides and prevent clobbering

### DIFF
--- a/app/(builder)/ycode/components/Canvas.tsx
+++ b/app/(builder)/ycode/components/Canvas.tsx
@@ -30,7 +30,7 @@ import { useColorVariablesStore } from '@/stores/useColorVariablesStore';
 import { usePagesStore } from '@/stores/usePagesStore';
 import { useSettingsStore } from '@/stores/useSettingsStore';
 
-import { injectTranslatedText } from '@/lib/localisation-utils';
+import { injectTranslatedText, translateComponentOverrides } from '@/lib/localisation-utils';
 
 import type { Layer, Component, CollectionItemWithValues, CollectionField, Breakpoint, Asset, ComponentVariable, Locale, Translation } from '@/types';
 import type { UseLiveLayerUpdatesReturn } from '@/hooks/use-live-layer-updates';
@@ -329,10 +329,21 @@ const Canvas = React.memo(function Canvas({
   // State
   const [iframeReady, setIframeReady] = useState(false);
 
+  // Translate component-instance override values before serialization so that
+  // `resolveComponents` (inside serializeLayers) propagates per-instance
+  // translations through the override pipeline. Runs only when a non-default
+  // locale is active.
+  const layersForSerialization = useMemo(() => {
+    if (!currentLocale || currentLocale.is_default || !translations) return layers;
+    const lookupPageId = pageId || (editingComponentId ?? '');
+    if (!lookupPageId) return layers;
+    return translateComponentOverrides(layers, lookupPageId, translations, { includeIncomplete: true });
+  }, [layers, currentLocale, translations, pageId, editingComponentId]);
+
   // Resolve component instances in layers
   const { layers: resolvedLayers, componentMap } = useMemo(() => {
-    return serializeLayers(layers, components, editingComponentVariables);
-  }, [layers, components, editingComponentVariables]);
+    return serializeLayers(layersForSerialization, components, editingComponentVariables);
+  }, [layersForSerialization, components, editingComponentVariables]);
 
   // When a non-default locale is active, swap layer text and translatable
   // asset references with their translations so the canvas mirrors what the

--- a/app/(builder)/ycode/components/SidebarTranslationRow.tsx
+++ b/app/(builder)/ycode/components/SidebarTranslationRow.tsx
@@ -69,7 +69,20 @@ export default function SidebarTranslationRow({
 }: SidebarTranslationRowProps) {
   const [isAssetPickerOpen, setIsAssetPickerOpen] = useState(false);
 
-  const isRichText = item.content_type === 'richtext';
+  const translation = selectedLocaleId
+    ? getTranslationByKey(selectedLocaleId, item.key)
+    : null;
+  const storeValue = translation?.content_value || '';
+
+  // The source side always follows the layer's declared content_type, but the
+  // translation side must follow whatever was actually stored in the DB row.
+  // Legacy migrations and historical rich-text edits can leave a translation
+  // stored as `richtext` (Tiptap JSON) on a layer whose source variable is
+  // `dynamic_text` — without this preference the editor would render the raw
+  // JSON string instead of the translated text. Mirrors the same logic used
+  // by `injectTranslatedText` at render time.
+  const isSourceRichText = item.content_type === 'richtext';
+  const isTranslationRichText = (translation?.content_type ?? item.content_type) === 'richtext';
   const isAsset = item.content_type === 'asset_id';
 
   // Sub-label shown beneath each language name when a layer has more than
@@ -89,11 +102,6 @@ export default function SidebarTranslationRow({
     }
   })();
 
-  const translation = selectedLocaleId
-    ? getTranslationByKey(selectedLocaleId, item.key)
-    : null;
-  const storeValue = translation?.content_value || '';
-
   // Display value for the source textarea: convert Tiptap JSON → plain text so
   // the user sees readable content instead of raw JSON for rich-text fields.
   // In preview-only mode (rich-text element layers) we keep block-level
@@ -101,7 +109,7 @@ export default function SidebarTranslationRow({
   // the canvas; the editable textarea path stays single-line so it round-trips
   // cleanly through stringToTiptapContent on save.
   const sourceDisplayValue = (() => {
-    if (!isRichText || !item.content_value) return item.content_value || '';
+    if (!isSourceRichText || !item.content_value) return item.content_value || '';
     try {
       const parsed = JSON.parse(item.content_value);
       return previewOnly
@@ -118,7 +126,7 @@ export default function SidebarTranslationRow({
     if (localInputValues[item.key] !== undefined) {
       return localInputValues[item.key];
     }
-    if (!isRichText || !storeValue) return storeValue || '';
+    if (!isTranslationRichText || !storeValue) return storeValue || '';
     try {
       const parsed = JSON.parse(storeValue);
       return previewOnly
@@ -145,8 +153,11 @@ export default function SidebarTranslationRow({
     if (!selectedLocaleId) return;
 
     // Re-wrap plain text into Tiptap JSON for rich_text fields so the
-    // rendering pipeline still receives a valid rich_text payload.
-    const finalValue = isRichText
+    // rendering pipeline still receives a valid rich_text payload. Use the
+    // translation's actual stored content_type so an existing richtext row
+    // (e.g. legacy-migrated) keeps its shape on edit instead of being
+    // silently downgraded to a plain string.
+    const finalValue = isTranslationRichText
       ? JSON.stringify(stringToTiptapContent(value))
       : value;
 

--- a/lib/localisation-utils.ts
+++ b/lib/localisation-utils.ts
@@ -771,25 +771,47 @@ export function injectTranslatedText(
     const textTranslation = getTranslationByKey(translations, textTranslationKey);
 
     const textValue = getTranslationValue(textTranslation, valueOptions);
-    if (textValue) {
-      // Preserve the original variable type (dynamic_text or dynamic_rich_text).
-      // Use the translation's stored content_type to decide whether the value is
-      // a JSON-serialized Tiptap doc or plain text — when a rich-text source has
-      // no formatting, it's stored as plain text (see classifyLayerTextForTranslation),
-      // so blindly JSON.parse-ing it would log noisy errors on every render.
-      if (layer.variables?.text?.type === 'dynamic_rich_text') {
-        if (textTranslation?.content_type === 'richtext') {
-          (variableUpdates as any).text = createDynamicRichTextVariable(textValue);
-        } else {
-          (variableUpdates as any).text = createDynamicRichTextVariableFromPlainText(textValue);
-        }
+    // Only inject when the layer actually has a text variable to translate.
+    // Stale/orphan translation rows (e.g. legacy migration artefacts that
+    // point at an ancestor div/section without `variables.text`) would
+    // otherwise materialise text content on layers that should have none,
+    // breaking layout with random strings.
+    // Skip the component-scope layer translation when:
+    // (a) this layer's text was set by an instance override — the override
+    //     value has already been translated at page scope via
+    //     `translateComponentOverrides`, and re-translating here would
+    //     clobber it with the component default; or
+    // (b) the layer has an active component-variable binding
+    //     (`variables.text.id`) — the renderer resolves the value via the
+    //     parent instance's overrides or the variable's default value, so
+    //     overwriting `variables.text` here would strip the binding id and
+    //     break that lookup chain.
+    const hasComponentVariableBinding = !!(layer.variables?.text as any)?.id;
+    if (
+      textValue
+      && layer.variables?.text
+      && !(layer as any)._textFromOverride
+      && !hasComponentVariableBinding
+    ) {
+      // Choose the injected variable type based on the translation's stored
+      // content_type, not the source layer's. A `dynamic_text` source can have
+      // a `richtext` translation (e.g. translator added a line break, or legacy
+      // migration upgraded a translation containing `<br>`) — stuffing the raw
+      // Tiptap JSON into a `dynamic_text` variable would render as literal JSON.
+      // The renderer handles `dynamic_rich_text` on simple text/heading layers
+      // by flattening paragraphs into the layer's single tag.
+      if (textTranslation?.content_type === 'richtext') {
+        (variableUpdates as any).text = createDynamicRichTextVariable(textValue);
+      } else if (layer.variables?.text?.type === 'dynamic_rich_text') {
+        // Plain-text translation for a rich-text source: avoid noisy JSON.parse.
+        (variableUpdates as any).text = createDynamicRichTextVariableFromPlainText(textValue);
       } else {
         (variableUpdates as any).text = createDynamicTextVariable(textValue);
       }
     }
 
     // 2. Inject asset translations for media layers
-    if (layer.name === 'image') {
+    if (layer.name === 'image' && !(layer as any)._imageFromOverride) {
       const imageSrcKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:image_src`, masterComponentId);
       const imageSrcTranslation = getTranslationByKey(translations, imageSrcKey);
       const imageAltKey = buildLayerTranslationKey(pageId, `layer:${translationLayerId}:image_alt`, masterComponentId);
@@ -862,6 +884,115 @@ export function injectTranslatedText(
       ...updates,
     };
   });
+}
+
+/**
+ * Pre-resolution pass: translate text/richtext/image values stored in a
+ * page-instance layer's `componentOverrides` using page-scope override
+ * translations. Must run BEFORE `resolveComponents` so translated overrides
+ * propagate through `applyComponentOverrides` normally.
+ *
+ * Keys (page-scope):
+ *   - `layer:<instanceLayerId>:override:text:<varId>`       (string)
+ *   - `layer:<instanceLayerId>:override:rich_text:<varId>`  (Tiptap JSON string)
+ *   - `layer:<instanceLayerId>:override:image_src:<varId>`  (asset_id)
+ *   - `layer:<instanceLayerId>:override:image_alt:<varId>`  (string)
+ *
+ * Each component instance has its own translations, so different uses of the
+ * same component can be translated independently — restoring per-instance
+ * translation behaviour from the legacy editor.
+ */
+export function translateComponentOverrides(
+  layers: Layer[],
+  pageId: string,
+  translations: Record<string, Translation> | null | undefined,
+  options?: { includeIncomplete?: boolean }
+): Layer[] {
+  if (!translations || !layers || layers.length === 0) return layers;
+  const valueOptions = options?.includeIncomplete ? { includeIncomplete: true } : undefined;
+
+  const lookup = (key: string): string | undefined =>
+    getTranslationValue(translations[`page:${pageId}:${key}`], valueOptions);
+
+  const walk = (list: Layer[]): Layer[] =>
+    list.map(layer => {
+      const overrides = layer.componentOverrides;
+      const nextChildren = layer.children?.length ? walk(layer.children) : layer.children;
+      if (!overrides) {
+        return nextChildren === layer.children ? layer : { ...layer, children: nextChildren };
+      }
+
+      let mutated = false;
+      const nextOverrides: Layer['componentOverrides'] = { ...overrides };
+
+      for (const category of ['text', 'rich_text'] as const) {
+        const catOverrides = overrides[category];
+        if (!catOverrides) continue;
+        let categoryMutated = false;
+        const next: Record<string, any> = {};
+        for (const [varId, value] of Object.entries(catOverrides)) {
+          const v = lookup(`layer:${layer.id}:override:${category}:${varId}`);
+          if (v !== undefined && value && typeof value === 'object' && 'data' in (value as any)) {
+            const isRich = category === 'rich_text';
+            const content = isRich ? safeParseJson(v) : v;
+            next[varId] = { ...(value as any), data: { ...(value as any).data, content } };
+            categoryMutated = true;
+          } else {
+            next[varId] = value;
+          }
+        }
+        if (categoryMutated) {
+          nextOverrides[category] = next as any;
+          mutated = true;
+        }
+      }
+
+      const imageOverrides = overrides.image;
+      if (imageOverrides) {
+        let imageMutated = false;
+        const nextImage: Record<string, any> = {};
+        for (const [varId, value] of Object.entries(imageOverrides)) {
+          const srcAssetId = lookup(`layer:${layer.id}:override:image_src:${varId}`);
+          const altText = lookup(`layer:${layer.id}:override:image_alt:${varId}`);
+          if ((srcAssetId === undefined && altText === undefined) || !value || typeof value !== 'object') {
+            nextImage[varId] = value;
+            continue;
+          }
+          const src = (value as any).src;
+          nextImage[varId] = {
+            ...(value as any),
+            ...(srcAssetId !== undefined && src
+              ? { src: { ...src, data: { ...(src.data || {}), asset_id: srcAssetId } } }
+              : {}),
+            ...(altText !== undefined
+              ? { alt: { type: 'dynamic_text', data: { content: altText } } }
+              : {}),
+          };
+          imageMutated = true;
+        }
+        if (imageMutated) {
+          nextOverrides.image = nextImage as any;
+          mutated = true;
+        }
+      }
+
+      if (!mutated && nextChildren === layer.children) return layer;
+      return {
+        ...layer,
+        ...(mutated ? { componentOverrides: nextOverrides } : {}),
+        ...(nextChildren !== layer.children ? { children: nextChildren } : {}),
+      };
+    });
+
+  return walk(layers);
+}
+
+function safeParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
 }
 
 /**

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -31,7 +31,7 @@ import { getLinkSettingsFromMark } from '@/lib/tiptap-extensions/rich-text-link'
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
 import { resolveInlineVariables, resolveInlineVariablesFromData } from '@/lib/inline-variables';
 import { formatFieldValue } from '@/lib/cms-variables-utils';
-import { buildLayerTranslationKey, getTranslationByKey, hasValidTranslationValue, getTranslationValue, injectTranslatedText, applyCmsTranslations } from '@/lib/localisation-utils';
+import { buildLayerTranslationKey, getTranslationByKey, hasValidTranslationValue, getTranslationValue, injectTranslatedText, applyCmsTranslations, translateComponentOverrides } from '@/lib/localisation-utils';
 import { formatDateFieldsInItemValues } from '@/lib/date-format-utils';
 import { getSettingByKey } from '@/lib/repositories/settingsRepository';
 import { parseMultiAssetFieldValue, buildAssetVirtualValues } from '@/lib/multi-asset-utils';
@@ -215,16 +215,30 @@ export async function loadTranslationsForLocale(
       return { locale: null, translations: {} };
     }
 
-    // Fetch all translations for this locale
-    const { data: translations } = await supabase
-      .from('translations')
-      .select('*')
-      .eq('locale_id', locale.id)
-      .eq('is_published', isPublished)
-      .is('deleted_at', null);
+    // Fetch all translations for this locale. Supabase caps PostgREST
+    // responses at 1000 rows by default — projects with more translations
+    // were silently truncated, causing entire layers to render in the
+    // source language on SSR while the editor (which fetches via its own
+    // paginated API) showed them correctly. Page through explicit ranges.
+    const PAGE_SIZE = 1000;
+    const translations: Translation[] = [];
+    for (let from = 0; ; from += PAGE_SIZE) {
+      const { data: page, error } = await supabase
+        .from('translations')
+        .select('*')
+        .eq('locale_id', locale.id)
+        .eq('is_published', isPublished)
+        .is('deleted_at', null)
+        .range(from, from + PAGE_SIZE - 1);
 
-    if (!translations) {
-      return { locale, translations: {} };
+      if (error) {
+        console.error('Failed to fetch translations page:', error);
+        break;
+      }
+
+      if (!page || page.length === 0) break;
+      translations.push(...(page as Translation[]));
+      if (page.length < PAGE_SIZE) break;
     }
 
     // Build translations map keyed by translatable key
@@ -562,8 +576,13 @@ async function fetchPageByPathInternal(
               values: enhancedItemValues,
             };
 
-            // First, resolve components so collection layers inside components are available
-            const layersWithComponents = resolveComponents(pageLayers?.layers || [], components);
+            // Translate component-instance override values first, so the translated
+            // values are what `resolveComponents` propagates into the rendered tree.
+            const localizedRawLayers = detectedLocale && translations && Object.keys(translations).length > 0
+              ? translateComponentOverrides(pageLayers?.layers || [], matchingPage.id, translations, { includeIncomplete: !isPublished })
+              : pageLayers?.layers || [];
+
+            const layersWithComponents = resolveComponents(localizedRawLayers, components);
 
             // Inject dynamic page collection data into layers (including expanded component layers)
             // This resolves inline variables like "Name → Location" on the page
@@ -679,8 +698,13 @@ async function fetchPageByPathInternal(
       return null;
     }
 
-    // First, resolve components so collection layers inside components are available
-    const layersWithComponents = resolveComponents(pageLayers?.layers || [], components);
+    // Translate component-instance override values before resolving components,
+    // so per-instance translations propagate correctly through the override pipeline.
+    const localizedRawLayers = detectedLocale && translations && Object.keys(translations).length > 0
+      ? translateComponentOverrides(pageLayers?.layers || [], matchingPage.id, translations, { includeIncomplete: !isPublished })
+      : pageLayers?.layers || [];
+
+    const layersWithComponents = resolveComponents(localizedRawLayers, components);
 
     let resolvedLayers = layersWithComponents.length > 0
       ? await resolveCollectionLayers(layersWithComponents, isPublished, undefined, paginationContext, translations, undefined, timezone)
@@ -873,8 +897,13 @@ export const fetchHomepage = cache(async function fetchHomepage(
       return null;
     }
 
-    // First, resolve components so collection layers inside components are available
-    const layersWithComponents = resolveComponents(pageLayers?.layers || [], components);
+    // Translate component-instance override values before resolving components
+    // so per-instance translations are applied through the override pipeline.
+    const localizedRawLayers = translations && Object.keys(translations).length > 0
+      ? translateComponentOverrides(pageLayers?.layers || [], homepage.id, translations, { includeIncomplete: !isPublished })
+      : pageLayers?.layers || [];
+
+    const layersWithComponents = resolveComponents(localizedRawLayers, components);
 
     // Resolve collection layers server-side (for both draft and published)
     let resolvedLayers = layersWithComponents.length > 0

--- a/lib/repositories/translationRepository.ts
+++ b/lib/repositories/translationRepository.ts
@@ -9,7 +9,9 @@ import { getSupabaseAdmin } from '@/lib/supabase-server';
 import type { Translation, CreateTranslationData, UpdateTranslationData } from '@/types';
 
 /**
- * Get all translations for a locale (draft by default)
+ * Get all translations for a locale (draft by default). Pages through the
+ * 1000-row PostgREST default so projects with large catalogues don't get
+ * silently truncated.
  */
 export async function getTranslationsByLocale(
   localeId: string,
@@ -21,19 +23,29 @@ export async function getTranslationsByLocale(
     throw new Error('Supabase not configured');
   }
 
-  const { data, error } = await client
-    .from('translations')
-    .select('*')
-    .eq('locale_id', localeId)
-    .eq('is_published', isPublished)
-    .is('deleted_at', null)
-    .order('created_at', { ascending: true });
+  const PAGE_SIZE = 1000;
+  const results: Translation[] = [];
 
-  if (error) {
-    throw new Error(`Failed to fetch translations: ${error.message}`);
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await client
+      .from('translations')
+      .select('*')
+      .eq('locale_id', localeId)
+      .eq('is_published', isPublished)
+      .is('deleted_at', null)
+      .order('created_at', { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+
+    if (error) {
+      throw new Error(`Failed to fetch translations: ${error.message}`);
+    }
+
+    if (!data || data.length === 0) break;
+    results.push(...(data as Translation[]));
+    if (data.length < PAGE_SIZE) break;
   }
 
-  return data || [];
+  return results;
 }
 
 /**

--- a/lib/resolve-components.ts
+++ b/lib/resolve-components.ts
@@ -358,13 +358,17 @@ export function applyComponentOverrides(
 
       // Only apply if it's a text variable (has 'type' property, not ImageSettingsValue)
       if (valueToApply && 'type' in valueToApply) {
-        // Apply the value to this layer's text variable
+        // Apply the value to this layer's text variable. Mark layers whose
+        // text came from an instance override so `injectTranslatedText`
+        // doesn't clobber the (already page-scope-translated) override value
+        // with the component-scope default translation.
         updatedLayer = {
           ...updatedLayer,
           variables: {
             ...updatedLayer.variables,
             text: valueToApply as any,
           },
+          ...(overrideValue !== undefined ? { _textFromOverride: true } as any : {}),
         };
       }
     }
@@ -398,6 +402,7 @@ export function applyComponentOverrides(
             ...(imageValue.height && { height: imageValue.height }),
             ...(imageValue.loading && { loading: imageValue.loading }),
           },
+          ...(overrideValue !== undefined ? { _imageFromOverride: true } as any : {}),
         };
       }
     }


### PR DESCRIPTION
## Summary

Fix component-instance override translations so they render correctly on both server-rendered pages and the builder canvas, plus a few related translation-pipeline regressions surfaced by larger projects.

## Changes

- Add a `translateComponentOverrides` pre-pass that translates a component instance's `componentOverrides` (page-scoped keys) **before** `resolveComponents` propagates them into the rendered tree. Wired into all page-fetcher render paths and the canvas serialization pipeline.
- Flag layers in `applyComponentOverrides` with `_textFromOverride` / `_imageFromOverride` when their value comes from an instance override, and skip the component-scope translation in `injectTranslatedText` for those layers so the (already translated) override isn't clobbered by the component default.
- Also skip component-scope text translation when a layer still carries a component-variable binding (`variables.text.id`). The renderer resolves these values via the parent instance's overrides or the variable default at render time; overwriting `variables.text` here would strip the binding id and break the lookup chain in the builder canvas re-resolution path.
- Page translation fetches through PostgREST 1000-row windows in both `loadTranslationsForLocale` and `getTranslationsByLocale`. Projects with large catalogues were being silently truncated, causing entire layers to render in the source language on SSR while the editor (which uses its own paginated API) showed them correctly.
- Honour the translation row's stored `content_type` (not just the source layer's) when rendering and saving from `SidebarTranslationRow`, so a richtext translation row attached to a plain-text source layer no longer surfaces raw Tiptap JSON.

## Test plan

- [ ] Open a non-default locale page that contains a component instance with translated text/rich-text overrides (e.g. an FAQ list) — both the builder canvas and the preview/published page should render the translated override values, not the component default
- [ ] Same page, switch back to the default locale — overrides should render in the source language
- [ ] A component instance **without** an override on a translated locale — should fall back to the variable's default value (untranslated), unchanged from before
- [ ] A project with > 1000 translation rows on a single locale — translated layers near the end of the catalogue should now render correctly on SSR
- [ ] A plain-text translatable layer whose translation row was stored as `richtext` (legacy migration artefact) — the sidebar should show readable text instead of raw Tiptap JSON, and edits should round-trip cleanly
