### PR TITLE
perf: cache page layers per request and precompute reference JSON

### DIFF
--- a/lib/mcp/page-layers.ts
+++ b/lib/mcp/page-layers.ts
@@ -1,0 +1,103 @@
+/**
+ * Cached read/write helpers for page layers used by MCP tools.
+ *
+ * Agents typically make 10-50 sequential tool calls against the same page. The
+ * naive `getDraftLayers` → `upsertDraftLayers` pattern hits Supabase twice per
+ * call (once for the tool's read, once inside the repo's write). This module
+ * collapses both:
+ *
+ *   1. Reads are cached per page on `globalThis` with a short TTL. Subsequent
+ *      reads inside a burst skip the DB entirely. The TTL is short enough that
+ *      builder-side edits resync within a few seconds.
+ *
+ *   2. Writes pass the cached `PageLayers` row to `upsertDraftLayers` via its
+ *      `existingDraft` parameter, so the repo skips its own internal read.
+ *      The repo's translation diff still runs against the cached snapshot.
+ *
+ * On any write error we evict the page from the cache so the next read pulls
+ * fresh data from the DB.
+ */
+
+import type { Layer, PageLayers } from '@/types';
+import {
+  getDraftLayers,
+  upsertDraftLayers,
+} from '@/lib/repositories/pageLayersRepository';
+import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
+
+interface CacheEntry {
+  pageLayers: PageLayers;
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5_000;
+
+const globalForPageCache = globalThis as unknown as {
+  __mcpPageLayersCache?: Map<string, CacheEntry>;
+};
+
+const cache = globalForPageCache.__mcpPageLayersCache ?? new Map<string, CacheEntry>();
+globalForPageCache.__mcpPageLayersCache = cache;
+
+function isFresh(entry: CacheEntry | undefined): entry is CacheEntry {
+  return entry !== undefined && entry.expiresAt > Date.now();
+}
+
+/**
+ * Fetch the draft `PageLayers` row for a page, served from the in-memory cache
+ * when fresh. Returns `null` if no draft exists.
+ */
+export async function getCachedDraft(pageId: string): Promise<PageLayers | null> {
+  const cached = cache.get(pageId);
+  if (isFresh(cached)) {
+    return cached.pageLayers;
+  }
+
+  const draft = await getDraftLayers(pageId);
+  if (draft) {
+    cache.set(pageId, { pageLayers: draft, expiresAt: Date.now() + CACHE_TTL_MS });
+  } else {
+    cache.delete(pageId);
+  }
+  return draft;
+}
+
+/**
+ * Convenience: return just the layer tree (or `[]` if no draft).
+ */
+export async function getCachedLayers(pageId: string): Promise<Layer[]> {
+  const draft = await getCachedDraft(pageId);
+  return (draft?.layers as Layer[]) || [];
+}
+
+/**
+ * Save layers for a page and update the cache. Passes the cached `PageLayers`
+ * snapshot to `upsertDraftLayers` so the repo skips its own pre-read.
+ *
+ * On error the cache entry is invalidated so the next read is forced to hit
+ * the database.
+ */
+export async function saveCachedLayers(pageId: string, layers: Layer[]): Promise<PageLayers> {
+  const cached = cache.get(pageId);
+  const existingDraft = isFresh(cached) ? cached.pageLayers : undefined;
+
+  let saved: PageLayers;
+  try {
+    saved = await upsertDraftLayers(pageId, layers, undefined, existingDraft);
+  } catch (error) {
+    cache.delete(pageId);
+    throw error;
+  }
+
+  cache.set(pageId, { pageLayers: saved, expiresAt: Date.now() + CACHE_TTL_MS });
+  broadcastLayersChanged(pageId, layers).catch(() => {});
+  return saved;
+}
+
+/**
+ * Drop the cached entry for a page. Use after operations that change the page
+ * outside this module's awareness (e.g. publishing, deleting).
+ */
+export function invalidateCachedPage(pageId: string): void {
+  cache.delete(pageId);
+}

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -53,6 +53,190 @@ const EXAMPLE_PROMPTS = {
   ],
 };
 
