### PR TITLE
feat: roll over date-preset pages once per local day via cron

### DIFF
--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -711,6 +711,25 @@ export async function POST(request: NextRequest) {
           : invalidationResult.reason,
       );
 
+      // Update the stored list of pages whose render depends on date presets
+      // (`$today`, etc.). The daily cron uses this to know which pages to
+      // invalidate when local midnight rolls over. Non-fatal — a publish that
+      // succeeds in every other respect shouldn't be torpedoed by a stale flag.
+      try {
+        const { recomputeTimeDependentPageIds } = await import('@/lib/services/datePresetsService');
+        const affectedForDateScan = [...new Set([...publishedPageIds, ...indirectlyAffectedPageIds])];
+        if (affectedForDateScan.length > 0) {
+          const datePresetResult = await recomputeTimeDependentPageIds(affectedForDateScan);
+          if (datePresetResult.added.length > 0 || datePresetResult.removed.length > 0) {
+            console.log(
+              `[Cache] date-preset flag: +${datePresetResult.added.length} / -${datePresetResult.removed.length} (total ${datePresetResult.total})`,
+            );
+          }
+        }
+      } catch (err) {
+        console.warn('[Cache] date-preset flag update failed:', err instanceof Error ? err.message : err);
+      }
+
       // After invalidation, prime the affected pages in the background so the
       // first real visitor doesn't pay the cold-cache cost. We absorb the
       // STALE/MISS server-side; the visitor's first hit is HIT.

--- a/app/(site)/[...slug]/page.tsx
+++ b/app/(site)/[...slug]/page.tsx
@@ -12,6 +12,8 @@ import { getSettingByKey } from '@/lib/repositories/settingsRepository';
 import { parseAuthCookie, getPasswordProtection, fetchFoldersForAuth } from '@/lib/page-auth';
 import { getSiteBaseUrl } from '@/lib/url-utils';
 import { matchRedirect } from '@/lib/redirect-utils';
+import { TIME_DEPENDENT_PAGES_TAG } from '@/lib/services/cacheService';
+import { PAGES_WITH_DATE_PRESETS_SETTING } from '@/lib/services/datePresetsService';
 import type { Page, PageFolder, Translation, Redirect as RedirectType } from '@/types';
 
 // Static by default for performance, dynamic only when pagination is requested
