### PR TITLE
fix: restore links, animations, and load-more on filterable collections

### DIFF
--- a/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
+++ b/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
@@ -521,6 +521,7 @@ export async function POST(
     const {
       layerTemplate,
       collectionLayerId,
+      collectionLayer,
       filterGroups = [],
       sortBy,
       sortOrder = 'asc',
@@ -530,6 +531,9 @@ export async function POST(
       collectionLayerClasses,
       collectionLayerTag,
       published: isPublished = true,
+      isPreview = false,
+      pageCollectionItemId,
+      pageCollectionSortedItemIds,
     } = body;
 
     if (!layerTemplate || !Array.isArray(layerTemplate)) {
@@ -547,7 +551,7 @@ export async function POST(
 
     if (matchingIds.length === 0) {
       return noCache({
-        data: { html: '', total: 0, count: 0, offset, hasMore: false },
+        data: { html: '', total: 0, count: 0, offset, hasMore: false, itemIds: [] },
       });
     }
 
@@ -652,6 +656,14 @@ export async function POST(
       undefined,
       collectionLayerClasses,
       collectionLayerTag,
+      {
+        isPreview: Boolean(isPreview),
+        pageCollectionItemId,
+        pageCollectionSortedItemIds: Array.isArray(pageCollectionSortedItemIds)
+          ? pageCollectionSortedItemIds
+          : undefined,
+      },
+      collectionLayer as Omit<Layer, 'children'> | undefined,
     );
 
     return noCache({
@@ -661,6 +673,7 @@ export async function POST(
         count: paginatedItems.length,
         offset: pageOffset,
         hasMore,
+        itemIds: paginatedItems.map(item => item.id),
       },
     });
   } catch (error) {

--- a/app/(builder)/ycode/api/collections/[id]/items/load-more/route.ts
+++ b/app/(builder)/ycode/api/collections/[id]/items/load-more/route.ts
@@ -1,39 +1,111 @@
 import { NextRequest } from 'next/server';
-import { getItemsWithValues } from '@/lib/repositories/collectionItemRepository';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { getItemsByCollectionId } from '@/lib/repositories/collectionItemRepository';
+import { getValuesByItemIds } from '@/lib/repositories/collectionItemValueRepository';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { enrichItemsWithCountValues } from '@/lib/repositories/collectionCountRepository';
 import { getAllPages } from '@/lib/repositories/pageRepository';
 import { getAllPageFolders } from '@/lib/repositories/pageFolderRepository';
 import { renderCollectionItemsToHtml, loadTranslationsForLocale } from '@/lib/page-fetcher';
 import { noCache } from '@/lib/api-response';
-import type { Layer } from '@/types';
+import type { Layer, CollectionItem, CollectionItemWithValues } from '@/types';
 
-// Disable caching for this route
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
+const IN_CHUNK_SIZE = 150;
+
+async function chunkedQuery<T>(
+  build: (chunk: string[]) => PromiseLike<{ data: T[] | null; error: unknown }>,
+  itemIds: string[],
+): Promise<T[]> {
+  if (itemIds.length === 0) return [];
+  if (itemIds.length <= IN_CHUNK_SIZE) {
+    const { data } = await build(itemIds);
+    return data || [];
+  }
+  const results: T[] = [];
+  for (let i = 0; i < itemIds.length; i += IN_CHUNK_SIZE) {
+    const { data } = await build(itemIds.slice(i, i + IN_CHUNK_SIZE));
+    if (data) results.push(...data);
+  }
+  return results;
+}
+
+async function getAllItemIdsForCollection(
+  collectionId: string,
+  isPublished: boolean,
+): Promise<string[]> {
+  const client = await getSupabaseAdmin();
+  if (!client) throw new Error('Supabase client not configured');
+
+  let query = client
+    .from('collection_items')
+    .select('id')
+    .eq('collection_id', collectionId)
+    .eq('is_published', isPublished)
+    .is('deleted_at', null);
+
+  if (isPublished) {
+    query = query.eq('is_publishable', true);
+  }
+
+  const { data, error } = await query;
+  if (error) throw new Error(`Failed to fetch item IDs: ${error.message}`);
+  return data?.map(d => d.id) || [];
+}
+
+async function getFieldValuesForItems(
+  fieldId: string,
+  isPublished: boolean,
+  itemIds: string[],
+): Promise<Map<string, string>> {
+  if (itemIds.length === 0) return new Map();
+  const client = await getSupabaseAdmin();
+  if (!client) throw new Error('Supabase client not configured');
+
+  const rows = await chunkedQuery<{ item_id: string; value: string | null }>(
+    chunk => client
+      .from('collection_item_values')
+      .select('item_id, value')
+      .eq('field_id', fieldId)
+      .eq('is_published', isPublished)
+      .is('deleted_at', null)
+      .in('item_id', chunk),
+    itemIds,
+  );
+
+  const map = new Map<string, string>();
+  for (const row of rows) {
+    map.set(row.item_id, row.value ?? '');
+  }
+  return map;
+}
+
+function reorderItemsById(items: CollectionItem[], idOrder: string[]): CollectionItem[] {
+  const byId = new Map(items.map(item => [item.id, item]));
+  const ordered: CollectionItem[] = [];
+  for (const id of idOrder) {
+    const item = byId.get(id);
+    if (item) ordered.push(item);
+  }
+  return ordered;
+}
+
 /**
  * POST /ycode/api/collections/[id]/items/load-more
- * Get paginated collection items for "Load More" functionality
- * Returns pre-rendered HTML for client-side appending
- *
- * Body (JSON):
- * - offset: number of items to skip (default: 0)
- * - limit: number of items to fetch (default: 10)
- * - itemIds: array of item IDs to filter by (for multi-reference fields)
- * - layerTemplate: Layer[] - the layer template to render items with
- * - collectionLayerId: string - the collection layer ID for unique item IDs
- * - published: whether to fetch published items (default: true for public pages)
+ * Returns pre-rendered HTML for the next page of a collection. Mirrors the
+ * SSR sort (`sortBy` / `sortOrder`) so offset-based paging stays consistent
+ * — otherwise a date-sorted SSR list followed by a manual-order DB page
+ * yields duplicates.
  */
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { id } = await params;
-    const collectionId = id;
+    const { id: collectionId } = await params;
 
-    // Parse request body
     const body = await request.json();
     const {
       offset = 0,
@@ -42,6 +114,8 @@ export async function POST(
       layerTemplate,
       collectionLayerId,
       collectionLayer,
+      sortBy,
+      sortOrder = 'asc',
       published = true,
       localeCode,
       collectionLayerClasses,
@@ -51,54 +125,74 @@ export async function POST(
       pageCollectionSortedItemIds,
     } = body;
 
-    // Validate required fields
     if (!layerTemplate || !Array.isArray(layerTemplate)) {
-      return noCache(
-        { error: 'layerTemplate is required and must be an array' },
-        400
-      );
+      return noCache({ error: 'layerTemplate is required and must be an array' }, 400);
     }
-
     if (!collectionLayerId) {
-      return noCache(
-        { error: 'collectionLayerId is required' },
-        400
-      );
+      return noCache({ error: 'collectionLayerId is required' }, 400);
     }
 
-    // Build filters
-    const filters: {
-      offset?: number;
-      limit?: number;
-      itemIds?: string[];
-    } = {
-      offset: isNaN(offset) ? 0 : Math.max(0, offset),
-      limit: isNaN(limit) || limit < 1 ? 10 : Math.min(limit, 100), // Cap at 100
-    };
+    const pageOffset = Math.max(0, isNaN(offset) ? 0 : offset);
+    const pageLimit = isNaN(limit) || limit < 1 ? 10 : Math.min(limit, 100);
 
-    if (itemIds && Array.isArray(itemIds) && itemIds.length > 0) {
-      filters.itemIds = itemIds;
+    // Pool of candidate ids: either the explicit list (multi-reference filter)
+    // or every item in the collection.
+    const candidateIds = Array.isArray(itemIds) && itemIds.length > 0
+      ? itemIds
+      : await getAllItemIdsForCollection(collectionId, published);
+
+    const total = candidateIds.length;
+
+    let pageRawItems: CollectionItem[] = [];
+
+    if (!sortBy || sortBy === 'none' || sortBy === 'manual') {
+      const { items } = await getItemsByCollectionId(collectionId, published, {
+        itemIds: candidateIds,
+        limit: pageLimit,
+        offset: pageOffset,
+      });
+      pageRawItems = items;
+    } else if (sortBy === 'random') {
+      // Random sort is unstable across requests; without a seed we can't
+      // reliably page it, so fall back to manual order to avoid duplicates.
+      const { items } = await getItemsByCollectionId(collectionId, published, {
+        itemIds: candidateIds,
+        limit: pageLimit,
+        offset: pageOffset,
+      });
+      pageRawItems = items;
+    } else {
+      const sortValueByItem = await getFieldValuesForItems(sortBy, published, candidateIds);
+      const sortedIds = [...candidateIds].sort((a, b) => {
+        const aStr = String(sortValueByItem.get(a) || '');
+        const bStr = String(sortValueByItem.get(b) || '');
+        const aNum = aStr.trim() !== '' ? Number(aStr) : NaN;
+        const bNum = bStr.trim() !== '' ? Number(bStr) : NaN;
+        if (!isNaN(aNum) && !isNaN(bNum)) {
+          return sortOrder === 'desc' ? bNum - aNum : aNum - bNum;
+        }
+        return sortOrder === 'desc' ? bStr.localeCompare(aStr) : aStr.localeCompare(bStr);
+      });
+      const pageItemIds = sortedIds.slice(pageOffset, pageOffset + pageLimit);
+      if (pageItemIds.length > 0) {
+        const { items } = await getItemsByCollectionId(collectionId, published, {
+          itemIds: pageItemIds,
+        });
+        pageRawItems = reorderItemsById(items, pageItemIds);
+      }
     }
 
-    // Fetch items with values
-    const { items, total } = await getItemsWithValues(
-      collectionId,
-      published,
-      filters
-    );
+    const valuesByItem = await getValuesByItemIds(pageRawItems.map(i => i.id), published);
+    const items: CollectionItemWithValues[] = pageRawItems.map(item => ({
+      ...item,
+      values: valuesByItem[item.id] || {},
+    }));
 
-    // Inject computed count field values so layers bound to a count field
-    // render the live number in the rendered HTML.
     await enrichItemsWithCountValues(items, collectionId, published);
 
-    // Build collection item slugs from the items we're rendering
     const collectionItemSlugs: Record<string, string> = {};
-
-    // Get the slug field for this collection
     const collectionFields = await getFieldsByCollectionId(collectionId, published, { excludeComputed: true });
     const slugField = collectionFields.find(f => f.key === 'slug');
-
-    // Extract slug values from items
     if (slugField) {
       for (const item of items) {
         if (item.values[slugField.id]) {
@@ -107,22 +201,19 @@ export async function POST(
       }
     }
 
-    // Fetch pages and folders for link resolution using repository functions
     const [pages, folders] = await Promise.all([
       getAllPages(),
       getAllPageFolders(),
     ]);
 
-    // Load locale and translations if locale code is provided
     let locale = null;
-    let translations: Record<string, any> | undefined;
+    let translations: Awaited<ReturnType<typeof loadTranslationsForLocale>>['translations'] | undefined;
     if (localeCode) {
       const localeData = await loadTranslationsForLocale(localeCode, published);
       locale = localeData.locale;
       translations = localeData.translations;
     }
 
-    // Render items to HTML using the provided template
     const html = await renderCollectionItemsToHtml(
       items,
       layerTemplate as Layer[],
@@ -152,79 +243,9 @@ export async function POST(
         items,
         html,
         total,
-        offset: filters.offset,
-        limit: filters.limit,
-        hasMore: (filters.offset || 0) + items.length < total,
-      }
-    });
-  } catch (error) {
-    console.error('Error fetching collection items for load-more:', error);
-    return noCache(
-      { error: error instanceof Error ? error.message : 'Failed to fetch items' },
-      500
-    );
-  }
-}
-
-/**
- * GET /ycode/api/collections/[id]/items/load-more
- * Legacy endpoint - returns raw data without rendering
- * Kept for backward compatibility
- *
- * Query params:
- * - offset: number of items to skip (default: 0)
- * - limit: number of items to fetch (default: 10)
- * - itemIds: comma-separated list of item IDs to filter by (for multi-reference fields)
- * - published: whether to fetch published items (default: true for public pages)
- */
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const { id } = await params;
-    const collectionId = id;
-
-    const { searchParams } = new URL(request.url);
-    const offset = parseInt(searchParams.get('offset') || '0', 10);
-    const limit = parseInt(searchParams.get('limit') || '10', 10);
-    const itemIdsParam = searchParams.get('itemIds');
-    const isPublished = searchParams.get('published') !== 'false';
-
-    // Parse itemIds if provided (for multi-reference filtering)
-    const itemIds = itemIdsParam ? itemIdsParam.split(',').filter(Boolean) : undefined;
-
-    // Build filters
-    const filters: {
-      offset?: number;
-      limit?: number;
-      itemIds?: string[];
-    } = {
-      offset: isNaN(offset) ? 0 : offset,
-      limit: isNaN(limit) || limit < 1 ? 10 : Math.min(limit, 100), // Cap at 100
-    };
-
-    if (itemIds && itemIds.length > 0) {
-      filters.itemIds = itemIds;
-    }
-
-    // Fetch items with values
-    const { items, total } = await getItemsWithValues(
-      collectionId,
-      isPublished,
-      filters
-    );
-
-    // Inject computed count field values for callers reading raw item data.
-    await enrichItemsWithCountValues(items, collectionId, isPublished);
-
-    return noCache({
-      data: {
-        items,
-        total,
-        offset: filters.offset,
-        limit: filters.limit,
-        hasMore: (filters.offset || 0) + items.length < total,
+        offset: pageOffset,
+        limit: pageLimit,
+        hasMore: pageOffset + items.length < total,
       }
     });
   } catch (error) {

--- a/app/(builder)/ycode/api/collections/[id]/items/load-more/route.ts
+++ b/app/(builder)/ycode/api/collections/[id]/items/load-more/route.ts
@@ -41,10 +41,14 @@ export async function POST(
       itemIds,
       layerTemplate,
       collectionLayerId,
+      collectionLayer,
       published = true,
       localeCode,
       collectionLayerClasses,
       collectionLayerTag,
+      isPreview = false,
+      pageCollectionItemId,
+      pageCollectionSortedItemIds,
     } = body;
 
     // Validate required fields
@@ -133,6 +137,14 @@ export async function POST(
       undefined,
       collectionLayerClasses,
       collectionLayerTag,
+      {
+        isPreview: Boolean(isPreview),
+        pageCollectionItemId,
+        pageCollectionSortedItemIds: Array.isArray(pageCollectionSortedItemIds)
+          ? pageCollectionSortedItemIds
+          : undefined,
+      },
+      collectionLayer as Omit<Layer, 'children'> | undefined,
     );
 
     return noCache({

--- a/components/AnimationInitializer.tsx
+++ b/components/AnimationInitializer.tsx
@@ -8,13 +8,15 @@
  * to prevent flickering. This component only handles animation triggers.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import gsap from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { SplitText } from 'gsap/SplitText';
 
+import { ITEMS_INJECTED_EVENT, type ItemsInjectedDetail } from '@/components/FilterableCollection';
 import { buildGsapProps, addTweenToTimeline, createSplitTextAnimation, generateInitialAnimationCSS, setColorVariableResolver } from '@/lib/animation-utils';
 import { getCurrentBreakpoint } from '@/lib/breakpoint-utils';
+import { remapLayerIdsForCollectionItem } from '@/lib/collection-utils';
 import { useColorVariablesStore } from '@/stores/useColorVariablesStore';
 import type { Layer, LayerInteraction, Breakpoint } from '@/types';
 
@@ -293,6 +295,61 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
   const [currentBreakpoint, setCurrentBreakpoint] = useState<Breakpoint>(() => getCurrentBreakpoint());
   const styleRef = useRef<HTMLStyleElement | null>(null);
 
+  // Tracks interaction ids whose one-shot animation (`load` or
+  // `scroll-into-view`) has already played. Keyed by interaction id, which
+  // is stable across effect re-runs for the same logical element:
+  // - Page-level layers keep their original id.
+  // - Filter/load-more items get `-fc-${itemId}` appended, so the same item
+  //   re-injected later (e.g. filter toggled) keeps the same id and is
+  //   skipped — no replay.
+  // Cleared on breakpoint changes since `resetAnimationStates` restores
+  // initial styles and animations need to re-run for the new breakpoint.
+  const playedOneShotInteractionsRef = useRef<Set<string>>(new Set());
+
+  // Extra layers built from collection items injected client-side (filter
+  // refetch, load-more). Indexed by collection layer id so a filter
+  // deactivation can drop just that collection's extras. Each value uses the
+  // `-fc-${itemId}` suffix that mirrors the server-side filter renderer.
+  const [extrasByCollection, setExtrasByCollection] = useState<Record<string, Layer[]>>({});
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<ItemsInjectedDetail>).detail;
+      const { collectionLayerId, layerTemplate, itemIds, append, collectionLayer } = detail || {};
+      if (!collectionLayerId || !collectionLayer || !layerTemplate) return;
+
+      setExtrasByCollection(prev => {
+        // Empty itemIds = filter deactivated, drop this collection's extras.
+        if (!append && (!itemIds || itemIds.length === 0)) {
+          if (!(collectionLayerId in prev)) return prev;
+          const next = { ...prev };
+          delete next[collectionLayerId];
+          return next;
+        }
+        // Rebuild the full collection layer per item so interactions on the
+        // wrapper itself are bound, then remap ids once.
+        const newLayers: Layer[] = itemIds.map(itemId => {
+          const fullLayer: Layer = { ...collectionLayer, children: layerTemplate };
+          return remapLayerIdsForCollectionItem(fullLayer, `-fc-${itemId}`);
+        });
+        if (append) {
+          return {
+            ...prev,
+            [collectionLayerId]: [...(prev[collectionLayerId] || []), ...newLayers],
+          };
+        }
+        return { ...prev, [collectionLayerId]: newLayers };
+      });
+    };
+    window.addEventListener(ITEMS_INJECTED_EVENT, handler);
+    return () => window.removeEventListener(ITEMS_INJECTED_EVENT, handler);
+  }, []);
+
+  const effectiveLayers = useMemo(() => {
+    const extras = Object.values(extrasByCollection).flat();
+    return extras.length > 0 ? [...layers, ...extras] : layers;
+  }, [layers, extrasByCollection]);
+
   // Register a color variable resolver so backgroundColor tweens that
   // reference color variables (e.g. "color:var(--id)") can be resolved to a
   // concrete rgba value GSAP can interpolate.
@@ -305,7 +362,7 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
   // (e.g. components embedded in rich text whose layer IDs are namespaced differently)
   useEffect(() => {
     if (!injectInitialCSS) return;
-    const { css, hiddenLayerInfo } = generateInitialAnimationCSS(layers);
+    const { css, hiddenLayerInfo } = generateInitialAnimationCSS(effectiveLayers);
     if (css) {
       const style = document.createElement('style');
       style.textContent = css;
@@ -326,7 +383,7 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
         styleRef.current = null;
       }
     };
-  }, [injectInitialCSS, layers]);
+  }, [injectInitialCSS, effectiveLayers]);
 
   // Listen for breakpoint changes on resize
   useEffect(() => {
@@ -340,13 +397,14 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
   }, []);
 
   useEffect(() => {
-    const collectedInteractions = collectInteractions(layers);
+    const collectedInteractions = collectInteractions(effectiveLayers);
     const hiddenLayerInfo = collectHiddenLayerInfo(collectedInteractions);
     const isBreakpointChange = prevBreakpointRef.current !== null && prevBreakpointRef.current !== currentBreakpoint;
 
     // Reset animation states when breakpoint changes
     if (isBreakpointChange) {
       resetAnimationStates(collectedInteractions, hiddenLayerInfo, currentBreakpoint);
+      playedOneShotInteractionsRef.current = new Set();
     }
 
     // Update previous breakpoint reference
@@ -377,8 +435,13 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
 
       switch (trigger) {
         case 'load': {
-          // Skip if breakpoint restriction not met
           if (!shouldRunOnBreakpoint(interaction, currentBreakpoint)) break;
+          // Skip if this interaction has already played. Stops effect
+          // re-runs (caused by filter/load-more state changes) from
+          // re-playing load animations on existing elements, and also
+          // prevents re-playing for filter items that get re-injected.
+          if (playedOneShotInteractionsRef.current.has(interaction.id)) break;
+          playedOneShotInteractionsRef.current.add(interaction.id);
 
           const timeline = getTimeline();
           timeline?.play();
@@ -443,13 +506,15 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
         }
 
         case 'scroll-into-view': {
-          // Skip if breakpoint restriction not met
           if (!shouldRunOnBreakpoint(interaction, currentBreakpoint)) break;
+          // Already fired in a previous effect run — don't recreate the
+          // trigger (which would re-fire `play` if the element is still in
+          // viewport after a filter/load-more state change).
+          if (playedOneShotInteractionsRef.current.has(interaction.id)) break;
 
           const scrollStart = interaction.timeline?.scrollStart || 'top 80%';
           const toggleActions = interaction.timeline?.toggleActions || 'play none none none';
 
-          // toggleActions requires timeline upfront
           const timeline = getTimeline();
           if (!timeline) break;
 
@@ -458,6 +523,9 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
             start: scrollStart,
             toggleActions,
             animation: timeline as any,
+            onEnter: () => {
+              playedOneShotInteractionsRef.current.add(interaction.id);
+            },
           });
 
           cleanupRef.current.push(() => scrollTrigger.kill());
@@ -499,7 +567,7 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
       timelines.forEach((tl) => tl.kill());
       ScrollTrigger.getAll().forEach((st) => st.kill());
     };
-  }, [layers, currentBreakpoint]);
+  }, [effectiveLayers, currentBreakpoint]);
 
   return null;
 }

