### PR TITLE
fix: render filtered collection items consistently across canvas and preview

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1321,6 +1321,7 @@ const LayerItemImpl: React.FC<{
     // Apply collection filters (evaluate against each item's own values)
     // In edit mode, skip conditions that have inputLayerId (dynamic filter inputs have no value at design time)
     const collectionFilters = collectionVariable?.filters;
+    const hasStaticFilters = !!collectionFilters?.groups?.some(g => g.conditions.some(c => !c.inputLayerId));
     if (collectionFilters?.groups?.length) {
       const effectiveFilters = isEditMode
         ? {
@@ -1345,8 +1346,19 @@ const LayerItemImpl: React.FC<{
       }
     }
 
+    // Mirror SSR semantics: when static filters are present we fetch all items
+    // (no API limit/offset) so filtering happens on the full set. Re-apply the
+    // configured limit/offset here so the canvas shows the same items as preview.
+    if (hasStaticFilters) {
+      const offset = collectionVariable?.offset ?? 0;
+      const limit = collectionVariable?.limit;
+      if (offset || limit) {
+        items = items.slice(offset, limit ? offset + limit : undefined);
+      }
+    }
+
     return items;
-  }, [collectionId, allCollectionItems, sourceFieldId, sourceFieldType, sourceFieldSource, collectionLayerData, pageCollectionItemData, collectionLayerItemId, pageCollectionItemId, getAsset, collectionVariable?.filters, isEditMode]);
+  }, [collectionId, allCollectionItems, sourceFieldId, sourceFieldType, sourceFieldSource, collectionLayerData, pageCollectionItemData, collectionLayerItemId, pageCollectionItemId, getAsset, collectionVariable?.filters, collectionVariable?.limit, collectionVariable?.offset, isEditMode]);
 
   const optionsSourceSort = layer.settings?.optionsSource;
 
@@ -1402,13 +1414,23 @@ const LayerItemImpl: React.FC<{
       }
     }
 
