### PR TITLE
feat: add blur, brightness, and grayscale animations

### DIFF
--- a/app/(builder)/ycode/components/InteractionsPanel.tsx
+++ b/app/(builder)/ycode/components/InteractionsPanel.tsx
@@ -73,6 +73,8 @@ import {
   parseAnimationValue,
   formatAnimationValue,
   setColorVariableResolver,
+  isFilterPropertyKey,
+  buildFilterString,
 } from '@/lib/animation-utils';
 import type { TriggerType, PropertyType, ParsedAnimationValue } from '@/lib/animation-utils';
 
@@ -2164,9 +2166,27 @@ export default function InteractionsPanel({
                         });
                       };
 
-                      const applyPreview = (value: string | null) => {
+                      const applyPreview = (value: string | null, side: 'from' | 'to' = 'to') => {
                         if (prop.key === 'display') return;
                         if (value === null || value === undefined) return;
+
+                        // Filter sub-properties share a single CSS `filter` declaration —
+                        // compose the full filter string from the tween's other filter
+                        // values so the preview reflects the combined effect.
+                        if (isFilterPropertyKey(prop.key)) {
+                          const base = side === 'from' ? selectedTween.from : selectedTween.to;
+                          const composed = { ...base, [prop.key]: value };
+                          const filterStr = buildFilterString(composed);
+                          if (filterStr !== null) {
+                            applyPreviewStyles(
+                              selectedTween.layer_id,
+                              { filter: filterStr },
+                              { splitText: selectedTween.splitText, duration: selectedTween.duration }
+                            );
+                          }
+                          return;
+                        }
+
                         const gsapValue = toGsapValue(value, prop);
                         if (gsapValue !== undefined) {
                           applyPreviewStyles(
@@ -2180,12 +2200,12 @@ export default function InteractionsPanel({
                       const handlePreviewFrom = () => {
                         if (isFromCurrent) return;
                         clearAllPreviewStyles();
-                        applyPreview(fromValue as string);
+                        applyPreview(fromValue as string, 'from');
                       };
 
                       const handlePreviewTo = () => {
                         clearAllPreviewStyles();
-                        applyPreview(selectedTween.to[prop.key] as string);
+                        applyPreview(selectedTween.to[prop.key] as string, 'to');
                       };
 
                       /** Helper to update property and apply preview after iframe re-renders */
@@ -2244,24 +2264,24 @@ export default function InteractionsPanel({
 
                       const handleFromChange = (value: string) => {
                         const resolved = resolveValue(value, parsedFrom);
-                        handlePropertyChange(() => setFromValue(resolved), () => applyPreview(resolved));
+                        handlePropertyChange(() => setFromValue(resolved), () => applyPreview(resolved, 'from'));
                       };
 
                       const handleFromUnitChange = (newUnit: string) => {
                         if (!parsedFrom) return;
                         const resolved = formatAnimationValue(parsedFrom.number, newUnit);
-                        handlePropertyChange(() => setFromValue(resolved), () => applyPreview(resolved));
+                        handlePropertyChange(() => setFromValue(resolved), () => applyPreview(resolved, 'from'));
                       };
 
                       const handleToChange = (value: string) => {
                         const resolved = resolveValue(value, parsedTo);
-                        handlePropertyChange(() => setToValue(resolved), () => applyPreview(resolved));
+                        handlePropertyChange(() => setToValue(resolved), () => applyPreview(resolved, 'to'));
                       };
 
                       const handleToUnitChange = (newUnit: string) => {
                         if (!parsedTo) return;
                         const resolved = formatAnimationValue(parsedTo.number, newUnit);
-                        handlePropertyChange(() => setToValue(resolved), () => applyPreview(resolved));
+                        handlePropertyChange(() => setToValue(resolved), () => applyPreview(resolved, 'to'));
                       };
 
                       /** Deferred blur: clears preview after pending RAF callbacks complete */

--- a/lib/animation-utils.ts
+++ b/lib/animation-utils.ts
@@ -49,7 +49,7 @@ export function createSplitTextAnimation(
 
 // Types
 export type TriggerType = 'click' | 'hover' | 'scroll-into-view' | 'while-scrolling' | 'load';
-export type PropertyType = 'position-x' | 'position-y' | 'scale' | 'rotation' | 'skew-x' | 'skew-y' | 'opacity' | 'width' | 'height' | 'background-color' | 'display' | 'split-text';
+export type PropertyType = 'position-x' | 'position-y' | 'scale' | 'rotation' | 'skew-x' | 'skew-y' | 'opacity' | 'width' | 'height' | 'background-color' | 'display' | 'split-text' | 'blur' | 'brightness' | 'grayscale';
 
 export interface PropertyConfig {
   key: keyof TweenProperties;
@@ -286,7 +286,75 @@ export const PROPERTY_OPTIONS: PropertyOption[] = [
       ],
     }],
   },
+  {
+    type: 'blur',
+    label: 'Blur',
+    properties: [{
+      key: 'filterBlur',
+      unit: 'px',
+      defaultFrom: '0',
+      defaultFromAfterCurrent: '0',
+      defaultTo: '5',
+    }],
+  },
+  {
+    type: 'brightness',
+    label: 'Brightness',
+    properties: [{
+      key: 'filterBrightness',
+      unit: '',
+      defaultFrom: '1',
+      defaultFromAfterCurrent: '1',
+      defaultTo: '1.15',
+    }],
+  },
+  {
+    type: 'grayscale',
+    label: 'Grayscale',
+    properties: [{
+      key: 'filterGrayscale',
+      unit: '%',
+      defaultFrom: '0',
+      defaultFromAfterCurrent: '0',
+      defaultTo: '100',
+    }],
+  },
 ];
+
+/** Keys whose values participate in the combined CSS `filter` property */
+export const FILTER_PROPERTY_KEYS = ['filterBlur', 'filterBrightness', 'filterGrayscale'] as const;
+export type FilterPropertyKey = typeof FILTER_PROPERTY_KEYS[number];
+
+/** Map a filter sub-property key to its CSS function name */
+const FILTER_CSS_FUNCTIONS: Record<FilterPropertyKey, string> = {
+  filterBlur: 'blur',
+  filterBrightness: 'brightness',
+  filterGrayscale: 'grayscale',
+};
+
+/** Check if a tween property key contributes to the combined CSS `filter` property */
+export function isFilterPropertyKey(key: string): key is FilterPropertyKey {
+  return (FILTER_PROPERTY_KEYS as readonly string[]).includes(key);
+}
+
+/**
+ * Build the CSS `filter` string from a set of sub-property values.
+ * Only includes defined functions; returns `null` if none are set.
+ */
+export function buildFilterString(values: Partial<Record<FilterPropertyKey, string | null | undefined>>): string | null {
+  const parts: string[] = [];
+  for (const key of FILTER_PROPERTY_KEYS) {
+    const raw = values[key];
+    if (raw === null || raw === undefined || raw === '') continue;
+    const cfg = PROPERTY_OPTIONS
+      .flatMap((opt) => opt.properties)
+      .find((p) => p.key === key);
+    if (!cfg) continue;
+    const cssVal = resolveCssValue(raw, cfg);
+    parts.push(`${FILTER_CSS_FUNCTIONS[key]}(${cssVal})`);
+  }
+  return parts.length > 0 ? parts.join(' ') : null;
+}
 
 export const TRIGGER_LABELS: Record<TriggerType, string> = {
   'click': 'Click',
@@ -590,6 +658,7 @@ export function generateInitialAnimationCSS(layers: Layer[]): InitialAnimationRe
           (interaction.tweens || []).forEach((tween) => {
             const styles: string[] = [];
             const transforms: string[] = [];
+            const filterValues: Partial<Record<FilterPropertyKey, string>> = {};
 
             // Build CSS from 'from' properties that have apply_styles: 'on-load'
             PROPERTY_OPTIONS.forEach((opt) => {
@@ -627,6 +696,9 @@ export function generateInitialAnimationCSS(layers: Layer[]): InitialAnimationRe
                   styles.push(`height: ${cssVal}`);
                 } else if (prop.key === 'backgroundColor') {
                   styles.push(`background-color: ${colorToCss(value)}`);
+                } else if (isFilterPropertyKey(prop.key)) {
+                  // Accumulate; combined into a single `filter` declaration below
+                  filterValues[prop.key] = value;
                 } else if (prop.key === 'display') {
                   // Track elements that should start hidden using data attribute
                   if (value === 'hidden') {
@@ -642,6 +714,12 @@ export function generateInitialAnimationCSS(layers: Layer[]): InitialAnimationRe
             // Combine all transforms into a single property
             if (transforms.length > 0) {
               styles.push(`transform: ${transforms.join(' ')}`);
+            }
+
+            // Combine accumulated filter sub-properties into a single CSS declaration
+            const filterStr = buildFilterString(filterValues);
+            if (filterStr !== null) {
+              styles.push(`filter: ${filterStr}`);
             }
 
             if (styles.length > 0) {
@@ -694,6 +772,9 @@ export function buildGsapProps(tween: InteractionTween): GsapAnimationProps {
         return;
       }
 
+      // Filter sub-properties are combined into a single CSS `filter` string below
+      if (isFilterPropertyKey(prop.key)) return;
+
       const fromVal = toGsapValue(tween.from[prop.key], prop);
       const toVal = toGsapValue(tween.to[prop.key], prop);
 
@@ -705,6 +786,14 @@ export function buildGsapProps(tween: InteractionTween): GsapAnimationProps {
       }
     });
   });
+
+  // Combine filter sub-properties into a single CSS `filter` string so GSAP
+  // can tween it as one property (otherwise multiple `filter` writes would
+  // overwrite each other).
+  const fromFilter = buildFilterString(tween.from);
+  const toFilter = buildFilterString(tween.to);
+  if (fromFilter !== null) fromProps.filter = fromFilter;
+  if (toFilter !== null) toProps.filter = toFilter;
 
   return { from: fromProps, to: toProps, displayStart, displayEnd };
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -340,7 +340,7 @@ export interface InteractionTween {
 
 export type ApplyStyles = 'on-load' | 'on-trigger';
 
-export type TweenPropertyKey = 'x' | 'y' | 'rotation' | 'scale' | 'skewX' | 'skewY' | 'autoAlpha' | 'display' | 'width' | 'height' | 'backgroundColor';
+export type TweenPropertyKey = 'x' | 'y' | 'rotation' | 'scale' | 'skewX' | 'skewY' | 'autoAlpha' | 'display' | 'width' | 'height' | 'backgroundColor' | 'filterBlur' | 'filterBrightness' | 'filterGrayscale';
 
 export type InteractionApplyStyles = Partial<Record<TweenPropertyKey, ApplyStyles>>;
 


### PR DESCRIPTION
## Summary

Restores the filter animations that were available in the legacy builder. Users can now animate `blur`, `brightness`, and `grayscale` on any layer through the Interactions panel — on click, hover, scroll-into-view, while-scrolling, or page-load triggers.

## Changes

- Add **Blur**, **Brightness**, and **Grayscale** as three independent items in the Interactions "Add property" dropdown
- Each property has its own from/to inputs, mode switcher, apply-on-load toggle, and live canvas preview, matching every other animatable property
- Combine all filter sub-properties into a single CSS `filter` declaration for GSAP playback, on-load CSS, and live preview — so multiple filters on the same tween compose (e.g. `filter: blur(5px) brightness(1.15)`) instead of overwriting each other on the shared CSS property
- Add helpers `buildFilterString`, `isFilterPropertyKey`, and `FILTER_PROPERTY_KEYS` in `lib/animation-utils.ts`
- Extend `TweenPropertyKey` with `filterBlur`, `filterBrightness`, `filterGrayscale`

Defaults match the legacy builder: blur 0→5px, brightness 1→1.15, grayscale 0→100%.

## Test plan

- [ ] Open the Interactions panel on any layer
- [ ] In a tween, open the "Add property" dropdown and verify Blur, Brightness, and Grayscale each appear as separate options
- [ ] Add Blur — focus the To input and confirm the canvas previews the blur live
- [ ] Add Brightness alongside Blur on the same tween — confirm both effects preview together (composed `filter`)
- [ ] Add Grayscale as a third property and confirm all three compose correctly during playback
- [ ] Trigger the animation (click/hover) and confirm filters animate smoothly between from and to values
- [ ] Toggle "Apply on load" for a filter property and confirm initial styles are applied server-side without flicker
- [ ] Switch animation mode (current → set, set → current) and confirm the filter preview updates accordingly
- [ ] Remove a filter property from the tween and confirm the remaining filters still apply correctly


Made with [Cursor](https://cursor.com)