+// Reference resources are fully static — their content is derived from compile-time
+// imports (ELEMENT_TEMPLATES, PRESET_CATALOG, ANIMATION_EASES) and inline constants.
+// Stringify them once at module load so every resource read just hands back the
+// cached string instead of re-serializing on every fetch.
+const ELEMENTS_REFERENCE_JSON = JSON.stringify({
+  templates: getAvailableTemplates(),
+  nesting_rules: {
+    cannot_have_children: [
+      'icon', 'image', 'audio', 'video', 'iframe',
+      'text', 'span', 'label', 'hr',
+      'input', 'textarea', 'select', 'checkbox', 'radio',
+      'htmlEmbed',
+    ],
+    section_cannot_contain_section: true,
+    links_cannot_nest: true,
+    component_instances_are_readonly: true,
+  },
+  element_types: {
+    structure: {
+      section: 'Full-width page section.',
+      div: 'Generic container.',
+      container: 'Max-width container (1280px) with padding.',
+      columns: '2-column flexbox layout.',
+      grid: '2x2 CSS Grid layout.',
+      collection: 'CMS collection list (repeats children for each item).',
+      hr: 'Horizontal divider line.',
+      table: 'Data table (<table>). Ships with header + 2 body rows.',
+      thead: '<thead> — add inside a table.',
+      tbody: '<tbody> — add inside a table.',
+      tr: '<tr> — add inside thead or tbody.',
+      td: '<td> — add inside a tr.',
+      th: '<th> — add inside a thead tr.',
+    },
+    content: {
+      heading: 'Heading text (h1). 48px bold.',
+      text: 'Paragraph text (p). 16px.',
+      richText: 'Rich text block. Use set_rich_text_content or rich_content in add_layer.',
+    },
+    media: {
+      image: 'Image element. Use update_layer_image to set asset.',
+      video: 'Video player. Use update_layer_video to set source.',
+      audio: 'Audio player.',
+      icon: 'SVG icon. 24x24px.',
+      iframe: 'Iframe embed. Use update_layer_iframe to set URL.',
+    },
+    interactive: {
+      button: 'Button with text child. Use update_layer_link to set destination.',
+      form: 'Form container.',
+      input: 'Text input.',
+      textarea: 'Multi-line text area.',
+      select: 'Dropdown select input.',
+      checkbox: 'Checkbox input.',
+      radio: 'Radio button input.',
+      filter: 'Collection filter input.',
+      label: 'Form label element.',
+    },
+    utility: {
+      htmlEmbed: 'Custom HTML/CSS/JS code. Set via update_layer_settings.',
+      slider: 'Carousel with navigation, pagination, autoplay. Configure via update_layer_settings.',
+      lightbox: 'Fullscreen gallery with thumbnails, navigation, zoom.',
+      map: 'Interactive map element.',
+      localeSelector: 'Language switcher for multi-language sites.',
+    },
+  },
+});
+
+const DESIGN_REFERENCE_JSON = JSON.stringify({
+  instructions: 'Set isActive: true on any category for it to take effect. Use ui_state parameter for hover/focus/active styles. Use bgGradientVars for gradient backgrounds.',
+  categories: {
+    layout: {
+      display: { type: 'enum', values: ['Flex', 'block', 'inline-block', 'grid', 'hidden'] },
+      flexDirection: { type: 'enum', values: ['row', 'column', 'row-reverse', 'column-reverse'] },
+      justifyContent: { type: 'enum', values: ['start', 'end', 'center', 'between', 'around', 'evenly'] },
+      alignItems: { type: 'enum', values: ['start', 'end', 'center', 'baseline', 'stretch'] },
+      gap: { type: 'css_value', examples: ['16px', '1rem'] },
+      gridTemplateColumns: { type: 'string', examples: ['4', '1fr 1fr 1fr', 'repeat(3, 1fr)'], description: 'A bare integer is accepted and normalized to repeat(N, 1fr).' },
+    },
+    typography: {
+      fontSize: { type: 'css_value', examples: ['16px', '48px'] },
+      fontWeight: { type: 'string', examples: ['400', '600', '700'] },
+      fontFamily: { type: 'string', examples: ['DM Sans', 'Plus Jakarta Sans'] },
+      lineHeight: { type: 'css_value', examples: ['1.1', '1.5'] },
+      letterSpacing: { type: 'css_value', examples: ['-0.03em', '0'] },
+      textAlign: { type: 'enum', values: ['left', 'center', 'right'] },
+      color: { type: 'color', examples: ['#171717', '#ffffff'] },
+    },
+    spacing: { padding: { type: 'css_value' }, margin: { type: 'css_value' } },
+    sizing: {
+      width: { type: 'css_value', examples: ['100%', 'auto'] },
+      maxWidth: { type: 'css_value', examples: ['1280px'] },
+      aspectRatio: { type: 'string', examples: ['16/9', '1/1'] },
+    },
+    borders: {
+      borderRadius: { type: 'css_value', examples: ['12px', '9999px'] },
+      borderWidth: { type: 'css_value' },
+      borderColor: { type: 'color' },
+    },
+    backgrounds: {
+      backgroundColor: { type: 'color', examples: ['#ffffff', '#0a0a0a'] },
+      backgroundClip: { type: 'enum', values: ['text', 'border', 'padding'] },
+      bgGradientVars: {
+        type: 'record',
+        description: 'CSS gradient values keyed by var name. "--bg-img" for desktop neutral.',
+        examples: [{ '--bg-img': 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)' }],
+      },
+    },
+    effects: {
+      opacity: { type: 'string' },
+      boxShadow: { type: 'string' },
+    },
+    positioning: {
+      position: { type: 'enum', values: ['relative', 'absolute', 'fixed', 'sticky'] },
+      zIndex: { type: 'string' },
+    },
+    transforms: {
+      translateX: { type: 'css_value', examples: ['10px', '50%'] },
+      translateY: { type: 'css_value', examples: ['10px', '50%'] },
+      scale: { type: 'css_value', examples: ['1', '1.05', '0.95'] },
+      rotate: { type: 'css_value', examples: ['0deg', '45deg', '-90deg'] },
+      skewX: { type: 'css_value', examples: ['0deg', '10deg'] },
+      skewY: { type: 'css_value', examples: ['0deg', '10deg'] },
+      transformOrigin: { type: 'string', examples: ['center', 'top left'] },
+    },
+    transitions: {
+      transitionProperty: { type: 'string', examples: ['all', 'colors', 'transform'] },
+      transitionDuration: { type: 'css_value', examples: ['150ms', '300ms'] },
+      transitionTimingFunction: { type: 'enum', values: ['linear', 'in', 'out', 'in-out'] },
+      transitionDelay: { type: 'css_value', examples: ['0ms', '100ms'] },
+    },
+  },
+});
+
+const ANIMATION_PRESETS_REFERENCE_JSON = JSON.stringify({
+  instructions: 'Use add_animation with a preset key for the common cases. Drop down to set_layer_interactions only when you need full GSAP control.',
+  presets: PRESET_CATALOG,
+  triggers: {
+    click: 'Fires on user click. Use for affordances (pulse, shake).',
+    hover: 'Fires on mouseenter, reverses on mouseleave. Auto-yoyos so you only define the "to" state.',
+    'scroll-into-view': 'Fires once when the element enters the viewport. Default for reveal presets.',
+    'while-scrolling': 'Tween is scrubbed by scroll position. Set timeline.scrub. Use for parallax / progress effects.',
+    load: 'Fires on page load. Use for loops or on-load entrance choreography.',
+  },
+  eases: ANIMATION_EASES,
+  tween_value_formats: {
+    'x | y | width | height': 'CSS length string with unit ("100px", "50%", "5rem").',
+    scale: 'Unitless number string ("1", "1.05").',
+    'rotation | skewX | skewY': 'Degrees with suffix ("45deg", "-90deg").',
+    autoAlpha: 'Opacity 0-100 as plain string ("0", "100") — no % suffix.',
+    backgroundColor: 'Hex or rgb() string ("#ffffff").',
+    display: '"visible" or "hidden".',
+  },
+  tween_position: {
+    number: 'Absolute time in seconds from timeline start.',
+    '">"': 'Start after the previous tween ends.',
+    '"<"': 'Start with the previous tween (overlap).',
+  },
+  apply_styles_modes: {
+    'on-load': 'Apply the "from" value immediately on page load. Use for reveal animations to avoid FOUC.',
+    'on-trigger': 'Apply the "from" value only when the trigger fires. Use for hover/click (element looks normal until interacted with).',
+  },
+  interaction_shape_example: {
+    id: 'int_xxx (auto-generated if omitted)',
+    trigger: 'scroll-into-view',
+    timeline: {
+      breakpoints: ['desktop', 'tablet', 'mobile'],
+      repeat: 0,
+      yoyo: false,
+      toggleActions: 'play none none none',
+    },
+    tweens: [{
+      id: 'twn_xxx (auto-generated if omitted)',
+      layer_id: 'lyr_xxx',
+      position: 0,
+      duration: 0.6,
+      ease: 'power1.out',
+      from: { autoAlpha: '0', y: '40px' },
+      to: { autoAlpha: '100', y: '0px' },
+      apply_styles: { autoAlpha: 'on-load', y: 'on-load' },
+    }],
+  },
+});
+
+const PROMPTS_REFERENCE_JSON = JSON.stringify(EXAMPLE_PROMPTS);
+
 export function registerReferenceResources(server: McpServer) {
   server.resource(
     'elements-reference',
@@ -65,67 +249,7 @@ export function registerReferenceResources(server: McpServer) {
       contents: [{
         uri: 'ycode://reference/elements',
         mimeType: 'application/json',
-        text: JSON.stringify({
-          templates: getAvailableTemplates(),
-          nesting_rules: {
-            cannot_have_children: [
-              'icon', 'image', 'audio', 'video', 'iframe',
-              'text', 'span', 'label', 'hr',
-              'input', 'textarea', 'select', 'checkbox', 'radio',
-              'htmlEmbed',
-            ],
-            section_cannot_contain_section: true,
-            links_cannot_nest: true,
-            component_instances_are_readonly: true,
-          },
-          element_types: {
-            structure: {
-              section: 'Full-width page section.',
-              div: 'Generic container.',
-              container: 'Max-width container (1280px) with padding.',
-              columns: '2-column flexbox layout.',
-              grid: '2x2 CSS Grid layout.',
-              collection: 'CMS collection list (repeats children for each item).',
-              hr: 'Horizontal divider line.',
-              table: 'Data table (<table>). Ships with header + 2 body rows.',
-              thead: '<thead> — add inside a table.',
-              tbody: '<tbody> — add inside a table.',
-              tr: '<tr> — add inside thead or tbody.',
-              td: '<td> — add inside a tr.',
-              th: '<th> — add inside a thead tr.',
-            },
-            content: {
-              heading: 'Heading text (h1). 48px bold.',
-              text: 'Paragraph text (p). 16px.',
-              richText: 'Rich text block. Use set_rich_text_content or rich_content in add_layer.',
-            },
-            media: {
-              image: 'Image element. Use update_layer_image to set asset.',
-              video: 'Video player. Use update_layer_video to set source.',
-              audio: 'Audio player.',
-              icon: 'SVG icon. 24x24px.',
-              iframe: 'Iframe embed. Use update_layer_iframe to set URL.',
-            },
-            interactive: {
-              button: 'Button with text child. Use update_layer_link to set destination.',
-              form: 'Form container.',
-              input: 'Text input.',
-              textarea: 'Multi-line text area.',
-              select: 'Dropdown select input.',
-              checkbox: 'Checkbox input.',
-              radio: 'Radio button input.',
-              filter: 'Collection filter input.',
-              label: 'Form label element.',
-            },
-            utility: {
-              htmlEmbed: 'Custom HTML/CSS/JS code. Set via update_layer_settings.',
-              slider: 'Carousel with navigation, pagination, autoplay. Configure via update_layer_settings.',
-              lightbox: 'Fullscreen gallery with thumbnails, navigation, zoom.',
-              map: 'Interactive map element.',
-              localeSelector: 'Language switcher for multi-language sites.',
-            },
-          },
-        }),
+        text: ELEMENTS_REFERENCE_JSON,
       }],
     }),
   );
@@ -141,71 +265,7 @@ export function registerReferenceResources(server: McpServer) {
       contents: [{
         uri: 'ycode://reference/design-properties',
         mimeType: 'application/json',
-        text: JSON.stringify({
-          instructions: 'Set isActive: true on any category for it to take effect. Use ui_state parameter for hover/focus/active styles. Use bgGradientVars for gradient backgrounds.',
-          categories: {
-            layout: {
-              display: { type: 'enum', values: ['Flex', 'block', 'inline-block', 'grid', 'hidden'] },
-              flexDirection: { type: 'enum', values: ['row', 'column', 'row-reverse', 'column-reverse'] },
-              justifyContent: { type: 'enum', values: ['start', 'end', 'center', 'between', 'around', 'evenly'] },
-              alignItems: { type: 'enum', values: ['start', 'end', 'center', 'baseline', 'stretch'] },
-              gap: { type: 'css_value', examples: ['16px', '1rem'] },
-              gridTemplateColumns: { type: 'string', examples: ['4', '1fr 1fr 1fr', 'repeat(3, 1fr)'], description: 'A bare integer is accepted and normalized to repeat(N, 1fr).' },
-            },
-            typography: {
-              fontSize: { type: 'css_value', examples: ['16px', '48px'] },
-              fontWeight: { type: 'string', examples: ['400', '600', '700'] },
-              fontFamily: { type: 'string', examples: ['DM Sans', 'Plus Jakarta Sans'] },
-              lineHeight: { type: 'css_value', examples: ['1.1', '1.5'] },
-              letterSpacing: { type: 'css_value', examples: ['-0.03em', '0'] },
-              textAlign: { type: 'enum', values: ['left', 'center', 'right'] },
-              color: { type: 'color', examples: ['#171717', '#ffffff'] },
-            },
-            spacing: { padding: { type: 'css_value' }, margin: { type: 'css_value' } },
-            sizing: {
-              width: { type: 'css_value', examples: ['100%', 'auto'] },
-              maxWidth: { type: 'css_value', examples: ['1280px'] },
-              aspectRatio: { type: 'string', examples: ['16/9', '1/1'] },
-            },
-            borders: {
-              borderRadius: { type: 'css_value', examples: ['12px', '9999px'] },
-              borderWidth: { type: 'css_value' },
-              borderColor: { type: 'color' },
-            },
-            backgrounds: {
-              backgroundColor: { type: 'color', examples: ['#ffffff', '#0a0a0a'] },
-              backgroundClip: { type: 'enum', values: ['text', 'border', 'padding'] },
-              bgGradientVars: {
-                type: 'record',
-                description: 'CSS gradient values keyed by var name. "--bg-img" for desktop neutral.',
-                examples: [{ '--bg-img': 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)' }],
-              },
-            },
-            effects: {
-              opacity: { type: 'string' },
-              boxShadow: { type: 'string' },
-            },
-            positioning: {
-              position: { type: 'enum', values: ['relative', 'absolute', 'fixed', 'sticky'] },
-              zIndex: { type: 'string' },
-            },
-            transforms: {
-              translateX: { type: 'css_value', examples: ['10px', '50%'] },
-              translateY: { type: 'css_value', examples: ['10px', '50%'] },
-              scale: { type: 'css_value', examples: ['1', '1.05', '0.95'] },
-              rotate: { type: 'css_value', examples: ['0deg', '45deg', '-90deg'] },
-              skewX: { type: 'css_value', examples: ['0deg', '10deg'] },
-              skewY: { type: 'css_value', examples: ['0deg', '10deg'] },
-              transformOrigin: { type: 'string', examples: ['center', 'top left'] },
-            },
-            transitions: {
-              transitionProperty: { type: 'string', examples: ['all', 'colors', 'transform'] },
-              transitionDuration: { type: 'css_value', examples: ['150ms', '300ms'] },
-              transitionTimingFunction: { type: 'enum', values: ['linear', 'in', 'out', 'in-out'] },
-              transitionDelay: { type: 'css_value', examples: ['0ms', '100ms'] },
-            },
-          },
-        }),
+        text: DESIGN_REFERENCE_JSON,
       }],
     }),
   );
