### PR TITLE
feat: add role-based access control for self-hosted

### DIFF
--- a/app/(builder)/ycode/api/auth/invite/route.ts
+++ b/app/(builder)/ycode/api/auth/invite/route.ts
@@ -1,43 +1,39 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { noCache } from '@/lib/api-response';
+import { requireManageMembers } from '@/lib/roles-server';
+import { ASSIGNABLE_ROLES } from '@/lib/roles';
 
 /**
  * POST /ycode/api/auth/invite
  *
- * Invite a user by email using Supabase's built-in invite system
+ * Invite a user by email using Supabase's built-in invite system.
+ * Requires owner or admin role.
  */
 export async function POST(request: NextRequest) {
   try {
+    const result = await requireManageMembers();
+    if ('status' in result) return result;
+
     const body = await request.json();
-    const { email, redirectTo } = body;
+    const { email, role = 'designer', redirectTo } = body;
 
     if (!email) {
-      return noCache(
-        { error: 'Email is required' },
-        400
-      );
+      return noCache({ error: 'Email is required' }, 400);
     }
 
-    // Validate email format
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {
-      return noCache(
-        { error: 'Invalid email format' },
-        400
-      );
+      return noCache({ error: 'Invalid email format' }, 400);
     }
+
+    const assignRole = ASSIGNABLE_ROLES.includes(role) ? role : 'designer';
 
     const client = await getSupabaseAdmin();
-
     if (!client) {
-      return noCache(
-        { error: 'Supabase not configured' },
-        500
-      );
+      return noCache({ error: 'Supabase not configured' }, 500);
     }
 
-    // Use Supabase's built-in invite functionality
     const { data, error } = await client.auth.admin.inviteUserByEmail(email, {
       redirectTo: redirectTo || undefined,
       data: {
@@ -47,15 +43,19 @@ export async function POST(request: NextRequest) {
 
     if (error) {
       console.error('[invite] Error inviting user:', error);
-      return noCache(
-        { error: error.message },
-        400
-      );
+      return noCache({ error: error.message }, 400);
+    }
+
+    if (data.user) {
+      await client.auth.admin.updateUserById(data.user.id, {
+        app_metadata: { role: assignRole },
+      });
     }
 
     return noCache({
       data: {
         user: data.user,
+        role: assignRole,
         message: `Invitation sent to ${email}`,
       },
     });

--- a/app/(builder)/ycode/api/auth/set-role/route.ts
+++ b/app/(builder)/ycode/api/auth/set-role/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { noCache } from '@/lib/api-response';
+import { requireManageMembers } from '@/lib/roles-server';
+import { ALL_ROLES } from '@/lib/roles';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /ycode/api/auth/set-role
+ *
+ * Set a user's role in app_metadata via the Supabase Admin API.
+ * Requires the caller to be owner or admin.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const result = await requireManageMembers();
+    if ('status' in result) return result;
+    const caller = result;
+
+    const body = await request.json();
+    const { userId, role } = body;
+
+    if (!userId || !role) {
+      return noCache({ error: 'userId and role are required' }, 400);
+    }
+
+    if (!ALL_ROLES.includes(role)) {
+      return noCache({ error: `Invalid role. Must be one of: ${ALL_ROLES.join(', ')}` }, 400);
+    }
+
+    if (role === 'owner' && caller.role !== 'owner') {
+      return noCache({ error: 'Only the owner can assign the owner role' }, 403);
+    }
+
+    const client = await getSupabaseAdmin();
+    if (!client) {
+      return noCache({ error: 'Supabase not configured' }, 500);
+    }
+
+    const { error } = await client.auth.admin.updateUserById(userId, {
+      app_metadata: { role },
+    });
+
+    if (error) {
+      console.error('[set-role] Error:', error);
+      return noCache({ error: error.message }, 400);
+    }
+
+    return noCache({ data: { success: true } });
+  } catch (error) {
+    console.error('[set-role] Unexpected error:', error);
+    return noCache({ error: 'Failed to set role' }, 500);
+  }
+}

--- a/app/(builder)/ycode/api/auth/users/route.ts
+++ b/app/(builder)/ycode/api/auth/users/route.ts
@@ -1,24 +1,21 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { noCache } from '@/lib/api-response';
+import { getCallerInfo, requireManageMembers } from '@/lib/roles-server';
+import { resolveRole, ASSIGNABLE_ROLES } from '@/lib/roles';
 
 /**
  * GET /ycode/api/auth/users
  *
- * List all users with their status (active or pending invite)
+ * List all users with their status (active or pending invite) and roles.
  */
 export async function GET(request: NextRequest) {
   try {
     const client = await getSupabaseAdmin();
-
     if (!client) {
-      return noCache(
-        { error: 'Supabase not configured' },
-        500
-      );
+      return noCache({ error: 'Supabase not configured' }, 500);
     }
 
-    // Fetch all users from Supabase Auth
     const { data, error } = await client.auth.admin.listUsers({
       page: 1,
       perPage: 1000,
@@ -26,18 +23,17 @@ export async function GET(request: NextRequest) {
 
     if (error) {
       console.error('[users] Error listing users:', error);
-      return noCache(
-        { error: error.message },
-        500
-      );
+      return noCache({ error: error.message }, 500);
     }
 
-    // Separate users into active and pending
+    const caller = await getCallerInfo();
+
     const activeUsers: Array<{
       id: string;
       email: string;
       display_name: string | null;
       avatar_url: string | null;
+      role: string;
       created_at: string;
       last_sign_in_at: string | null;
     }> = [];
@@ -45,27 +41,21 @@ export async function GET(request: NextRequest) {
     const pendingInvites: Array<{
       id: string;
       email: string;
+      role: string;
       invited_at: string;
     }> = [];
 
     for (const user of data.users) {
-      // Get metadata - check both user_metadata and raw_user_meta_data
-       
       const userAny = user as any;
       const metadata = user.user_metadata || userAny.raw_user_meta_data || {};
-
-      // Check if this user was invited (we set invited_at when sending invite)
+      const appMeta = user.app_metadata || userAny.raw_app_meta_data || {};
       const wasInvited = !!metadata.invited_at;
-
-      // A user is "pending" if:
-      // 1. They were invited AND haven't signed in after the invite
-      // 2. They have no identities (no password set)
       const hasIdentities = user.identities && user.identities.length > 0;
       const hasSignedIn = user.last_sign_in_at !== null;
+      const emailConfirmed = !!user.email_confirmed_at;
+      const isPending = wasInvited && !emailConfirmed && !hasIdentities && !hasSignedIn;
 
-      // User is pending if they were invited but haven't completed setup
-      // (no sign-in after invite, or no identities meaning no password set)
-      const isPending = wasInvited && (!hasSignedIn || !hasIdentities);
+      const userRole = resolveRole(appMeta.role as string);
 
       if (!isPending) {
         activeUsers.push({
@@ -73,78 +63,123 @@ export async function GET(request: NextRequest) {
           email: user.email || '',
           display_name: metadata.display_name || metadata.full_name || null,
           avatar_url: metadata.avatar_url || null,
+          role: userRole,
           created_at: user.created_at,
           last_sign_in_at: user.last_sign_in_at || null,
         });
       } else {
-        // User was invited but hasn't completed setup
         pendingInvites.push({
           id: user.id,
           email: user.email || '',
+          role: userRole,
           invited_at: metadata.invited_at || user.created_at,
         });
       }
     }
 
     return noCache({
-      data: {
-        activeUsers,
-        pendingInvites,
-      },
+      data: { activeUsers, pendingInvites, callerRole: caller?.role || null },
     });
   } catch (error) {
     console.error('[users] Unexpected error:', error);
-    return noCache(
-      { error: 'Failed to fetch users' },
-      500
-    );
+    return noCache({ error: 'Failed to fetch users' }, 500);
   }
 }
 
 /**
- * DELETE /ycode/api/auth/users
+ * PATCH /ycode/api/auth/users?id=...
  *
- * Delete a user or cancel a pending invite
+ * Change a user's role. Requires owner or admin.
+ */
+export async function PATCH(request: NextRequest) {
+  try {
+    const result = await requireManageMembers();
+    if ('status' in result) return result;
+    const caller = result;
+
+    const { searchParams } = new URL(request.url);
+    const targetId = searchParams.get('id');
+    if (!targetId) {
+      return noCache({ error: 'ID is required' }, 400);
+    }
+
+    const body = await request.json();
+    const { role } = body;
+    if (!role || !ASSIGNABLE_ROLES.includes(role)) {
+      return noCache({ error: `Role must be one of: ${ASSIGNABLE_ROLES.join(', ')}` }, 400);
+    }
+
+    if (role === 'admin' && caller.role !== 'owner') {
+      return noCache({ error: 'Only the owner can assign the admin role' }, 403);
+    }
+
+    const client = await getSupabaseAdmin();
+    if (!client) {
+      return noCache({ error: 'Supabase not configured' }, 500);
+    }
+
+    const { data: targetData } = await client.auth.admin.getUserById(targetId);
+    if (targetData?.user?.app_metadata?.role === 'owner') {
+      return noCache({ error: 'Cannot change the owner\'s role' }, 400);
+    }
+
+    const { error } = await client.auth.admin.updateUserById(targetId, {
+      app_metadata: { role },
+    });
+
+    if (error) {
+      console.error('[users] Error updating role:', error);
+      return noCache({ error: error.message }, 400);
+    }
+
+    return noCache({ data: { success: true } });
+  } catch (error) {
+    console.error('[users] Unexpected error:', error);
+    return noCache({ error: 'Failed to update role' }, 500);
+  }
+}
+
+/**
+ * DELETE /ycode/api/auth/users?id=...
+ *
+ * Delete a user or cancel a pending invite. Requires owner or admin.
  */
 export async function DELETE(request: NextRequest) {
   try {
+    const result = await requireManageMembers();
+    if ('status' in result) return result;
+    const caller = result;
+
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get('id');
 
     if (!userId) {
-      return noCache(
-        { error: 'User ID is required' },
-        400
-      );
+      return noCache({ error: 'User ID is required' }, 400);
+    }
+
+    if (userId === caller.userId) {
+      return noCache({ error: 'Cannot remove yourself' }, 400);
     }
 
     const client = await getSupabaseAdmin();
-
     if (!client) {
-      return noCache(
-        { error: 'Supabase not configured' },
-        500
-      );
+      return noCache({ error: 'Supabase not configured' }, 500);
+    }
+
+    const { data: targetData } = await client.auth.admin.getUserById(userId);
+    if (targetData?.user?.app_metadata?.role === 'owner') {
+      return noCache({ error: 'Cannot remove the owner' }, 400);
     }
 
     const { error } = await client.auth.admin.deleteUser(userId);
-
     if (error) {
       console.error('[users] Error deleting user:', error);
-      return noCache(
-        { error: error.message },
-        400
-      );
+      return noCache({ error: error.message }, 400);
     }
 
-    return noCache({
-      data: { success: true },
-    });
+    return noCache({ data: { success: true } });
   } catch (error) {
     console.error('[users] Unexpected error:', error);
-    return noCache(
-      { error: 'Failed to delete user' },
-      500
-    );
+    return noCache({ error: 'Failed to delete user' }, 500);
   }
 }

--- a/app/(builder)/ycode/components/CMS.tsx
+++ b/app/(builder)/ycode/components/CMS.tsx
@@ -42,6 +42,7 @@ import { CollectionStatusPill, parseStatusValue } from './CollectionStatusPill';
 import { extractPlainTextFromTiptap } from '@/lib/tiptap-utils';
 import { parseCollectionLinkValue, resolveCollectionLinkValue } from '@/lib/link-utils';
 import { useEditorUrl } from '@/hooks/use-editor-url';
+import { useRole } from '@/hooks/use-role';
 import FieldsDropdown from './FieldsDropdown';
 import AirtableSyncButton from './AirtableSyncButton';
 import CollectionItemContextMenu from './CollectionItemContextMenu';
@@ -198,6 +199,7 @@ interface SortableCollectionItemProps {
   renameValue: string;
   itemCount?: number;
   isItemCountLoading?: boolean;
+  canManageSchema?: boolean;
   onRenameValueChange: (value: string) => void;
   onSelect: () => void;
   onDoubleClick: () => void;
@@ -219,6 +221,7 @@ function SortableCollectionItem({
   renameValue,
   itemCount,
   isItemCountLoading,
+  canManageSchema = true,
   onRenameValueChange,
   onSelect,
   onDoubleClick,
@@ -289,6 +292,7 @@ function SortableCollectionItem({
             <span>{collection.name}</span>
           </div>
 
+          {canManageSchema && (
           <div className="group-hover:opacity-100 opacity-0">
             <DropdownMenu
               open={openDropdownId === collection.id}
@@ -317,12 +321,14 @@ function SortableCollectionItem({
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
+          )}
 
-          <span className="group-hover:hidden block text-xs opacity-50">
+          <span className={cn('block text-xs opacity-50', canManageSchema && 'group-hover:hidden')}>
             {isItemCountLoading ? <Spinner className="size-3" /> : (itemCount ?? collection.draft_items_count)}
           </span>
         </div>
       </ContextMenuTrigger>
+      {canManageSchema && (
       <ContextMenuContent>
         <ContextMenuItem onClick={onRename}>
           Rename
@@ -331,6 +337,7 @@ function SortableCollectionItem({
           Delete
         </ContextMenuItem>
       </ContextMenuContent>
+      )}
     </ContextMenu>
   );
 }
@@ -389,6 +396,7 @@ const CMS = React.memo(function CMS() {
   const invalidateLayerData = useCollectionLayerStore((state) => state.invalidateLayerData);
 
   const { urlState, navigateToCollection, navigateToCollectionItem, navigateToNewCollectionItem, navigateToCollections } = useEditorUrl();
+  const { canEditStructure: canManageSchema } = useRole();
 
   // Track previous collection ID to prevent unnecessary reloads
   const prevCollectionIdRef = React.useRef<string | null>(null);
@@ -1542,6 +1550,7 @@ const CMS = React.memo(function CMS() {
                               </span>
                             )}
                           </button>
+                          {canManageSchema && (
                           <DropdownMenu
                             open={openDropdownId === field.id}
                             onOpenChange={(open) => !showSkeleton && setOpenDropdownId(open ? field.id : null)}
@@ -1584,10 +1593,12 @@ const CMS = React.memo(function CMS() {
                               </DropdownMenuItem>
                             </DropdownMenuContent>
                           </DropdownMenu>
+                          )}
                         </div>
                       </th>
                     );
                   })}
+                  {canManageSchema && (
                   <th className="px-4 py-3 text-left font-medium text-sm w-24 sticky right-0 top-0 z-20 bg-background border-b border-border">
                     <Button
                       size="sm"
@@ -1599,6 +1610,7 @@ const CMS = React.memo(function CMS() {
                       Add field
                     </Button>
                   </th>
+                  )}
                   <th className="sticky top-0 z-10 bg-background border-b border-border" />
                 </tr>
               </thead>
@@ -2030,6 +2042,7 @@ const CMS = React.memo(function CMS() {
     <div className="w-64 shrink-0 bg-background border-r flex flex-col overflow-hidden px-4">
       <header className="py-5 flex items-center justify-between shrink-0">
         <span className="font-medium">Collections</span>
+        {canManageSchema && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -2062,6 +2075,7 @@ const CMS = React.memo(function CMS() {
             </DropdownMenuSub>
           </DropdownMenuContent>
         </DropdownMenu>
+        )}
       </header>
       <div className="flex-1 overflow-y-auto no-scrollbar">
         <DndContext
@@ -2081,13 +2095,14 @@ const CMS = React.memo(function CMS() {
                   isSelected={selectedCollectionId === collection.id}
                   isHovered={hoveredCollectionId === collection.id}
                   openDropdownId={collectionDropdownId}
-                  isRenaming={collectionRename.renamingId === collection.id}
+                  isRenaming={canManageSchema && collectionRename.renamingId === collection.id}
                   renameValue={collectionRename.renameValue}
                   itemCount={itemsTotalCount[collection.id]}
                   isItemCountLoading={loadingSampleCollectionId === collection.id}
+                  canManageSchema={canManageSchema}
                   onRenameValueChange={collectionRename.setRenameValue}
                   onSelect={() => handleCollectionSelect(collection.id)}
-                  onDoubleClick={() => handleCollectionDoubleClick(collection)}
+                  onDoubleClick={canManageSchema ? () => handleCollectionDoubleClick(collection) : () => {}}
                   onMouseEnter={() => setHoveredCollectionId(collection.id)}
                   onMouseLeave={() => setHoveredCollectionId(null)}
                   onDropdownOpenChange={(open) => setCollectionDropdownId(open ? collection.id : null)}
@@ -2188,6 +2203,7 @@ const CMS = React.memo(function CMS() {
             />
           )}
 
+          {canManageSchema && (
           <FieldsDropdown
             fields={collectionFields}
             searchQuery={fieldSearchQuery}
@@ -2195,6 +2211,7 @@ const CMS = React.memo(function CMS() {
             onToggleVisibility={handleToggleFieldVisibility}
             onReorder={handleReorderFields}
           />
+          )}
 
           <Button
             size="sm"
@@ -2233,10 +2250,12 @@ const CMS = React.memo(function CMS() {
                 This collection has no fields. Add fields to start managing items.
               </EmptyDescription>
             </Empty>
+            {canManageSchema && (
             <Button onClick={() => { setEditingField(null); setFieldDialogOpen(true); }}>
               <Icon name="plus" />
               Add Field
             </Button>
+            )}
           </div>
         ) : (
           <>

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -37,6 +37,7 @@ import { useEditorUrl } from '@/hooks/use-editor-url';
 import { useEditComponent } from '@/hooks/use-edit-component';
 import { useZoom } from '@/hooks/use-zoom';
 import { useUndoRedo } from '@/hooks/use-undo-redo';
+import { useRole } from '@/hooks/use-role';
 
 // 5. Stores
 import { useEditorStore } from '@/stores/useEditorStore';
@@ -583,6 +584,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
   liveLayerUpdates,
   liveComponentUpdates,
 }: CenterCanvasProps) {
+  const { canEditStructure } = useRole();
   const selectedLayerId = useEditorStore((state) => state.selectedLayerId);
 
   const [showAddBlockPanel, setShowAddBlockPanel] = useState(false);
@@ -2582,10 +2584,10 @@ const CenterCanvas = React.memo(function CenterCanvas({
                         pageId={currentPageId || ''}
                         onLayerClick={handleCanvasLayerClick}
                         onLayerUpdate={handleCanvasLayerUpdate}
-                        onDeleteLayer={handleCanvasDeleteLayer}
+                        onDeleteLayer={canEditStructure ? handleCanvasDeleteLayer : undefined}
                         onContentHeightChange={setReportedContentHeight}
                         onContentWidthChange={editingComponentId ? setReportedContentWidth : undefined}
-                        onGapUpdate={handleCanvasGapUpdate}
+                        onGapUpdate={canEditStructure ? handleCanvasGapUpdate : undefined}
                         onZoomGesture={handleZoomGesture}
                         onZoomIn={zoomIn}
                         onZoomOut={zoomOut}
@@ -2599,7 +2601,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
                         onIframeReady={handleIframeReady}
                         onLayerHover={handleCanvasLayerHover}
                         onCanvasClick={handleCanvasClick}
-                        onComponentEdit={handleCanvasComponentEdit}
+                        onComponentEdit={canEditStructure ? handleCanvasComponentEdit : undefined}
                         editingComponentVariables={editingComponentVariables}
                         forceVisibleLayerIds={activeInteractionTriggerLayerId ? activeInteractionTargetLayerIds : undefined}
                         zoom={zoom}
@@ -2622,28 +2624,29 @@ const CenterCanvas = React.memo(function CenterCanvas({
                                   <Icon name="layout" className="size-3 text-neutral-900" />
                                 </EmptyMedia>
                                 <EmptyHeader>
-                                  <EmptyTitle className="text-sm">Start building</EmptyTitle>
+                                  <EmptyTitle className="text-sm">{canEditStructure ? 'Start building' : 'No content yet'}</EmptyTitle>
                                   <EmptyDescription>
-                                    Add your first block to begin creating your page.
+                                    {canEditStructure
+                                      ? 'Add your first block to begin creating your page.'
+                                      : 'This page has no content to edit yet.'}
                                   </EmptyDescription>
                                 </EmptyHeader>
-                                <Button
-                                  onClick={(e) => {
-                                    // Stop propagation to prevent canvas click handler from
-                                    // dispatching closeElementLibrary and immediately closing the panel
-                                    e.stopPropagation();
-                                    // Open ElementLibrary with layouts tab active
-                                    window.dispatchEvent(new CustomEvent('toggleElementLibrary', {
-                                      detail: { tab: 'layouts' }
-                                    }));
-                                  }}
-                                  size="sm"
-                                  variant="secondary"
-                                  className="bg-neutral-900/5 hover:bg-neutral-900/10 text-neutral-900"
-                                >
-                                  <Icon name="plus" />
-                                  Add layout
-                                </Button>
+                                {canEditStructure && (
+                                  <Button
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      window.dispatchEvent(new CustomEvent('toggleElementLibrary', {
+                                        detail: { tab: 'layouts' }
+                                      }));
+                                    }}
+                                    size="sm"
+                                    variant="secondary"
+                                    className="bg-neutral-900/5 hover:bg-neutral-900/10 text-neutral-900"
+                                  >
+                                    <Icon name="plus" />
+                                    Add layout
+                                  </Button>
+                                )}
                               </EmptyContent>
                             </Empty>
                           </div>
@@ -2657,12 +2660,14 @@ const CenterCanvas = React.memo(function CenterCanvas({
                           <Icon name="layout" className="w-10 h-10 text-blue-500" />
                         </div>
                         <h2 className="text-2xl font-bold text-gray-900 mb-3">
-                          Start building
+                          {canEditStructure ? 'Start building' : 'No content yet'}
                         </h2>
                         <p className="text-gray-600 mb-8">
-                          Add your first block to begin creating your page.
+                          {canEditStructure
+                            ? 'Add your first block to begin creating your page.'
+                            : 'This page has no content to edit yet.'}
                         </p>
-                        <div className="relative inline-block">
+                        {canEditStructure && <div className="relative inline-block">
                           <Button
                             onClick={() => setShowAddBlockPanel(!showAddBlockPanel)}
                             size="lg"
@@ -2798,7 +2803,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
                               </div>
                             </div>
                           )}
-                        </div>
+                        </div>}
                       </div>
                     </div>
                   )}

--- a/app/(builder)/ycode/components/HeaderBar.tsx
+++ b/app/(builder)/ycode/components/HeaderBar.tsx
@@ -38,6 +38,7 @@ import Icon from '@/components/ui/icon';
 import { Separator } from '@/components/ui/separator';
 import { BackupRestoreDialog } from '@/components/project/BackupRestoreDialog';
 import { isCloudVersion } from '@/lib/utils';
+import { useRole } from '@/hooks/use-role';
 
 interface HeaderBarProps {
   user: User | null;
@@ -83,6 +84,8 @@ export default function HeaderBar({
   const router = useRouter();
   const pathname = usePathname();
   const pageDropdownRef = useRef<HTMLDivElement>(null);
+  const { isEditor, canManageSettings, canManageMembers } = useRole();
+  const editorSidebarTab = useEditorStore((s) => s.activeSidebarTab);
   const currentPageCollectionItemId = useEditorStore((s) => s.currentPageCollectionItemId);
   const storeCurrentPageId = useEditorStore((s) => s.currentPageId);
   const isPreviewMode = useEditorStore((s) => s.isPreviewMode);
@@ -382,11 +385,13 @@ export default function HeaderBar({
                 <DropdownMenuSeparator />
               </>
             )}
-            <DropdownMenuItem
-              onClick={() => router.push('/ycode/settings/general')}
-            >
-              Settings
-            </DropdownMenuItem>
+            {canManageSettings && (
+              <DropdownMenuItem
+                onClick={() => router.push('/ycode/settings/general')}
+              >
+                Settings
+              </DropdownMenuItem>
+            )}
 
             <DropdownMenuItem
               onClick={() => openFileManager()}
@@ -394,17 +399,21 @@ export default function HeaderBar({
               File manager
             </DropdownMenuItem>
 
-            <DropdownMenuItem
-              onClick={() => router.push('/ycode/integrations/apps')}
-            >
-              Integrations
-            </DropdownMenuItem>
+            {canManageSettings && (
+              <>
+                <DropdownMenuItem
+                  onClick={() => router.push('/ycode/integrations/apps')}
+                >
+                  Integrations
+                </DropdownMenuItem>
 
-            <DropdownMenuItem
-              onClick={() => setShowTransferDialog(true)}
-            >
-              Backup &amp; Restore
-            </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => setShowTransferDialog(true)}
+                >
+                  Backup &amp; Restore
+                </DropdownMenuItem>
+              </>
+            )}
 
             <DropdownMenuSeparator />
 
@@ -452,38 +461,73 @@ export default function HeaderBar({
         </DropdownMenu>
 
         <div className="flex gap-1">
-          <Button
-            variant={activeNavButton === 'design' ? 'secondary' : 'ghost'}
-            size="sm"
-            onClick={() => {
-              setOptimisticNav('design');
-              setActiveSidebarTab('layers');
-              // Restore last design URL if available
-              if (lastDesignUrl) {
-                router.push(lastDesignUrl);
-              } else {
-                const targetPageId = storeCurrentPageId || findHomepage(storePages)?.id || storePages[0]?.id;
-                if (targetPageId) {
-                  navigateToLayers(targetPageId);
+          {isEditor ? (
+            <>
+              <Button
+                variant={(activeNavButton === 'design' && editorSidebarTab !== 'pages') ? 'secondary' : 'ghost'}
+                size="sm"
+                onClick={() => {
+                  setOptimisticNav('design');
+                  setActiveSidebarTab('layers');
+                  if (lastDesignUrl) {
+                    router.push(lastDesignUrl);
+                  } else {
+                    const targetPageId = storeCurrentPageId || findHomepage(storePages)?.id || storePages[0]?.id;
+                    if (targetPageId) {
+                      navigateToLayers(targetPageId);
+                    }
+                  }
+                }}
+              >
+                <Icon name="pencil" />
+                Content editor
+              </Button>
+              <Button
+                variant={editorSidebarTab === 'pages' ? 'secondary' : 'ghost'}
+                size="sm"
+                onClick={() => {
+                  setActiveSidebarTab('pages');
+                  const targetPageId = storeCurrentPageId || findHomepage(storePages)?.id || storePages[0]?.id;
+                  if (targetPageId) {
+                    navigateToLayers(targetPageId);
+                  }
+                }}
+              >
+                <Icon name="page" />
+                Pages
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant={activeNavButton === 'design' ? 'secondary' : 'ghost'}
+              size="sm"
+              onClick={() => {
+                setOptimisticNav('design');
+                setActiveSidebarTab('layers');
+                if (lastDesignUrl) {
+                  router.push(lastDesignUrl);
+                } else {
+                  const targetPageId = storeCurrentPageId || findHomepage(storePages)?.id || storePages[0]?.id;
+                  if (targetPageId) {
+                    navigateToLayers(targetPageId);
+                  }
                 }
-              }
-            }}
-          >
-            <Icon name="cursor-default" />
-            Design
-          </Button>
+              }}
+            >
+              <Icon name="cursor-default" />
+              Design
+            </Button>
+          )}
           <Button
             variant={activeNavButton === 'cms' ? 'secondary' : 'ghost'}
             size="sm"
             onClick={() => {
-              // Save current design URL before navigating away
               const isDesignRoute = routeType === 'layers' || routeType === 'page' || routeType === 'component';
               if (isDesignRoute) {
                 setLastDesignUrl(window.location.pathname + window.location.search);
               }
               setOptimisticNav('cms');
               setActiveSidebarTab('cms');
-              // Navigate to last selected or first available collection
               const targetCollectionId = storeSelectedCollectionId || collections[0]?.id;
               if (targetCollectionId) {
                 setSelectedCollectionId(targetCollectionId);
@@ -496,22 +540,23 @@ export default function HeaderBar({
             <Icon name="database" />
             CMS
           </Button>
-          <Button
-            variant={activeNavButton === 'forms' ? 'secondary' : 'ghost'}
-            size="sm"
-            onClick={() => {
-              // Save current design URL before navigating away
-              const isDesignRoute = routeType === 'layers' || routeType === 'page' || routeType === 'component';
-              if (isDesignRoute) {
-                setLastDesignUrl(window.location.pathname + window.location.search);
-              }
-              setOptimisticNav('forms');
-              router.push('/ycode/forms');
-            }}
-          >
-            <Icon name="form" />
-            Forms
-          </Button>
+          {!isEditor && (
+            <Button
+              variant={activeNavButton === 'forms' ? 'secondary' : 'ghost'}
+              size="sm"
+              onClick={() => {
+                const isDesignRoute = routeType === 'layers' || routeType === 'page' || routeType === 'component';
+                if (isDesignRoute) {
+                  setLastDesignUrl(window.location.pathname + window.location.search);
+                }
+                setOptimisticNav('forms');
+                router.push('/ycode/forms');
+              }}
+            >
+              <Icon name="form" />
+              Forms
+            </Button>
+          )}
         </div>
       </div>
 
@@ -547,7 +592,7 @@ export default function HeaderBar({
                 </DropdownMenuRadioItem>
               ))}
             </DropdownMenuRadioGroup>
-            {!pathname?.startsWith('/ycode/localization') && (
+            {canManageSettings && !pathname?.startsWith('/ycode/localization') && (
               <>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
@@ -577,7 +622,7 @@ export default function HeaderBar({
           </a>
         </Button>
 
-        {hasUpdate && (
+        {hasUpdate && canManageSettings && (
           <>
             <div className="h-5">
               <Separator orientation="vertical" />
@@ -601,7 +646,7 @@ export default function HeaderBar({
         <ActiveUsersInHeader />
 
         {/* Invite User */}
-        <InviteUserButton />
+        {canManageMembers && <InviteUserButton />}
 
         {/* Save Status Indicator */}
         <div className="flex items-center justify-end w-16 text-xs text-zinc-500 dark:text-white/50">

--- a/app/(builder)/ycode/components/KeyboardShortcutsDialog.tsx
+++ b/app/(builder)/ycode/components/KeyboardShortcutsDialog.tsx
@@ -7,7 +7,7 @@
  * Can be opened via the settings dropdown or with Shift+/
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -15,6 +15,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { useEditorStore } from '@/stores/useEditorStore';
+import { useRole } from '@/hooks/use-role';
 
 interface ShortcutKey {
   name: string;
@@ -118,17 +119,35 @@ function ShortcutCategory({ category }: { category: ShortcutCategory }) {
   );
 }
 
+const STRUCTURAL_SHORTCUTS = new Set([
+  'Copy', 'Paste', 'Cut', 'Duplicate', 'Copy style', 'Paste style',
+  'Rename', 'Delete', 'Create component', 'Detach instance',
+  'Show/Hide element', 'Open add elements',
+]);
+
 export default function KeyboardShortcutsDialog() {
   const isOpen = useEditorStore((state) => state.keyboardShortcutsOpen);
   const setKeyboardShortcutsOpen = useEditorStore((state) => state.setKeyboardShortcutsOpen);
+  const { isEditor } = useRole();
+
+  const filteredCategories = useMemo(() => {
+    if (!isEditor) return shortcutCategories;
+
+    const filterCategory = (cat: ShortcutCategory): ShortcutCategory => ({
+      ...cat,
+      shortcuts: cat.shortcuts.filter(s => !STRUCTURAL_SHORTCUTS.has(s.name)),
+    });
+
+    return {
+      left: shortcutCategories.left.map(filterCategory).filter(c => c.shortcuts.length > 0),
+      right: shortcutCategories.right.map(filterCategory).filter(c => c.shortcuts.length > 0),
+    };
+  }, [isEditor]);
 
   // Handle Shift+/ keyboard shortcut (Shift+/ produces '?' on most keyboards)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Check for Shift + / (produces '?' character)
-      // Also check e.code === 'Slash' for physical key detection
       if (e.shiftKey && (e.key === '?' || e.code === 'Slash')) {
-        // Don't trigger if user is typing in an input field
         const target = e.target as HTMLElement;
         if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
           return;
@@ -154,14 +173,14 @@ export default function KeyboardShortcutsDialog() {
         <div className="grid grid-cols-2 gap-8">
           {/* Left column */}
           <div className="space-y-6">
-            {shortcutCategories.left.map((category) => (
+            {filteredCategories.left.map((category) => (
               <ShortcutCategory key={category.name} category={category} />
             ))}
           </div>
 
           {/* Right column */}
           <div className="space-y-6">
-            {shortcutCategories.right.map((category) => (
+            {filteredCategories.right.map((category) => (
               <ShortcutCategory key={category.name} category={category} />
             ))}
           </div>

--- a/app/(builder)/ycode/components/LayerContextMenu.tsx
+++ b/app/(builder)/ycode/components/LayerContextMenu.tsx
@@ -40,6 +40,7 @@ interface LayerContextMenuProps {
   layerId: string;
   pageId: string;
   children: React.ReactNode;
+  readOnly?: boolean;
   isLocked?: boolean;
   onLayerSelect?: (layerId: string) => void;
   liveLayerUpdates?: UseLiveLayerUpdatesReturn | null;
@@ -961,6 +962,7 @@ function LayerContextMenu({
   layerId,
   pageId,
   children,
+  readOnly = false,
   isLocked = false,
   onLayerSelect,
   liveLayerUpdates,
@@ -1016,6 +1018,8 @@ function LayerContextMenu({
     },
     [canvasPortalContainer, onLayerSelect, layerId]
   );
+
+  if (readOnly) return <>{children}</>;
 
   return (
     <ContextMenu onOpenChange={handleOpenChange}>

--- a/app/(builder)/ycode/components/LayersTree.tsx
+++ b/app/(builder)/ycode/components/LayersTree.tsx
@@ -157,6 +157,7 @@ interface LayersTreeProps {
   pageId: string;
   liveLayerUpdates?: UseLiveLayerUpdatesReturn | null;
   liveComponentUpdates?: UseLiveComponentUpdatesReturn | null;
+  readOnly?: boolean;
 }
 
 const ROW_HEIGHT = 32;
@@ -259,6 +260,7 @@ interface LayerRowProps {
   onRenameStart: (id: string) => void;
   onRenameConfirm: (id: string, newName: string | null) => void;
   onToggleVisibility: (id: string) => void;
+  readOnly?: boolean;
 }
 
 // Helper to check if a node is a descendant of another
@@ -300,6 +302,7 @@ const LayerRow = React.memo(function LayerRow({
   onRenameStart,
   onRenameConfirm,
   onToggleVisibility,
+  readOnly,
 }: LayerRowProps) {
   const {
     getComponentById,
@@ -555,6 +558,7 @@ const LayerRow = React.memo(function LayerRow({
       liveLayerUpdates={liveLayerUpdates}
       liveComponentUpdates={liveComponentUpdates}
       editingComponentId={editingComponentId}
+      readOnly={readOnly}
     >
       <div
         className="relative flex group/row"
@@ -978,6 +982,7 @@ export default function LayersTree({
   pageId,
   liveLayerUpdates,
   liveComponentUpdates,
+  readOnly = false,
 }: LayersTreeProps) {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
@@ -1290,13 +1295,15 @@ export default function LayersTree({
   }, [editingComponentId, pageId, updateLayer, updateComponentDraft, flattenedNodes]);
 
   // Configure sensors for drag detection
-  const sensors = useSensors(
+  const defaultSensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
         distance: 8, // 8px movement required to start drag
       },
     })
   );
+  const noSensors = useSensors();
+  const sensors = readOnly ? noSensors : defaultSensors;
 
   const handleMultiSelect = useCallback((id: string, modifiers: { meta: boolean; shift: boolean }) => {
     if (id === 'body') {
@@ -2231,6 +2238,7 @@ export default function LayersTree({
                 onRenameStart={handleRenameStart}
                 onRenameConfirm={handleRenameConfirm}
                 onToggleVisibility={handleToggleVisibility}
+                readOnly={readOnly}
               />
             </VirtualLayerRow>
           );

--- a/app/(builder)/ycode/components/LeftSidebar.tsx
+++ b/app/(builder)/ycode/components/LeftSidebar.tsx
@@ -41,6 +41,7 @@ interface LeftSidebarProps {
   onPageSelect: (pageId: string) => void;
   liveLayerUpdates?: UseLiveLayerUpdatesReturn | null;
   liveComponentUpdates?: UseLiveComponentUpdatesReturn | null;
+  readOnly?: boolean;
 }
 
 const LeftSidebar = React.memo(function LeftSidebar({
@@ -49,6 +50,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
   onPageSelect,
   liveLayerUpdates,
   liveComponentUpdates,
+  readOnly = false,
 }: LeftSidebarProps) {
   // Intentionally NOT subscribing to selectedLayerId here — it's only read
   // inside the asset-select handler. A subscription would re-render the
@@ -341,10 +343,12 @@ const LeftSidebar = React.memo(function LeftSidebar({
             }}
             className="h-full overflow-hidden gap-0!"
           >
-            <TabsList className="w-full shrink-0">
-              <TabsTrigger value="layers">Layers</TabsTrigger>
-              <TabsTrigger value="pages">Pages</TabsTrigger>
-            </TabsList>
+            {!readOnly && (
+              <TabsList className="w-full shrink-0">
+                <TabsTrigger value="layers">Layers</TabsTrigger>
+                <TabsTrigger value="pages">Pages</TabsTrigger>
+              </TabsList>
+            )}
 
             <hr className="mt-4" />
 
@@ -401,15 +405,17 @@ const LeftSidebar = React.memo(function LeftSidebar({
                 />
               )}
               <header className="py-5 flex justify-between shrink-0 z-20">
-                <span className="font-medium">{editingComponentId ? 'Layers' : 'Layers'}</span>
-                <div className="-my-1">
-                  <Button
-                    size="xs" variant="secondary"
-                    onClick={() => setShowElementLibrary(prev => !prev)}
-                  >
-                    <Icon name="plus" className={`${showElementLibrary ? 'rotate-45' : 'rotate-0'} transition-transform duration-100`} />
-                  </Button>
-                </div>
+                <span className="font-medium">Layers</span>
+                {!readOnly && (
+                  <div className="-my-1">
+                    <Button
+                      size="xs" variant="secondary"
+                      onClick={() => setShowElementLibrary(prev => !prev)}
+                    >
+                      <Icon name="plus" className={`${showElementLibrary ? 'rotate-45' : 'rotate-0'} transition-transform duration-100`} />
+                    </Button>
+                  </div>
+                )}
               </header>
 
               <div
@@ -434,6 +440,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
                     pageId={currentPageId || ''}
                     liveLayerUpdates={liveLayerUpdates}
                     liveComponentUpdates={liveComponentUpdates}
+                    readOnly={readOnly}
                   />
                 )}
               </div>
@@ -451,6 +458,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
                 currentPageId={currentPageId}
                 onPageSelect={onPageSelect}
                 setCurrentPageId={setCurrentPageId}
+                readOnly={readOnly}
               />
             </TabsContent>
 

--- a/app/(builder)/ycode/components/LeftSidebarPages.tsx
+++ b/app/(builder)/ycode/components/LeftSidebarPages.tsx
@@ -31,6 +31,7 @@ interface LeftSidebarPagesProps {
   currentPageId: string | null;
   onPageSelect: (pageId: string) => void;
   setCurrentPageId: (pageId: string | null) => void;
+  readOnly?: boolean;
 }
 
 const LeftSidebarPages = React.forwardRef<LeftSidebarPagesHandle, LeftSidebarPagesProps>(({
@@ -39,6 +40,7 @@ const LeftSidebarPages = React.forwardRef<LeftSidebarPagesHandle, LeftSidebarPag
   currentPageId,
   onPageSelect,
   setCurrentPageId,
+  readOnly = false,
 }, ref) => {
   const { urlState } = useEditorUrl();
   const activeSidebarTab = useEditorStore((state) => state.activeSidebarTab);
@@ -776,52 +778,54 @@ const LeftSidebarPages = React.forwardRef<LeftSidebarPagesHandle, LeftSidebarPag
     <>
       <header className="py-5 flex justify-between shrink-0 sticky top-0 bg-linear-to-b from-background to-transparent z-20">
         <span className="font-medium">Pages</span>
-        <div className="-my-1">
-          <DropdownMenu onOpenChange={setIsMenuOpen}>
-            <DropdownMenuTrigger asChild>
-              <Button size="xs" variant="secondary">
-                <Icon name="plus" className={`${isMenuOpen ? 'rotate-45' : 'rotate-0'} transition-transform duration-100`} />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="start"
-              side="bottom"
-              onCloseAutoFocus={(e) => e.preventDefault()}
-              className="max-h-125 overflow-y-auto"
-            >
-              <DropdownMenuItem onClick={() => handleAddPage()}>
-                <Icon name="page" className="size-3 opacity-60" />
-                Regular
-              </DropdownMenuItem>
-              <DropdownMenuSub>
-                <DropdownMenuSubTrigger>
-                  <Icon name="dynamicPage" className="size-3 opacity-60" />
-                  CMS
-                </DropdownMenuSubTrigger>
-                <DropdownMenuSubContent>
-                  {collections.length > 0 ? (
-                    collections.map(collection => (
-                      <DropdownMenuItem key={collection.id} onClick={() => handleAddPage(collection.id)}>
+        {!readOnly && (
+          <div className="-my-1">
+            <DropdownMenu onOpenChange={setIsMenuOpen}>
+              <DropdownMenuTrigger asChild>
+                <Button size="xs" variant="secondary">
+                  <Icon name="plus" className={`${isMenuOpen ? 'rotate-45' : 'rotate-0'} transition-transform duration-100`} />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="start"
+                side="bottom"
+                onCloseAutoFocus={(e) => e.preventDefault()}
+                className="max-h-125 overflow-y-auto"
+              >
+                <DropdownMenuItem onClick={() => handleAddPage()}>
+                  <Icon name="page" className="size-3 opacity-60" />
+                  Regular
+                </DropdownMenuItem>
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <Icon name="dynamicPage" className="size-3 opacity-60" />
+                    CMS
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    {collections.length > 0 ? (
+                      collections.map(collection => (
+                        <DropdownMenuItem key={collection.id} onClick={() => handleAddPage(collection.id)}>
+                          <Icon name="database" className="size-3 opacity-60" />
+                          {collection.name}
+                        </DropdownMenuItem>
+                      ))
+                    ) : (
+                      <DropdownMenuItem key={null} onClick={() => navigateToCollections()}>
                         <Icon name="database" className="size-3 opacity-60" />
-                        {collection.name}
+                        Add a collection
                       </DropdownMenuItem>
-                    ))
-                  ) : (
-                    <DropdownMenuItem key={null} onClick={() => navigateToCollections()}>
-                      <Icon name="database" className="size-3 opacity-60" />
-                      Add a collection
-                    </DropdownMenuItem>
-                  )}
-                </DropdownMenuSubContent>
-              </DropdownMenuSub>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={handleAddFolder}>
-                <Icon name="folder" className="size-3 opacity-60" />
-                Folder
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+                    )}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleAddFolder}>
+                  <Icon name="folder" className="size-3 opacity-60" />
+                  Folder
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
       </header>
 
       <div className="flex flex-col gap-3">
@@ -837,11 +841,11 @@ const LeftSidebarPages = React.forwardRef<LeftSidebarPagesHandle, LeftSidebarPag
             setCurrentPageId(pageId);
             handlePageSelect(pageId); // This will also navigate
           }}
-          onReorder={handleReorder}
+          onReorder={readOnly ? undefined : handleReorder}
           onPageSettings={handleEditPage}
           onFolderSettings={handleEditFolder}
-          onDuplicate={handleDuplicate}
-          onDelete={deletePageOrFolderItem}
+          onDuplicate={readOnly ? undefined : handleDuplicate}
+          onDelete={readOnly ? undefined : deletePageOrFolderItem}
         />
 
         <div className="flex items-center gap-2 mt-2">

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -73,6 +73,7 @@ import { useFontsStore } from '@/stores/useFontsStore';
 import { useLocalisationStore } from '@/stores/useLocalisationStore';
 import { useMigrationStore } from '@/stores/useMigrationStore';
 import { useVersionsStore } from '@/stores/useVersionsStore';
+import { useRole } from '@/hooks/use-role';
 // Collaboration temporarily disabled
 // import { useCollaborationPresenceStore } from '@/stores/useCollaborationPresenceStore';
 
@@ -97,6 +98,11 @@ interface YCodeBuilderProps {
 export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCodeBuilderProps) {
   const router = useRouter();
   const { routeType, resourceId, sidebarTab, navigateToLayers, navigateToCollection, navigateToCollections, navigateToComponent, urlState, updateQueryParams } = useEditorUrl();
+
+  // Role-based access
+  const { isEditor, canEditStructure } = useRole();
+  const canEditStructureRef = useRef(canEditStructure);
+  canEditStructureRef.current = canEditStructure;
 
   // Optimize store subscriptions - use selective selectors to prevent unnecessary re-renders
   const signOut = useAuthStore((state) => state.signOut);
@@ -203,6 +209,20 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
       setCurrentCollaborationUser(user.id, user.email || '', avatarUrl);
     }
   }, [user, setCurrentCollaborationUser]);
+
+  // Redirect editors away from restricted routes
+  useEffect(() => {
+    if (!isEditor || !authInitialized) return;
+    const restricted = routeType === 'settings' || routeType === 'integrations' || routeType === 'component';
+    if (restricted) {
+      const targetPageId = currentPageId || pages[0]?.id;
+      if (targetPageId) {
+        navigateToLayers(targetPageId);
+      } else {
+        router.replace('/ycode');
+      }
+    }
+  }, [isEditor, authInitialized, routeType, currentPageId, pages, navigateToLayers, router]);
 
   // Sidebar tab from store - immediately synced when tab changes in LeftSidebar
   const activeSidebarTab = useEditorStore((state) => state.activeSidebarTab);
@@ -1231,10 +1251,13 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
       // Note: Undo/Redo shortcuts (Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z, Cmd/Ctrl+Y) are handled in CenterCanvas.tsx
       // This prevents duplication and ensures they work both in the main window and inside the iframe
 
+      const isContentOnlyRole = !canEditStructureRef.current;
+
       // Layer-specific shortcuts (only work on layers tab)
       if (activeTab === 'layers') {
         // A - Toggle Element Library (when on layers tab and not typing)
         if (e.key === 'a' && !isInputFocused && !e.metaKey && !e.ctrlKey && !e.altKey) {
+          if (isContentOnlyRole) return;
           e.preventDefault();
           // Dispatch custom event to toggle ElementLibrary
           window.dispatchEvent(new CustomEvent('toggleElementLibrary'));
@@ -1249,7 +1272,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         }
 
         // Shift + Cmd + H - Toggle layer visibility (Show/Hide)
-        if (e.shiftKey && e.metaKey && e.code === 'KeyH') {
+        if (e.shiftKey && e.metaKey && e.code === 'KeyH' && !isContentOnlyRole) {
           if (!isInputFocused && (currentPageId || editingComponentId) && selectedLayerId) {
             e.preventDefault();
             const layers = getCurrentLayers();
@@ -1317,7 +1340,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         }
 
         // Arrow Up/Down - Reorder layer within siblings
-        if ((e.key === 'ArrowUp' || e.key === 'ArrowDown') && (currentPageId || editingComponentId) && selectedLayerId && !isInputFocused) {
+        if ((e.key === 'ArrowUp' || e.key === 'ArrowDown') && !isContentOnlyRole && (currentPageId || editingComponentId) && selectedLayerId && !isInputFocused) {
           e.preventDefault();
 
           const layers = getCurrentLayers();
@@ -1431,7 +1454,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         }
 
         // Copy: Cmd/Ctrl + C (supports multi-select)
-        if ((e.metaKey || e.ctrlKey) && e.key === 'c') {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'c' && !isContentOnlyRole) {
           if (!isInputFocused && (currentPageId || editingComponentId)) {
             e.preventDefault();
 
@@ -1476,7 +1499,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         }
 
         // Cut: Cmd/Ctrl + X (supports multi-select)
-        if ((e.metaKey || e.ctrlKey) && e.key === 'x') {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'x' && !isContentOnlyRole) {
           if (!isInputFocused && (currentPageId || editingComponentId)) {
             e.preventDefault();
 
@@ -1547,7 +1570,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         }
 
         // Paste: Cmd/Ctrl + V
-        if ((e.metaKey || e.ctrlKey) && e.key === 'v') {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'v' && !isContentOnlyRole) {
           if (!isInputFocused && (currentPageId || editingComponentId)) {
             e.preventDefault();
             // Use clipboard store for paste (works with context menu)
@@ -1587,7 +1610,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         }
 
         // Duplicate: Cmd/Ctrl + D (supports multi-select)
-        if ((e.metaKey || e.ctrlKey) && e.key === 'd') {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'd' && !isContentOnlyRole) {
           if (!isInputFocused && currentPageId) {
             e.preventDefault();
             if (selectedLayerIds.length > 1) {
@@ -1611,14 +1634,14 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         }
 
         // F2 - Rename selected layer
-        if (e.key === 'F2' && !isInputFocused && (currentPageId || editingComponentId) && selectedLayerId && selectedLayerId !== 'body') {
+        if (e.key === 'F2' && !isContentOnlyRole && !isInputFocused && (currentPageId || editingComponentId) && selectedLayerId && selectedLayerId !== 'body') {
           e.preventDefault();
           useEditorStore.getState().setRenamingLayerId(selectedLayerId);
           return;
         }
 
         // Delete: Delete or Backspace (supports multi-select)
-        if ((e.key === 'Delete' || e.key === 'Backspace')) {
+        if ((e.key === 'Delete' || e.key === 'Backspace') && !isContentOnlyRole) {
           if (!isInputFocused && (currentPageId || editingComponentId)) {
             e.preventDefault();
             if (selectedLayerIds.length > 1) {
@@ -1711,7 +1734,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
 
         // Copy Style: Option + Cmd + C
         // Use e.code for physical key detection (e.key produces special chars with Option)
-        if (e.altKey && e.metaKey && e.code === 'KeyC') {
+        if (e.altKey && e.metaKey && e.code === 'KeyC' && !isContentOnlyRole) {
           if (!isInputFocused && (currentPageId || editingComponentId) && selectedLayerId) {
             e.preventDefault();
             const layers = getCurrentLayers();
@@ -1725,7 +1748,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
 
         // Paste Style: Option + Cmd + V
         // Use e.code for physical key detection (e.key produces special chars with Option)
-        if (e.altKey && e.metaKey && e.code === 'KeyV') {
+        if (e.altKey && e.metaKey && e.code === 'KeyV' && !isContentOnlyRole) {
           if (!isInputFocused && (currentPageId || editingComponentId) && selectedLayerId) {
             e.preventDefault();
             const style = pasteStyleFromClipboard();
@@ -1747,7 +1770,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         }
 
         // Create Component: Option + Cmd + K
-        if (e.altKey && e.metaKey && e.code === 'KeyK') {
+        if (e.altKey && e.metaKey && e.code === 'KeyK' && !isContentOnlyRole) {
           if (!isInputFocused && currentPageId && selectedLayerId && !editingComponentId) {
             e.preventDefault();
             const layers = getCurrentLayers();
@@ -1760,7 +1783,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         }
 
         // Detach from Component: Option + Cmd + B
-        if (e.altKey && e.metaKey && e.code === 'KeyB') {
+        if (e.altKey && e.metaKey && e.code === 'KeyB' && !isContentOnlyRole) {
           if (!isInputFocused && currentPageId && selectedLayerId && !editingComponentId) {
             e.preventDefault();
             const layers = getCurrentLayers();
@@ -2008,14 +2031,27 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
           <IntegrationsContent>{children}</IntegrationsContent>
         ) : (
           <>
-            {/* Left Sidebar - Pages & Layers (hidden in CMS mode) */}
-            <div className={activeTab === 'cms' ? 'hidden' : 'contents'}>
+            {/* Left Sidebar - Pages & Layers
+                - Hidden in CMS mode
+                - For editor role: only shown when "Pages" tab is active */}
+            <div className={activeTab === 'cms' || (isEditor && activeTab !== 'pages') ? 'hidden' : 'contents'}>
               <LeftSidebar
-                onLayerSelect={setSelectedLayerId}
+                onLayerSelect={(layerId) => {
+                  setSelectedLayerId(layerId);
+                  if (isEditor) {
+                    useEditorStore.getState().setActiveSidebarTab('layers');
+                  }
+                }}
                 currentPageId={currentPageId}
-                onPageSelect={setCurrentPageId}
+                onPageSelect={(pageId: string) => {
+                  setCurrentPageId(pageId);
+                  if (isEditor) {
+                    useEditorStore.getState().setActiveSidebarTab('layers');
+                  }
+                }}
                 liveLayerUpdates={liveLayerUpdates}
                 liveComponentUpdates={liveComponentUpdates}
+                readOnly={!canEditStructure}
               />
             </div>
 
@@ -2038,10 +2074,12 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
                 liveComponentUpdates={liveComponentUpdates}
               />
 
-              {/* Right Sidebar - Properties */}
-              <RightSidebar
-                onLayerUpdate={handleLayerUpdate}
-              />
+              {/* Right Sidebar - Properties (hidden for editor role) */}
+              {!isEditor && (
+                <RightSidebar
+                  onLayerUpdate={handleLayerUpdate}
+                />
+              )}
             </div>
           </>
         )}

--- a/app/(builder)/ycode/settings/users/page.tsx
+++ b/app/(builder)/ycode/settings/users/page.tsx
@@ -15,18 +15,22 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Spinner } from '@/components/ui/spinner';
 import { getUserInitials, generateUserColor } from '@/lib/collaboration-utils';
 import { useAuthStore } from '@/stores/useAuthStore';
+import { useRole } from '@/hooks/use-role';
 
 interface ActiveUser {
   id: string;
   email: string;
   display_name: string | null;
   avatar_url: string | null;
+  role?: string;
   created_at: string;
   last_sign_in_at: string | null;
 }
@@ -34,28 +38,28 @@ interface ActiveUser {
 interface PendingInvite {
   id: string;
   email: string;
+  role?: string;
   invited_at: string;
 }
 
 export default function UsersSettingsPage() {
   const router = useRouter();
   const currentUser = useAuthStore((state) => state.user);
+  const { canManageMembers, role: clientRole } = useRole();
 
   const [activeUsers, setActiveUsers] = useState<ActiveUser[]>([]);
   const [pendingInvites, setPendingInvites] = useState<PendingInvite[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  // Invite form state
   const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState<string>('designer');
   const [isInviting, setIsInviting] = useState(false);
   const [inviteError, setInviteError] = useState<string | null>(null);
   const [inviteSuccess, setInviteSuccess] = useState<string | null>(null);
 
-  // Delete dialog state
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [userToDelete, setUserToDelete] = useState<{ id: string; email: string; type: 'user' | 'invite' } | null>(null);
 
-  // Fetch users on mount
   useEffect(() => {
     fetchUsers();
   }, []);
@@ -78,7 +82,6 @@ export default function UsersSettingsPage() {
   const handleInvite = useCallback(async () => {
     if (!inviteEmail.trim()) return;
 
-    // Basic email validation
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(inviteEmail)) {
       setInviteError('Please enter a valid email address');
@@ -95,6 +98,7 @@ export default function UsersSettingsPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           email: inviteEmail.trim(),
+          role: inviteRole,
           redirectTo: window.location.origin + '/ycode/accept-invite',
         }),
       });
@@ -110,19 +114,18 @@ export default function UsersSettingsPage() {
       setInviteSuccess(`Invitation sent to ${invitedEmail}`);
       setInviteEmail('');
 
-      // Add to pending invites list immediately
       if (result.data?.user) {
         setPendingInvites((prev) => [
           {
             id: result.data.user.id,
             email: invitedEmail,
+            role: result.data.role || inviteRole,
             invited_at: new Date().toISOString(),
           },
           ...prev,
         ]);
       }
 
-      // Clear success message after a few seconds
       setTimeout(() => setInviteSuccess(null), 3000);
     } catch (error) {
       console.error('Failed to send invite:', error);
@@ -130,7 +133,7 @@ export default function UsersSettingsPage() {
     } finally {
       setIsInviting(false);
     }
-  }, [inviteEmail]);
+  }, [inviteEmail, inviteRole]);
 
   const handleDelete = async () => {
     if (!userToDelete) return;
@@ -140,15 +143,23 @@ export default function UsersSettingsPage() {
         method: 'DELETE',
       });
 
-      if (response.ok) {
+      const result = await response.json();
+
+      if (response.ok && result.data?.success) {
         if (userToDelete.type === 'user') {
           setActiveUsers(activeUsers.filter(u => u.id !== userToDelete.id));
         } else {
           setPendingInvites(pendingInvites.filter(i => i.id !== userToDelete.id));
         }
+      } else {
+        console.error('Failed to delete user:', result.error);
+        setInviteError(result.error || 'Failed to remove user');
+        setTimeout(() => setInviteError(null), 5000);
       }
     } catch (error) {
       console.error('Failed to delete user:', error);
+      setInviteError('Failed to remove user');
+      setTimeout(() => setInviteError(null), 5000);
     } finally {
       setShowDeleteDialog(false);
       setUserToDelete(null);
@@ -177,6 +188,32 @@ export default function UsersSettingsPage() {
     }
   };
 
+  const handleChangeRole = async (userId: string, newRole: string) => {
+    try {
+      const response = await fetch(`/ycode/api/auth/users?id=${userId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role: newRole }),
+      });
+
+      const result = await response.json();
+
+      if (response.ok && result.data?.success) {
+        setActiveUsers((prev) =>
+          prev.map((u) => u.id === userId ? { ...u, role: newRole } : u)
+        );
+      } else {
+        console.error('Failed to change role:', result.error);
+        setInviteError(result.error || 'Failed to change role');
+        setTimeout(() => setInviteError(null), 5000);
+      }
+    } catch (error) {
+      console.error('Failed to change role:', error);
+      setInviteError('Failed to change role');
+      setTimeout(() => setInviteError(null), 5000);
+    }
+  };
+
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('en-US', {
       year: 'numeric',
@@ -190,16 +227,17 @@ export default function UsersSettingsPage() {
     return formatDate(dateString);
   };
 
+  const canManage = canManageMembers;
+
   return (
     <div className="p-8">
       <div className="max-w-3xl mx-auto">
 
-        {/* Page Header */}
         <header className="pt-8 pb-3">
           <span className="text-base font-medium">Users</span>
         </header>
 
-        {/* Invite User Section */}
+        {canManage && (
         <div className="flex flex-col gap-6 bg-secondary/20 p-8 rounded-lg">
           <header>
             <FieldLegend>Invite user</FieldLegend>
@@ -225,6 +263,16 @@ export default function UsersSettingsPage() {
               disabled={isInviting}
               className="flex-1"
             />
+            <Select value={inviteRole} onValueChange={setInviteRole}>
+              <SelectTrigger className="w-[120px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="admin">Admin</SelectItem>
+                <SelectItem value="designer">Designer</SelectItem>
+                <SelectItem value="editor">Editor</SelectItem>
+              </SelectContent>
+            </Select>
             <Button
               onClick={handleInvite}
               disabled={isInviting || !inviteEmail.trim()}
@@ -241,8 +289,8 @@ export default function UsersSettingsPage() {
             <p className="text-xs text-green-500">{inviteSuccess}</p>
           )}
         </div>
+        )}
 
-        {/* Active Users Section */}
         <header className="pt-10 pb-3">
           <span className="text-base font-medium">Active users</span>
         </header>
@@ -263,14 +311,12 @@ export default function UsersSettingsPage() {
             <div className="border-t -mb-4 divide-y">
               {[...activeUsers]
                 .sort((a, b) => {
-                  // Current user first
                   if (a.id === currentUser?.id) return -1;
                   if (b.id === currentUser?.id) return 1;
                   return 0;
                 })
                 .map((user) => (
                 <div key={user.id} className="py-4 flex items-center gap-4">
-                  {/* Avatar */}
                   <div
                     className="size-8 rounded-full bg-neutral-700 flex items-center justify-center text-xs font-medium text-white shrink-0 overflow-hidden"
                     style={{ backgroundColor: user.avatar_url ? undefined : generateUserColor(user.id) }}
@@ -298,6 +344,9 @@ export default function UsersSettingsPage() {
                       {user.display_name && (
                         <span className="text-xs text-muted-foreground">{user.email}</span>
                       )}
+                      {user.role && (
+                        <span className="text-[10px] text-muted-foreground bg-secondary px-1.5 py-0.5 rounded capitalize">{user.role}</span>
+                      )}
                     </div>
                     <div className="text-xs text-muted-foreground">
                       Joined {formatDate(user.created_at)} · Last seen: {formatLastSeen(user.last_sign_in_at)}
@@ -317,17 +366,36 @@ export default function UsersSettingsPage() {
                         >
                           My profile
                         </DropdownMenuItem>
-                      ) : (
-                        <DropdownMenuItem
-                          className="text-destructive focus:text-destructive"
-                          onClick={() => {
-                            setUserToDelete({ id: user.id, email: user.email, type: 'user' });
-                            setShowDeleteDialog(true);
-                          }}
-                        >
-                          Remove user
+                      ) : user.role === 'owner' ? (
+                        <DropdownMenuItem disabled>
+                          Owner
                         </DropdownMenuItem>
-                      )}
+                      ) : canManage ? (
+                        <>
+                          <DropdownMenuItem
+                            disabled={user.role === 'designer'}
+                            onClick={() => handleChangeRole(user.id, 'designer')}
+                          >
+                            Set as Designer
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            disabled={user.role === 'editor'}
+                            onClick={() => handleChangeRole(user.id, 'editor')}
+                          >
+                            Set as Editor
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            className="text-destructive focus:text-destructive"
+                            onClick={() => {
+                              setUserToDelete({ id: user.id, email: user.email, type: 'user' });
+                              setShowDeleteDialog(true);
+                            }}
+                          >
+                            Remove user
+                          </DropdownMenuItem>
+                        </>
+                      ) : null}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </div>
@@ -340,7 +408,6 @@ export default function UsersSettingsPage() {
           )}
         </div>
 
-        {/* Pending Invites Section */}
         <header className="pt-10 pb-3">
           <span className="text-base font-medium">Pending invites</span>
         </header>
@@ -361,7 +428,6 @@ export default function UsersSettingsPage() {
             <div className="border-t -mb-4 divide-y">
               {pendingInvites.map((invite) => (
                 <div key={invite.id} className="py-4 flex items-center gap-4">
-                  {/* Avatar */}
                   <div
                     className="size-8 rounded-full flex items-center justify-center text-xs font-medium text-white shrink-0 opacity-50"
                     style={{ backgroundColor: generateUserColor(invite.id) }}
@@ -375,12 +441,16 @@ export default function UsersSettingsPage() {
                       <span className="text-xs text-muted-foreground bg-secondary px-1.5 py-0.5 rounded">
                         Pending
                       </span>
+                      {invite.role && (
+                        <span className="text-[10px] text-muted-foreground bg-secondary px-1.5 py-0.5 rounded capitalize">{invite.role}</span>
+                      )}
                     </div>
                     <div className="text-xs text-muted-foreground">
                       Invited {formatDate(invite.invited_at)}
                     </div>
                   </div>
 
+                  {canManage && (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button variant="secondary" size="xs">
@@ -404,6 +474,7 @@ export default function UsersSettingsPage() {
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
+                  )}
                 </div>
               ))}
             </div>
@@ -416,7 +487,6 @@ export default function UsersSettingsPage() {
 
       </div>
 
-      {/* Delete/Cancel Confirmation Dialog */}
       <ConfirmDialog
         open={showDeleteDialog}
         onOpenChange={setShowDeleteDialog}

--- a/app/(builder)/ycode/welcome/page.tsx
+++ b/app/(builder)/ycode/welcome/page.tsx
@@ -884,12 +884,21 @@ export default function WelcomePage() {
         const { useAuthStore } = await import('@/stores/useAuthStore');
         const { signUp } = useAuthStore.getState();
 
-        // Sign up admin user
         const result = await signUp(email, password);
 
         if (result.error) {
           setError(result.error);
           return;
+        }
+
+        // Assign owner role to the first user
+        const { user: newUser } = useAuthStore.getState();
+        if (newUser?.id) {
+          await fetch('/ycode/api/auth/set-role', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ userId: newUser.id, role: 'owner' }),
+          });
         }
 
         // Complete setup

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -469,6 +469,8 @@ const LayerItemImpl: React.FC<{
   const isDragging = activeLayerId === layer.id;
   const textEditable = isTextEditable(layer);
 
+  const isEditor = useAuthStore((state) => state.role === 'editor');
+
   // Collaboration layer locking - use unified resource lock system
   const currentUserId = useAuthStore((state) => state.user?.id);
   const lockKey = getResourceLockKey(RESOURCE_TYPES.LAYER, layer.id);
@@ -3346,6 +3348,7 @@ const LayerItemImpl: React.FC<{
         onLayerSelect={onLayerClick}
         liveLayerUpdates={liveLayerUpdates}
         liveComponentUpdates={liveComponentUpdates}
+        readOnly={isEditor}
       >
         {content}
       </LayerContextMenu>

--- a/database/migrations/20260527000001_bootstrap_user_roles.ts
+++ b/database/migrations/20260527000001_bootstrap_user_roles.ts
@@ -1,0 +1,39 @@
+import type { Knex } from 'knex';
+
+/**
+ * Bootstrap user roles in Supabase auth.users.
+ *
+ * - The earliest-created user (the person who set up the app) becomes 'owner'.
+ * - All other users without a role default to 'designer'.
+ *
+ * Roles are stored in raw_app_meta_data (Supabase's app_metadata),
+ * which is only writable via the Admin API or direct SQL.
+ */
+
+export async function up(knex: Knex): Promise<void> {
+  // Set the first-ever user as owner (if they don't already have a role)
+  await knex.raw(`
+    UPDATE auth.users
+    SET raw_app_meta_data = raw_app_meta_data || '{"role": "owner"}'::jsonb
+    WHERE id = (
+      SELECT id FROM auth.users
+      ORDER BY created_at ASC
+      LIMIT 1
+    )
+    AND (raw_app_meta_data->>'role') IS NULL
+  `);
+
+  // Set all remaining users without a role to designer
+  await knex.raw(`
+    UPDATE auth.users
+    SET raw_app_meta_data = raw_app_meta_data || '{"role": "designer"}'::jsonb
+    WHERE (raw_app_meta_data->>'role') IS NULL
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    UPDATE auth.users
+    SET raw_app_meta_data = raw_app_meta_data - 'role'
+  `);
+}

--- a/hooks/use-role.ts
+++ b/hooks/use-role.ts
@@ -1,0 +1,36 @@
+/**
+ * Centralized role access hook for the builder.
+ *
+ * Reads the user's role from the auth store (populated from Supabase
+ * app_metadata) and exposes boolean permission helpers.
+ *
+ * Role hierarchy: owner > admin > designer > editor
+ * - editor: content-only (text, images, component fields, translations, CMS items)
+ * - designer: full builder access (layout, design, content)
+ * - admin: designer + member/settings management
+ * - owner: admin + destructive actions
+ */
+
+import { useAuthStore } from '@/stores/useAuthStore';
+import {
+  resolveRole,
+  canManageMembers,
+  canEditStructure,
+  canManageSettings,
+  type UserRole,
+} from '@/lib/roles';
+
+export type { UserRole };
+
+export function useRole() {
+  const role = resolveRole(useAuthStore(state => state.role));
+
+  return {
+    role,
+    isEditor: role === 'editor',
+    canEditStructure: canEditStructure(role),
+    canEditContent: true,
+    canManageMembers: canManageMembers(role),
+    canManageSettings: canManageSettings(role),
+  };
+}

--- a/lib/roles-server.ts
+++ b/lib/roles-server.ts
@@ -1,0 +1,39 @@
+/**
+ * Server-side role helpers for API routes.
+ *
+ * Authenticates the caller via Supabase session cookies and resolves
+ * their role. Provides permission-check wrappers that return early
+ * NextResponse errors so route handlers stay concise.
+ */
+
+import { getAuthUser } from '@/lib/supabase-auth';
+import { noCache } from '@/lib/api-response';
+import { resolveRole, canManageMembers as checkCanManage, type UserRole } from '@/lib/roles';
+
+export interface CallerInfo {
+  userId: string;
+  role: UserRole;
+}
+
+/**
+ * Authenticate the caller and resolve their role from app_metadata.
+ * Returns null if not authenticated.
+ */
+export async function getCallerInfo(): Promise<CallerInfo | null> {
+  const auth = await getAuthUser();
+  if (!auth) return null;
+
+  const role = resolveRole(auth.user.app_metadata?.role as string);
+  return { userId: auth.user.id, role };
+}
+
+/**
+ * Require the caller to be owner or admin.
+ * Returns CallerInfo on success, or a 401/403 NextResponse on failure.
+ */
+export async function requireManageMembers() {
+  const caller = await getCallerInfo();
+  if (!caller) return noCache({ error: 'Not authenticated' }, 401);
+  if (!checkCanManage(caller.role)) return noCache({ error: 'Insufficient permissions' }, 403);
+  return caller;
+}

--- a/lib/roles.ts
+++ b/lib/roles.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared role definitions and permission helpers.
+ *
+ * Role hierarchy: owner > admin > designer > editor
+ */
+
+export const ALL_ROLES = ['owner', 'admin', 'designer', 'editor'] as const;
+export type UserRole = (typeof ALL_ROLES)[number];
+
+export const ASSIGNABLE_ROLES = ['admin', 'designer', 'editor'] as const;
+export const DEFAULT_ROLE: UserRole = 'designer';
+
+export function resolveRole(raw: string | undefined | null): UserRole {
+  if (raw && ALL_ROLES.includes(raw as UserRole)) return raw as UserRole;
+  return DEFAULT_ROLE;
+}
+
+export function extractRoleFromUser(user: { app_metadata?: Record<string, unknown> } | null): UserRole | null {
+  return (user?.app_metadata?.role as UserRole) || null;
+}
+
+export function canManageMembers(role: UserRole): boolean {
+  return role === 'owner' || role === 'admin';
+}
+
+export function canEditStructure(role: UserRole): boolean {
+  return role !== 'editor';
+}
+
+export function canManageSettings(role: UserRole): boolean {
+  return role !== 'editor';
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -60,6 +60,7 @@ function isPublicApiRoute(pathname: string, method: string): boolean {
   }
 
   if (PUBLIC_API_EXACT.includes(pathname)) return true;
+
   if (PUBLIC_API_PREFIXES.some((prefix) => pathname.startsWith(prefix))) return true;
 
   // Collection item endpoints for published pages (POST only — filter, load-more)
@@ -113,7 +114,13 @@ async function verifyApiAuth(request: NextRequest): Promise<NextResponse | null>
     );
   }
 
-  return null;
+  // Authenticated — pass through with any refreshed cookies
+  const authResponse = NextResponse.next({ request });
+  response.cookies.getAll().forEach((cookie) => {
+    authResponse.cookies.set(cookie.name, cookie.value);
+  });
+
+  return authResponse;
 }
 
 export async function proxy(request: NextRequest) {
@@ -131,9 +138,14 @@ export async function proxy(request: NextRequest) {
   if (pathname.startsWith('/ycode/api') || pathname.startsWith('/ycode/preview')) {
     const authResponse = await verifyApiAuth(request);
     if (authResponse) {
-      if (pathname.startsWith('/ycode/preview')) {
-        return NextResponse.redirect(new URL('/ycode', request.url));
+      if (authResponse.status === 401) {
+        if (pathname.startsWith('/ycode/preview')) {
+          return NextResponse.redirect(new URL('/ycode', request.url));
+        }
+        return authResponse;
       }
+      // Authenticated — pass through
+      authResponse.headers.set('x-pathname', pathname);
       return authResponse;
     }
   }

--- a/stores/useAuthStore.ts
+++ b/stores/useAuthStore.ts
@@ -6,11 +6,13 @@
 
 import { create } from 'zustand';
 import { createBrowserClient } from '../lib/supabase-browser';
+import { extractRoleFromUser } from '@/lib/roles';
 import type { User, Session } from '@supabase/supabase-js';
 
 interface AuthState {
   user: User | null;
   session: Session | null;
+  role: string | null;
   loading: boolean;
   initialized: boolean;
   error: string | null;
@@ -30,6 +32,7 @@ type AuthStore = AuthState & AuthActions;
 export const useAuthStore = create<AuthStore>((set, get) => ({
   user: null,
   session: null,
+  role: null,
   loading: false,
   initialized: false,
   error: null,
@@ -55,19 +58,27 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
 
       // Validate session server-side (getUser verifies the JWT, unlike getSession)
       const { data: { user } } = await supabase.auth.getUser();
+
+      if (user) {
+        // Refresh the session so the JWT contains the latest app_metadata
+        // (role changes via Admin API don't update existing JWTs)
+        await supabase.auth.refreshSession();
+      }
+
       const { data: { session } } = await supabase.auth.getSession();
 
       set({
         user: user ?? null,
         session: user ? session : null,
+        role: extractRoleFromUser(user),
         initialized: true,
       });
 
-      // Listen for auth changes
       supabase.auth.onAuthStateChange((_event, session) => {
         set({
           user: session?.user ?? null,
           session,
+          role: extractRoleFromUser(session?.user ?? null),
         });
       });
     } catch (error) {
@@ -119,6 +130,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       set({
         user: data.user,
         session: data.session,
+        role: extractRoleFromUser(data.user),
         loading: false,
       });
 
@@ -157,6 +169,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       set({
         user: data.user,
         session: data.session,
+        role: extractRoleFromUser(data.user),
         loading: false,
       });
 
@@ -178,10 +191,10 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       const supabase = await createBrowserClient();
 
       if (!supabase) {
-        // If Supabase is not configured, just clear local state
         set({
           user: null,
           session: null,
+          role: null,
           loading: false,
         });
         return;
@@ -197,6 +210,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       set({
         user: null,
         session: null,
+        role: null,
         loading: false,
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

Add a full role-based access control system to the self-hosted builder with
four roles (owner > admin > designer > editor). The first user is bootstrapped
as owner via migration, invited users default to designer, and roles can be
changed from the settings UI.

## Changes

- Add bootstrap migration assigning the first user as owner and all others as designer
- Create shared `lib/roles.ts` (types, constants, permission functions) and `lib/roles-server.ts` (auth + permission wrappers for API routes)
- Add `hooks/use-role.ts` hook for client-side permission gating
- Store and refresh role from `app_metadata` in `useAuthStore`, with session refresh on init to pick up server-side role changes
- Add API routes for set-role, invite (with role), and user management (PATCH role, DELETE) with shared `requireManageMembers()` guard
- Implement editor UI: hidden right sidebar, "Content editor" + "Pages" header nav, read-only layers/pages trees, gated CMS schema operations
- Block structural keyboard shortcuts and canvas operations for editors while preserving content editing (text, images, CMS items)
- Gate settings, integrations, backup, invite, and locales behind role permissions
- Filter keyboard shortcuts dialog for editors
- Remove dead `x-user-role` header injection from proxy (API routes self-authenticate)

## Test plan

- [ ] Run bootstrap migration — first user gets owner, others get designer
- [ ] As owner, change a user to editor via settings > users
- [ ] As editor, verify: right sidebar hidden, "Content editor" + "Pages" in header, no Design/Forms nav
- [ ] As editor, verify: cannot add/delete/reorder layers or pages, no context menus
- [ ] As editor, verify: CMS items editable but schema (fields, collections) is read-only
- [ ] As editor, verify: settings/integrations routes redirect to canvas
- [ ] As editor, verify: structural keyboard shortcuts (copy, paste, delete, etc.) are blocked
- [ ] As editor, verify: double-click text editing on canvas still works
- [ ] Change role back to designer — refresh shows full builder UI
- [ ] As owner/admin, invite a new user with a specific role — verify role is set

Made with [Cursor](https://cursor.com)