+    // When static filters are present, fetch the full set so client-side
+    // filtering matches SSR (which filters then limits). The API's default
+    // `limit=25` would otherwise return a page of items that all fail the
+    // filter (e.g. all past events for a "date >= today" filter), hiding the
+    // layer. Mirrors the per-collection cap used by SSR's collection cache.
+    const FILTERED_FETCH_LIMIT = 5000;
+    const hasStaticFilters = !!collectionVariable.filters?.groups?.some(
+      g => g.conditions.some(c => !c.inputLayerId)
+    );
+
     fetchLayerData(
       layer.id,
       collectionVariable.id,
       sortBy,
       sortOrder,
-      collectionVariable.limit,
-      collectionVariable.offset
+      hasStaticFilters ? FILTERED_FETCH_LIMIT : collectionVariable.limit,
+      hasStaticFilters ? 0 : collectionVariable.offset
     );
   }, [
     isEditMode,
@@ -1420,6 +1442,7 @@ const LayerItemImpl: React.FC<{
     collectionVariable?.sort_order_inputLayerId,
     collectionVariable?.limit,
     collectionVariable?.offset,
+    collectionVariable?.filters,
     optionsSourceSort?.sortFieldId,
     optionsSourceSort?.sortOrder,
     sortByInputDefaultValue,

--- a/hooks/use-canvas-slider.ts
+++ b/hooks/use-canvas-slider.ts
@@ -8,12 +8,26 @@
  * Swiper JS is bundled and initialized here per-slider instance.
  */
 
-import { useEffect, useRef, useMemo } from 'react';
+import { useEffect, useRef, useMemo, useState } from 'react';
 import Swiper from 'swiper';
 import type { Layer, SliderSettings } from '@/types';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { DEFAULT_SLIDER_SETTINGS } from '@/lib/slider-constants';
 import { buildCanvasSwiperOptions, applySwiperEasing } from '@/lib/slider-utils';
+
+/**
+ * Count the real (non-duplicate) swiper-slide DOM children inside the
+ * given slider element. Used to detect when collection-backed slides
+ * arrive after the initial Swiper init, so we can recreate Swiper with
+ * the right slide count (and avoid the "not enough slides for loop" warning).
+ */
+function countRealSlides(sliderEl: HTMLElement): number {
+  const wrapper = sliderEl.querySelector('.swiper-wrapper');
+  if (!wrapper) return 0;
+  return wrapper.querySelectorAll(
+    ':scope > .swiper-slide:not(.swiper-slide-duplicate)',
+  ).length;
+}
 
 /** Registry of active Swiper instances and their layer refs */
 const swiperRegistry = new Map<string, { swiper: Swiper; layerRef: React.RefObject<Layer> }>();
@@ -101,9 +115,58 @@ export function useCanvasSlider(
   const settingsRef = useRef(settings);
   useEffect(() => { settingsRef.current = settings; });
 
+  // Track the real (non-duplicate) swiper-slide count in the DOM. Collection-
+  // backed slides expand asynchronously after data fetches, so the count we
+  // see at first init is often 0. Within the init effect we use this only
+  // through `initBucket` (below) so Swiper is recreated when transitioning
+  // between "no slides", "too few for loop", and "enough" — not on every
+  // single add/remove (those still go through the wrapper observer's
+  // swiper.update()).
+  const [slideCount, setSlideCount] = useState(0);
+
+  useEffect(() => {
+    if (!isSlider || !elementRef.current) return;
+    const el = elementRef.current;
+
+    const measure = () => setSlideCount(countRealSlides(el));
+    measure();
+
+    const ObsCtor = el.ownerDocument.defaultView?.MutationObserver;
+    if (!ObsCtor) return;
+
+    let raf: number | undefined;
+    const observer = new ObsCtor(() => {
+      if (raf) cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(measure);
+    });
+    observer.observe(el, { childList: true, subtree: true });
+
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      observer.disconnect();
+    };
+  }, [isSlider, elementRef]);
+
+  // Bucket the slide count so we only force a Swiper reinit when transitions
+  // matter (no slides → some, or insufficient → enough for loop). Within
+  // the same bucket, slide add/remove is handled by swiper.update().
+  // Loop requires at least `slidesPerView + slidesPerGroup` slides; with
+  // slidesPerView='auto' the safest conservative threshold is 2.
+  const needsLoop = settings.loop === 'loop';
+  const minSlidesForLoop = Math.max(2, (settings.slidesPerGroup || 1) + 1);
+  const initBucket = slideCount === 0
+    ? 'empty'
+    : needsLoop && slideCount < minSlidesForLoop
+      ? 'too-few-for-loop'
+      : 'ok';
+
   // Initialize / destroy Swiper when the slider mounts or settings change
   useEffect(() => {
     if (!isSlider || !elementRef.current) return;
+    // Skip init when no slides exist yet (e.g. collection-backed slides
+    // still loading). The slideCount effect above will bump the bucket
+    // once slides arrive, retriggering this effect.
+    if (initBucket === 'empty') return;
 
     const el = elementRef.current;
 
@@ -251,7 +314,7 @@ export function useCanvasSlider(
       swiperRef.current = null;
       setSliderAnimating(false);
     };
-  }, [isSlider, elementRef, settingsKey, layer.id]);
+  }, [isSlider, elementRef, settingsKey, layer.id, initBucket]);
 
   // Navigate to the slide containing the selected layer
   useEffect(() => {

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -11,7 +11,7 @@ import { applyComponentOverrides } from '@/lib/resolve-components';
 import { getComponentVariantLayers } from '@/lib/component-variant-utils';
 import { resolveFieldFromSources } from '@/lib/cms-variables-utils';
 import { compareDateFilter, isDateFieldType, isDatePreset, resolveDateFilterValue } from '@/lib/collection-field-utils';
-import { parseMultiReferenceValue } from '@/lib/collection-utils';
+import { parseMultiReferenceValue, normalizeBooleanValue } from '@/lib/collection-utils';
 import { getInheritedValue } from '@/lib/tailwind-class-mapper';
 import cloneDeep from 'lodash/cloneDeep';
 import { layerHasLink, hasLinkInTree, hasRichTextLinks } from '@/lib/link-utils';
@@ -2010,7 +2010,10 @@ function evaluateCondition(
       // Text operators
       case 'is':
         if (fieldType === 'boolean') {
-          return value.toLowerCase() === compareValue.toLowerCase();
+          // Booleans may be stored as 'true'/'false', '1'/'0', or '' (depending
+          // on import source — UI, Airtable sync, CSV, etc.). Normalize both
+          // sides so the comparison is source-agnostic.
+          return normalizeBooleanValue(value) === normalizeBooleanValue(compareValue);
         }
         if (fieldType === 'number') {
           return parseFloat(value) === parseFloat(compareValue);
@@ -2021,6 +2024,9 @@ function evaluateCondition(
         return value === compareValue;
 
       case 'is_not':
+        if (fieldType === 'boolean') {
+          return normalizeBooleanValue(value) !== normalizeBooleanValue(compareValue);
+        }
         if (fieldType === 'number') {
           return parseFloat(value) !== parseFloat(compareValue);
         }

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -1955,21 +1955,32 @@ async function buildCollectionCache(
     }
   }
 
-  // Phase 2: Fetch ref collection fields + ALL items in parallel
+  // Phase 2: Fetch ref collection fields + items in parallel.
+  // Items are fetched per-collection because a single `.in('collection_id', [...])`
+  // query is bounded by Supabase/PostgREST's `db-max-rows` setting (often 1000),
+  // so a large collection can starve smaller ones in the same page.
   const allCollIds = [...ids, ...refCollectionIds];
+  const PER_COLLECTION_LIMIT = 5000;
 
-  let itemsQuery = client
-    .from('collection_items')
-    .select('*')
-    .in('collection_id', allCollIds)
-    .eq('is_published', isPublished)
-    .is('deleted_at', null)
-    .order('manual_order', { ascending: true })
-    .order('created_at', { ascending: false })
-    .limit(5000);
-  if (isPublished) {
-    itemsQuery = itemsQuery.eq('is_publishable', true);
-  }
+  const buildItemsQuery = (collectionId: string) => {
+    let q = client
+      .from('collection_items')
+      .select('*')
+      .eq('collection_id', collectionId)
+      .eq('is_published', isPublished)
+      .is('deleted_at', null)
+      .order('manual_order', { ascending: true })
+      .order('created_at', { ascending: false })
+      .limit(PER_COLLECTION_LIMIT);
+    if (isPublished) q = q.eq('is_publishable', true);
+    return q;
+  };
+
+  const itemsPromise = Promise.all(allCollIds.map(buildItemsQuery))
+    .then(results => ({
+      data: results.flatMap(r => r.data || []),
+      error: results.find(r => r.error)?.error,
+    }));
 
   const refFieldsPromise = refCollectionIds.length > 0
     ? client.from('collection_fields').select('*')
@@ -1981,7 +1992,7 @@ async function buildCollectionCache(
       .limit(5000)
     : Promise.resolve({ data: [] as any[] });
 
-  const [{ data: itemsData }, { data: refFieldsRaw }] = await Promise.all([itemsQuery, refFieldsPromise]);
+  const [{ data: itemsData }, { data: refFieldsRaw }] = await Promise.all([itemsPromise, refFieldsPromise]);
 
   // Build field structures
   const allFieldsData = [...(fieldsData || []), ...(refFieldsRaw || [])];


### PR DESCRIPTION
## Summary

Filtered collections behaved inconsistently between the editor canvas and the rendered preview/published page. This consolidates the rendering pipeline so the canvas mirrors what visitors actually see, fixes a server-side starvation bug when a page contains many large collections, and makes boolean visibility conditions tolerant of how items were imported.

## Changes

- **Per-collection item fetch in SSR.** The collection cache used a single `.in('collection_id', [...])` query capped at 1,000 rows by PostgREST's `db-max-rows`. A single large collection (e.g. 1,100+ Airtable-synced events) consumed the full result, leaving every other collection on the page empty — including sliders that then rendered with no slides. Items are now fetched per-collection in parallel with their own per-collection cap.
- **Reinit canvas Swiper when slides arrive.** Collection-backed slides expand asynchronously after data loads. The Swiper instance was created with zero slides on first paint, triggering the "not enough slides for loop mode" warning and breaking loop/autoplay. The hook now tracks the live slide count and recreates Swiper when the count transitions between "empty", "too few for loop", and "enough".
- **Match SSR filter ordering on the canvas.** SSR fetches all items, applies static filters, then limits. The canvas was doing the opposite (limit then filter), so a layer like "next 4 events with date ≥ today" sorted ascending would fetch 4 past events and filter them all out, hiding the layer entirely. The canvas now fetches the full set when static filters are present and re-applies `limit`/`offset` after filtering.
- **Normalize boolean comparisons in visibility conditions.** Booleans live in `collection_item_values` as `'true'`/`'false'` (UI), `'true'`/`''` (Airtable sync), or `'1'`/`'0'` (other imports). The `is`/`is_not` operators did a raw string compare, so `'' is false` returned false and conditional layers were silently hidden. Both sides now run through the existing `normalizeBooleanValue` helper.

## Test plan

- [ ] Open a page whose draft contains 1,000+ items in one collection and a slider bound to a different, smaller collection — slider renders its slides in preview
- [ ] Reload the canvas with a collection-backed slider on a fresh draft — Swiper initializes once the slides arrive, no "not enough slides" warning, loop/autoplay work
- [ ] Bind a slider/list to a collection with a "date is after \$today" filter sorted ascending — canvas and preview show the same upcoming items (not "No collection items")
- [ ] On a collection item where the boolean field came from an Airtable sync (stored as `''`) and another stored as `'false'` — a layer with visibility "boolean is false" renders in both cases
- [ ] On the same items, a layer with visibility "boolean is true" stays hidden

Made with [Cursor](https://cursor.com)