@@ -221,55 +281,7 @@ export function registerReferenceResources(server: McpServer) {
       contents: [{
         uri: 'ycode://reference/animation-presets',
         mimeType: 'application/json',
-        text: JSON.stringify({
-          instructions: 'Use add_animation with a preset key for the common cases. Drop down to set_layer_interactions only when you need full GSAP control.',
-          presets: PRESET_CATALOG,
-          triggers: {
-            click: 'Fires on user click. Use for affordances (pulse, shake).',
-            hover: 'Fires on mouseenter, reverses on mouseleave. Auto-yoyos so you only define the "to" state.',
-            'scroll-into-view': 'Fires once when the element enters the viewport. Default for reveal presets.',
-            'while-scrolling': 'Tween is scrubbed by scroll position. Set timeline.scrub. Use for parallax / progress effects.',
-            load: 'Fires on page load. Use for loops or on-load entrance choreography.',
-          },
-          eases: ANIMATION_EASES,
-          tween_value_formats: {
-            'x | y | width | height': 'CSS length string with unit ("100px", "50%", "5rem").',
-            scale: 'Unitless number string ("1", "1.05").',
-            'rotation | skewX | skewY': 'Degrees with suffix ("45deg", "-90deg").',
-            autoAlpha: 'Opacity 0-100 as plain string ("0", "100") — no % suffix.',
-            backgroundColor: 'Hex or rgb() string ("#ffffff").',
-            display: '"visible" or "hidden".',
-          },
-          tween_position: {
-            number: 'Absolute time in seconds from timeline start.',
-            '">"': 'Start after the previous tween ends.',
-            '"<"': 'Start with the previous tween (overlap).',
-          },
-          apply_styles_modes: {
-            'on-load': 'Apply the "from" value immediately on page load. Use for reveal animations to avoid FOUC.',
-            'on-trigger': 'Apply the "from" value only when the trigger fires. Use for hover/click (element looks normal until interacted with).',
-          },
-          interaction_shape_example: {
-            id: 'int_xxx (auto-generated if omitted)',
-            trigger: 'scroll-into-view',
-            timeline: {
-              breakpoints: ['desktop', 'tablet', 'mobile'],
-              repeat: 0,
-              yoyo: false,
-              toggleActions: 'play none none none',
-            },
-            tweens: [{
-              id: 'twn_xxx (auto-generated if omitted)',
-              layer_id: 'lyr_xxx',
-              position: 0,
-              duration: 0.6,
-              ease: 'power1.out',
-              from: { autoAlpha: '0', y: '40px' },
-              to: { autoAlpha: '100', y: '0px' },
-              apply_styles: { autoAlpha: 'on-load', y: 'on-load' },
-            }],
-          },
-        }),
+        text: ANIMATION_PRESETS_REFERENCE_JSON,
       }],
     }),
   );