--- a/components/FilterableCollection.tsx
+++ b/components/FilterableCollection.tsx
@@ -20,9 +20,35 @@ interface FilterableCollectionProps {
   collectionLayerClasses?: string[];
   collectionLayerTag?: string;
   isPublished?: boolean;
+  /** Preview mode forces server-rendered links to use the `/ycode/preview` prefix. */
+  isPreview?: boolean;
+  /** Item ID of the dynamic-page collection being rendered (for `current-page` link keywords). */
+  pageCollectionItemId?: string;
+  /** Ordered ids of the dynamic page's collection — powers `next-item` / `previous-item` link keywords. */
+  pageCollectionSortedItemIds?: string[];
+  /** Full collection layer (sans children) — lets the server rebuild proper item wrappers (link/action/attributes). */
+  collectionLayer?: Omit<Layer, 'children'>;
 }
 
 const FC_FILTERED_ATTR = 'data-fc-filtered';
+
+/**
+ * Browser custom event dispatched after collection HTML is appended/replaced
+ * client-side. AnimationInitializer / SliderInitializer listen for it so they
+ * can bind animations and sliders to the freshly injected DOM nodes.
+ */
+export interface ItemsInjectedDetail {
+  collectionLayerId: string;
+  layerTemplate: Layer[];
+  itemIds: string[];
+  append: boolean;
+  /** Full collection layer (sans children) — when present, initializers
+   * rebuild the full layer tree per item (so animations on the wrapper
+   * itself are bound), matching SSR. */
+  collectionLayer?: Omit<Layer, 'children'>;
+}
+
+export const ITEMS_INJECTED_EVENT = 'ycode:items-injected';
 
 export default function FilterableCollection({
   children,
@@ -39,6 +65,10 @@ export default function FilterableCollection({
   collectionLayerClasses,
   collectionLayerTag,
   isPublished = true,
+  isPreview = false,
+  pageCollectionItemId,
+  pageCollectionSortedItemIds,
+  collectionLayer,
 }: FilterableCollectionProps) {
   const markerRef = useRef<HTMLSpanElement>(null);
   const ssrChildrenRef = useRef<Element[]>([]);
@@ -97,7 +127,7 @@ export default function FilterableCollection({
     parent.querySelectorAll(`[${FC_FILTERED_ATTR}]`).forEach(el => el.remove());
   }, [getParent]);
 
-  const injectFilteredHTML = useCallback((html: string, append: boolean) => {
+  const injectFilteredHTML = useCallback((html: string, append: boolean, itemIds: string[]) => {
     const parent = getParent();
     if (!parent) return;
     if (!append) {
@@ -111,7 +141,9 @@ export default function FilterableCollection({
       if (child instanceof Element) child.setAttribute(FC_FILTERED_ATTR, '');
       parent.appendChild(child);
     }
-  }, [getParent, hideSSR, clearFilteredDOM]);
+    const detail: ItemsInjectedDetail = { collectionLayerId, layerTemplate, itemIds, append, collectionLayer };
+    window.dispatchEvent(new CustomEvent<ItemsInjectedDetail>(ITEMS_INJECTED_EVENT, { detail }));
+  }, [getParent, hideSSR, clearFilteredDOM, collectionLayerId, layerTemplate, collectionLayer]);
 
   // Capture SSR children on mount (before paint) and hide if pending
   useLayoutEffect(() => {
@@ -536,6 +568,10 @@ export default function FilterableCollection({
         published: isPublished,
         collectionLayerClasses,
         collectionLayerTag,
+        isPreview,
+        pageCollectionItemId,
+        pageCollectionSortedItemIds,
+        collectionLayer,
       }),
       signal: controller.signal,
     })
@@ -556,7 +592,8 @@ export default function FilterableCollection({
           return;
         }
 
-        injectFilteredHTML(data.html ?? '', append);
+        const responseItemIds: string[] = Array.isArray(data.itemIds) ? data.itemIds : [];
+        injectFilteredHTML(data.html ?? '', append, responseItemIds);
 
         const total = data.total ?? 0;
         const count = data.count ?? 0;
@@ -586,7 +623,7 @@ export default function FilterableCollection({
           abortRef.current = null;
         }
       });
-  }, [collectionId, collectionLayerId, layerTemplate, effectiveSortBy, effectiveSortOrder, limit, paginationMode, updateEmptyStateElements, injectFilteredHTML, collectionLayerClasses, collectionLayerTag, isPublished]);
+  }, [collectionId, collectionLayerId, layerTemplate, effectiveSortBy, effectiveSortOrder, limit, paginationMode, updateEmptyStateElements, injectFilteredHTML, collectionLayerClasses, collectionLayerTag, isPublished, isPreview, pageCollectionItemId, pageCollectionSortedItemIds, collectionLayer]);
 
   const fetchFilteredRef = useRef(fetchFiltered);
   useEffect(() => { fetchFilteredRef.current = fetchFiltered; }, [fetchFiltered]);
@@ -652,6 +689,17 @@ export default function FilterableCollection({
       const wrapper = getSsrPaginationWrapper();
       if (wrapper) wrapper.style.display = '';
       updateEmptyStateElements(-1);
+
+      // Notify initializers (animations, sliders) that injected items are
+      // gone so they can drop any extras for this collection.
+      const clearDetail: ItemsInjectedDetail = {
+        collectionLayerId,
+        layerTemplate,
+        itemIds: [],
+        append: false,
+        collectionLayer,
+      };
+      window.dispatchEvent(new CustomEvent<ItemsInjectedDetail>(ITEMS_INJECTED_EVENT, { detail: clearDetail }));
       return;
     }
 

--- a/components/FilterableCollection.tsx
+++ b/components/FilterableCollection.tsx
@@ -151,7 +151,7 @@ export default function FilterableCollection({
     const parent = markerRef.current.parentElement;
     if (!parent) return;
     ssrChildrenRef.current = Array.from(parent.children).filter(
-      el => el !== markerRef.current
+      el => el !== markerRef.current && !(el as HTMLElement).hasAttribute('data-collection-marker')
     );
     if (pendingFirstEvalRef.current) {
       hideSSR();
@@ -767,7 +767,10 @@ export default function FilterableCollection({
   // Zero DOM footprint: invisible marker + direct children
   return (
     <>
-      <span ref={markerRef} style={{ display: 'none' }} />
+      <span
+        ref={markerRef} data-collection-marker=""
+        style={{ display: 'none' }}
+      />
       {children}
     </>
   );

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -232,6 +232,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
                 collectionLayerId={originalLayerId}
                 itemIds={layer._paginationMeta!.itemIds}
                 layerTemplate={layer._paginationMeta!.layerTemplate}
+                collectionLayer={layer._filterConfig?.collectionLayer || layer._paginationMeta!.collectionLayer}
               >
                 {content}
               </LoadMoreCollection>
@@ -265,6 +266,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
               collectionLayerClasses={layer._filterConfig!.collectionLayerClasses}
               collectionLayerTag={layer._filterConfig!.collectionLayerTag}
               isPublished={layer._filterConfig!.isPublished}
+              collectionLayer={layer._filterConfig!.collectionLayer}
             >
               {content}
             </FilterableCollection>

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -159,7 +159,7 @@ const LayerRendererPublic: React.FC<LayerRendererPublicProps> = ({
 
       const originalLayerId = layer.id.replace(/-fragment$/, '');
       const hasFilter = !!layer._filterConfig;
-      const hasPagination = layer._paginationMeta && isPublished;
+      const hasPagination = !!layer._paginationMeta;
 
       if (hasPagination || hasFilter) {
         let content: React.ReactNode = renderedChildren;

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -174,6 +174,10 @@ const LayerRendererPublic: React.FC<LayerRendererPublicProps> = ({
                 collectionLayerId={originalLayerId}
                 itemIds={layer._paginationMeta!.itemIds}
                 layerTemplate={layer._paginationMeta!.layerTemplate}
+                isPreview={isPreview}
+                pageCollectionItemId={pageCollectionItemId}
+                pageCollectionSortedItemIds={pageCollectionSortedItemIds}
+                collectionLayer={layer._filterConfig?.collectionLayer || layer._paginationMeta!.collectionLayer}
               >
                 {content}
               </LoadMoreCollection>
@@ -206,6 +210,10 @@ const LayerRendererPublic: React.FC<LayerRendererPublicProps> = ({
               collectionLayerClasses={layer._filterConfig!.collectionLayerClasses}
               collectionLayerTag={layer._filterConfig!.collectionLayerTag}
               isPublished={layer._filterConfig!.isPublished}
+              isPreview={isPreview}
+              pageCollectionItemId={pageCollectionItemId}
+              pageCollectionSortedItemIds={pageCollectionSortedItemIds}
+              collectionLayer={layer._filterConfig!.collectionLayer}
             >
               {content}
             </FilterableCollection>

--- a/components/LoadMoreCollection.tsx
+++ b/components/LoadMoreCollection.tsx
@@ -1,17 +1,12 @@
 'use client';
 
 /**
- * LoadMoreCollection Component
+ * LoadMoreCollection
  *
- * Client component that handles "Load More" pagination for collection layers.
- * Hydrates from SSR with initial items and fetches more on button click.
- * 
- * Features:
- * - Initial items rendered via SSR
- * - "Load More" button appends pre-rendered items without page reload
- * - Loading spinner during fetch (same style as PaginatedCollection)
- * - Automatic button hide when all items loaded
- * - Works with multi-reference fields (itemIds filtering)
+ * Wires up the SSR-rendered "load more" button for a collection layer.
+ * Renders no real wrapper (only an invisible marker + the SSR children)
+ * so the parent layer's flex/grid layout is preserved, then appends
+ * server-rendered HTML for additional items as direct siblings.
  */
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
@@ -36,11 +31,7 @@ interface LoadMoreCollectionProps {
   collectionLayer?: Omit<Layer, 'children'>;
 }
 
-interface LoadMoreState {
-  loadedCount: number;
-  isLoading: boolean;
-  hasMore: boolean;
-}
+const LOAD_MORE_APPENDED_ATTR = 'data-lm-appended';
 
 export default function LoadMoreCollection({
   children,
@@ -53,44 +44,38 @@ export default function LoadMoreCollection({
   pageCollectionSortedItemIds,
   collectionLayer,
 }: LoadMoreCollectionProps) {
-  const { totalItems, itemsPerPage, collectionId } = paginationMeta;
-  const containerRef = useRef<HTMLDivElement>(null);
-  const itemsContainerRef = useRef<HTMLDivElement>(null);
-  
-  const [state, setState] = useState<LoadMoreState>({
-    loadedCount: itemsPerPage,
-    isLoading: false,
-    hasMore: itemsPerPage < totalItems,
-  });
+  const { totalItems, itemsPerPage, collectionId, isPublished, sortBy, sortOrder } = paginationMeta;
+  const markerRef = useRef<HTMLSpanElement>(null);
 
-  // Fetch more items with pre-rendered HTML
+  const [loadedCount, setLoadedCount] = useState(itemsPerPage);
+  const [hasMore, setHasMore] = useState(itemsPerPage < totalItems);
+  const [isLoading, setIsLoading] = useState(false);
+
   const loadMore = useCallback(async () => {
-    if (state.isLoading || !state.hasMore) return;
-    
-    // Need layerTemplate to render items
+    if (isLoading || !hasMore) return;
+
     if (!layerTemplate || layerTemplate.length === 0) {
       console.error('LoadMoreCollection: layerTemplate is required for rendering');
       return;
     }
-    
-    setState(prev => ({ ...prev, isLoading: true }));
-    
+
+    setIsLoading(true);
+
     try {
-      // POST request with template for server-side rendering
       const response = await fetch(
         `/ycode/api/collections/${collectionId}/items/load-more`,
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            offset: state.loadedCount,
+            offset: loadedCount,
             limit: itemsPerPage,
-            published: true,
-            itemIds: itemIds,
-            layerTemplate: layerTemplate,
-            collectionLayerId: collectionLayerId,
+            published: isPublished !== false,
+            itemIds,
+            layerTemplate,
+            collectionLayerId,
+            sortBy,
+            sortOrder,
             isPreview,
             pageCollectionItemId,
             pageCollectionSortedItemIds,
@@ -98,21 +83,27 @@ export default function LoadMoreCollection({
           }),
         }
       );
-      
+
       if (!response.ok) {
         throw new Error('Failed to load more items');
       }
-      
+
       const result = await response.json();
-      const { items, html, hasMore } = result.data;
+      const { items, html, hasMore: nextHasMore } = result.data;
       const newItemIds: string[] = Array.isArray(items)
         ? (items as CollectionItem[]).map(item => item.id)
         : [];
 
-      // Append rendered HTML to the items container
-      if (html && itemsContainerRef.current) {
-        itemsContainerRef.current.insertAdjacentHTML('beforeend', html);
-        if (layerTemplate && newItemIds.length > 0) {
+      const parent = markerRef.current?.parentElement;
+      if (html && parent) {
+        const temp = document.createElement('div');
+        temp.innerHTML = html;
+        while (temp.firstChild) {
+          const child = temp.firstChild;
+          if (child instanceof Element) child.setAttribute(LOAD_MORE_APPENDED_ATTR, '');
+          parent.appendChild(child);
+        }
+        if (newItemIds.length > 0) {
           const detail: ItemsInjectedDetail = {
             collectionLayerId,
             layerTemplate,
@@ -123,76 +114,72 @@ export default function LoadMoreCollection({
           window.dispatchEvent(new CustomEvent<ItemsInjectedDetail>(ITEMS_INJECTED_EVENT, { detail }));
         }
       }
-      
-      setState(prev => ({
-        loadedCount: prev.loadedCount + items.length,
-        isLoading: false,
-        hasMore,
-      }));
+
+      setLoadedCount(prev => prev + items.length);
+      setHasMore(nextHasMore);
     } catch (error) {
       console.error('Load more failed:', error);
-      setState(prev => ({ ...prev, isLoading: false }));
+    } finally {
+      setIsLoading(false);
     }
-  }, [state.loadedCount, state.isLoading, state.hasMore, itemsPerPage, collectionId, collectionLayerId, itemIds, layerTemplate, isPreview, pageCollectionItemId, pageCollectionSortedItemIds, collectionLayer]);
+  }, [
+    isLoading,
+    hasMore,
+    layerTemplate,
+    collectionId,
+    loadedCount,
+    itemsPerPage,
+    isPublished,
+    itemIds,
+    collectionLayerId,
+    sortBy,
+    sortOrder,
+    isPreview,
+    pageCollectionItemId,
+    pageCollectionSortedItemIds,
+    collectionLayer,
+  ]);
 
-  // Handle click events on load more button (delegated)
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement;
-      const button = target.closest('[data-pagination-action="load_more"]') as HTMLElement;
-      
+      const button = target.closest('[data-pagination-action="load_more"]') as HTMLElement | null;
       if (!button) return;
-      
-      const layerId = button.getAttribute('data-collection-layer-id');
-      
-      // Only handle clicks for this collection
-      if (layerId !== collectionLayerId) return;
-      
+      if (button.getAttribute('data-collection-layer-id') !== collectionLayerId) return;
       e.preventDefault();
       loadMore();
     };
-    
+
     document.addEventListener('click', handleClick);
     return () => document.removeEventListener('click', handleClick);
   }, [collectionLayerId, loadMore]);
 
-  // Update the count display and button visibility when state changes
   useEffect(() => {
-    // Update count display - use data-layer-id attribute (not id)
-    // The count element has ID format: ${collectionLayerId}-pagination-count
     const countElement = document.querySelector(
       `[data-pagination-for="${collectionLayerId}"] [data-layer-id$="-pagination-count"]`
     );
     if (countElement) {
-      countElement.textContent = `Showing ${state.loadedCount} of ${totalItems}`;
+      countElement.textContent = `Showing ${loadedCount} of ${totalItems}`;
     }
-    
-    // Hide load more button when all items are loaded
+
     const loadMoreButton = document.querySelector(
       `[data-pagination-for="${collectionLayerId}"] [data-pagination-action="load_more"]`
-    ) as HTMLElement;
+    ) as HTMLElement | null;
     if (loadMoreButton) {
-      loadMoreButton.style.display = state.hasMore ? '' : 'none';
+      loadMoreButton.style.display = hasMore ? '' : 'none';
+      loadMoreButton.toggleAttribute('disabled', isLoading);
+      loadMoreButton.style.opacity = isLoading ? '0.6' : '';
+      loadMoreButton.style.pointerEvents = isLoading ? 'none' : '';
     }
-  }, [state.loadedCount, state.hasMore, totalItems, collectionLayerId]);
+  }, [loadedCount, hasMore, totalItems, collectionLayerId, isLoading]);
 
   return (
-    <div 
-      ref={containerRef}
-      className={`relative ${state.isLoading ? 'opacity-50 pointer-events-none' : ''}`}
-      data-loadmore-collection={collectionLayerId}
-    >
-      {/* Loading overlay - same style as PaginatedCollection */}
-      {state.isLoading && (
-        <div className="absolute inset-0 flex items-center justify-center bg-white/50 z-10">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900" />
-        </div>
-      )}
-      
-      {/* Collection content container - SSR items + dynamically appended items */}
-      <div ref={itemsContainerRef}>
-        {children}
-      </div>
-    </div>
+    <>
+      <span
+        ref={markerRef} data-collection-marker=""
+        style={{ display: 'none' }}
+      />
+      {children}
+    </>
   );
 }

--- a/components/LoadMoreCollection.tsx
+++ b/components/LoadMoreCollection.tsx
@@ -15,7 +15,8 @@
  */
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import type { CollectionPaginationMeta, Layer } from '@/types';
+import { ITEMS_INJECTED_EVENT, type ItemsInjectedDetail } from '@/components/FilterableCollection';
+import type { CollectionPaginationMeta, CollectionItem, Layer } from '@/types';
 
 interface LoadMoreCollectionProps {
   children: React.ReactNode;
@@ -25,6 +26,14 @@ interface LoadMoreCollectionProps {
   layerTemplate?: Layer[];
   /** Optional: item IDs for multi-reference filtering */
   itemIds?: string[];
+  /** Preview mode forces server-rendered links to use the `/ycode/preview` prefix. */
+  isPreview?: boolean;
+  /** Item ID of the dynamic-page collection being rendered (for `current-page` link keywords). */
+  pageCollectionItemId?: string;
+  /** Ordered ids of the dynamic page's collection — powers `next-item` / `previous-item` link keywords. */
+  pageCollectionSortedItemIds?: string[];
+  /** Full collection layer (sans children) — lets the server rebuild proper item wrappers (link/action/attributes). */
+  collectionLayer?: Omit<Layer, 'children'>;
 }
 
 interface LoadMoreState {
@@ -39,6 +48,10 @@ export default function LoadMoreCollection({
   collectionLayerId,
   layerTemplate,
   itemIds,
+  isPreview = false,
+  pageCollectionItemId,
+  pageCollectionSortedItemIds,
+  collectionLayer,
 }: LoadMoreCollectionProps) {
   const { totalItems, itemsPerPage, collectionId } = paginationMeta;
   const containerRef = useRef<HTMLDivElement>(null);
@@ -78,6 +91,10 @@ export default function LoadMoreCollection({
             itemIds: itemIds,
             layerTemplate: layerTemplate,
             collectionLayerId: collectionLayerId,
+            isPreview,
+            pageCollectionItemId,
+            pageCollectionSortedItemIds,
+            collectionLayer,
           }),
         }
       );
@@ -88,10 +105,23 @@ export default function LoadMoreCollection({
       
       const result = await response.json();
       const { items, html, hasMore } = result.data;
-      
+      const newItemIds: string[] = Array.isArray(items)
+        ? (items as CollectionItem[]).map(item => item.id)
+        : [];
+
       // Append rendered HTML to the items container
       if (html && itemsContainerRef.current) {
         itemsContainerRef.current.insertAdjacentHTML('beforeend', html);
+        if (layerTemplate && newItemIds.length > 0) {
+          const detail: ItemsInjectedDetail = {
+            collectionLayerId,
+            layerTemplate,
+            itemIds: newItemIds,
+            append: true,
+            collectionLayer,
+          };
+          window.dispatchEvent(new CustomEvent<ItemsInjectedDetail>(ITEMS_INJECTED_EVENT, { detail }));
+        }
       }
       
       setState(prev => ({
@@ -103,7 +133,7 @@ export default function LoadMoreCollection({
       console.error('Load more failed:', error);
       setState(prev => ({ ...prev, isLoading: false }));
     }
-  }, [state.loadedCount, state.isLoading, state.hasMore, itemsPerPage, collectionId, collectionLayerId, itemIds, layerTemplate]);
+  }, [state.loadedCount, state.isLoading, state.hasMore, itemsPerPage, collectionId, collectionLayerId, itemIds, layerTemplate, isPreview, pageCollectionItemId, pageCollectionSortedItemIds, collectionLayer]);
 
   // Handle click events on load more button (delegated)
   useEffect(() => {

--- a/components/SliderInitializer.tsx
+++ b/components/SliderInitializer.tsx
@@ -6,8 +6,9 @@
  * and mounts Swiper instances.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import Swiper from 'swiper';
+import { ITEMS_INJECTED_EVENT } from '@/components/FilterableCollection';
 import type { SliderSettings } from '@/types';
 import {
   buildProductionSwiperOptions,
@@ -17,50 +18,69 @@ import {
   syncSliderStateAttributes,
 } from '@/lib/slider-utils';
 
+/** Tag attached to sliders we've already mounted so re-scans skip them. */
+const INITIALIZED_ATTR = 'data-slider-initialized';
+
 export default function SliderInitializer() {
+  const swiperInstancesRef = useRef<Swiper[]>([]);
+
   useEffect(() => {
     loadSwiperCss(document);
 
-    const sliderElements = document.querySelectorAll<HTMLElement>('[data-slider-id]');
-    const swiperInstances: Swiper[] = [];
+    const initSliders = () => {
+      const sliderElements = document.querySelectorAll<HTMLElement>(
+        `[data-slider-id]:not([${INITIALIZED_ATTR}])`,
+      );
 
-    sliderElements.forEach((el) => {
-      const settingsJson = el.getAttribute('data-slider-settings');
-      if (!settingsJson) return;
+      sliderElements.forEach((el) => {
+        const settingsJson = el.getAttribute('data-slider-settings');
+        if (!settingsJson) return;
 
-      try {
-        const settings: SliderSettings = JSON.parse(settingsJson);
-        const config = buildProductionSwiperOptions(settings);
+        try {
+          const settings: SliderSettings = JSON.parse(settingsJson);
+          const config = buildProductionSwiperOptions(settings);
 
-        // Scope navigation/pagination to this specific slider via data attributes
-        if (config.navigation && typeof config.navigation === 'object') {
-          config.navigation.nextEl = el.querySelector('[data-slider-next]') as HTMLElement;
-          config.navigation.prevEl = el.querySelector('[data-slider-prev]') as HTMLElement;
+          if (config.navigation && typeof config.navigation === 'object') {
+            config.navigation.nextEl = el.querySelector('[data-slider-next]') as HTMLElement;
+            config.navigation.prevEl = el.querySelector('[data-slider-prev]') as HTMLElement;
+          }
+          if (config.pagination && typeof config.pagination === 'object') {
+            const isFraction = settings.paginationType === 'fraction';
+            const selector = isFraction ? '[data-slider-fraction]' : '[data-slider-pagination]';
+            config.pagination.el = el.querySelector(selector) as HTMLElement;
+          }
+
+          configureBulletRenderer(el, config);
+
+          const swiper = new Swiper(el, config);
+          applySwiperEasing(el, settings.easing);
+          syncSliderStateAttributes(swiper);
+
+          const paginationEl = el.querySelector('[data-slider-pagination]') as HTMLElement | null;
+          if (paginationEl) paginationEl.style.visibility = '';
+
+          el.setAttribute(INITIALIZED_ATTR, '');
+          swiperInstancesRef.current.push(swiper);
+        } catch {
+          console.error('Failed to initialize slider:', el.getAttribute('data-slider-id'));
         }
-        if (config.pagination && typeof config.pagination === 'object') {
-          const isFraction = settings.paginationType === 'fraction';
-          const selector = isFraction ? '[data-slider-fraction]' : '[data-slider-pagination]';
-          config.pagination.el = el.querySelector(selector) as HTMLElement;
-        }
+      });
+    };
 
-        configureBulletRenderer(el, config);
+    initSliders();
 
-        const swiper = new Swiper(el, config);
-        applySwiperEasing(el, settings.easing);
-        syncSliderStateAttributes(swiper);
-
-        // Reveal pagination now that Swiper has generated the real bullets
-        const paginationEl = el.querySelector('[data-slider-pagination]') as HTMLElement | null;
-        if (paginationEl) paginationEl.style.visibility = '';
-
-        swiperInstances.push(swiper);
-      } catch {
-        console.error('Failed to initialize slider:', el.getAttribute('data-slider-id'));
-      }
-    });
+    // Re-scan after filter/load-more injects new collection items so sliders
+    // inside those items get mounted. Defer to the next frame so the DOM has
+    // settled after injection.
+    const handleItemsInjected = () => {
+      requestAnimationFrame(initSliders);
+    };
+    window.addEventListener(ITEMS_INJECTED_EVENT, handleItemsInjected);
 
     return () => {
-      swiperInstances.forEach((swiper) => swiper.destroy(true, true));
+      window.removeEventListener(ITEMS_INJECTED_EVENT, handleItemsInjected);
+      swiperInstancesRef.current.forEach((swiper) => swiper.destroy(true, true));
+      swiperInstancesRef.current = [];
     };
   }, []);
 

--- a/lib/collection-utils.ts
+++ b/lib/collection-utils.ts
@@ -1,4 +1,4 @@
-import type { Collection, CollectionFieldType, CollectionSorting } from '@/types';
+import type { Collection, CollectionFieldType, CollectionSorting, Layer } from '@/types';
 import { sanitizeSlug } from './page-utils';
 
 /**
@@ -334,4 +334,47 @@ export function resolveReferenceFieldsSync(
   }
 
   return enhancedValues;
+}
+
+/**
+ * Recursively suffix all layer IDs (and matching interaction tween `layer_id`
+ * references) in a subtree so each rendered collection item has unique DOM
+ * targets. Lets animations bind to the correct element per item instead of
+ * sharing one DOM node.
+ */
+export function remapLayerIdsForCollectionItem(layer: Layer, suffix: string): Layer {
+  const originalIds = new Set<string>();
+  const collectIds = (l: Layer) => {
+    originalIds.add(l.id);
+    l.children?.forEach(collectIds);
+  };
+  collectIds(layer);
+
+  const remapLayer = (l: Layer): Layer => {
+    const remapped: Layer = {
+      ...l,
+      id: `${l.id}${suffix}`,
+    };
+
+    if (l.interactions?.length) {
+      remapped.interactions = l.interactions.map(interaction => ({
+        ...interaction,
+        id: `${interaction.id}${suffix}`,
+        tweens: interaction.tweens.map(tween => ({
+          ...tween,
+          layer_id: originalIds.has(tween.layer_id)
+            ? `${tween.layer_id}${suffix}`
+            : tween.layer_id,
+        })),
+      }));
+    }
+
+    if (l.children) {
+      remapped.children = l.children.map(remapLayer);
+    }
+
+    return remapped;
+  };
+
+  return remapLayer(layer);
 }

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -14,7 +14,7 @@ import { buildImageSizes, generateImageSrcset, getOptimizedImageUrl, getAssetPro
 import { resolveComponents, applyComponentOverrides } from '@/lib/resolve-components';
 import { getComponentVariantLayers } from '@/lib/component-variant-utils';
 import { isTiptapDoc, hasBlockElementsWithResolver } from '@/lib/tiptap-utils';
-import { castValue } from '@/lib/collection-utils';
+import { castValue, parseMultiReferenceValue, remapLayerIdsForCollectionItem } from '@/lib/collection-utils';
 import { DEFAULT_TEXT_STYLES } from '@/lib/text-format-utils';
 
 // Pagination context passed through to resolveCollectionLayers
@@ -35,7 +35,6 @@ import { buildLayerTranslationKey, getTranslationByKey, hasValidTranslationValue
 import { formatDateFieldsInItemValues } from '@/lib/date-format-utils';
 import { getSettingByKey } from '@/lib/repositories/settingsRepository';
 import { parseMultiAssetFieldValue, buildAssetVirtualValues } from '@/lib/multi-asset-utils';
-import { parseMultiReferenceValue } from '@/lib/collection-utils';
 import { combineBgValues, mergeStaticBgVars } from '@/lib/tailwind-class-mapper';
 import { generateInitialAnimationCSS } from '@/lib/animation-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS } from '@/lib/map-utils';
@@ -1546,63 +1545,6 @@ function resolveRichTextVariables(
 }
 
 /**
- * Resolve collection layers server-side by fetching their data
- * Recursively traverses the layer tree and injects collection items
- * @param layers - Layer tree to resolve
- * @param isPublished - Whether to fetch published or draft items
- * @param parentItemValues - Optional parent item values for multi-reference filtering
- * @param paginationContext - Optional pagination context with page numbers
- * @param translations - Optional translations map for CMS field translations
- * @returns Layers with collection data injected
- */
-
-/**
- * Remaps all layer IDs in a subtree to make them unique per collection item.
- * Also updates interaction tween layer_id references to match the new IDs.
- * This prevents animations from targeting only the first collection item
- * when multiple items share the same child layer IDs in the DOM.
- */
-function remapLayerIdsForCollectionItem(layer: Layer, suffix: string): Layer {
-  // First pass: collect all original IDs in the subtree
-  const originalIds = new Set<string>();
-  const collectIds = (l: Layer) => {
-    originalIds.add(l.id);
-    l.children?.forEach(collectIds);
-  };
-  collectIds(layer);
-
-  // Second pass: remap IDs and interaction tween references
-  const remapLayer = (l: Layer): Layer => {
-    const remapped: Layer = {
-      ...l,
-      id: `${l.id}${suffix}`,
-    };
-
-    if (l.interactions?.length) {
-      remapped.interactions = l.interactions.map(interaction => ({
-        ...interaction,
-        // Make interaction ID unique so AnimationInitializer caches separate timelines per item
-        id: `${interaction.id}${suffix}`,
-        tweens: interaction.tweens.map(tween => ({
-          ...tween,
-          layer_id: originalIds.has(tween.layer_id)
-            ? `${tween.layer_id}${suffix}`
-            : tween.layer_id,
-        })),
-      }));
-    }
-
-    if (l.children) {
-      remapped.children = l.children.map(remapLayer);
-    }
-
-    return remapped;
-  };
-
-  return remapLayer(layer);
-}
-
-/**
  * Walk Tiptap JSON nodes, resolve collections inside richTextComponent nodes,
  * and store the result as `_resolvedLayers` so the renderer can use them directly.
  * Tracks ancestor component IDs to prevent infinite circular resolution.
@@ -2136,6 +2078,21 @@ async function buildCollectionCache(
   return { itemsByCollection, totalByCollection, fieldsByCollection, fieldTypeMap, itemsById };
 }
 
+/** Return a shallow copy of `layer` without its `children`. */
+function stripChildren(layer: Layer): Omit<Layer, 'children'> {
+  const { children: _children, ...rest } = layer;
+  return rest;
+}
+
+/**
+ * Resolve collection layers server-side by fetching their data.
+ * Recursively traverses the layer tree and injects collection items.
+ * @param layers - Layer tree to resolve
+ * @param isPublished - Whether to fetch published or draft items
+ * @param parentItemValues - Optional parent item values for multi-reference filtering
+ * @param paginationContext - Optional pagination context with page numbers
+ * @param translations - Optional translations map for CMS field translations
+ */
 export async function resolveCollectionLayers(
   layers: Layer[],
   isPublished: boolean,
@@ -2514,6 +2471,9 @@ export async function resolveCollectionLayers(
               itemIds: allowedItemIds, // For multi-reference filtering in load_more
               // Store the original layer template for load_more client-side rendering
               layerTemplate: paginationConfig.mode === 'load_more' ? layer.children : undefined,
+              collectionLayer: paginationConfig.mode === 'load_more'
+                ? stripChildren(layer)
+                : undefined,
             };
           }
 
@@ -2560,6 +2520,10 @@ export async function resolveCollectionLayers(
               collectionLayerClasses: Array.isArray(layer.classes) ? layer.classes : (layer.classes ? [layer.classes] : []),
               collectionLayerTag: layer.name || 'div',
               isPublished,
+              // Full collection layer (sans children) — used to rebuild the
+              // proper wrapper (link/action/attributes) when items are
+              // re-rendered client-side via filter/load-more.
+              collectionLayer: stripChildren(layer),
             } : undefined,
           };
         } catch (error) {
@@ -3215,6 +3179,11 @@ export async function renderCollectionItemsToHtml(
   tenantId?: string,
   collectionLayerClasses?: string[],
   collectionLayerTag?: string,
+  pageLinkContext?: PageLinkContext,
+  // When provided, items are rendered as full clones of the collection layer
+  // (matching SSR exactly), so link/action wrappers and layer-level
+  // attributes are preserved. Falls back to a generic wrapper otherwise.
+  collectionLayer?: Omit<Layer, 'children'>,
 ): Promise<string> {
   // Fetch collection fields, timezone, and map tokens in parallel
   const [collectionFields, timezoneRaw] = await Promise.all([
@@ -3247,8 +3216,18 @@ export async function renderCollectionItemsToHtml(
     preprocessed.map(async ({ item, rawValues }, index) => {
       const enhancedValues = allEnhancedValues[index];
 
-      // Deep clone the template for each item
-      const clonedTemplate = JSON.parse(JSON.stringify(layerTemplate));
+      // Deep clone the template for each item. ID remapping is deferred:
+      // - When `collectionLayer` is provided (preferred path), we'll rebuild
+      //   the full layer first and remap the entire subtree once at the end,
+      //   so SSR-equivalent wrappers are generated and IDs aren't doubled.
+      // - Otherwise we pre-remap children with the `-fc-${itemId}` suffix
+      //   used by the legacy generic-wrapper path. The `-fc-` namespace
+      //   prevents collisions with SSR clones (which use `-item-`).
+      const idSuffix = `-fc-${item.id}`;
+      const clonedTemplateRaw: Layer[] = JSON.parse(JSON.stringify(layerTemplate)) as Layer[];
+      const clonedTemplate: Layer[] = collectionLayer
+        ? clonedTemplateRaw
+        : clonedTemplateRaw.map(layer => remapLayerIdsForCollectionItem(layer, idSuffix));
 
       // Inject collection data into each layer of the template (text, images, etc.)
       const injectedLayers = await Promise.all(
@@ -3324,15 +3303,45 @@ export async function renderCollectionItemsToHtml(
       // Apply conditional visibility based on this item's field values
       resolvedLayers = filterByVisibility(resolvedLayers, item.values);
 
-      // Convert layers to HTML (handles fragments from resolved collections)
+      // Preferred path: rebuild a full clone of the collection layer just
+      // like SSR does (link/action/attributes preserved). Renders one HTML
+      // node via layerToHtml so wrappers like <a> are emitted properly.
+      // IDs aren't pre-remapped (see clonedTemplate above), so the whole
+      // subtree gets a single remap pass here.
+      if (collectionLayer) {
+        const slugField = collectionFields.find(f => f.key === 'slug');
+        const itemSlug = slugField ? (rawValues[slugField.id] || item.values[slugField.id]) : undefined;
+
+        const clonedLayer: Layer = {
+          ...collectionLayer,
+          attributes: {
+            ...(collectionLayer.attributes || {}),
+            'data-collection-item-id': item.id,
+          },
+          variables: {
+            ...(collectionLayer.variables || {}),
+            collection: undefined,
+          },
+          children: resolvedLayers,
+          _collectionItemValues: enhancedValues,
+          _collectionItemId: item.id,
+          _collectionItemSlug: itemSlug,
+        };
+
+        const remapped = remapLayerIdsForCollectionItem(clonedLayer, idSuffix);
+        return layerToHtml(remapped, item.id, pages, folders, enrichedSlugs, locale, translations, anchorMap, item.values, undefined, assetMap, undefined, undefined, undefined, undefined, pageLinkContext);
+      }
+
+      // Fallback: render children and wrap with a generic container. Used
+      // when the caller didn't pass the full collection layer (older API
+      // contracts). Loses link/action wrappers but keeps content rendering.
       const itemHtml = resolvedLayers
         .map((layer) =>
-          layerToHtml(layer, item.id, pages, folders, enrichedSlugs, locale, translations, anchorMap, item.values, undefined, assetMap, undefined, undefined)
+          layerToHtml(layer, item.id, pages, folders, enrichedSlugs, locale, translations, anchorMap, item.values, undefined, assetMap, undefined, undefined, undefined, undefined, pageLinkContext)
         )
         .join('');
 
-      // Wrap in collection item container matching the SSR clone structure
-      const itemWrapperId = `${collectionLayerId}-item-${item.id}`;
+      const itemWrapperId = `${collectionLayerId}-fc-${item.id}`;
       const wrapperTag = collectionLayerTag || 'div';
       const wrapperClassStr = Array.isArray(collectionLayerClasses) && collectionLayerClasses.length > 0
         ? ` class="${collectionLayerClasses.join(' ')}"`
@@ -3972,7 +3981,7 @@ function renderTiptapToHtml(
  * cloned collection layer or current item), so layer-level link resolution
  * can produce next/previous-style URLs and respect preview prefixes.
  */
-interface PageLinkContext {
+export interface PageLinkContext {
   pageCollectionItemId?: string;
   pageCollectionSortedItemIds?: string[];
   isPreview?: boolean;

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -2474,6 +2474,9 @@ export async function resolveCollectionLayers(
               collectionLayer: paginationConfig.mode === 'load_more'
                 ? stripChildren(layer)
                 : undefined,
+              isPublished,
+              sortBy: collectionVariable.sort_by,
+              sortOrder: collectionVariable.sort_order,
             };
           }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ycode",
-  "version": "1.12.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ycode",
-      "version": "1.12.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/types/index.ts
+++ b/types/index.ts
@@ -460,6 +460,11 @@ export interface Layer {
     collectionLayerClasses?: string[];
     collectionLayerTag?: string;
     isPublished?: boolean;
+    // Full collection layer (sans children) used by the client to rebuild
+    // proper item wrappers (anchor/link/attribute) when injecting filtered
+    // or load-more items. Without this, the wrapper would be a plain <div>
+    // and lose link/action behavior.
+    collectionLayer?: Omit<Layer, 'children'>;
   };
 }
 
@@ -1307,6 +1312,10 @@ export interface CollectionPaginationMeta {
   mode?: 'pages' | 'load_more'; // Pagination mode
   itemIds?: string[]; // For multi-reference filtering in load_more mode
   layerTemplate?: Layer[]; // Layer template for rendering new items in load_more mode
+  // Full collection layer (sans children) — used by load-more (and filter)
+  // to rebuild proper item wrappers (link/action/attributes) when items are
+  // re-rendered client-side.
+  collectionLayer?: Omit<Layer, 'children'>;
 }
 
 // Conditional Visibility Types

--- a/types/index.ts
+++ b/types/index.ts
@@ -1316,6 +1316,14 @@ export interface CollectionPaginationMeta {
   // to rebuild proper item wrappers (link/action/attributes) when items are
   // re-rendered client-side.
   collectionLayer?: Omit<Layer, 'children'>;
+  // Whether SSR rendered this collection from published data. The client
+  // must fetch load-more items from the same source so draft previews
+  // don't accidentally append published rows (or vice versa).
+  isPublished?: boolean;
+  // Sort applied by SSR — load-more must mirror it or offset-based
+  // paging will return overlapping (duplicate) items.
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
 }
 
 // Conditional Visibility Types


### PR DESCRIPTION
## Summary

After applying filters or clicking load-more on a collection, the injected items lost their links and animations, page-level on-load animations replayed on every filter change, and in preview the load-more button was inert / produced duplicate items in a broken layout. Two underlying causes: client-injected items were rendered with a generic `<div>` wrapper (dropping the collection layer's `<a>`/actions/attributes) and shared `data-layer-id`s with hidden SSR clones; and `LoadMoreCollection` was gated on `isPublished`, wrapped its children in an extra `<div>`, and fetched with hardcoded `published=true` and the DB-default order, so paging diverged from SSR.

## Changes

### Filter / load-more content fidelity
- Carry the full collection layer (sans children) through `_filterConfig` / `_paginationMeta` so the renderer can clone it like SSR and emit proper `<a>` / action wrappers via `layerToHtml`
- Use a distinct `-fc-${itemId}` suffix for injected items so they never collide with hidden SSR clones
- Dispatch a `ycode:items-injected` event after inject/clear so `AnimationInitializer` rebuilds extras (full layer per item, remapped once) and `SliderInitializer` re-scans for new sliders
- Track played one-shot interactions (`load`, `scroll-into-view`) by interaction id so they fire once for page layers and once per injected item, with no replay on subsequent filter changes
- Move `remapLayerIdsForCollectionItem` to `lib/collection-utils` so the client can import it without pulling server-only deps
- Add `collectionLayer` prop to builder `LayerRenderer` for parity with the public renderer

### Load-more in preview
- Drop the `isPublished` gate on `LoadMoreCollection` in `LayerRendererPublic` so the button mounts in preview (this renderer is never used in the builder canvas)
- Replace `LoadMoreCollection`'s wrapper `<div>` with the same marker + fragment pattern `FilterableCollection` uses, and surface loading state on the button itself, so the parent's flex/grid layout isn't collapsed
- Tag both collection markers with `data-collection-marker` and make `FilterableCollection`'s SSR capture skip them, so `showSSR()` doesn't clear `LoadMoreCollection`'s marker `display:none` (which was taking a flex slot and shifting the first item)
- Thread `isPublished` / `sortBy` / `sortOrder` through `_paginationMeta` and port the field-sort-then-slice logic from the filter route into the load-more route, so paged results match SSR order and don't duplicate items
- Remove the legacy `GET` handler on `/items/load-more` (route is POST-only now)

## Test plan

- [ ] On a page with a filterable collection (e.g. `/ycode/preview/explore`), change a filter and confirm injected cards have working links and hover animations
- [ ] Confirm on-load animations on page-level layers do not replay when filters change
- [ ] Confirm on-load animations on newly injected items play once and don't replay on further filter changes
- [ ] Clear filters and confirm SSR items reappear cleanly with their original interactions intact
- [ ] On `/ycode/preview/news` (load-more collection in preview), click Load More and confirm new items append in the 3-column grid (no vertical stacking)
- [ ] Confirm load-more in preview returns draft items (not published) and matches the sort order of the SSR set
- [ ] Click Load More repeatedly and confirm no duplicate items appear
- [ ] On a published page, confirm load-more still fetches the published set and any sliders/lightboxes in new items initialize