### PR TITLE
fix: paginate translation publish to bypass PostgREST 1000-row cap

### DIFF
--- a/lib/services/localisationService.ts
+++ b/lib/services/localisationService.ts
@@ -8,6 +8,7 @@
  */
 
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { fetchAllRows, SUPABASE_WRITE_BATCH_SIZE } from '@/lib/supabase-constants';
 import type { Locale, Translation, TranslationSourceType } from '@/types';
 
 export interface ChangedLocale {
@@ -145,16 +146,18 @@ export async function publishLocalisation(): Promise<PublishLocalisationResult> 
   // `buildSlugSnapshot` reads to compute OLD URLs for slug renames.
   // ──────────────────────────────────────────────────────────────────────
 
-  const [
-    { data: existingPublishedLocalesRaw },
-    { data: existingPublishedTranslationsRaw },
-  ] = await Promise.all([
+  // Translations regularly exceed the 1000-row PostgREST default, so page
+  // through both the existing-published snapshot and the draft fetch below.
+  // A single-shot SELECT silently truncated the publish set, leaving rows
+  // 1001..N permanently in draft.
+  const [existingPublishedLocalesRes, existingPublishedTranslations] = await Promise.all([
     client.from('locales').select('*').eq('is_published', true),
-    client.from('translations').select('*').eq('is_published', true),
+    fetchAllRows<Translation>((from, to) =>
+      client.from('translations').select('*').eq('is_published', true).range(from, to)
+    ),
   ]);
 
-  const existingPublishedLocales: Locale[] = existingPublishedLocalesRaw || [];
-  const existingPublishedTranslations: Translation[] = existingPublishedTranslationsRaw || [];
+  const existingPublishedLocales: Locale[] = existingPublishedLocalesRes.data || [];
 
   const publishedLocalesById = new Map<string, Locale>();
   for (const l of existingPublishedLocales) publishedLocalesById.set(l.id, l);
@@ -274,14 +277,16 @@ export async function publishLocalisation(): Promise<PublishLocalisationResult> 
   // === TRANSLATIONS ===
   const translationsStart = performance.now();
 
-  // Step 4: Fetch all draft translations (including soft-deleted)
-  const { data: allDraftTranslations, error: translationsError } = await client
-    .from('translations')
-    .select('*')
-    .eq('is_published', false);
-
-  if (translationsError) {
-    throw new Error(`Failed to fetch draft translations: ${translationsError.message}`);
+  // Step 4: Fetch all draft translations (including soft-deleted). Paged
+  // for the same 1000-row reason as the published snapshot above.
+  let allDraftTranslations: Translation[];
+  try {
+    allDraftTranslations = await fetchAllRows<Translation>((from, to) =>
+      client.from('translations').select('*').eq('is_published', false).range(from, to)
+    );
+  } catch (translationsError) {
+    const message = translationsError instanceof Error ? translationsError.message : String(translationsError);
+    throw new Error(`Failed to fetch draft translations: ${message}`);
   }
 
   // ──────────────────────────────────────────────────────────────────────
@@ -349,7 +354,9 @@ export async function publishLocalisation(): Promise<PublishLocalisationResult> 
       }
     }
 
-    // Step 6: Upsert published translations
+    // Step 6: Upsert published translations in write-sized batches so the
+    // PostgREST request payload stays well under URL/body limits when a
+    // project has tens of thousands of translations.
     if (activeDraftTranslations.length > 0) {
       const publishedTranslations = activeDraftTranslations.map((translation: Translation) => ({
         id: translation.id,
@@ -366,14 +373,15 @@ export async function publishLocalisation(): Promise<PublishLocalisationResult> 
         deleted_at: null,
       }));
 
-      const { error: upsertError } = await client
-        .from('translations')
-        .upsert(publishedTranslations, {
-          onConflict: 'id,is_published',
-        });
+      for (let i = 0; i < publishedTranslations.length; i += SUPABASE_WRITE_BATCH_SIZE) {
+        const batch = publishedTranslations.slice(i, i + SUPABASE_WRITE_BATCH_SIZE);
+        const { error: upsertError } = await client
+          .from('translations')
+          .upsert(batch, { onConflict: 'id,is_published' });
 
-      if (upsertError) {
-        throw new Error(`Failed to upsert published translations: ${upsertError.message}`);
+        if (upsertError) {
+          throw new Error(`Failed to upsert published translations: ${upsertError.message}`);
+        }
       }
 
       publishedTranslationsCount = activeDraftTranslations.length;

--- a/lib/supabase-constants.ts
+++ b/lib/supabase-constants.ts
@@ -17,3 +17,23 @@ export const SUPABASE_QUERY_LIMIT = 1000;
  * Smaller to avoid Supabase URL length limits on write operations.
  */
 export const SUPABASE_WRITE_BATCH_SIZE = 100;
+
+/**
+ * Page through a Supabase SELECT past the 1000-row default cap.
+ * `buildPage(from, to)` must return a fresh query each call (Supabase
+ * builders aren't reusable). Stops on error or short page.
+ */
+export async function fetchAllRows<T>(
+  buildPage: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: unknown }>,
+  pageSize: number = SUPABASE_QUERY_LIMIT,
+): Promise<T[]> {
+  const all: T[] = [];
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await buildPage(from, from + pageSize - 1);
+    if (error) throw error;
+    if (!data || data.length === 0) break;
+    all.push(...data);
+    if (data.length < pageSize) break;
+  }
+  return all;
+}


### PR DESCRIPTION
## Summary

`publishLocalisation` made three single-shot SELECT calls against `translations`. PostgREST defaults to 1000 rows per response, so any project with more than 1000 draft translations was silently truncating the publish set — rows 1001..N never made it to `is_published=true`. Preview reads drafts via the recently-paginated `loadTranslationsForLocale` path and looked correct, while the published page rendered partially-translated content.

## Changes

- Add a small reusable `fetchAllRows(buildPage)` helper to `lib/supabase-constants.ts` next to the existing `SUPABASE_QUERY_LIMIT` constant
- Page both the existing-published snapshot and the draft fetch in `publishLocalisation` via the helper
- Batch the translations upsert in `SUPABASE_WRITE_BATCH_SIZE` (100) chunks — mirrors the pattern used by `assetFolderRepository`/`assetRepository` so the request payload stays safe when projects ship tens of thousands of translations

## Test plan

- [ ] On a project with > 1000 draft translations on at least one locale, run publish from the builder
- [ ] DB check — `SELECT locale_id, is_published, COUNT(*) FROM translations WHERE deleted_at IS NULL GROUP BY 1,2;` — published counts should now match active draft counts per locale
- [ ] Load a published page in a non-default locale — every translatable string should render in the target language (previously a partial mix of source + target language)
- [ ] Confirm preview is unaffected (it never relied on the published rows)
