### PR TITLE
fix: incorrect 'changes detected' after publishing

### DIFF
--- a/app/(builder)/ycode/api/publish/preview/route.ts
+++ b/app/(builder)/ycode/api/publish/preview/route.ts
@@ -5,6 +5,7 @@ import { getUnpublishedCollections } from '@/lib/repositories/collectionReposito
 import { getUnpublishedComponents } from '@/lib/repositories/componentRepository';
 import { getUnpublishedLayerStyles } from '@/lib/repositories/layerStyleRepository';
 import { getUnpublishedAssets } from '@/lib/repositories/assetRepository';
+import { getUnpublishedTranslationsCount } from '@/lib/repositories/translationRepository';
 import { getDeletedDraftCount } from '@/lib/sync-utils';
 import { noCache } from '@/lib/api-response';
 
@@ -19,6 +20,7 @@ export interface PublishPreviewCounts {
   components: number;
   layerStyles: number;
   assets: number;
+  translations: number;
   total: number;
 }
 
@@ -36,6 +38,7 @@ export async function GET(_request: NextRequest) {
       componentsChanged, componentsDeleted,
       layerStylesChanged, layerStylesDeleted,
       assetsChanged, assetsDeleted,
+      translationsChanged,
     ] = await Promise.all([
       getUnpublishedPagesCount(),
       getDeletedDraftCount('pages'),
@@ -49,6 +52,7 @@ export async function GET(_request: NextRequest) {
       getDeletedDraftCount('layer_styles'),
       getUnpublishedAssets().then(a => a.length),
       getDeletedDraftCount('assets'),
+      getUnpublishedTranslationsCount(),
     ]);
 
     const pages = pagesChanged + pagesDeleted;
@@ -57,10 +61,11 @@ export async function GET(_request: NextRequest) {
     const components = componentsChanged + componentsDeleted;
     const layerStyles = layerStylesChanged + layerStylesDeleted;
     const assets = assetsChanged + assetsDeleted;
-    const total = pages + collections + collectionItems + components + layerStyles + assets;
+    const translations = translationsChanged;
+    const total = pages + collections + collectionItems + components + layerStyles + assets + translations;
 
     return noCache({
-      data: { pages, collections, collectionItems, components, layerStyles, assets, total } satisfies PublishPreviewCounts,
+      data: { pages, collections, collectionItems, components, layerStyles, assets, translations, total } satisfies PublishPreviewCounts,
     });
   } catch (error) {
     console.error('Error fetching publish preview:', error);

--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -15,7 +15,7 @@ import {
 } from '@/lib/services/cacheService';
 import { findAffectedPages } from '@/lib/repositories/pageLayersRepository';
 import { dispatchSitePublishedEvent } from '@/lib/services/webhookService';
-import { getAllDraftPages, hardDeleteSoftDeletedPages } from '@/lib/repositories/pageRepository';
+import { getAllDraftPages, hardDeleteSoftDeletedPages, backfillMissingPageHashes } from '@/lib/repositories/pageRepository';
 import { publishComponents, getUnpublishedComponents, hardDeleteSoftDeletedComponents } from '@/lib/repositories/componentRepository';
 import { publishLayerStyles, getUnpublishedLayerStyles, hardDeleteSoftDeletedLayerStyles } from '@/lib/repositories/layerStyleRepository';
 import { getAllCollections } from '@/lib/repositories/collectionRepository';
@@ -157,6 +157,16 @@ export async function POST(request: NextRequest) {
     const deletedCollectionItemSlugs: Map<string, string[]> = new Map();
     const renamedPageOldRoutes: string[] = [];
     let localisationResult: PublishLocalisationResult | null = null;
+
+    // Backfill any missing content_hash values before publish so change
+    // detection and the upsert-only-when-changed paths see consistent hashes
+    // on both draft and published rows (legacy migrations and templates
+    // insert rows without computing hashes).
+    try {
+      await backfillMissingPageHashes();
+    } catch (error) {
+      console.error('[publish] Failed to backfill page hashes:', error);
+    }
 
     // Publish folders first (pages depend on them)
     {

--- a/app/(builder)/ycode/components/PublishPopover.tsx
+++ b/app/(builder)/ycode/components/PublishPopover.tsx
@@ -20,6 +20,7 @@ interface PublishPreviewCounts {
   components: number;
   layerStyles: number;
   assets: number;
+  translations: number;
   total: number;
 }
 
@@ -31,6 +32,7 @@ const BREAKDOWN_ITEMS: { key: keyof Omit<PublishPreviewCounts, 'total'>; label: 
   { key: 'collectionItems', label: 'Collection items', icon: 'database' },
   { key: 'layerStyles', label: 'Layer styles', icon: 'cube' },
   { key: 'assets', label: 'Assets', icon: 'image' },
+  { key: 'translations', label: 'Translations', icon: 'globe' },
 ];
 
 interface PublishPopoverProps {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -199,6 +199,7 @@ export const publishApi = {
     components: number;
     layerStyles: number;
     assets: number;
+    translations: number;
     total: number;
   }>> {
     return apiRequest('/ycode/api/publish/preview');

--- a/lib/repositories/layerStyleRepository.ts
+++ b/lib/repositories/layerStyleRepository.ts
@@ -759,6 +759,28 @@ export async function deleteStyle(id: string): Promise<void> {
 }
 
 /**
+ * Recursively check whether any layer in the tree references one of the
+ * given style IDs — either directly via `layer.styleId` or through a
+ * `textStyles` entry. Used to skip drafts that don't reference any of
+ * the changed styles so we don't bump their content_hash for no reason.
+ */
+function layersReferenceAnyStyle(layers: Layer[], styleIds: Set<string>): boolean {
+  for (const layer of layers) {
+    if (layer.styleId && styleIds.has(layer.styleId)) return true;
+    if (layer.textStyles) {
+      for (const ts of Object.values(layer.textStyles)) {
+        const tsStyleId = (ts as { styleId?: string })?.styleId;
+        if (tsStyleId && styleIds.has(tsStyleId)) return true;
+      }
+    }
+    if (Array.isArray(layer.children) && layer.children.length > 0) {
+      if (layersReferenceAnyStyle(layer.children, styleIds)) return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Propagate updated layer style values into the draft layers of every page
  * and component that references them.
  *
@@ -806,6 +828,8 @@ export async function syncLayerStyleChangesToDrafts(
     return { affectedPageIds: [], affectedComponentIds: [] };
   }
 
+  const styleIdSet = new Set(styles.map(s => s.id));
+
   // --- Sync draft page_layers ---
   const { data: pageLayersRecords } = await client
     .from('page_layers')
@@ -821,6 +845,16 @@ export async function syncLayerStyleChangesToDrafts(
     // style anyway, and hashing a missing `layers` field with our default
     // `[]` would diverge from whatever the original save path stored.
     if (!Array.isArray(record.layers)) continue;
+
+    // Skip drafts that don't reference any of the changed styles.
+    // Without this, recomputing the hash for unrelated drafts (e.g. those
+    // with NULL content_hash from a legacy import/template apply) bumps
+    // them into "affected" status and writes a fresh hash to the draft.
+    // The published row never sees this hash because the downstream
+    // CSS catch-up step only republishes pages found by findAffectedPages,
+    // which scans for actual style references — so the draft drifts ahead
+    // of published and getUnpublishedPages keeps flagging them.
+    if (!layersReferenceAnyStyle(record.layers as Layer[], styleIdSet)) continue;
 
     let layers = record.layers as Layer[];
     for (const style of styles) {
@@ -864,6 +898,17 @@ export async function syncLayerStyleChangesToDrafts(
     // Same guard as page_layers above: components with no layer tree have
     // nothing to sync, and forcing `[]` would diverge from the stored hash.
     if (!Array.isArray(record.layers)) continue;
+
+    // Skip components that don't reference any of the changed styles in
+    // their primary tree OR any variant tree. Same rationale as the
+    // page_layers guard above — keep over-eager hash bumps out of unrelated
+    // components.
+    const variantsList = Array.isArray(record.variants) ? (record.variants as ComponentVariant[]) : [];
+    const primaryReferences = layersReferenceAnyStyle(record.layers as Layer[], styleIdSet);
+    const variantReferences = variantsList.some(
+      v => Array.isArray(v.layers) && layersReferenceAnyStyle(v.layers as Layer[], styleIdSet),
+    );
+    if (!primaryReferences && !variantReferences) continue;
 
     let layers = record.layers as Layer[];
     for (const style of styles) {

--- a/lib/repositories/pageRepository.ts
+++ b/lib/repositories/pageRepository.ts
@@ -9,7 +9,7 @@ import { reorderSiblings } from '@/lib/repositories/pageFolderRepository';
 import type { Page, PageSettings } from '../../types';
 import { isHomepage } from '../page-utils';
 import { incrementSiblingOrders, fixOrphanedPageSlugs } from '../services/pageService';
-import { generatePageMetadataHash } from '../hash-utils';
+import { generatePageMetadataHash, generatePageLayersHash } from '../hash-utils';
 
 /**
  * Query filters for page lookups
@@ -902,10 +902,100 @@ export async function duplicatePage(pageId: string): Promise<Page> {
 }
 
 /**
+ * Backfill missing `content_hash` on pages and page_layers (draft + published).
+ *
+ * Legacy migrations and template applies insert rows without computing a hash,
+ * which leaves `content_hash` as NULL. Without backfill, draft hashes get
+ * computed lazily on edit while published hashes stay NULL, causing change
+ * detection to report false positives forever.
+ *
+ * Safe to call repeatedly — converges to a no-op once all rows have a hash.
+ */
+export async function backfillMissingPageHashes(): Promise<{
+  pagesUpdated: number;
+  layersUpdated: number;
+}> {
+  const client = await getSupabaseAdmin();
+  if (!client) return { pagesUpdated: 0, layersUpdated: 0 };
+
+  let pagesUpdated = 0;
+  let layersUpdated = 0;
+
+  const { data: pagesToBackfill } = await client
+    .from('pages')
+    .select('*')
+    .is('content_hash', null)
+    .is('deleted_at', null);
+
+  if (pagesToBackfill && pagesToBackfill.length > 0) {
+    const upsertRows = pagesToBackfill.map((page) => ({
+      ...page,
+      content_hash: generatePageMetadataHash({
+        name: page.name,
+        slug: page.slug,
+        settings: page.settings || {},
+        is_index: page.is_index || false,
+        is_dynamic: page.is_dynamic || false,
+        error_page: page.error_page ?? null,
+      }),
+    }));
+
+    const { error } = await client
+      .from('pages')
+      .upsert(upsertRows, { onConflict: 'id,is_published' });
+
+    if (!error) {
+      pagesUpdated = upsertRows.length;
+    } else {
+      console.error('Failed to backfill page content_hash:', error);
+    }
+  }
+
+  const { data: layersToBackfill } = await client
+    .from('page_layers')
+    .select('*')
+    .is('content_hash', null)
+    .is('deleted_at', null);
+
+  if (layersToBackfill && layersToBackfill.length > 0) {
+    const upsertRows = layersToBackfill.map((row) => ({
+      ...row,
+      content_hash: generatePageLayersHash({
+        layers: row.layers || [],
+        generated_css: row.generated_css ?? null,
+      }),
+    }));
+
+    const { error } = await client
+      .from('page_layers')
+      .upsert(upsertRows, { onConflict: 'id,is_published' });
+
+    if (!error) {
+      layersUpdated = upsertRows.length;
+    } else {
+      console.error('Failed to backfill page_layers content_hash:', error);
+    }
+  }
+
+  return { pagesUpdated, layersUpdated };
+}
+
+/**
+ * Treat a null on either side as "unchanged" — null hashes are pre-backfill
+ * legacy rows that will be repaired on the next backfill pass, not real diffs.
+ */
+function hashesDiffer(a: string | null, b: string | null): boolean {
+  if (a === null || b === null) return false;
+  return a !== b;
+}
+
+/**
  * Get count of unpublished pages efficiently.
  * Uses 2 bulk queries instead of N+1 per-page lookups.
  */
 export async function getUnpublishedPagesCount(): Promise<number> {
+  await backfillMissingPageHashes();
+
   const client = await getSupabaseAdmin();
 
   if (!client) {
@@ -962,10 +1052,12 @@ export async function getUnpublishedPagesCount(): Promise<number> {
       continue;
     }
 
-    const pageMetadataChanged = draft.content_hash !== pub.content_hash;
+    const pageMetadataChanged = hashesDiffer(draft.content_hash, pub.content_hash);
 
-    const layersChanged =
-      (draft.page_layers[0]?.content_hash ?? null) !== pub.layerHash;
+    const layersChanged = hashesDiffer(
+      draft.page_layers[0]?.content_hash ?? null,
+      pub.layerHash
+    );
 
     const folderChanged = draft.page_folder_id !== pub.page_folder_id;
 
@@ -986,70 +1078,72 @@ export async function getUnpublishedPagesCount(): Promise<number> {
  * Uses content_hash for efficient change detection
  */
 export async function getUnpublishedPages(): Promise<Page[]> {
+  await backfillMissingPageHashes();
+
   const client = await getSupabaseAdmin();
 
   if (!client) {
     throw new Error('Supabase not configured');
   }
 
-  // Get all draft pages with their layers' content_hash in a single efficient query
-  const { data: draftPagesWithLayers, error } = await client
-    .from('pages')
-    .select(`
-      *,
-      page_layers!inner(content_hash)
-    `)
-    .eq('is_published', false)
-    .eq('page_layers.is_published', false)
-    .is('deleted_at', null)
-    .is('page_layers.deleted_at', null)
-    .order('created_at', { ascending: false });
+  const [draftResult, publishedResult] = await Promise.all([
+    client
+      .from('pages')
+      .select('*, page_layers!inner(content_hash)')
+      .eq('is_published', false)
+      .eq('page_layers.is_published', false)
+      .is('deleted_at', null)
+      .is('page_layers.deleted_at', null)
+      .order('created_at', { ascending: false }),
+    client
+      .from('pages')
+      .select('id, content_hash, page_folder_id, page_layers!inner(content_hash)')
+      .eq('is_published', true)
+      .eq('page_layers.is_published', true)
+      .is('deleted_at', null)
+      .is('page_layers.deleted_at', null),
+  ]);
 
-  if (error) {
-    throw new Error(`Failed to fetch draft pages: ${error.message}`);
+  if (draftResult.error) {
+    throw new Error(`Failed to fetch draft pages: ${draftResult.error.message}`);
   }
 
-  if (!draftPagesWithLayers || draftPagesWithLayers.length === 0) {
+  if (!draftResult.data || draftResult.data.length === 0) {
     return [];
+  }
+
+  const publishedMap = new Map<string, {
+    content_hash: string | null;
+    page_folder_id: string | null;
+    layerHash: string | null;
+  }>();
+  for (const pub of publishedResult.data || []) {
+    publishedMap.set(pub.id, {
+      content_hash: pub.content_hash,
+      page_folder_id: pub.page_folder_id,
+      layerHash: pub.page_layers[0]?.content_hash ?? null,
+    });
   }
 
   const unpublishedPages: Page[] = [];
 
-  // Check each draft page
-  for (const draftPage of draftPagesWithLayers) {
-    // Check if a published version exists
-    const { data: publishedPageWithLayers } = await client
-      .from('pages')
-      .select(`
-        id,
-        content_hash,
-        page_folder_id,
-        page_layers!inner(content_hash)
-      `)
-      .eq('id', draftPage.id)
-      .eq('is_published', true)
-      .eq('page_layers.is_published', true)
-      .is('deleted_at', null)
-      .is('page_layers.deleted_at', null)
-      .single();
+  for (const draftPage of draftResult.data) {
+    const pub = publishedMap.get(draftPage.id);
 
-    // If no published version exists, needs first-time publishing
-    if (!publishedPageWithLayers) {
+    if (!pub) {
       unpublishedPages.push(draftPage);
       continue;
     }
 
-    const pageMetadataChanged =
-      draftPage.content_hash !== publishedPageWithLayers.content_hash;
+    const pageMetadataChanged = hashesDiffer(draftPage.content_hash, pub.content_hash);
 
-    const layersChanged =
-      (draftPage.page_layers[0]?.content_hash ?? null) !==
-      (publishedPageWithLayers.page_layers[0]?.content_hash ?? null);
+    const layersChanged = hashesDiffer(
+      draftPage.page_layers[0]?.content_hash ?? null,
+      pub.layerHash
+    );
 
-    // Check if page was moved to a different folder
-    const folderChanged = draftPage.page_folder_id !== publishedPageWithLayers.page_folder_id;
+    const folderChanged = draftPage.page_folder_id !== pub.page_folder_id;
 
-    // If any of these changed, needs republishing
     if (pageMetadataChanged || layersChanged || folderChanged) {
       unpublishedPages.push(draftPage);
     }

--- a/lib/repositories/translationRepository.ts
+++ b/lib/repositories/translationRepository.ts
@@ -6,7 +6,13 @@
  */
 
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { fetchAllRows } from '@/lib/supabase-constants';
 import type { Translation, CreateTranslationData, UpdateTranslationData } from '@/types';
+
+type TranslationDiffRow = Pick<
+  Translation,
+  'id' | 'content_value' | 'is_completed' | 'deleted_at'
+>;
 
 /**
  * Get all translations for a locale (draft by default). Pages through the
@@ -363,4 +369,67 @@ export async function upsertTranslations(
   }
 
   return data || [];
+}
+
+/**
+ * Count translations needing publish: drafts with no published counterpart,
+ * pending soft-deletes, or rows whose content_value/is_completed differs from
+ * published. Mirrors the diff logic in `publishLocalisation` so the preview
+ * matches what will actually publish. Paginates both sides to avoid the
+ * 1000-row PostgREST default silently truncating the count.
+ */
+export async function getUnpublishedTranslationsCount(): Promise<number> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    return 0;
+  }
+
+  const cols = 'id, content_value, is_completed, deleted_at';
+
+  // Order by id so .range() pagination is deterministic — without an ORDER BY
+  // PostgREST returns rows in arbitrary order between pages, which causes
+  // duplicates and gaps when paging tens of thousands of translations, leading
+  // to spurious "missing in published map" hits and inflated change counts.
+  const [draftRows, publishedRows] = await Promise.all([
+    fetchAllRows<TranslationDiffRow>((from, to) =>
+      client.from('translations').select(cols).eq('is_published', false).order('id', { ascending: true }).range(from, to)
+    ),
+    fetchAllRows<TranslationDiffRow>((from, to) =>
+      client.from('translations').select(cols).eq('is_published', true).order('id', { ascending: true }).range(from, to)
+    ),
+  ]);
+
+  if (draftRows.length === 0) {
+    return 0;
+  }
+
+  const publishedById = new Map<string, TranslationDiffRow>();
+  for (const t of publishedRows) {
+    publishedById.set(t.id, t);
+  }
+
+  let count = 0;
+  for (const draft of draftRows) {
+    const pub = publishedById.get(draft.id);
+
+    if (!pub || pub.deleted_at) {
+      if (!draft.deleted_at) count++;
+      continue;
+    }
+
+    if (draft.deleted_at) {
+      count++;
+      continue;
+    }
+
+    if (
+      draft.content_value !== pub.content_value ||
+      draft.is_completed !== pub.is_completed
+    ) {
+      count++;
+    }
+  }
+
+  return count;
 }

--- a/lib/supabase-constants.ts
+++ b/lib/supabase-constants.ts
@@ -17,3 +17,23 @@ export const SUPABASE_QUERY_LIMIT = 1000;
  * Smaller to avoid Supabase URL length limits on write operations.
  */
 export const SUPABASE_WRITE_BATCH_SIZE = 100;
+
+/**
+ * Page through a Supabase SELECT past the 1000-row default cap.
+ * `buildPage(from, to)` must return a fresh query each call (Supabase
+ * builders aren't reusable). Stops on error or short page.
+ */
+export async function fetchAllRows<T>(
+  buildPage: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: unknown }>,
+  pageSize: number = SUPABASE_QUERY_LIMIT,
+): Promise<T[]> {
+  const all: T[] = [];
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await buildPage(from, from + pageSize - 1);
+    if (error) throw error;
+    if (!data || data.length === 0) break;
+    all.push(...data);
+    if (data.length < pageSize) break;
+  }
+  return all;
+}


### PR DESCRIPTION
## Summary

After publishing, the change-detection popover kept reporting pages and translations as unpublished even when nothing had actually changed. The root cause was a mix of NULL `content_hash` values left by legacy data, over-eager hash bumps in the layer-style sync step, and non-deterministic `.range()` pagination on translations.

## Changes

- Self-heal NULL `content_hash` on pages and `page_layers` via a `backfillMissingPageHashes` helper, called from `getUnpublishedPages` / `getUnpublishedPagesCount` and at the top of the publish endpoint. Legacy migrations and template applies insert rows without a hash, so drafts get one on first edit while published rows stay NULL — the mismatch then reports forever.
- Make page change detection null-tolerant so a missing hash on either side counts as "unchanged" instead of "changed".
- Stop `syncLayerStyleChangesToDrafts` from recomputing the hash on drafts that don't reference any of the changed styles, which used to push draft hashes ahead of published for no reason.
- Add a translations count to the publish preview, mirroring the diff logic in `publishLocalisation`.
- Order paginated translation reads by `id` so `.range()` is deterministic — without it, projects with >1000 translations got duplicates and gaps between pages and the count was inflated by hundreds of false hits.
- Backport `fetchAllRows` helper from cloud into `lib/supabase-constants.ts` so the new count function can page past the 1000-row PostgREST default.

## Test plan

- [ ] On a project with no draft edits, open the publish popover — all counts (including translations) should be 0.
- [ ] Apply a template to a fresh project, then open the publish popover before any edits — no pages should be flagged as changed.
- [ ] Edit one layer style used by a single page, click publish — only that page should appear in the next change preview (not every page in the project).
- [ ] Publish, then immediately reopen the popover — total should drop to 0.
- [ ] On a project with >1000 translations, verify the translations count is accurate (not inflated).

Made with [Cursor](https://cursor.com)