@@ -150,7 +152,7 @@ export async function generateStaticParams() {
  * Fetch published page and layers data from database
  * Cached per slug and page for revalidation
  */
-async function fetchPublishedPageWithLayers(slugPath: string) {
+async function fetchPublishedPageWithLayers(slugPath: string, isTimeDependent: boolean) {
   // Tags are both 'route-/X' AND 'all-pages':
   // - route-/X lets selective invalidation purge just this page's data cache
   // - all-pages lets full invalidation (color variables, redirects, etc.)
@@ -159,7 +161,10 @@ async function fetchPublishedPageWithLayers(slugPath: string) {
   // doesn't cascade to entries that only share 'all-pages'. (Next.js bug
   // #63509 would apply if we used revalidateTag for selective, but we route
   // exclusively through invalidateByTag on Vercel.)
+  // `time-dependent-pages` is added opt-in for pages with `$today`/preset-based
+  // visibility or filter rules so the daily cron can roll them over.
   const tags = [`route-/${slugPath}`, 'all-pages'];
+  if (isTimeDependent) tags.push(TIME_DEPENDENT_PAGES_TAG);
   const opts = { tags, revalidate: false as const };
 
   const [core, layers] = await Promise.all([
@@ -193,6 +198,32 @@ async function fetchPublishedPageForMetadata(slugPath: string) {
     [`metadata-/${slugPath}`],
     { tags: [`route-/${slugPath}`, 'all-pages'], revalidate: false }
   )();
+}
+
+/**
+ * Returns whether the page at `slugPath` is in the stored "time-dependent"
+ * set. The membership check needs the page's ID, which we resolve via the
+ * cached metadata fetch (already in cache for the metadata path; cheap one
+ * extra read on a cold cache for the render path).
+ */
+async function isTimeDependentPage(slugPath: string): Promise<boolean> {
+  try {
+    const [timeDependentIds, pageMeta] = await Promise.all([
+      unstable_cache(
+        async () => {
+          const value = await getSettingByKey(PAGES_WITH_DATE_PRESETS_SETTING);
+          return Array.isArray(value) ? (value as string[]) : [];
+        },
+        ['data-for-time-dependent-page-ids'],
+        { tags: ['all-pages'], revalidate: false },
+      )(),
+      fetchPublishedPageForMetadata(slugPath),
+    ]);
+    if (timeDependentIds.length === 0) return false;
+    return !!pageMeta && timeDependentIds.includes(pageMeta.page.id);
+  } catch {
+    return false;
+  }
 }
 
 async function fetchCachedRedirects(): Promise<RedirectType[] | null> {
@@ -267,7 +298,10 @@ export default async function Page({ params }: PageProps) {
   // Tag this response for Vercel CDN cache invalidation. The publish endpoint
   // purges this exact tag (route-/<slug>) so only this URL's cache entry is
   // invalidated. No-ops outside Vercel.
-  await addCacheTag([`route-/${slugPath}`, 'all-pages']);
+  const isTimeDependent = await isTimeDependentPage(slugPath);
+  const responseTags = [`route-/${slugPath}`, 'all-pages'];
+  if (isTimeDependent) responseTags.push(TIME_DEPENDENT_PAGES_TAG);
+  await addCacheTag(responseTags);
 
   // Check for redirects before processing the page
   const currentPath = `/${slugPath}`;
@@ -285,7 +319,7 @@ export default async function Page({ params }: PageProps) {
 
   // Fetch page data and global settings in parallel
   const [data, globalSettings] = await Promise.all([
-    fetchPublishedPageWithLayers(slugPath),
+    fetchPublishedPageWithLayers(slugPath, isTimeDependent),
     fetchCachedGlobalSettings(),
   ]);
 

--- a/app/(site)/api/cron/revalidate-date-presets/route.ts
+++ b/app/(site)/api/cron/revalidate-date-presets/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { invalidateTimeDependentPages } from '@/lib/services/cacheService';
+import { getSettingByKey } from '@/lib/repositories/settingsRepository';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * GET /api/cron/revalidate-date-presets
+ *
+ * Hourly cron that purges the `time-dependent-pages` cache tag exactly once
+ * per local day, so cached pages using `$today`/`$this_week`/etc. presets
+ * actually roll over.
+ *
+ * The cron is scheduled hourly but only does work when the site's configured
+ * timezone is at the midnight hour — that way published pages get one
+ * invalidation per day regardless of which TZ the user lives in.
+ *
+ * Secured via CRON_SECRET or Vercel's Authorization header.
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const timezone = ((await getSettingByKey('timezone')) as string | null) || 'UTC';
+    const currentHour = getHourInTimezone(timezone);
+
+    // Skip silently outside the midnight hour. Returning OK keeps Vercel's
+    // cron monitor green; the next hour will retry the check.
+    if (currentHour !== 0) {
+      return NextResponse.json({ data: { skipped: true, timezone, hour: currentHour } });
+    }
+
+    const ok = await invalidateTimeDependentPages();
+    return NextResponse.json({ data: { invalidated: ok, timezone, hour: currentHour } });
+  } catch (error) {
+    console.error('[Cron] Date-preset revalidation error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to revalidate date-preset pages' },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * Returns the current hour (0-23) in the given IANA timezone. Falls back to
+ * the UTC hour if the timezone string is invalid (e.g. typo in the setting).
+ */
+function getHourInTimezone(timezone: string): number {
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hour: 'numeric',
+      hour12: false,
+    });
+    const parts = formatter.formatToParts(new Date());
+    const hourPart = parts.find(p => p.type === 'hour');
+    if (!hourPart) return new Date().getUTCHours();
+    const parsed = parseInt(hourPart.value, 10);
+    // Intl returns '24' for midnight in some locales; normalize to 0.
+    return Number.isNaN(parsed) ? new Date().getUTCHours() : parsed % 24;
+  } catch {
+    return new Date().getUTCHours();
+  }
+}

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -11,6 +11,8 @@ import { getSettingByKey } from '@/lib/repositories/settingsRepository';
 import { matchRedirect } from '@/lib/redirect-utils';
 import { parseAuthCookie, getPasswordProtection, fetchFoldersForAuth } from '@/lib/page-auth';
 import { getSiteBaseUrl } from '@/lib/url-utils';
+import { TIME_DEPENDENT_PAGES_TAG } from '@/lib/services/cacheService';
+import { PAGES_WITH_DATE_PRESETS_SETTING } from '@/lib/services/datePresetsService';
 import type { Redirect as RedirectType } from '@/types';
 import type { Metadata } from 'next';
 
@@ -21,7 +23,7 @@ export const revalidate = false; // Cache indefinitely until publish invalidates
  * Fetch homepage data from database
  * Cached with tag-based revalidation (no time-based stale cache)
  */
-async function fetchPublishedHomepage() {
+async function fetchPublishedHomepage(isTimeDependent: boolean) {
   // Tags are both 'route-/' AND 'all-pages':
   // - route-/ lets selective invalidation purge just this page's data cache
   // - all-pages lets full invalidation (color variables, redirects, etc.)
@@ -30,7 +32,10 @@ async function fetchPublishedHomepage() {
   // invalidation of one route doesn't disturb others. (Next.js bug #63509
   // would apply if we used revalidateTag for selective on Vercel, but we
   // route exclusively through invalidateByTag here.)
+  // `time-dependent-pages` is added opt-in for pages with `$today`/preset-based
+  // visibility or filter rules so the daily cron can roll them over.
   const tags = ['route-/', 'all-pages'];
+  if (isTimeDependent) tags.push(TIME_DEPENDENT_PAGES_TAG);
   const opts = { tags, revalidate: false as const };
 
   const [core, layers] = await Promise.all([
@@ -105,6 +110,38 @@ async function fetchCachedFoldersForAuth() {
   }
 }
 
+/**
+ * Returns whether the homepage is in the stored "time-dependent" set.
+ * We fetch the homepage core once (cached) to resolve the page ID, then
+ * check membership in the cached id list.
+ */
+async function isHomepageTimeDependent(): Promise<boolean> {
+  try {
+    const [timeDependentIds, core] = await Promise.all([
+      unstable_cache(
+        async () => {
+          const value = await getSettingByKey(PAGES_WITH_DATE_PRESETS_SETTING);
+          return Array.isArray(value) ? (value as string[]) : [];
+        },
+        ['data-for-time-dependent-page-ids'],
+        { tags: ['all-pages'], revalidate: false },
+      )(),
+      unstable_cache(
+        async () => {
+          const data = await fetchHomepage(true);
+          return data ? splitPageData(data as PageData).core : null;
+        },
+        ['core-/'],
+        { tags: ['route-/', 'all-pages'], revalidate: false },
+      )(),
+    ]);
+    if (timeDependentIds.length === 0) return false;
+    return !!core && timeDependentIds.includes(core.page.id);
+  } catch {
+    return false;
+  }
+}
+
 async function fetchCachedErrorPage(errorCode: 401) {
   return unstable_cache(
     async () => {
@@ -120,7 +157,10 @@ export default async function Home() {
   // Tag this response for Vercel CDN cache invalidation. The publish endpoint
   // purges this exact tag (route-/) so only the homepage cache entry is
   // invalidated. No-ops outside Vercel.
-  await addCacheTag(['route-/', 'all-pages']);
+  const isTimeDependent = await isHomepageTimeDependent();
+  const responseTags = ['route-/', 'all-pages'];
+  if (isTimeDependent) responseTags.push(TIME_DEPENDENT_PAGES_TAG);
+  await addCacheTag(responseTags);
 
   // Check for redirects targeting the homepage
   const redirects = await fetchCachedRedirects();
@@ -136,7 +176,7 @@ export default async function Home() {
   }
 
   // Cache-first homepage path; pagination is served through internal dynamic routes.
-  const data = await fetchPublishedHomepage();
+  const data = await fetchPublishedHomepage(isTimeDependent);
 
   // If no published homepage exists, show default landing page
   if (!data || !data.pageLayers) {
@@ -239,9 +279,11 @@ export default async function Home() {
 
 // Generate metadata
 export async function generateMetadata(): Promise<Metadata> {
-  // Fetch page and global settings in parallel
+  // Keep tag set consistent across metadata + render so we don't create two
+  // cache entries with diverging tags for the same underlying fetch.
+  const isTimeDependent = await isHomepageTimeDependent();
   const [data, globalSettings] = await Promise.all([
-    fetchPublishedHomepage(),
+    fetchPublishedHomepage(isTimeDependent),
     fetchCachedGlobalSettings(),
   ]);
 

--- a/lib/date-presets-detector.ts
+++ b/lib/date-presets-detector.ts
@@ -1,0 +1,87 @@
+import { isDatePreset } from '@/lib/collection-field-utils';
+import { getComponentVariantLayers } from '@/lib/component-variant-utils';
+import type {
+  Component,
+  ConditionalVisibility,
+  Layer,
+  VisibilityCondition,
+} from '@/types';
+
+/**
+ * Detects whether a layer tree uses time-dependent date presets (`$today`,
+ * `$this_week`, etc.) anywhere in its conditional visibility rules or
+ * collection filters. Used at publish time to flag pages whose rendered
+ * output rolls over each day so the cron can invalidate just those.
+ */
+
+function conditionHasDatePreset(condition: VisibilityCondition): boolean {
+  return isDatePreset(condition.value) || isDatePreset(condition.value2);
+}
+
+function visibilityHasDatePreset(visibility: ConditionalVisibility | undefined): boolean {
+  if (!visibility?.groups) return false;
+  for (const group of visibility.groups) {
+    if (!group.conditions) continue;
+    for (const condition of group.conditions) {
+      if (conditionHasDatePreset(condition)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Walks a single layer and its descendants (including the layer trees of any
+ * referenced components, all variants) looking for a date preset reference.
+ * `visitedComponents` prevents infinite loops on circular component refs.
+ */
+function layerHasDatePresets(
+  layer: Layer,
+  componentsById: Map<string, Component>,
+  visitedComponents: Set<string>,
+): boolean {
+  if (visibilityHasDatePreset(layer.variables?.conditionalVisibility)) return true;
+  if (visibilityHasDatePreset(layer.variables?.collection?.filters)) return true;
+
+  if (layer.componentId && !visitedComponents.has(layer.componentId)) {
+    visitedComponents.add(layer.componentId);
+    const component = componentsById.get(layer.componentId);
+    if (component) {
+      // Walk every variant — any variant carrying a preset means the page
+      // could render it depending on which variant ends up selected.
+      const variants = component.variants && component.variants.length > 0
+        ? component.variants
+        : [{ id: 'default', name: 'Default', layers: component.layers }];
+      for (const variant of variants) {
+        const variantLayers = getComponentVariantLayers(component, variant.id);
+        for (const variantLayer of variantLayers) {
+          if (layerHasDatePresets(variantLayer, componentsById, visitedComponents)) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  if (layer.children) {
+    for (const child of layer.children) {
+      if (layerHasDatePresets(child, componentsById, visitedComponents)) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Returns true when any layer in the tree (or any referenced component
+ * variant) uses a date preset in conditional visibility or collection filters.
+ */
+export function pageHasDatePresets(
+  layers: Layer[],
+  componentsById: Map<string, Component>,
+): boolean {
+  const visited = new Set<string>();
+  for (const layer of layers) {
+    if (layerHasDatePresets(layer, componentsById, visited)) return true;
+  }
+  return false;
+}

--- a/lib/services/cacheService.ts
+++ b/lib/services/cacheService.ts
@@ -94,6 +94,33 @@ export async function invalidatePages(routePaths: string[]): Promise<boolean> {
 }
 
 /**
+ * Tag shared by every page response whose render evaluates a date preset
+ * (`$today`, `$this_week`, etc.) in conditional visibility or collection
+ * filters. The daily cron purges this tag at the site's local midnight so
+ * "today" buckets actually roll over for cached pages.
+ */
+export const TIME_DEPENDENT_PAGES_TAG = 'time-dependent-pages';
+
+/**
+ * Invalidate every page tagged as time-dependent. One tag = one purge call,
+ * regardless of how many pages carry it. Same precision rules as
+ * `invalidatePage` apply (Vercel: invalidateByTag; self-hosted: revalidateTag).
+ */
+export async function invalidateTimeDependentPages(): Promise<boolean> {
+  try {
+    if (process.env.VERCEL === '1') {
+      await invalidateByTag(TIME_DEPENDENT_PAGES_TAG);
+    } else {
+      revalidateTag(TIME_DEPENDENT_PAGES_TAG, { expire: 0 });
+    }
+    return true;
+  } catch (error) {
+    console.error('❌ [Cache] Time-dependent invalidation error:', error);
+    return false;
+  }
+}
+
+/**
  * Clear all cache (full site invalidation)
  * Invalidates the root layout which cascades to all pages
  */

--- a/lib/services/datePresetsService.ts
+++ b/lib/services/datePresetsService.ts
@@ -1,0 +1,66 @@
+import { getSettingByKey, setSetting } from '@/lib/repositories/settingsRepository';
+import { getPublishedLayersByIds } from '@/lib/repositories/pageLayersRepository';
+import { getAllComponents } from '@/lib/repositories/componentRepository';
+import { pageHasDatePresets } from '@/lib/date-presets-detector';
+import type { Component } from '@/types';
+
+/** Setting key storing the list of published page IDs whose render depends on a date preset. */
+export const PAGES_WITH_DATE_PRESETS_SETTING = 'pages_with_date_presets';
+
+/**
+ * Returns the currently stored list of page IDs flagged as time-dependent.
+ * Tolerates an unset or malformed value by returning an empty array.
+ */
+export async function getTimeDependentPageIds(): Promise<string[]> {
+  const value = await getSettingByKey(PAGES_WITH_DATE_PRESETS_SETTING);
+  return Array.isArray(value) ? value.filter((id): id is string => typeof id === 'string') : [];
+}
+
+/**
+ * Incrementally update the stored list of time-dependent page IDs after a publish.
+ * Re-scans only the pages that changed (directly or indirectly) and toggles their
+ * membership based on whether their published layers still reference a date preset.
+ * Pages outside `affectedPageIds` keep their existing flag — they weren't republished.
+ */
+export async function recomputeTimeDependentPageIds(
+  affectedPageIds: string[],
+): Promise<{ added: string[]; removed: string[]; total: number }> {
+  if (affectedPageIds.length === 0) {
+    const existing = await getTimeDependentPageIds();
+    return { added: [], removed: [], total: existing.length };
+  }
+
+  // Load published layers for the affected pages and all components in one shot.
+  // Components are loaded in full because a preset can live in any variant tree
+  // that a layer references via componentId.
+  const [layersByPage, components] = await Promise.all([
+    getPublishedLayersByIds(affectedPageIds),
+    getAllComponents(true),
+  ]);
+
+  const componentsById = new Map<string, Component>();
+  for (const component of components) componentsById.set(component.id, component);
+
+  const existing = new Set(await getTimeDependentPageIds());
+  const added: string[] = [];
+  const removed: string[] = [];
+
+  for (const pageId of affectedPageIds) {
+    const layers = layersByPage.find(l => l.page_id === pageId)?.layers ?? [];
+    const isTimeDependent = pageHasDatePresets(layers, componentsById);
+
+    if (isTimeDependent && !existing.has(pageId)) {
+      existing.add(pageId);
+      added.push(pageId);
+    } else if (!isTimeDependent && existing.has(pageId)) {
+      existing.delete(pageId);
+      removed.push(pageId);
+    }
+  }
+
+  if (added.length > 0 || removed.length > 0) {
+    await setSetting(PAGES_WITH_DATE_PRESETS_SETTING, [...existing]);
+  }
+
+  return { added, removed, total: existing.size };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,10 @@
     {
       "path": "/api/cron/airtable-webhooks",
       "schedule": "0 3 * * *"
+    },
+    {
+      "path": "/api/cron/revalidate-date-presets",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Pages whose visibility or collection filters use date presets like `$today` stayed cached indefinitely after publish, so "today"-bucketed content never rolled over on the live site until the next manual publish. This adds an opt-in daily cache invalidation keyed on the site's configured timezone — each affected page rebuilds at most once per local day.

## Changes

- Add `lib/date-presets-detector.ts` — walks a page's layer tree (including referenced component variants) looking for date presets in conditional visibility or collection filters
- Add `lib/services/datePresetsService.ts` — incrementally recomputes the set of time-dependent page IDs after a publish (only scans pages actually changed/affected) and stores it in the `pages_with_date_presets` setting
- Hook the publish flow (`/ycode/api/publish`) to update the stored set after each publish using the existing `publishedPageIds + indirectlyAffectedPageIds` it already tracks
- Add `TIME_DEPENDENT_PAGES_TAG` + `invalidateTimeDependentPages()` to `cacheService` (uses `invalidateByTag` on Vercel, `revalidateTag` self-hosted)
- Tag public page responses (`/` and `/[...slug]`) with `time-dependent-pages` opt-in when the page is in the stored set — both the `unstable_cache` data layer and the Vercel CDN HTML layer
- Add `/api/cron/revalidate-date-presets` route — fires hourly, reads the site timezone setting, only purges the tag when the current hour matches local midnight (so each tagged page rebuilds at most 1×/day)
- Add Vercel cron entry at `0 * * * *`

## Test plan

- [ ] Add a layer with conditional visibility `field is $today` on a date or date_only field, publish, confirm `pages_with_date_presets` setting now contains the page ID
- [ ] Remove the preset, republish, confirm the ID is removed from the setting
- [ ] Add a date preset filter to a collection list, publish, confirm the parent page is added to the set
- [ ] Confirm a component used by multiple pages: adding a preset inside the component adds **all referencing pages** to the set after publish
- [ ] Visit a page in the set on Vercel — response carries `x-vercel-cache: HIT` and the cache tags include `time-dependent-pages` (visible in Vercel dashboard)
- [ ] Call `GET /api/cron/revalidate-date-presets` with `Authorization: Bearer $CRON_SECRET` outside the midnight hour → returns `{ skipped: true, hour: N }` and does NOT invalidate
- [ ] Call it during the midnight hour (e.g. temporarily set site timezone to a TZ where it's currently 00:xx) → returns `{ invalidated: true }` and tagged pages are purged
- [ ] Verify pages **not** in the set are unaffected by the cron invalidation
- [ ] Self-hosted (no `VERCEL` env): cron invalidation falls back to `revalidateTag` and clears Next.js's in-process cache

Made with [Cursor](https://cursor.com)