### PR TITLE
feat: make password protection page editable in the builder

### DIFF
--- a/app/(builder)/ycode/components/FormSettings.tsx
+++ b/app/(builder)/ycode/components/FormSettings.tsx
@@ -124,6 +124,27 @@ export default function FormSettings({ layer, onLayerUpdate }: FormSettingsProps
     return null;
   }
 
+  // Password-protected forms gate access to locked pages — they are wired to
+  // /api/page-auth/verify automatically, so the standard form options
+  // (success action, redirect, email notification) don't apply.
+  const isPasswordForm = formSettings.form_type === 'password_protected';
+
+  if (isPasswordForm) {
+    return (
+      <SettingsPanel
+        title="Form Settings"
+        isOpen={isOpen}
+        onToggle={() => setIsOpen(!isOpen)}
+      >
+        <div className="text-xs text-muted-foreground leading-relaxed">
+          This form gates access to password-protected pages. Style it freely;
+          the submit handler is wired automatically. On a wrong password, the
+          Error alert layer inside the form is shown.
+        </div>
+      </SettingsPanel>
+    );
+  }
+
   const emailNotification = formSettings.email_notification || { enabled: false, to: '' };
 
   const handleEmailToChange = (value: string) => {

--- a/app/(builder)/ycode/components/InputSettings.tsx
+++ b/app/(builder)/ycode/components/InputSettings.tsx
@@ -7,7 +7,7 @@
  * Allows configuring type, placeholder, value, and behavior attributes
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -21,10 +21,12 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import SettingsPanel from './SettingsPanel';
+import { findAncestor } from '@/lib/layer-utils';
 import type { Layer } from '@/types';
 
 interface InputSettingsProps {
   layer: Layer | null;
+  allLayers?: Layer[];
   onLayerUpdate: (layerId: string, updates: Partial<Layer>) => void;
 }
 
@@ -41,7 +43,7 @@ const INPUT_TYPES = [
   { value: 'range', label: 'Range' },
 ];
 
-export default function InputSettings({ layer, onLayerUpdate }: InputSettingsProps) {
+export default function InputSettings({ layer, allLayers, onLayerUpdate }: InputSettingsProps) {
   const [isOpen, setIsOpen] = useState(true);
 
   // Check if this is a form input element
@@ -54,6 +56,21 @@ export default function InputSettings({ layer, onLayerUpdate }: InputSettingsPro
   const isCheckboxInput = isInputLayer && layer?.attributes?.type === 'checkbox';
   const isRadioInput = isInputLayer && layer?.attributes?.type === 'radio';
   const isCheckboxOrRadio = isCheckboxInput || isRadioInput;
+
+  // Lock name/type for the password input on the 401 page: when this input
+  // sits inside a password-protected form AND has structural restrictions,
+  // the verify endpoint relies on type=password / name=password.
+  const isLockedPasswordInput = useMemo(() => {
+    if (!layer || !isInputLayer || !allLayers) return false;
+    if (layer.restrictions?.copy !== false || layer.restrictions?.delete !== false) return false;
+    const parentForm = findAncestor(
+      allLayers,
+      layer.id,
+      (candidate) => candidate.name === 'form'
+        && candidate.settings?.form?.form_type === 'password_protected'
+    );
+    return !!parentForm;
+  }, [layer, isInputLayer, allLayers]);
 
   // Get current attribute values
   const attributes = layer?.attributes || {};
@@ -202,6 +219,7 @@ export default function InputSettings({ layer, onLayerUpdate }: InputSettingsPro
                   value={name}
                   onChange={(e) => handleAttributeChange('name', e.target.value)}
                   placeholder="Field"
+                  disabled={isLockedPasswordInput}
                 />
               </div>
             </div>
@@ -214,6 +232,7 @@ export default function InputSettings({ layer, onLayerUpdate }: InputSettingsPro
                   <Select
                     value={inputType}
                     onValueChange={(val) => handleAttributeChange('type', val)}
+                    disabled={isLockedPasswordInput}
                   >
                     <SelectTrigger>
                       <SelectValue />
@@ -230,6 +249,13 @@ export default function InputSettings({ layer, onLayerUpdate }: InputSettingsPro
                   </Select>
                 </div>
               </div>
+            )}
+
+            {isLockedPasswordInput && (
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                Name and type are locked because this input gates a password-protected page.
+                Restyle it freely.
+              </p>
             )}
 
             {/* Placeholder - for input and textarea (select placeholder is in SelectOptionsSettings) */}

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -2897,6 +2897,7 @@ const RightSidebar = React.memo(function RightSidebar({
 
             <InputSettings
               layer={selectedLayer}
+              allLayers={allLayers}
               onLayerUpdate={handleLayerUpdate}
             />
 

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -81,6 +81,18 @@ function buildAnchorMap(layers: Layer[]): Record<string, string> {
   return map;
 }
 
+/**
+ * Context for password-protected page gating. When supplied, `form` layers with
+ * `settings.form.form_type === 'password_protected'` (e.g. on the 401 system page)
+ * submit to /api/page-auth/verify instead of /ycode/api/form-submissions.
+ */
+export type PasswordProtectionContext = {
+  pageId?: string;
+  folderId?: string;
+  redirectUrl: string;
+  isPublished: boolean;
+};
+
 interface LayerRendererPublicProps {
   layers: Layer[];
   isPublished?: boolean;
@@ -117,6 +129,11 @@ interface LayerRendererPublicProps {
    * the hero image during the HTML parse rather than after CSS/layout.
    */
   lcpCandidateLayerId?: string | null;
+  /**
+   * When set (typically on the 401 error page), a password-protected form layer
+   * uses this context to call the page-auth verify endpoint and redirect on success.
+   */
+  passwordProtection?: PasswordProtectionContext;
 }
 
 const LayerRendererPublic: React.FC<LayerRendererPublicProps> = ({
@@ -148,6 +165,7 @@ const LayerRendererPublic: React.FC<LayerRendererPublicProps> = ({
   isSlideChild: isSlideChildProp,
   serverSettings,
   lcpCandidateLayerId,
+  passwordProtection,
 }) => {
   const anchorMap = useMemo(() => {
     return anchorMapProp || buildAnchorMap(layers);
@@ -253,6 +271,7 @@ const LayerRendererPublic: React.FC<LayerRendererPublicProps> = ({
         isSlideChild={isSlideChildProp}
         serverSettings={serverSettings}
         lcpCandidateLayerId={lcpCandidateLayerId}
+        passwordProtection={passwordProtection}
       />
     );
   };
@@ -294,6 +313,7 @@ const LayerItem: React.FC<{
   isSlideChild?: boolean;
   serverSettings?: Record<string, unknown>;
   lcpCandidateLayerId?: string | null;
+  passwordProtection?: PasswordProtectionContext;
 }> = ({
   layer,
   isPublished,
@@ -323,6 +343,7 @@ const LayerItem: React.FC<{
   isSlideChild,
   serverSettings,
   lcpCandidateLayerId,
+  passwordProtection,
 }) => {
   const classesString = getClassesString(layer);
   const collectionLayerItemId = layer._collectionItemId || collectionItemId;
@@ -380,7 +401,8 @@ const LayerItem: React.FC<{
     components: componentsProp,
     serverSettings,
     lcpCandidateLayerId,
-  }), [isPublished, pageId, collectionLayerData, collectionLayerItemId, effectiveLayerDataMap, pageCollectionItemId, pageCollectionItemData, pageCollectionSortedItemIds, hiddenLayerInfo, currentLocale, availableLocales, localeSelectorFormat, isInsideForm, isInsideLink, parentFormSettings, pages, folders, collectionItemSlugs, isPreview, translations, anchorMap, resolvedAssets, componentsProp, serverSettings, lcpCandidateLayerId]);
+    passwordProtection,
+  }), [isPublished, pageId, collectionLayerData, collectionLayerItemId, effectiveLayerDataMap, pageCollectionItemId, pageCollectionItemData, pageCollectionSortedItemIds, hiddenLayerInfo, currentLocale, availableLocales, localeSelectorFormat, isInsideForm, isInsideLink, parentFormSettings, pages, folders, collectionItemSlugs, isPreview, translations, anchorMap, resolvedAssets, componentsProp, serverSettings, lcpCandidateLayerId, passwordProtection]);
 
   const renderComponentBlock: RenderComponentBlockFn = useCallback(
     (comp, resolvedLayers, _overrides, key, innerAncestorIds) => {
@@ -1094,11 +1116,62 @@ const LayerItem: React.FC<{
     if (htmlTag === 'form') {
       const formId = layer.settings?.id;
       const formSettings = layer.settings?.form;
+      const isPasswordForm = formSettings?.form_type === 'password_protected';
 
       elementProps.onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
 
         const form = e.currentTarget;
+
+        // Password-protected forms gate access to locked pages via /api/page-auth/verify.
+        // The standard /ycode/api/form-submissions path is skipped entirely.
+        if (isPasswordForm) {
+          const passwordInput =
+            form.querySelector<HTMLInputElement>('input[type="password"][name="password"]')
+            || form.querySelector<HTMLInputElement>('input[name="password"]')
+            || form.querySelector<HTMLInputElement>('input[type="password"]');
+          const submittedPassword = passwordInput?.value ?? '';
+
+          const errorAlert = form.querySelector('[data-alert-type="error"]') as HTMLElement | null;
+          const successAlert = form.querySelector('[data-alert-type="success"]') as HTMLElement | null;
+          if (errorAlert) errorAlert.style.display = 'none';
+          if (successAlert) successAlert.style.display = 'none';
+
+          try {
+            const response = await fetch('/api/page-auth/verify', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                pageId: passwordProtection?.pageId,
+                folderId: passwordProtection?.folderId,
+                password: submittedPassword,
+                redirectUrl: passwordProtection?.redirectUrl
+                  ?? (typeof window !== 'undefined' ? window.location.pathname : '/'),
+                isPublished: passwordProtection?.isPublished ?? true,
+              }),
+            });
+
+            const data = await response.json().catch(() => ({}));
+
+            if (response.ok) {
+              const target = data?.redirectUrl;
+              if (target && typeof window !== 'undefined') {
+                window.location.href = target;
+              } else if (typeof window !== 'undefined') {
+                window.location.reload();
+              }
+              return;
+            }
+
+            if (errorAlert) errorAlert.style.display = '';
+            if (passwordInput) passwordInput.value = '';
+          } catch (error) {
+            console.error('Password verification error:', error);
+            if (errorAlert) errorAlert.style.display = '';
+          }
+          return;
+        }
+
         const formData = new FormData(form);
         const payload: Record<string, any> = {};
 

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -21,7 +21,7 @@ import { getSettingByKey } from '@/lib/repositories/settingsRepository';
 import { getItemsWithValues, getItemsWithValuesByIds } from '@/lib/repositories/collectionItemRepository';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { REF_PAGE_PREFIX, REF_COLLECTION_PREFIX, isCollectionItemKeyword, parseCollectionLinkValue } from '@/lib/link-utils';
-import { getClassesString } from '@/lib/layer-utils';
+import { getClassesString, hasPasswordFormLayer } from '@/lib/layer-utils';
 import type { Layer, Component, Page, CollectionItemWithValues, CollectionField, Locale, PageFolder } from '@/types';
 
 interface PageLinkRef { collection_item_id: string; page_id: string }
@@ -296,6 +296,10 @@ export default async function PageRenderer({
   // Layers are always pre-resolved by the caller (page-fetcher).
   // Components are passed through for rich-text embedded component rendering in LayerRenderer.
   const resolvedLayers = layers || [];
+  // When the 401 page contains an editable password-protected form layer, the form
+  // is rendered & wired inline by LayerRendererPublic; otherwise we fall back to
+  // the hardcoded PasswordForm so older / customised 401 pages still work.
+  const hasInlinePasswordForm = is401Page && hasPasswordFormLayer(resolvedLayers);
 
   // Single tree traversal — derive both sets from the flat list
   const allPageLinks = collectLayerPageLinks(resolvedLayers);
@@ -700,10 +704,12 @@ export default async function PageRenderer({
           components={components}
           serverSettings={serverSettings}
           lcpCandidateLayerId={lcpCandidateLayerId}
+          passwordProtection={is401Page ? passwordProtection : undefined}
         />
 
-        {/* Inject password form for 401 error pages */}
-        {is401Page && passwordProtection && (
+        {/* Fallback hardcoded password form: only when the 401 page has no inline
+            password-protected form layer (e.g. older / customised 401 pages). */}
+        {is401Page && passwordProtection && !hasInlinePasswordForm && (
           <PasswordForm
             pageId={passwordProtection.pageId}
             folderId={passwordProtection.folderId}

--- a/components/PasswordForm.tsx
+++ b/components/PasswordForm.tsx
@@ -3,10 +3,23 @@
 import { useState, FormEvent } from 'react';
 
 /**
- * Password Form Component
+ * Password Form Component (fallback only)
  *
- * A client-side form for entering passwords to access protected pages.
- * Submits to /api/page-auth/verify and handles success/error states.
+ * Modern installs render the password gate as editable layers on the 401
+ * system page (a `form` layer with `settings.form.form_type === 'password_protected'`
+ * containing input/error-alert/submit-button — see `DEFAULT_ERROR_PAGES` in
+ * `lib/page-utils.ts`). LayerRendererPublic wires that form's submit handler
+ * to `/api/page-auth/verify` automatically.
+ *
+ * This standalone client component is kept as a safety net for two cases:
+ *  1. Existing 401 pages that pre-date the editable form (covered by the
+ *     `add_password_form_to_401_page` migration, but the fallback protects
+ *     unmigrated databases).
+ *  2. Customised 401 pages where the user explicitly removed the password form
+ *     layer (despite `restrictions: { copy: false, delete: false }`).
+ *
+ * `PageRenderer` only renders this component when the 401 page tree contains
+ * no password-protected form layer.
  */
 
 export interface PasswordFormProps {

--- a/database/migrations/20260525000001_add_password_form_to_401_page.ts
+++ b/database/migrations/20260525000001_add_password_form_to_401_page.ts
@@ -1,0 +1,255 @@
+import type { Knex } from 'knex';
+import type { Layer } from '@/types';
+import { getTiptapTextContent } from '@/lib/text-format-utils';
+import { generatePageLayersHash } from '@/lib/hash-utils';
+
+/**
+ * Migration: Add password form layers to existing 401 error pages
+ *
+ * Earlier installs seeded the 401 system page with a non-editable hardcoded
+ * password form (appended to the rendered output). The 401 page tree itself
+ * contained only heading + description text. The renderer now expects an
+ * editable form layer with `settings.form.form_type === 'password_protected'`
+ * on the 401 page so users can restyle the input/button in the builder canvas.
+ *
+ * This migration injects the form/input/error-alert/submit-button subtree into
+ * existing 401 pages (both draft + published page_layers rows). It is idempotent:
+ * pages that already contain a password-protected form are skipped.
+ */
+
+interface LayerNode extends Layer {
+  children?: LayerNode[];
+}
+
+function buildPasswordFormSubtree(): LayerNode {
+  return {
+    id: 'layer-1762789200000-pw-form',
+    name: 'form',
+    settings: {
+      id: 'password-protected-form',
+      form: { form_type: 'password_protected' },
+    },
+    attributes: { method: 'POST', action: '' },
+    design: {
+      layout: { isActive: true, display: 'Flex', flexDirection: 'column', gap: '16' },
+      sizing: { isActive: true, width: '100%' },
+      spacing: { isActive: true, marginTop: '1rem' },
+    },
+    classes: 'w-full flex flex-col mt-[1rem] gap-[16px]',
+    restrictions: { copy: false, delete: false },
+    customName: 'Password form',
+    children: [
+      {
+        id: 'layer-1762789200002-pw-error',
+        name: 'div',
+        alertType: 'error',
+        hiddenGenerated: true,
+        design: {
+          backgrounds: { isActive: true, backgroundColor: '#fee2e2' },
+          borders: { isActive: true, borderRadius: '0.75rem' },
+          layout: { isActive: true, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' },
+          sizing: { isActive: true, height: '38' },
+          spacing: { isActive: true, paddingTop: '1rem', paddingBottom: '1rem', paddingLeft: '16', paddingRight: '16' },
+          typography: { isActive: true, fontSize: '14px', color: '#991b1b', fontWeight: '500' },
+        },
+        classes: 'bg-[#fee2e2] text-[#991b1b] text-[14px] font-[500] rounded-[0.75rem] pr-[16px] pl-[16px] h-[38px] justify-center items-center flex flex-col',
+        restrictions: { copy: false, delete: false },
+        customName: 'Error alert',
+        children: [
+          {
+            id: 'layer-1762789200003-pw-error-text',
+            name: 'text',
+            settings: { tag: 'span' },
+            classes: '',
+            design: {},
+            children: [],
+            customName: 'Message',
+            restrictions: { editText: true },
+            variables: {
+              text: {
+                type: 'dynamic_rich_text',
+                data: {
+                  content: getTiptapTextContent('Incorrect password. Please try again.'),
+                },
+              },
+            },
+          } as LayerNode,
+        ],
+      } as LayerNode,
+      {
+        id: 'layer-1762789200010-pw-row',
+        name: 'div',
+        design: {
+          layout: { isActive: true, display: 'Flex', flexDirection: 'row', gap: '12', alignItems: 'stretch' },
+          sizing: { isActive: true, width: '100%' },
+        },
+        classes: 'w-full flex flex-row items-stretch gap-[12px]',
+        restrictions: { copy: false, delete: false },
+        customName: 'Row',
+        children: [
+          {
+            id: 'layer-1762789200001-pw-input',
+            name: 'input',
+            attributes: {
+              type: 'password',
+              name: 'password',
+              placeholder: '',
+              required: true,
+              autoComplete: 'current-password',
+            },
+            settings: { id: 'password' },
+            design: {
+              sizing: { isActive: true, width: '100%', height: '38px' },
+              spacing: { isActive: true, paddingLeft: '1rem', paddingRight: '1rem' },
+              borders: { isActive: true, borderWidth: '1px', borderColor: 'rgba(115, 115, 115, 0.15)', borderRadius: '0.75rem' },
+              typography: { isActive: true, fontSize: '14px', color: '#171717', lineHeight: '24px', letterSpacing: '0px', placeholderColor: '#a8a8a8' },
+              backgrounds: { isActive: true, backgroundColor: 'rgba(212, 212, 212, 0.1)' },
+            },
+            classes: 'w-[100%] h-[38px] pl-[16px] pr-[16px] text-[14px] leading-[24px] tracking-[0px] text-[#171717] bg-[#d4d4d4]/10 border border-solid border-[#737373]/[0.15] rounded-[12px] placeholder:text-[#a8a8a8] focus:outline-none focus:border-[#737373]/20 disabled:opacity-50 cursor-text',
+            children: [],
+            restrictions: { copy: false, delete: false },
+            customName: 'Password input',
+          } as LayerNode,
+          {
+            id: 'layer-1762789200004-pw-submit',
+            name: 'button',
+            attributes: { type: 'submit' },
+            design: {
+              spacing: { isActive: true, paddingLeft: '16', paddingRight: '16' },
+              backgrounds: { isActive: true, backgroundColor: '#171717' },
+              typography: { isActive: true, color: '#ffffff', fontSize: '14px' },
+            },
+            classes: 'flex flex-row items-center justify-center text-[#FFFFFF] pr-[16px] pl-[16px] h-[38px] text-[14px] rounded-[12px] bg-[#171717] cursor-pointer',
+            restrictions: { copy: false, delete: false },
+            customName: 'Submit button',
+            children: [
+              {
+                id: 'layer-1762789200005-pw-submit-text',
+                name: 'text',
+                settings: { tag: 'span' },
+                classes: '',
+                design: {},
+                children: [],
+                customName: 'Label',
+                restrictions: { editText: true },
+                variables: {
+                  text: {
+                    type: 'dynamic_rich_text',
+                    data: {
+                      content: getTiptapTextContent('Submit'),
+                    },
+                  },
+                },
+              } as LayerNode,
+            ],
+          } as LayerNode,
+        ],
+      } as LayerNode,
+    ],
+  } as LayerNode;
+}
+
+function hasPasswordFormLayer(layers: LayerNode[] | undefined): boolean {
+  if (!layers || layers.length === 0) return false;
+  for (const layer of layers) {
+    if (layer.name === 'form' && (layer.settings as any)?.form?.form_type === 'password_protected') {
+      return true;
+    }
+    if (layer.children && hasPasswordFormLayer(layer.children)) return true;
+  }
+  return false;
+}
+
+/**
+ * Pick the deepest single-child flex container with `justifyContent: 'center'`
+ * (matches the default 401 template's centred container). Falls back to the
+ * 'body' layer if no such container is found so we always have a parent.
+ */
+function pickInsertionTarget(layers: LayerNode[]): LayerNode | null {
+  let best: LayerNode | null = null;
+
+  const walk = (nodes: LayerNode[]) => {
+    for (const node of nodes) {
+      const layout = (node.design as any)?.layout;
+      const isCenteredFlex = layout?.display === 'Flex'
+        && (layout?.justifyContent === 'center' || layout?.alignItems === 'center');
+      if (isCenteredFlex) {
+        best = node;
+      }
+      if (node.children) walk(node.children);
+    }
+  };
+  walk(layers);
+
+  if (best) return best;
+
+  // Fallback: append directly under body
+  const body = layers.find(l => l.id === 'body' || l.name === 'body');
+  return body ?? null;
+}
+
+function injectPasswordForm(layers: LayerNode[]): LayerNode[] {
+  if (hasPasswordFormLayer(layers)) return layers;
+
+  // Deep clone so we don't mutate the input
+  const cloned: LayerNode[] = JSON.parse(JSON.stringify(layers));
+  const target = pickInsertionTarget(cloned);
+  if (!target) return cloned;
+
+  target.children = target.children || [];
+  target.children.push(buildPasswordFormSubtree());
+  return cloned;
+}
+
+export async function up(knex: Knex): Promise<void> {
+  const hasPagesTable = await knex.schema.hasTable('pages');
+  const hasPageLayersTable = await knex.schema.hasTable('page_layers');
+  if (!hasPagesTable || !hasPageLayersTable) return;
+
+  // Only target 401 system pages (both draft + published rows).
+  const errorPages: Array<{ id: string }> = await knex('pages')
+    .where({ error_page: 401 })
+    .whereNull('deleted_at')
+    .select('id');
+
+  if (errorPages.length === 0) return;
+
+  for (const page of errorPages) {
+    const layerRows: Array<{ id: string; layers: any; generated_css: string | null; is_published: boolean }> =
+      await knex('page_layers')
+        .where({ page_id: page.id })
+        .whereNull('deleted_at')
+        .select('id', 'layers', 'generated_css', 'is_published');
+
+    for (const row of layerRows) {
+      let layers: LayerNode[];
+      try {
+        layers = typeof row.layers === 'string' ? JSON.parse(row.layers) : (row.layers as LayerNode[]);
+      } catch {
+        continue;
+      }
+      if (!Array.isArray(layers)) continue;
+
+      if (hasPasswordFormLayer(layers)) continue; // idempotent — skip already-migrated
+
+      const updated = injectPasswordForm(layers);
+      const contentHash = generatePageLayersHash({
+        layers: updated,
+        generated_css: row.generated_css,
+      });
+
+      await knex('page_layers')
+        .where({ id: row.id, is_published: row.is_published })
+        .update({
+          layers: JSON.stringify(updated),
+          content_hash: contentHash,
+          updated_at: knex.fn.now(),
+        });
+    }
+  }
+}
+
+export async function down(_knex: Knex): Promise<void> {
+  // Reversing this migration would risk wiping user customisations on top of
+  // the injected form layers. Treat as forward-only.
+}

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -122,6 +122,24 @@ export function canDeleteLayer(layer: Layer): boolean {
 }
 
 /**
+ * Recursively check if a layer tree contains a password-protected form layer.
+ * Used by PageRenderer to decide whether to inject the hardcoded PasswordForm
+ * fallback when the 401 page has been customised without a password form.
+ */
+export function hasPasswordFormLayer(layers: Layer[] | undefined | null): boolean {
+  if (!layers || layers.length === 0) return false;
+  for (const layer of layers) {
+    if (layer.name === 'form' && layer.settings?.form?.form_type === 'password_protected') {
+      return true;
+    }
+    if (layer.children && hasPasswordFormLayer(layer.children)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Get the ancestor layer matching a callback condition
  * Traverses up the tree from the given layer until a matching ancestor is found
  * Uses a flat map for efficient O(1) parent lookups

--- a/lib/page-utils.ts
+++ b/lib/page-utils.ts
@@ -1358,7 +1358,15 @@ export interface ErrorPageConfig {
 
 /**
  * Default error pages configuration
- * Used for seeding database and creating new error pages
+ * Used for seeding database and creating new error pages.
+ *
+ * The 401 page ships with a password-protected form layer
+ * (`settings.form.form_type === 'password_protected'`). At runtime,
+ * `LayerRendererPublic` detects this marker and wires its submit handler to
+ * `/api/page-auth/verify` instead of the standard form-submissions endpoint.
+ * The form/input/button layers are marked `restrictions: { copy: false, delete: false }`
+ * so the structure cannot be removed (only restyled). If the form is missing on
+ * an existing 401 page, `PageRenderer` falls back to the hardcoded `PasswordForm`.
  */
 export const DEFAULT_ERROR_PAGES: ErrorPageConfig[] = [
   {
@@ -1382,39 +1390,59 @@ export const DEFAULT_ERROR_PAGES: ErrorPageConfig[] = [
             id: 'layer-1762789137823-g2cdo46ld',
             name: 'section',
             design: {
-              layout: { display: 'Flex', isActive: true, flexDirection: 'column' },
-              sizing: { height: '100vh', isActive: true },
-              spacing: { isActive: true, paddingTop: '3rem', paddingBottom: '3rem' },
+              layout: { display: 'Flex', isActive: true, flexDirection: 'column', alignItems: 'center', justifyContent: 'center' },
+              sizing: { isActive: true, minHeight: '100vh' },
+              spacing: { isActive: true, paddingTop: '4rem', paddingBottom: '4rem', paddingLeft: '1rem', paddingRight: '1rem' },
             },
-            classes: 'flex flex-col gap-[1rem] py-[3rem] h-[100vh]',
+            classes: 'flex flex-col items-center justify-center min-h-[100vh] px-[1rem] py-[4rem]',
             children: [
               {
                 id: 'layer-1762789141753-zpz5jyobc',
                 name: 'div',
                 design: {
-                  sizing: { height: '100vh', isActive: true, maxWidth: '80rem' },
-                  spacing: { isActive: true, marginLeft: 'auto', marginRight: 'auto', paddingLeft: '1rem', paddingRight: '1rem' },
+                  layout: { isActive: true, display: 'Flex', flexDirection: 'column', alignItems: 'center', gap: '16' },
+                  sizing: { isActive: true, width: '100%', maxWidth: '32rem' },
+                  typography: { isActive: true, textAlign: 'center' },
                 },
-                classes: 'max-w-[80rem] mx-auto px-[1rem] h-[100vh]',
+                classes: 'w-full max-w-[32rem] flex flex-col items-center text-center gap-[16px]',
                 children: [
                   {
-                    id: 'layer-1762789168560-icft8ynp5',
+                    id: 'layer-1762789150900-pw-icon',
+                    name: 'icon',
+                    settings: { tag: 'div' },
+                    design: {
+                      sizing: { isActive: true, width: '32', height: '32' },
+                      typography: { isActive: true, color: '#9ca3af' },
+                    },
+                    classes: 'text-[#9ca3af] w-[32px] h-[32px]',
+                    children: [],
+                    customName: 'Lock icon',
+                    variables: {
+                      icon: {
+                        src: {
+                          type: 'static_text',
+                          data: {
+                            content: '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>',
+                          },
+                        },
+                      },
+                    },
+                  },
+                  {
+                    id: 'layer-1762789150930-pw-text-block',
                     name: 'div',
                     design: {
-                      layout: { gap: '6', display: 'flex', isActive: true, alignItems: 'center', flexDirection: 'column', justifyContent: 'center' },
-                      sizing: { height: '100%', isActive: true },
-                      typography: { isActive: true, textAlign: 'center' },
+                      layout: { isActive: true, display: 'Flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' },
+                      sizing: { isActive: true, width: '100%' },
                     },
-                    classes: 'items-center text-center h-full flex flex-col justify-center gap-[6px]',
+                    classes: 'w-full flex flex-col items-center gap-[0.5rem]',
                     children: [
                       {
                         id: 'layer-1762789150944-5qezgblbe',
                         name: 'heading',
-                        settings: {
-                          tag: 'h1',
-                        },
+                        settings: { tag: 'h1' },
                         design: {
-                          typography: { color: '#111827', fontSize: '30', isActive: true, fontWeight: '700' },
+                          typography: { isActive: true, color: '#111827', fontSize: '30', fontWeight: '700' },
                         },
                         classes: 'font-[700] text-[#111827] text-[30px]',
                         children: [],
@@ -1424,57 +1452,158 @@ export const DEFAULT_ERROR_PAGES: ErrorPageConfig[] = [
                           text: {
                             type: 'dynamic_rich_text',
                             data: {
-                              content: getTiptapTextContent('401')
-                            }
-                          }
+                              content: getTiptapTextContent('Password protected'),
+                            },
+                          },
                         },
                       },
                       {
                         id: 'layer-1762789197005-7z2wy597y',
                         name: 'text',
-                        settings: {
-                          tag: 'p',
-                        },
+                        settings: { tag: 'p' },
                         design: {
-                          typography: { fontSize: '12', color: '#111827', isActive: true },
+                          typography: { isActive: true, fontSize: '12', color: '#111827' },
                         },
                         classes: 'text-[12px] text-[#111827]',
                         children: [],
-                        customName: 'Text',
+                        customName: 'Subtitle',
                         restrictions: { editText: true },
                         variables: {
                           text: {
                             type: 'dynamic_rich_text',
                             data: {
-                              content: getTiptapTextContent('Password protected')
-                            }
-                          }
-                        },
-                      },
-                      {
-                        id: 'layer-1762789197006-7z2wy597z',
-                        name: 'text',
-                        settings: {
-                          tag: 'p',
-                        },
-                        design: {
-                          typography: { fontSize: '12', color: '#111827', isActive: true },
-                        },
-                        classes: 'text-[12px] text-[#111827]',
-                        children: [],
-                        customName: 'Text',
-                        restrictions: { editText: true },
-                        variables: {
-                          text: {
-                            type: 'dynamic_rich_text',
-                            data: {
-                              content: getTiptapTextContent('Enter the password to access this page.')
-                            }
-                          }
+                              content: getTiptapTextContent('To access this page, please enter the required password below.'),
+                            },
+                          },
                         },
                       },
                     ],
-                    customName: 'Container',
+                    customName: 'Text block',
+                  },
+                  {
+                    id: 'layer-1762789200000-pw-form',
+                    name: 'form',
+                    settings: {
+                      id: 'password-protected-form',
+                      form: { form_type: 'password_protected' },
+                    },
+                    attributes: { method: 'POST', action: '' },
+                    design: {
+                      layout: { isActive: true, display: 'Flex', flexDirection: 'column', gap: '16' },
+                      sizing: { isActive: true, width: '100%' },
+                      spacing: { isActive: true, marginTop: '1rem' },
+                    },
+                    classes: 'w-full flex flex-col mt-[1rem] gap-[16px]',
+                    restrictions: { copy: false, delete: false },
+                    customName: 'Password form',
+                    children: [
+                      {
+                        id: 'layer-1762789200002-pw-error',
+                        name: 'div',
+                        alertType: 'error',
+                        hiddenGenerated: true,
+                        design: {
+                          backgrounds: { isActive: true, backgroundColor: '#fee2e2' },
+                          borders: { isActive: true, borderRadius: '0.75rem' },
+                          layout: { isActive: true, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' },
+                          sizing: { isActive: true, height: '38' },
+                          spacing: { isActive: true, paddingTop: '1rem', paddingBottom: '1rem', paddingLeft: '16', paddingRight: '16' },
+                          typography: { isActive: true, fontSize: '14px', color: '#991b1b', fontWeight: '500' },
+                        },
+                        classes: 'bg-[#fee2e2] text-[#991b1b] text-[14px] font-[500] rounded-[0.75rem] pr-[16px] pl-[16px] h-[38px] justify-center items-center flex flex-col',
+                        restrictions: { copy: false, delete: false },
+                        customName: 'Error alert',
+                        children: [
+                          {
+                            id: 'layer-1762789200003-pw-error-text',
+                            name: 'text',
+                            settings: { tag: 'span' },
+                            classes: '',
+                            design: {},
+                            children: [],
+                            customName: 'Message',
+                            restrictions: { editText: true },
+                            variables: {
+                              text: {
+                                type: 'dynamic_rich_text',
+                                data: {
+                                  content: getTiptapTextContent('Incorrect password. Please try again.'),
+                                },
+                              },
+                            },
+                          },
+                        ],
+                      },
+                      {
+                        id: 'layer-1762789200010-pw-row',
+                        name: 'div',
+                        design: {
+                          layout: { isActive: true, display: 'Flex', flexDirection: 'row', gap: '12', alignItems: 'stretch' },
+                          sizing: { isActive: true, width: '100%' },
+                        },
+                        classes: 'w-full flex flex-row items-stretch gap-[12px]',
+                        restrictions: { copy: false, delete: false },
+                        customName: 'Row',
+                        children: [
+                          {
+                            id: 'layer-1762789200001-pw-input',
+                            name: 'input',
+                            attributes: {
+                              type: 'password',
+                              name: 'password',
+                              placeholder: '',
+                              required: true,
+                              autoComplete: 'current-password',
+                            },
+                            settings: { id: 'password' },
+                            design: {
+                              sizing: { isActive: true, width: '100%', height: '38px' },
+                              spacing: { isActive: true, paddingLeft: '1rem', paddingRight: '1rem' },
+                              borders: { isActive: true, borderWidth: '1px', borderColor: 'rgba(115, 115, 115, 0.15)', borderRadius: '0.75rem' },
+                              typography: { isActive: true, fontSize: '14px', color: '#171717', lineHeight: '24px', letterSpacing: '0px', placeholderColor: '#a8a8a8' },
+                              backgrounds: { isActive: true, backgroundColor: 'rgba(212, 212, 212, 0.1)' },
+                            },
+                            classes: 'w-[100%] h-[38px] pl-[16px] pr-[16px] text-[14px] leading-[24px] tracking-[0px] text-[#171717] bg-[#d4d4d4]/10 border border-solid border-[#737373]/[0.15] rounded-[12px] placeholder:text-[#a8a8a8] focus:outline-none focus:border-[#737373]/20 disabled:opacity-50 cursor-text',
+                            children: [],
+                            restrictions: { copy: false, delete: false },
+                            customName: 'Password input',
+                          },
+                          {
+                            id: 'layer-1762789200004-pw-submit',
+                            name: 'button',
+                            attributes: { type: 'submit' },
+                            design: {
+                              spacing: { isActive: true, paddingLeft: '16', paddingRight: '16' },
+                              backgrounds: { isActive: true, backgroundColor: '#171717' },
+                              typography: { isActive: true, color: '#ffffff', fontSize: '14px' },
+                            },
+                            classes: 'flex flex-row items-center justify-center text-[#FFFFFF] pr-[16px] pl-[16px] h-[38px] text-[14px] rounded-[12px] bg-[#171717] cursor-pointer',
+                            restrictions: { copy: false, delete: false },
+                            customName: 'Submit button',
+                            children: [
+                              {
+                                id: 'layer-1762789200005-pw-submit-text',
+                                name: 'text',
+                                settings: { tag: 'span' },
+                                classes: '',
+                                design: {},
+                                children: [],
+                                customName: 'Label',
+                                restrictions: { editText: true },
+                                variables: {
+                                  text: {
+                                    type: 'dynamic_rich_text',
+                                    data: {
+                                      content: getTiptapTextContent('Submit'),
+                                    },
+                                  },
+                                },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
                   },
                 ],
                 customName: 'Container',

--- a/types/index.ts
+++ b/types/index.ts
@@ -167,7 +167,12 @@ export interface DesignProperties {
   transitions?: TransitionsDesign;
 }
 
+export type FormType = 'standard' | 'password_protected';
+
 export interface FormSettings {
+  // 'password_protected' wires the form to the page-auth verify endpoint and gates access to
+  // password-protected pages; 'standard' (default) submits to /ycode/api/form-submissions.
+  form_type?: FormType;
   success_action?: 'message' | 'redirect'; // What happens on successful submission (default: 'message')
   success_message?: string; // Message shown on successful submission (deprecated - now uses alert child)
   error_message?: string; // Message shown on failed submission (deprecated - now uses alert child)


### PR DESCRIPTION
## Summary

The 401 system page is now rendered entirely from editable layers in the builder canvas. Users can restyle the password input, submit button, error alert, and surrounding content (heading, icon, copy) using the regular layer tools instead of being stuck with the hardcoded `PasswordForm` component.

A form layer marked `settings.form.form_type === 'password_protected'` is wired to `/api/page-auth/verify` automatically by `LayerRendererPublic`. The hardcoded `PasswordForm` component is kept as a runtime fallback for 401 pages that lack an inline password form (older installs, customised pages).

Closes #192

## Changes

- Add `FormType` union and `form_type` field to `FormSettings` in `types/index.ts`
- Thread a new `PasswordProtectionContext` prop through `LayerRendererPublic` (via `sharedRendererProps`) and branch the existing form `onSubmit` handler when `form_type === 'password_protected'`: POST to `/api/page-auth/verify`, redirect on success, surface `[data-alert-type="error"]` on failure
- Update `PageRenderer` to pass `passwordProtection` into the renderer for 401 pages; the standalone `<PasswordForm>` is only injected when the layer tree contains no inline password-protected form
- Redesign the seeded 401 page in `DEFAULT_ERROR_PAGES` (lock icon, heading, subtitle, horizontal input + black submit button, error alert) — all layers are `restrictions: { copy: false, delete: false }` so the structure can't be removed but every part is restylable
- Add `hasPasswordFormLayer(layers)` helper to `lib/layer-utils.ts`
- Builder UX: hide standard form options (success action, redirect, email notifications) when the selected form is password-protected and show an explanatory note; lock the password input's `name` and `type` fields when the input sits inside a password-protected form with structural restrictions
- Add an idempotent migration (`20260525000001_add_password_form_to_401_page`) that injects the password form subtree into every existing 401 page (draft + published `page_layers` rows), recomputes `content_hash`, and skips pages that already contain a password-protected form
- Document `PasswordForm.tsx` as a fallback-only component

## Test plan

- [ ] Fresh install: 401 page renders with the new editable layout (lock icon, heading, subtitle, horizontal form) in the builder canvas
- [ ] Upgrade install: run migrations on an existing project — the 401 page gains the password form layers without losing existing customisations
- [ ] Restyle the password input and submit button in the builder; reload the published 401 page and confirm the styles apply
- [ ] Set a page password in page settings, publish, visit the page in incognito — the rendered 401 page should show the form from the layer tree (no hardcoded form at the bottom)
- [ ] Submit an incorrect password — the "Error alert" layer should appear; the input should clear
- [ ] Submit the correct password — should redirect to the original protected URL
- [ ] Try deleting the form/input/button via the layers tree — should be blocked by the locked restrictions
- [ ] Select the password form in the builder — form settings panel shows the password-protected notice instead of standard form options
- [ ] Select the password input — `name` and `type` fields are disabled with an explanatory note
- [ ] Delete the inline form layer from a 401 page (via JSON edit) — runtime falls back to the hardcoded `PasswordForm`

Made with [Cursor](https://cursor.com)