### PR TITLE
fix(static-export): on-load interactions, component-publish propagation, hung export spinner

### DIFF
--- a/app/(builder)/ycode/api/apps/static-export/export/route.ts
+++ b/app/(builder)/ycode/api/apps/static-export/export/route.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from 'crypto';
+
 import { NextRequest } from 'next/server';
-import { exportSite } from '@/lib/apps/static-export';
+import { exportSite, saveLastExportJob } from '@/lib/apps/static-export';
 import { noCache } from '@/lib/api-response';
 
 export const dynamic = 'force-dynamic';
@@ -15,18 +17,40 @@ export const revalidate = 0;
  */
 export async function POST(_request: NextRequest) {
   try {
-    // Start the export — fire it off without awaiting for the HTTP response.
-    // The engine persists the terminal job to app_settings, so we don't
-    // need any module-scope state here (which would never survive across
-    // serverless isolates anyway).
-    exportSite().catch((err) => {
-      console.error('[Static Export] Export job failed:', err);
+    // Generate the job id in the route handler and persist the `running`
+    // job synchronously BEFORE returning. The client polls /status by
+    // job id; if we let the engine generate it on its own (deferred via
+    // setImmediate), the client's initial /status fetch races ahead of
+    // the engine's first write and pulls the previous completed job —
+    // it then polls that stale id forever.
+    const jobId = randomUUID();
+    const startedAt = new Date().toISOString();
+
+    await saveLastExportJob({
+      id: jobId,
+      status: 'running',
+      startedAt,
+      completedAt: null,
+      error: null,
+      pagesExported: 0,
+      filesWritten: 0,
+    }).catch(() => { /* non-fatal — engine will retry the write */ });
+
+    // Detach via setImmediate so the engine Promise isn't part of the
+    // request's async context. Without this, Next.js / the Node runtime
+    // keeps the response stream open until the engine settles, leaving
+    // the client `await response.json()` hanging.
+    setImmediate(() => {
+      exportSite(jobId).catch((err) => {
+        console.error('[Static Export] Export job failed:', err);
+      });
     });
 
     return noCache({
       data: {
         message: 'Export started',
         status: 'running',
+        jobId,
       },
     });
   } catch (error) {

--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -613,9 +613,13 @@ export async function POST(request: NextRequest) {
           const { generateCSSForPages } = await import('@/lib/server/cssGenerator');
           await generateCSSForPages(cssAffectedPageIds);
 
-          // Re-publish layers for these pages so published version has fresh CSS
+          // Re-publish layers for these pages so published version has fresh CSS.
+          // force=true: the draft layers' JSONB still references the changed
+          // component/style by ID, so content_hash is unchanged even though
+          // the resolved/rendered output differs. Without force, downstream
+          // consumers (static export, GitHub writer) see stale data.
           const { batchPublishPageLayers } = await import('@/lib/repositories/pageLayersRepository');
-          const relayerResult = await batchPublishPageLayers(cssAffectedPageIds);
+          const relayerResult = await batchPublishPageLayers(cssAffectedPageIds, { force: true });
           if (relayerResult.changedPageIds.length > 0) {
             publishedPageIds.push(...relayerResult.changedPageIds);
             console.log(`[Cache] CSS catch-up: republished ${relayerResult.changedPageIds.length} page layer(s)`);

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -295,8 +295,22 @@ const INTERACTIONS_BOOT_SCRIPT = `
     });
   }
 
+  function applyLoadTriggers() {
+    interactions.forEach(function (i) {
+      if (i.trigger !== 'load') return;
+      if (!matchesBreakpoint(i.breakpoints)) return;
+      i.tweens.forEach(function (t) {
+        var target = getEl(t.targetLayerId);
+        if (!target) return;
+        var value = t.toDisplay || t.fromDisplay;
+        if (value) setDisplay(target, value);
+      });
+    });
+  }
+
   function boot() {
     applyOnLoad();
+    applyLoadTriggers();
     window.addEventListener('resize', applyOnLoad);
 
     interactions.forEach(function (i) {

--- a/lib/apps/static-export/engine.ts
+++ b/lib/apps/static-export/engine.ts
@@ -96,8 +96,8 @@ async function resolvePageOgImage(page: Page): Promise<string | null> {
   }
 }
 
-export async function exportSite(): Promise<ExportJob> {
-  const jobId = randomUUID()
+export async function exportSite(presetJobId?: string): Promise<ExportJob> {
+  const jobId = presetJobId ?? randomUUID()
   const job: ExportJob = {
     id: jobId,
     status: 'running',

--- a/lib/apps/static-export/index.ts
+++ b/lib/apps/static-export/index.ts
@@ -15,6 +15,6 @@
  *   - engine.ts          — orchestration (exportSite)
  */
 
-export { APP_ID, getExportConfig, saveExportConfig, getLastExportJob } from './config'
+export { APP_ID, getExportConfig, saveExportConfig, getLastExportJob, saveLastExportJob } from './config'
 export { exportSite } from './engine'
 export { computeOutputKey } from './paths'

--- a/lib/repositories/pageLayersRepository.ts
+++ b/lib/repositories/pageLayersRepository.ts
@@ -414,7 +414,10 @@ export async function publishPageLayers(draftPageId: string, publishedPageId: st
  * @param pageIds - Array of page IDs to publish layers for
  * @returns Object with count and the page IDs that actually changed
  */
-export async function batchPublishPageLayers(pageIds: string[]): Promise<{ count: number; changedPageIds: string[] }> {
+export async function batchPublishPageLayers(
+  pageIds: string[],
+  options: { force?: boolean } = {},
+): Promise<{ count: number; changedPageIds: string[] }> {
   if (pageIds.length === 0) {
     return { count: 0, changedPageIds: [] };
   }
@@ -454,8 +457,13 @@ export async function batchPublishPageLayers(pageIds: string[]): Promise<{ count
   for (const draft of draftLayers) {
     const existing = publishedById.get(draft.id);
 
-    // Only include if new or content_hash changed
-    if (!existing || existing.content_hash !== draft.content_hash) {
+    // Skip the content_hash equality check when forced. The catch-up path
+    // for component/style changes calls this with force=true because the
+    // draft layers' JSONB still references the component by ID (so the
+    // hash is unchanged) even though the resolved/rendered output now
+    // differs. Without force, the static export reads stale published
+    // layers and downstream writers (GitHub) see an empty diff.
+    if (options.force || !existing || existing.content_hash !== draft.content_hash) {
       layersToUpsert.push({
         id: draft.id,
         page_id: draft.page_id,


### PR DESCRIPTION
## Summary

Three related bugs surfaced while wiring up a mobile menu hamburger via the new Static Export. Each fix exposes the next, so they ship as one PR. All three are confirmed fixed end-to-end on a real self-hosted instance.

## Changes

### 1. `trigger: 'load'` interactions ignored in the static export
The export runtime's interactions boot script only handled `click`. Tweens under a Page-Load trigger were collected into the per-page JSON blob but never applied to the DOM. The editor / preview path runs them via GSAP's `AnimationInitializer`, so the discrepancy only showed up in exported HTML.

Added `applyLoadTriggers()` alongside the existing on-load CSS step. For each load-trigger interaction whose breakpoint matches, walks the tweens and sets `toDisplay` (falling back to `fromDisplay`) on each target via the existing `setDisplay` helper.

### 2. Component-only publishes didn't propagate to downstream consumers
When a publish only contained component changes (no direct page edits), the publish route ran the indirect catch-up at `api/publish/route.ts`. `findAffectedPages` correctly identified the pages referencing the changed component, `generateCSSForPages` regenerated CSS, then `batchPublishPageLayers` was supposed to re-emit those pages' published layer rows.

But `batchPublishPageLayers` skipped pages where `draft.content_hash === existing.content_hash` — and the draft layers' JSONB still contains the same component **id**. The component's internal layers changed; the page's reference to it didn't, so the content hash never moved. Catch-up returned `changedPageIds: []`, published `page_layers` stayed stale, and the static export read stale data. Observed downstream: the GitHub writer correctly detected "no diff" and skipped the commit, so nothing landed at the destination — even though the job reported `pagesExported: 7, filesWritten: 55`.

Added an opt-in `options.force` flag to `batchPublishPageLayers` that bypasses the hash equality skip, and threaded `{ force: true }` through the publish route's component/style catch-up call site only. The explicit page-publish path keeps its hash gate untouched.

### 3. Export Now spinner hung even after the engine completed
The export route called `exportSite().catch(...)` without `await` and returned `{ status: 'running' }`. Even though the response object was built immediately, Node / Next held the response stream open until the unawaited Promise settled — about 7 seconds for the test export. The client's `await response.json()` never resolved, so the spinner state never cleared.

Detaching via `setImmediate` released the response stream, but then exposed a race with the status-polling UI: the engine generated its own job id and persisted the `running` record *after* the client had already fetched `/status` to discover the id. The client locked onto the **previous** completed job's id and polled it forever.

Final shape:
- `exportSite()` accepts an optional `presetJobId` and reuses it if passed.
- The route generates the id, persists the `running` job synchronously **before** responding, detaches the engine via `setImmediate(() => exportSite(jobId))`, and includes `jobId` in the response body so future client code can skip the follow-up `/status` round-trip.

This eliminates both the hung-fetch symptom (response closes promptly) and the stale-id symptom (the running record exists before the client can read it).

## Test plan

- [x] **Bug 1** — Add a Page-Load → Set Display → Hidden interaction on a layer (e.g. mobile menu block), publish, run Export Now, open exported HTML, confirm the layer renders hidden without GSAP.
- [x] **Bug 2** — Edit only a component (no page-level changes). Publish — log should show `[Cache] CSS catch-up: republished N page layer(s)`. Run Export Now with a GitHub writer configured — confirm the destination receives a non-empty commit reflecting the change.
- [x] **Bug 3** — Click Export Now. Spinner appears, polling fires at ~1.5s cadence, spinner clears within ~1.5s of the engine actually completing (visible via toast). Repeat several times — polling should always converge.
- [x] `npm run type-check` passes.
- [x] Existing click-toggle interactions still work in exported HTML (regression check).
- [x] Page-only publishes still take the normal path (regression check on the `force` flag — only catch-up call passes `force: true`).

## Compatibility / risk

- **Backwards compatible.** `batchPublishPageLayers(pageIds)` works unchanged; the new `options.force` defaults to `false`. `exportSite()` works unchanged; the new `presetJobId` defaults to `randomUUID()`.
- **No schema changes**, no new env vars.
- The response shape from `POST /ycode/api/apps/static-export/export` gains a `jobId` field — purely additive.

🤖 Co-authored with [Claude Code](https://claude.com/claude-code). Disclosure for review transparency.