### PR TITLE
fix: prevent intro animation flicker on page load

### DIFF
--- a/app/(builder)/ycode/components/InteractionsPanel.tsx
+++ b/app/(builder)/ycode/components/InteractionsPanel.tsx
@@ -67,6 +67,8 @@ import {
   buildGsapProps,
   addTweenToTimeline,
   createSplitTextAnimation,
+  getDefaultApplyStyles,
+  getEffectiveApplyStyle,
   updateInteractionById,
   updateInteractionTweens,
   updateTweenById,
@@ -948,16 +950,7 @@ export default function InteractionsPanel({
       ease: 'power1.out',
       from: {},
       to: {},
-      apply_styles: {
-        x: 'on-trigger',
-        y: 'on-trigger',
-        rotation: 'on-trigger',
-        scale: 'on-trigger',
-        skewX: 'on-trigger',
-        skewY: 'on-trigger',
-        autoAlpha: 'on-trigger',
-        display: 'on-trigger',
-      },
+      apply_styles: getDefaultApplyStyles(selectedInteraction.trigger),
     };
 
     const updatedInteractions = updateInteractionById(
@@ -2278,34 +2271,47 @@ export default function InteractionsPanel({
 
                       return (
                         <div key={prop.key} className="flex items-center gap-1.25">
-                          {!prop.toOnly && (
-                            <>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Button
-                                    size="xs"
-                                    variant="secondary"
-                                    className="size-7 p-0 shrink-0 transition-none"
-                                    disabled={isFromCurrent}
-                                    onClick={() => {
-                                      const currentValue = selectedTween.apply_styles?.[prop.key] || 'on-trigger';
-                                      handleUpdateTween(selectedTween.id, {
-                                        apply_styles: {
-                                          ...selectedTween.apply_styles,
-                                          [prop.key]: currentValue === 'on-load' ? 'on-trigger' : 'on-load',
-                                        },
-                                      });
-                                    }}
-                                  >
-                                    <Icon name={selectedTween.apply_styles?.[prop.key] === 'on-load' ? 'page' : 'cursor-default'} />
-                                  </Button>
-                                </TooltipTrigger>
-                                <TooltipContent side="top" align="start">
-                                  {selectedTween.apply_styles?.[prop.key] === 'on-load'
-                                    ? 'Apply property style on page load'
-                                    : 'Apply property style on trigger'}
-                                </TooltipContent>
-                              </Tooltip>
+                          {!prop.toOnly && (() => {
+                            const effectiveApplyStyle = selectedInteraction
+                              ? getEffectiveApplyStyle(selectedInteraction.trigger, prop.key, selectedTween.apply_styles)
+                              : (selectedTween.apply_styles?.[prop.key] || 'on-trigger');
+                            // Intro triggers (load, scroll-into-view) are implicitly on-load
+                            // to prevent flicker — lock the toggle in that case.
+                            const isImplicitOnLoad = selectedInteraction
+                              ? (selectedInteraction.trigger === 'load' || selectedInteraction.trigger === 'scroll-into-view')
+                              : false;
+                            const isOnLoad = effectiveApplyStyle === 'on-load';
+
+                            return (
+                              <>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button
+                                      size="xs"
+                                      variant="secondary"
+                                      className="size-7 p-0 shrink-0 transition-none"
+                                      disabled={isFromCurrent || isImplicitOnLoad}
+                                      onClick={() => {
+                                        const currentValue = selectedTween.apply_styles?.[prop.key] || 'on-trigger';
+                                        handleUpdateTween(selectedTween.id, {
+                                          apply_styles: {
+                                            ...selectedTween.apply_styles,
+                                            [prop.key]: currentValue === 'on-load' ? 'on-trigger' : 'on-load',
+                                          },
+                                        });
+                                      }}
+                                    >
+                                      <Icon name={isOnLoad ? 'page' : 'cursor-default'} />
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="top" align="start">
+                                    {isImplicitOnLoad
+                                      ? 'Always applied on page load for this trigger'
+                                      : isOnLoad
+                                        ? 'Apply property style on page load'
+                                        : 'Apply property style on trigger'}
+                                  </TooltipContent>
+                                </Tooltip>
 
                               <div className="w-full flex items-center gap-1.5">
                                 {isFromCurrent ? (
@@ -2434,10 +2440,11 @@ export default function InteractionsPanel({
                                   >
                                     Set value <Icon name="chevronRight" className="size-2.5 opacity-60" /> Set value
                                   </DropdownMenuCheckboxItem>
-                                </DropdownMenuContent>
-                              </DropdownMenu>
-                            </>
-                          )}
+                                  </DropdownMenuContent>
+                                </DropdownMenu>
+                              </>
+                            );
+                          })()}
 
                           <div className="w-full flex items-center gap-1.5">
                             {isToCurrent ? (

--- a/components/AnimationInitializer.tsx
+++ b/components/AnimationInitializer.tsx
@@ -14,7 +14,7 @@ import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { SplitText } from 'gsap/SplitText';
 
 import { ITEMS_INJECTED_EVENT, type ItemsInjectedDetail } from '@/components/FilterableCollection';
-import { buildGsapProps, addTweenToTimeline, createSplitTextAnimation, generateInitialAnimationCSS, setColorVariableResolver } from '@/lib/animation-utils';
+import { buildGsapProps, addTweenToTimeline, createSplitTextAnimation, generateInitialAnimationCSS, getEffectiveApplyStyle, setColorVariableResolver } from '@/lib/animation-utils';
 import { getCurrentBreakpoint } from '@/lib/breakpoint-utils';
 import { remapLayerIdsForCollectionItem } from '@/lib/collection-utils';
 import { useColorVariablesStore } from '@/stores/useColorVariablesStore';
@@ -78,8 +78,12 @@ function collectHiddenLayerInfo(interactions: CollectedInteraction[]): Map<strin
     const breakpoints = interaction.timeline?.breakpoints || null;
 
     (interaction.tweens || []).forEach((tween) => {
-      // Check if this tween has display: hidden with on-load apply style
-      if (tween.from?.display === 'hidden' && tween.apply_styles?.display === 'on-load') {
+      // Hide if display:hidden with effective on-load mode (explicit, or implicit
+      // for intro triggers like load/scroll-into-view).
+      if (
+        tween.from?.display === 'hidden' &&
+        getEffectiveApplyStyle(interaction.trigger, 'display', tween.apply_styles) === 'on-load'
+      ) {
         hiddenMap.set(tween.layer_id, breakpoints);
       }
     });

--- a/lib/animation-utils.ts
+++ b/lib/animation-utils.ts
@@ -2,8 +2,47 @@
  * Animation utility functions and constants for GSAP interactions
  */
 
-import type { InteractionTween, TweenProperties, Layer, Breakpoint } from '@/types';
+import type { InteractionTween, LayerInteraction, TweenProperties, Layer, Breakpoint, ApplyStyles, TweenPropertyKey } from '@/types';
 import { BREAKPOINTS } from '@/lib/breakpoint-utils';
+
+/**
+ * One-shot intro triggers where the `from` state should be applied on initial
+ * paint to avoid the element flashing in its `to` state before JS runs.
+ */
+const IMPLICIT_ON_LOAD_TRIGGERS: ReadonlyArray<LayerInteraction['trigger']> = ['load', 'scroll-into-view'];
+
+/**
+ * Returns the effective apply mode for a tween property, treating intro
+ * triggers (load, scroll-into-view) as implicit `on-load` so the initial
+ * state is painted server-side. Stops `to`-state flashes before the
+ * timeline starts.
+ */
+export function getEffectiveApplyStyle(
+  trigger: LayerInteraction['trigger'],
+  propertyKey: TweenPropertyKey,
+  applyStyles: InteractionTween['apply_styles'] | undefined
+): ApplyStyles {
+  if (IMPLICIT_ON_LOAD_TRIGGERS.includes(trigger)) return 'on-load';
+  return applyStyles?.[propertyKey] || 'on-trigger';
+}
+
+/**
+ * Default `apply_styles` for a new tween based on the interaction trigger.
+ * Intro triggers default every property to `on-load` to avoid flicker.
+ */
+export function getDefaultApplyStyles(trigger: LayerInteraction['trigger']): InteractionTween['apply_styles'] {
+  const mode: ApplyStyles = IMPLICIT_ON_LOAD_TRIGGERS.includes(trigger) ? 'on-load' : 'on-trigger';
+  return {
+    x: mode,
+    y: mode,
+    rotation: mode,
+    scale: mode,
+    skewX: mode,
+    skewY: mode,
+    autoAlpha: mode,
+    display: mode,
+  };
+}
 
 /**
  * Creates a SplitText instance with responsive animation support
@@ -446,10 +485,11 @@ export function collectEditorHiddenLayerIds(layers: Layer[]): Map<string, Breakp
       if (layer.interactions) {
         layer.interactions.forEach((interaction) => {
           (interaction.tweens || []).forEach((tween) => {
-            // Check if display: hidden with on-load apply style
+            // Check if display: hidden with effective on-load apply style
+            // (explicit on-load OR intro trigger like load/scroll-into-view)
             if (
               tween.from?.display === 'hidden' &&
-              tween.apply_styles?.display === 'on-load'
+              getEffectiveApplyStyle(interaction.trigger, 'display', tween.apply_styles) === 'on-load'
             ) {
               const breakpoints = interaction.timeline?.breakpoints || [];
               const existing = hiddenLayerMap.get(tween.layer_id);
@@ -591,11 +631,11 @@ export function generateInitialAnimationCSS(layers: Layer[]): InitialAnimationRe
             const styles: string[] = [];
             const transforms: string[] = [];
 
-            // Build CSS from 'from' properties that have apply_styles: 'on-load'
+            // Build CSS from 'from' properties whose effective apply mode is 'on-load'.
+            // Intro triggers (load, scroll-into-view) are implicitly on-load to prevent flicker.
             PROPERTY_OPTIONS.forEach((opt) => {
               opt.properties.forEach((prop) => {
-                // Only apply styles for properties with apply_styles: 'on-load'
-                if (tween.apply_styles?.[prop.key] !== 'on-load') return;
+                if (getEffectiveApplyStyle(interaction.trigger, prop.key, tween.apply_styles) !== 'on-load') return;
 
                 const value = tween.from[prop.key];
                 if (value === null || value === undefined) return;

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -11,6 +11,7 @@
 import { layerToHtml, buildAnchorMap } from '@/lib/page-fetcher'
 import type { PageData } from '@/lib/page-fetcher'
 import { getClassesString } from '@/lib/layer-utils'
+import { getEffectiveApplyStyle } from '@/lib/animation-utils'
 
 import type { Layer, Page, PageFolder } from '@/types'
 
@@ -362,7 +363,7 @@ export function collectInteractions(layers: Layer[]): ExportedInteraction[] {
                 toDisplay === 'hidden' || toDisplay === 'visible'
                   ? (toDisplay as 'hidden' | 'visible')
                   : undefined,
-              applyDisplayOnLoad: t.apply_styles?.display === 'on-load',
+              applyDisplayOnLoad: getEffectiveApplyStyle(interaction.trigger, 'display', t.apply_styles) === 'on-load',
             }
           })
           .filter((t) => t.fromDisplay !== undefined || t.toDisplay !== undefined)

--- a/lib/text-format-utils.ts
+++ b/lib/text-format-utils.ts
@@ -311,16 +311,23 @@ function resolveImageLinkHref(
 /**
  * Flatten multi-paragraph Tiptap content into a single paragraph with hardBreak nodes.
  * Used for heading/text elements that should not contain nested block elements.
- * Converts: [paragraph("a"), paragraph("b")] → [paragraph("a", hardBreak, "b")]
+ * Treats `heading` blocks like paragraphs so their inline content is preserved without
+ * producing a nested <h1>-<h6> inside the simple text layer's own heading tag.
+ * Converts: [paragraph("a"), heading("b")] → [paragraph("a", hardBreak, "b")]
  */
 export function flattenTiptapParagraphs(content: any): any {
   if (!content || typeof content !== 'object' || content.type !== 'doc') return content;
   const blocks = content.content;
-  if (!Array.isArray(blocks) || blocks.length <= 1) return content;
+  if (!Array.isArray(blocks) || blocks.length === 0) return content;
+
+  const FLATTENABLE = new Set(['paragraph', 'heading']);
+  const allFlattenable = blocks.every((b: any) => FLATTENABLE.has(b?.type));
+  if (!allFlattenable) return content;
+
+  if (blocks.length === 1 && blocks[0].type === 'paragraph') return content;
 
   const merged: any[] = [];
   blocks.forEach((block: any, i: number) => {
-    if (block.type !== 'paragraph') return;
     if (i > 0 && merged.length > 0) {
       merged.push({ type: 'hardBreak' });
     }


### PR DESCRIPTION
## Summary

Animations on `load` and `scroll-into-view` triggers shipped the element in its end state, then GSAP jumped it back to the start state once the timeline played — producing a visible flicker. The fix makes intro triggers paint their initial state server-side so the page loads in the correct starting state. Closes #243.

## Changes

- Treat `load` and `scroll-into-view` triggers as implicit `on-load` so `generateInitialAnimationCSS` emits the initial-state CSS in the SSR `<style>` tag.
- New tweens on intro triggers default every property's `apply_styles` to `on-load`.
- Disable the per-property apply-style toggle for intro triggers with a tooltip explaining the behavior — UI now matches what actually renders.
- Apply the same effective-apply-style logic in `AnimationInitializer` (for `data-gsap-hidden`), the editor canvas hidden-layer collector, and the static HTML export.
- Flatten nested `heading` blocks inside simple text layers so they no longer produce invalid nested `<h1>`-`<h6>` tags, which broke the initial-state attribute selector matching.

## Test plan

- [ ] Add a `load` animation that fades text in (`autoAlpha: 0 → 100`), publish, and reload — text should start invisible, not flash visible then re-fade.
- [ ] Same with a `scroll-into-view` trigger on an above-the-fold element.
- [ ] Click/hover animations still behave as before (no premature initial state applied).
- [ ] In the editor, open an existing intro animation — the apply-style toggle for each property is disabled and tooltip reads "Always applied on page load for this trigger".
- [ ] Create a new animation on a `click` trigger — toggle remains enabled and defaults to on-trigger.
- [ ] A text layer with multiple heading paragraphs renders as a single heading with line breaks, not nested headings.

Made with [Cursor](https://cursor.com)