@@ -285,7 +297,7 @@ export function registerReferenceResources(server: McpServer) {
       contents: [{
         uri: 'ycode://reference/prompts',
         mimeType: 'application/json',
-        text: JSON.stringify(EXAMPLE_PROMPTS),
+        text: PROMPTS_REFERENCE_JSON,
       }],
     }),
   );

--- a/lib/mcp/tools/animations.ts
+++ b/lib/mcp/tools/animations.ts
@@ -2,8 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { Layer, LayerInteraction } from '@/types';
-import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
-import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
+import { getCachedLayers as getPageLayers, saveCachedLayers } from '@/lib/mcp/page-layers';
 import { findLayerById, updateLayerById, generateId } from '@/lib/mcp/utils';
 import {
   ANIMATION_EASES,
@@ -11,14 +10,8 @@ import {
   buildInteractionFromPreset,
 } from '@/lib/mcp/animation-presets';
 
-async function getPageLayers(pageId: string): Promise<Layer[]> {
-  const pageLayers = await getDraftLayers(pageId);
-  return (pageLayers?.layers as Layer[]) || [];
-}
-
 async function savePageLayers(pageId: string, layers: Layer[]): Promise<void> {
-  await upsertDraftLayers(pageId, layers);
-  broadcastLayersChanged(pageId, layers).catch(() => {});
+  await saveCachedLayers(pageId, layers);
 }
 
 const presetEnum = z.enum(ANIMATION_PRESETS);

--- a/lib/mcp/tools/batch.ts
+++ b/lib/mcp/tools/batch.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Layer, Breakpoint, UIState } from '@/types';
-import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
 import {
   findLayerById,
   updateLayerById,
@@ -15,7 +14,7 @@ import {
   applyDesignToLayer,
 } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
-import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
+import { getCachedLayers, saveCachedLayers } from '@/lib/mcp/page-layers';
 import { designSchema, richTextBlockSchema, templateEnum } from './shared-schemas';
 
 const addLayerOp = z.object({
@@ -106,8 +105,7 @@ EXAMPLE:
       operations: z.array(operationSchema).min(1).max(50).describe('Array of operations to execute in order'),
     },
     async ({ page_id, operations }) => {
-      const pageLayers = await getDraftLayers(page_id);
-      let layers = (pageLayers?.layers as Layer[]) || [];
+      let layers = await getCachedLayers(page_id);
 
       const refMap = new Map<string, string>();
       const results: Array<{ op: number; status: string; detail: string }> = [];
@@ -241,11 +239,10 @@ EXAMPLE:
 
       const errors = results.filter((r) => r.status === 'error');
       if (errors.length === operations.length) {
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'All operations failed', results }, null, 2) }], isError: true };
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ message: 'All operations failed', results }) }], isError: true };
       }
 
