### PR TITLE
fix: expose CMS item field values via MCP

### DIFF
--- a/lib/mcp/tools/collections.ts
+++ b/lib/mcp/tools/collections.ts
@@ -11,7 +11,6 @@ import {
   reorderFields,
 } from '@/lib/repositories/collectionFieldRepository';
 import {
-  getItemsByCollectionId,
   getItemsWithValues,
   createItem,
   updateItem,
@@ -132,14 +131,14 @@ FIELD TYPES:
 
   server.tool(
     'list_collection_items',
-    'List items in a collection with their field values.',
+    'List items in a collection with their field values. Each item includes a `values` object keyed by field ID containing the actual content (text, references, etc.).',
     {
       collection_id: z.string().describe('The collection ID'),
       search: z.string().optional().describe('Search term to filter items'),
     },
     async ({ collection_id, search }) => {
       const fields = await getFieldsByCollectionId(collection_id);
-      const { items, total } = await getItemsByCollectionId(collection_id, false, search ? { search } : undefined);
+      const { items, total } = await getItemsWithValues(collection_id, false, search ? { search } : undefined);
       return {
         content: [{
           type: 'text' as const,


### PR DESCRIPTION
## Summary

The `list_collection_items` MCP tool advertised "with their field values" in its description but actually returned only item metadata (IDs, timestamps, `manual_order`) — no field values. Agents connected via MCP could see that items existed but couldn't read their content, blocking use cases like translating CMS source text into other locales.

## Changes

- Swap `getItemsByCollectionId` for `getItemsWithValues` in `list_collection_items` so each item exposes a `values` object keyed by field ID
- Tighten the tool description so future agents know to expect the `values` payload
- Drop the now-unused `getItemsByCollectionId` import

## Test plan

- [ ] Connect an MCP client to the Ycode MCP endpoint
- [ ] Call `list_collection_items` for a collection that has text content
- [ ] Confirm each returned item now includes a `values` object keyed by field ID with the actual content
- [ ] Confirm `search` still narrows the result set as before
- [ ] Confirm `create_collection_item` output shape is unchanged (it already used `getItemsWithValues`)