### PR TITLE
fix: make date filters day-aware and support date_only

### DIFF
--- a/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
+++ b/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
@@ -8,7 +8,7 @@ import { getAllPages } from '@/lib/repositories/pageRepository';
 import { getAllPageFolders } from '@/lib/repositories/pageFolderRepository';
 import { renderCollectionItemsToHtml, loadTranslationsForLocale } from '@/lib/page-fetcher';
 import { noCache } from '@/lib/api-response';
-import { isDatePreset, resolveDateFilterValue } from '@/lib/collection-field-utils';
+import { compareDateFilter, isDateFieldType, isDatePreset, resolveDateFilterValue } from '@/lib/collection-field-utils';
 import type { Layer, CollectionItem, CollectionItemWithValues } from '@/types';
 
 export const dynamic = 'force-dynamic';
@@ -125,6 +125,17 @@ async function getIdsMatchingFilter(
         }
         return result;
       }
+      if (isDateFieldType(filter.fieldType)) {
+        const data = await chunkedQuery(
+          chunk => selectIdsAndValues(chunk).neq('value', ''),
+          allItemIds,
+        );
+        const result = new Set<string>();
+        for (const row of data) {
+          if (compareDateFilter(String(row.value), 'is', value)) result.add(row.item_id);
+        }
+        return result;
+      }
       const data = await chunkedQuery(
         chunk => selectIds(chunk).ilike('value', escapeLikeValue(value)),
         allItemIds,
@@ -166,6 +177,17 @@ async function getIdsMatchingFilter(
           if (isTruthy !== targetBool) result.add(row.item_id);
         }
         return result;
+      }
+      if (isDateFieldType(filter.fieldType)) {
+        const data = await chunkedQuery(
+          chunk => selectIdsAndValues(chunk).neq('value', ''),
+          allItemIds,
+        );
+        const matchIds = new Set<string>();
+        for (const row of data) {
+          if (compareDateFilter(String(row.value), 'is', value)) matchIds.add(row.item_id);
+        }
+        return new Set([...allSet].filter(id => !matchIds.has(id)));
       }
       const data = await chunkedQuery(
         chunk => selectIds(chunk).ilike('value', escapeLikeValue(value)),
@@ -226,32 +248,26 @@ async function getIdsMatchingFilter(
       return result;
     }
 
-    // --- Date ---
+    // --- Date (day-aware: `YYYY-MM-DD` filter values span the full UTC day) ---
     case 'is_before': {
-      const filterDate = new Date(value).getTime();
-      if (isNaN(filterDate)) return new Set();
       const data = await chunkedQuery(
         chunk => selectIdsAndValues(chunk).neq('value', ''),
         allItemIds,
       );
       const result = new Set<string>();
       for (const row of data) {
-        const d = new Date(String(row.value)).getTime();
-        if (!isNaN(d) && d < filterDate) result.add(row.item_id);
+        if (compareDateFilter(String(row.value), 'is_before', value)) result.add(row.item_id);
       }
       return result;
     }
     case 'is_after': {
-      const filterDate = new Date(value).getTime();
-      if (isNaN(filterDate)) return new Set();
       const data = await chunkedQuery(
         chunk => selectIdsAndValues(chunk).neq('value', ''),
         allItemIds,
       );
       const result = new Set<string>();
       for (const row of data) {
-        const d = new Date(String(row.value)).getTime();
-        if (!isNaN(d) && d > filterDate) result.add(row.item_id);
+        if (compareDateFilter(String(row.value), 'is_after', value)) result.add(row.item_id);
       }
       return result;
     }
@@ -260,27 +276,20 @@ async function getIdsMatchingFilter(
       const endRaw = (filter.value2 || '').trim();
       if (!startRaw && !endRaw) return new Set();
 
-      const startDate = startRaw ? new Date(startRaw).getTime() : null;
-      const endDate = endRaw ? new Date(endRaw).getTime() : null;
-      if ((startDate !== null && isNaN(startDate)) || (endDate !== null && isNaN(endDate))) {
-        return new Set();
-      }
-
       const data = await chunkedQuery(
         chunk => selectIdsAndValues(chunk).neq('value', ''),
         allItemIds,
       );
       const result = new Set<string>();
       for (const row of data) {
-        const d = new Date(String(row.value)).getTime();
-        if (isNaN(d)) continue;
-
-        if (startDate !== null && endDate !== null) {
-          if (d >= startDate && d <= endDate) result.add(row.item_id);
-        } else if (startDate !== null) {
-          if (d >= startDate) result.add(row.item_id);
-        } else if (endDate !== null) {
-          if (d <= endDate) result.add(row.item_id);
+        const storedValue = String(row.value);
+        // Open-ended ranges fall back to the relevant single-bound operator.
+        if (startRaw && endRaw) {
+          if (compareDateFilter(storedValue, 'is_between', startRaw, endRaw)) result.add(row.item_id);
+        } else if (startRaw) {
+          if (!compareDateFilter(storedValue, 'is_before', startRaw)) result.add(row.item_id);
+        } else if (endRaw) {
+          if (!compareDateFilter(storedValue, 'is_after', endRaw)) result.add(row.item_id);
         }
       }
       return result;
@@ -427,7 +436,7 @@ async function getFilteredItemIds(
 
     for (let filter of group) {
       if (currentIds.size === 0) break;
-      if (filter.fieldType === 'date' && isDatePreset(filter.value)) {
+      if (isDateFieldType(filter.fieldType) && isDatePreset(filter.value)) {
         const resolved = resolveDateFilterValue(filter.operator, filter.value, filter.value2);
         if (resolved) {
           filter = { ...filter, operator: resolved.operator, value: resolved.value, value2: resolved.value2 };

--- a/components/FilterableCollection.tsx
+++ b/components/FilterableCollection.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react';
 import { useFilterStore } from '@/stores/useFilterStore';
 import type { ConditionalVisibility, Layer } from '@/types';
-import { isDatePreset, resolveDateFilterValue } from '@/lib/collection-field-utils';
+import { isDateFieldType, isDatePreset, resolveDateFilterValue } from '@/lib/collection-field-utils';
 
 interface FilterableCollectionProps {
   children: React.ReactNode;
@@ -230,7 +230,7 @@ export default function FilterableCollection({
         }
 
         let resolvedOperator: string = condition.operator;
-        if (condition.fieldType === 'date' && isDatePreset(value)) {
+        if (isDateFieldType(condition.fieldType) && isDatePreset(value)) {
           const resolved = resolveDateFilterValue(condition.operator, value, value2);
           if (!resolved) continue;
           resolvedOperator = resolved.operator;

--- a/lib/collection-field-utils.ts
+++ b/lib/collection-field-utils.ts
@@ -291,8 +291,8 @@ export function resolveDatePreset(preset: string): { start: string; end: string 
 
 /**
  * Resolve a filter value that may be a date preset into operator + concrete
- * value(s) suitable for the filter API.  For presets, the operator is widened
- * to a range comparison; for plain values it's returned as-is.
+ * value(s) suitable for the filter API. Presets always widen to `is_between`
+ * so the full day(s) are captured; plain values are returned as-is.
  */
 export function resolveDateFilterValue(
   operator: string,
@@ -306,9 +306,6 @@ export function resolveDateFilterValue(
 
   switch (operator) {
     case 'is':
-      return range.start === range.end
-        ? { operator: 'is', value: range.start }
-        : { operator: 'is_between', value: range.start, value2: range.end };
     case 'is_between':
       return { operator: 'is_between', value: range.start, value2: range.end };
     case 'is_before':
@@ -317,6 +314,65 @@ export function resolveDateFilterValue(
       return { operator: 'is_after', value: range.end };
     default:
       return { operator: 'is_between', value: range.start, value2: range.end };
+  }
+}
+
+/** Match `YYYY-MM-DD` (the format emitted by `<input type="date">` and date presets). */
+const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isDateOnlyString(value: string | undefined | null): boolean {
+  return !!value && DATE_ONLY_REGEX.test(value);
+}
+
+/**
+ * Convert a filter date string to start/end-of-day UTC timestamps.
+ * For `YYYY-MM-DD` inputs the range spans the entire UTC day so that filters
+ * match datetime values (which are stored as full ISO strings) regardless of
+ * the time component. For other inputs, both bounds equal the parsed
+ * timestamp. Returns `null` if the input cannot be parsed.
+ */
+export function dateStringToDayBounds(
+  value: string | undefined | null,
+): { start: number; end: number } | null {
+  if (!value) return null;
+  if (isDateOnlyString(value)) {
+    const start = Date.parse(`${value}T00:00:00.000Z`);
+    const end = Date.parse(`${value}T23:59:59.999Z`);
+    if (isNaN(start) || isNaN(end)) return null;
+    return { start, end };
+  }
+  const ts = Date.parse(value);
+  return isNaN(ts) ? null : { start: ts, end: ts };
+}
+
+/**
+ * Compare a stored date/datetime value against a filter value using day-aware
+ * semantics (so `is today` matches any timestamp on today's date).
+ * Returns `false` if either value cannot be parsed.
+ */
+export function compareDateFilter(
+  storedValue: string,
+  operator: 'is' | 'is_before' | 'is_after' | 'is_between',
+  filterValue: string,
+  filterValue2?: string,
+): boolean {
+  const valueTs = Date.parse(storedValue);
+  if (isNaN(valueTs)) return false;
+  const bounds = dateStringToDayBounds(filterValue);
+  if (!bounds) return false;
+
+  switch (operator) {
+    case 'is':
+      return valueTs >= bounds.start && valueTs <= bounds.end;
+    case 'is_before':
+      return valueTs < bounds.start;
+    case 'is_after':
+      return valueTs > bounds.end;
+    case 'is_between': {
+      const bounds2 = dateStringToDayBounds(filterValue2);
+      if (!bounds2) return false;
+      return valueTs >= bounds.start && valueTs <= bounds2.end;
+    }
   }
 }
 

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -10,7 +10,7 @@ import { getCmsFieldBinding } from '@/lib/tiptap-utils';
 import { applyComponentOverrides } from '@/lib/resolve-components';
 import { getComponentVariantLayers } from '@/lib/component-variant-utils';
 import { resolveFieldFromSources } from '@/lib/cms-variables-utils';
-import { isDatePreset, resolveDateFilterValue } from '@/lib/collection-field-utils';
+import { compareDateFilter, isDateFieldType, isDatePreset, resolveDateFilterValue } from '@/lib/collection-field-utils';
 import { parseMultiReferenceValue } from '@/lib/collection-utils';
 import { getInheritedValue } from '@/lib/tailwind-class-mapper';
 import cloneDeep from 'lodash/cloneDeep';
@@ -1976,7 +1976,7 @@ function evaluateCondition(
     let effectiveOperator = condition.operator;
     const fieldType = condition.fieldType || 'text';
 
-    if (fieldType === 'date' && isDatePreset(compareValue)) {
+    if (isDateFieldType(fieldType) && isDatePreset(compareValue)) {
       const resolved = resolveDateFilterValue(effectiveOperator, compareValue, compareValue2);
       if (resolved) {
         effectiveOperator = resolved.operator as typeof effectiveOperator;
@@ -1997,11 +1997,17 @@ function evaluateCondition(
         if (fieldType === 'number') {
           return parseFloat(value) === parseFloat(compareValue);
         }
+        if (isDateFieldType(fieldType)) {
+          return compareDateFilter(value, 'is', compareValue);
+        }
         return value === compareValue;
 
       case 'is_not':
         if (fieldType === 'number') {
           return parseFloat(value) !== parseFloat(compareValue);
+        }
+        if (isDateFieldType(fieldType)) {
+          return !compareDateFilter(value, 'is', compareValue);
         }
         return value !== compareValue;
 
@@ -2030,25 +2036,15 @@ function evaluateCondition(
       case 'gte':
         return parseFloat(value) >= parseFloat(compareValue);
 
-      // Date operators
-      case 'is_before': {
-        const dateValue = new Date(value);
-        const compareDateValue = new Date(compareValue);
-        return dateValue < compareDateValue;
-      }
+      // Date operators (day-aware: `YYYY-MM-DD` filter values span the full UTC day)
+      case 'is_before':
+        return compareDateFilter(value, 'is_before', compareValue);
 
-      case 'is_after': {
-        const dateValue = new Date(value);
-        const compareDateValue = new Date(compareValue);
-        return dateValue > compareDateValue;
-      }
+      case 'is_after':
+        return compareDateFilter(value, 'is_after', compareValue);
 
-      case 'is_between': {
-        const dateValue = new Date(value);
-        const startDate = new Date(compareValue);
-        const endDate = new Date(compareValue2 ?? '');
-        return dateValue >= startDate && dateValue <= endDate;
-      }
+      case 'is_between':
+        return compareDateFilter(value, 'is_between', compareValue, compareValue2);
 
       case 'is_not_empty':
         return isPresent;


### PR DESCRIPTION
## Summary

Date filters using presets like "Today" weren't matching against `date` (datetime) fields, and `date_only` fields silently bypassed preset resolution entirely. This made both collection filters and conditional visibility unusable for the most common time-based use cases.

## Changes

- Always widen `is + preset` to `is_between` so the resolved range spans the full day(s) instead of collapsing to a zero-width timestamp
- Add `compareDateFilter` helper that performs day-aware comparisons by converting `YYYY-MM-DD` filter values into full UTC day bounds (`00:00:00.000` → `23:59:59.999`)
- Replace narrow `fieldType === 'date'` checks with `isDateFieldType()` so `date_only` fields go through the same preset/comparison path as `date`
- Apply the new helper across all three evaluation paths:
  - `lib/layer-utils.ts` — `evaluateVisibility` (SSR + client, for conditional visibility AND collection filters)
  - `app/(builder)/ycode/api/collections/[id]/items/filter/route.ts` — server-side filter API
  - `components/FilterableCollection.tsx` — client-side filtering with linked inputs

## Test plan

- [ ] Collection list: filter on a `date` field with operator `is` + preset `Today` — items dated today (with any time component) appear
- [ ] Same with `date_only` field — items dated today appear
- [ ] Filter with operator `is_between` + preset `This week` — items across the full week range match
- [ ] Filter with `is_before` / `is_after` + a `YYYY-MM-DD` value — uses start-of-day / end-of-day bounds correctly (no time-component bleed)
- [ ] Conditional visibility on a layer using a `date` field + `Today` preset — layer shows/hides for items dated today
- [ ] Conditional visibility on a `date_only` field with the same setup — same correct behavior
- [ ] FilterableCollection with a linked date input — typing a `YYYY-MM-DD` matches stored datetimes on that day
- [ ] Negation (`is_not` on a date field) inverts the day match correctly

Made with [Cursor](https://cursor.com)