-      await upsertDraftLayers(page_id, layers);
-      broadcastLayersChanged(page_id, layers).catch(() => {});
+      await saveCachedLayers(page_id, layers);
 
       const refEntries = Object.fromEntries(refMap);
       return {
@@ -255,7 +252,7 @@ EXAMPLE:
             message: `Executed ${results.filter((r) => r.status === 'ok').length}/${operations.length} operations`,
             ref_ids: Object.keys(refEntries).length > 0 ? refEntries : undefined,
             results,
-          }, null, 2),
+          }),
         }],
       };
     },

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DesignProperties, Layer, LinkSettings } from '@/types';
-import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
 import {
   findLayerById,
   updateLayerById,
@@ -16,17 +15,11 @@ import {
 } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
 import { layerToExportHtml } from '@/lib/html-layer-converter';
-import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
+import { getCachedLayers as getPageLayers, saveCachedLayers } from '@/lib/mcp/page-layers';
 import { designSchema, richTextBlockSchema, templateEnum } from './shared-schemas';
 
-async function getPageLayers(pageId: string): Promise<Layer[]> {
-  const pageLayers = await getDraftLayers(pageId);
-  return (pageLayers?.layers as Layer[]) || [];
-}
-
 async function savePageLayers(pageId: string, layers: Layer[]): Promise<void> {
-  await upsertDraftLayers(pageId, layers);
-  broadcastLayersChanged(pageId, layers).catch(() => {});
+  await saveCachedLayers(pageId, layers);
 }
 
 export function registerLayerTools(server: McpServer) {

--- a/lib/mcp/tools/layouts.ts
+++ b/lib/mcp/tools/layouts.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Layer } from '@/types';
-import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
+import { getCachedLayers, saveCachedLayers } from '@/lib/mcp/page-layers';
 import {
   getLayoutTemplate,
   getLayoutCategory,
@@ -9,7 +9,6 @@ import {
   getLayoutsByCategory,
 } from '@/lib/templates/blocks';
 import { findLayerById, insertLayer, canHaveChildren } from '@/lib/mcp/utils';
-import { broadcastLayersChanged } from '@/lib/mcp/broadcast';
 
 interface CatalogEntry {
   key: string;
@@ -73,8 +72,7 @@ Use list_layouts to see available layouts.`,
 
       const category = getLayoutCategory(layout_key);
 
-      const pageLayers = await getDraftLayers(page_id);
-      let layers = (pageLayers?.layers as Layer[]) || [];
+      let layers: Layer[] = await getCachedLayers(page_id);
 
       if (parent_layer_id) {
         const parent = findLayerById(layers, parent_layer_id);
@@ -104,8 +102,7 @@ Use list_layouts to see available layouts.`,
         layers = [...layers, layoutLayer];
       }
 
-      await upsertDraftLayers(page_id, layers);
-      broadcastLayersChanged(page_id, layers).catch(() => {});
+      await saveCachedLayers(page_id, layers);
 
       return {
         content: [{

--- a/lib/mcp/tools/pages.ts
+++ b/lib/mcp/tools/pages.ts
@@ -82,7 +82,8 @@ export function registerPageTools(server: McpServer) {
         classes: '',
         children: [],
       }];
-      await upsertDraftLayers(page.id, initialLayers);
+      // Brand-new page guarantees no existing draft — assert it to skip the repo's pre-read.
+      await upsertDraftLayers(page.id, initialLayers, undefined, null);
 
       broadcastPageCreated(page).catch(() => {});
       broadcastLayersChanged(page.id, initialLayers).catch(() => {});

--- a/lib/mcp/tools/styles.ts
+++ b/lib/mcp/tools/styles.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DesignProperties, Layer } from '@/types';
 import { getAllStyles, createStyle, updateStyle, deleteStyle } from '@/lib/repositories/layerStyleRepository';
-import { getDraftLayers, upsertDraftLayers } from '@/lib/repositories/pageLayersRepository';
+import { getCachedDraft, saveCachedLayers } from '@/lib/mcp/page-layers';
 import { findLayerById, updateLayerById, designToClassString } from '@/lib/mcp/utils';
 import { designSchema } from './shared-schemas';
 
@@ -45,7 +45,7 @@ export function registerStyleTools(server: McpServer) {
       style_id: z.string().describe('The style ID'),
     },
     async ({ page_id, layer_id, style_id }) => {
-      const pageLayers = await getDraftLayers(page_id);
+      const pageLayers = await getCachedDraft(page_id);
       if (!pageLayers) {
         return { content: [{ type: 'text' as const, text: `Error: Page "${page_id}" has no layers.` }], isError: true };
       }
@@ -57,7 +57,7 @@ export function registerStyleTools(server: McpServer) {
       }
 
       const updated = updateLayerById(layers, layer_id, (l) => ({ ...l, styleId: style_id }));
-      await upsertDraftLayers(page_id, updated);
+      await saveCachedLayers(page_id, updated);
 
       return { content: [{ type: 'text' as const, text: `Applied style "${style_id}" to "${layer.customName || layer.name}"` }] };
     },

--- a/lib/repositories/pageLayersRepository.ts
+++ b/lib/repositories/pageLayersRepository.ts
@@ -108,11 +108,17 @@ export async function getPublishedLayers(pageId: string): Promise<PageLayers | n
  * @param pageId - Page ID
  * @param layers - Page layers
  * @param additionalData - Optional additional fields (e.g., metadata)
+ * @param existingDraft - Optional pre-fetched draft to skip the internal
+ *   `getDraftLayers` read. Callers that already have the row (e.g. the MCP
+ *   page-layers cache) can pass it through to avoid a redundant DB round trip.
+ *   Pass `null` to assert "no draft exists" without re-checking. Omit (or
+ *   pass `undefined`) to preserve the original fetch-then-decide behavior.
  */
 export async function upsertDraftLayers(
   pageId: string,
   layers: Layer[],
-  additionalData?: Record<string, any>
+  additionalData?: Record<string, any>,
+  existingDraft?: PageLayers | null,
 ): Promise<PageLayers> {
   const client = await getSupabaseAdmin();
 
@@ -120,12 +126,14 @@ export async function upsertDraftLayers(
     throw new Error('Supabase not configured');
   }
 
-  // Check if draft exists
-  const existingDraft = await getDraftLayers(pageId);
+  // Use the caller-provided draft when available, otherwise fall back to a fresh read.
+  const resolvedDraft = existingDraft !== undefined
+    ? existingDraft
+    : await getDraftLayers(pageId);
 
   // Detect removed and changed layer content, update translations accordingly
-  if (existingDraft && existingDraft.layers) {
-    const oldContentMap = extractLayerContentMap(existingDraft.layers, 'page', pageId);
+  if (resolvedDraft && resolvedDraft.layers) {
+    const oldContentMap = extractLayerContentMap(resolvedDraft.layers, 'page', pageId);
     const newContentMap = extractLayerContentMap(layers, 'page', pageId);
 
     // Find removed keys (exist in old but not in new)
@@ -150,7 +158,7 @@ export async function upsertDraftLayers(
   // Use provided generated_css, or preserve the existing value for hash consistency
   const cssForHash = additionalData?.generated_css !== undefined
     ? (additionalData.generated_css as string) || null
-    : existingDraft?.generated_css || null;
+    : resolvedDraft?.generated_css || null;
 
   const contentHash = generatePageLayersHash({
     layers,
@@ -168,12 +176,12 @@ export async function upsertDraftLayers(
     Object.assign(updateData, additionalData);
   }
 
-  if (existingDraft) {
+  if (resolvedDraft) {
     // Update existing draft
     const { data, error } = await client
       .from('page_layers')
       .update(updateData)
-      .eq('id', existingDraft.id)
+      .eq('id', resolvedDraft.id)
       .eq('is_published', false)
       .select()
       .single();


### PR DESCRIPTION
## Summary

Second round of MCP perf wins, layered on top of #262. Removes the two
remaining hot-path round trips on every tool call and stops re-serializing
static reference data.

## Changes

- **Per-page in-memory layer cache (`lib/mcp/page-layers.ts`)**: caches the
  latest `PageLayers` row on `globalThis` with a 5s TTL. Sequential tool
  calls on the same page are served from memory — no Supabase read.
- **`upsertDraftLayers` accepts `existingDraft`**: callers that already
  hold the row (the new cache, plus `create_page` which knows there is no
  draft yet) pass it through, skipping the repo's internal pre-read. So a
  single MCP write now costs **1 DB round trip instead of 2**.
- **All MCP tool files rewired**: `layers`, `batch`, `animations`,
  `styles`, `layouts`, `pages` route through the new helper. The duplicate
  inline `getPageLayers` / `savePageLayers` helpers are gone.
- **Reference resources precomputed**: `elements-reference`,
  `design-reference`, `animation-presets-reference`, and `prompts-reference`
  are stringified once at module load, not on every fetch. These payloads
  are several KB each — that work happens zero times per request now.
- **Drop two leftover `null, 2` pretty-print args** in `batch.ts` response
  payloads (missed in #262).

## Expected impact

For a typical agent burst of ~20 layer mutations against the same page:

- Before: 40 DB round trips for layers (2 per call) + N stringify passes
  on static refs.
- After: ~1-2 DB round trips for layers (initial fetch only) + 0 stringify
  passes on static refs.

Most batches should be **end-to-end ~30-50% faster**, dominated by network
RTT to Supabase.

## Test plan

- [ ] Connect a fresh MCP session and run a 10-step layer batch — confirm
      changes apply correctly and survive reconnect.
- [ ] Verify the builder live-updates on each tool call (broadcast still
      fires from `saveCachedLayers`).
- [ ] `create_page` then immediately `add_layer` — confirm the brand-new
      page's `null` draft assertion doesn't break the first write.
- [ ] Fetch each reference resource (`elements`, `design`, `animation-presets`,
      `prompts`) and confirm payloads are unchanged.
- [ ] Run two MCP sessions concurrently against different pages — confirm
      the cache doesn't cross-contaminate.

Made with [Cursor](https://cursor.com)