### PR TITLE
feat: filter collections by current item identity

### DIFF
--- a/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
+++ b/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
@@ -8,7 +8,7 @@ import { getAllPages } from '@/lib/repositories/pageRepository';
 import { getAllPageFolders } from '@/lib/repositories/pageFolderRepository';
 import { renderCollectionItemsToHtml, loadTranslationsForLocale } from '@/lib/page-fetcher';
 import { noCache } from '@/lib/api-response';
-import { compareDateFilter, isDateFieldType, isDatePreset, resolveDateFilterValue } from '@/lib/collection-field-utils';
+import { compareDateFilter, isDateFieldType, isDatePreset, parseItemIdList, resolveDateFilterValue } from '@/lib/collection-field-utils';
 import type { Layer, CollectionItem, CollectionItemWithValues } from '@/types';
 
 export const dynamic = 'force-dynamic';
@@ -22,6 +22,12 @@ interface FilterCondition {
   value: string;
   value2?: string;
   fieldType?: string;
+  // 'collection_field' (default, legacy) compares against a stored field value;
+  // 'self' compares the item's own ID against a set of IDs.
+  source?: 'collection_field' | 'self';
+  // For source === 'self': also include the current dynamic page item's ID
+  // in the comparison set at runtime.
+  includesCurrentPageItem?: boolean;
 }
 
 // PostgREST encodes .in() values into a URL query param.
@@ -414,10 +420,30 @@ async function getIdsMatchingFilter(
   }
 }
 
+/**
+ * Build the set of IDs matched by a `source: 'self'` filter. Operates purely on
+ * the input ID set — no DB roundtrip needed because the comparison is identity-based.
+ */
+function getSelfFilterMatches(
+  filter: FilterCondition,
+  candidateIds: string[],
+  pageCollectionItemId?: string,
+): Set<string> {
+  const compareSet = new Set<string>(parseItemIdList(filter.value));
+  if (filter.includesCurrentPageItem && pageCollectionItemId) {
+    compareSet.add(pageCollectionItemId);
+  }
+  if (filter.operator === 'is_not_one_of') {
+    return new Set(candidateIds.filter(id => !compareSet.has(id)));
+  }
+  return new Set(candidateIds.filter(id => compareSet.has(id)));
+}
+
 async function getFilteredItemIds(
   collectionId: string,
   isPublished: boolean,
   filterGroups: FilterCondition[][],
+  pageCollectionItemId?: string,
 ): Promise<{ matchingIds: string[]; total: number }> {
   const client = await getSupabaseAdmin();
   if (!client) throw new Error('Supabase client not configured');
@@ -436,6 +462,11 @@ async function getFilteredItemIds(
 
     for (let filter of group) {
       if (currentIds.size === 0) break;
+      if (filter.source === 'self') {
+        const matchingForFilter = getSelfFilterMatches(filter, [...currentIds], pageCollectionItemId);
+        currentIds = new Set([...currentIds].filter(id => matchingForFilter.has(id)));
+        continue;
+      }
       if (isDateFieldType(filter.fieldType) && isDatePreset(filter.value)) {
         const resolved = resolveDateFilterValue(filter.operator, filter.value, filter.value2);
         if (resolved) {
@@ -547,6 +578,7 @@ export async function POST(
       collectionId,
       isPublished,
       filterGroups,
+      pageCollectionItemId,
     );
 
     if (matchingIds.length === 0) {

--- a/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
+++ b/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
@@ -49,6 +49,7 @@ import {
   DATE_PRESET_OPTIONS,
   isDatePreset,
   isDateFieldType,
+  SELF_OPERATORS,
 } from '@/lib/collection-field-utils';
 import { getCollectionVariable, isInputInsideFilter, resolveFilterInputId, findLayerById } from '@/lib/layer-utils';
 import { useEditorStore } from '@/stores/useEditorStore';
@@ -70,10 +71,16 @@ function ReferenceItemsSelector({
   collectionId,
   value,
   onChange,
+  currentPageItem,
 }: {
   collectionId: string;
   value: string; // JSON array of item IDs
   onChange: (value: string) => void;
+  /** When provided, renders a "Current page item" entry above the items list. */
+  currentPageItem?: {
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+  };
 }) {
   const [open, setOpen] = useState(false);
   const [items, setItems] = useState<CollectionItemWithValues[]>([]);
@@ -135,23 +142,18 @@ function ReferenceItemsSelector({
 
   // Get display text for closed state
   const getDisplayText = () => {
-    if (selectedIds.length === 0) return 'Select items...';
+    const totalCount = selectedIds.length + (currentPageItem?.checked ? 1 : 0);
+    if (totalCount === 0) return 'Select items...';
 
-    // Find display names for selected items
-    const selectedNames = selectedIds
-      .map(id => {
-        const item = items.find(i => i.id === id);
-        return item ? getDisplayName(item) : null;
-      })
-      .filter(Boolean);
-
-    if (selectedNames.length > 0) {
-      return selectedNames.length <= 2
-        ? selectedNames.join(', ')
-        : `${selectedNames.length} items selected`;
+    const labels: string[] = [];
+    if (currentPageItem?.checked) labels.push('Current page item');
+    for (const id of selectedIds) {
+      const item = items.find(i => i.id === id);
+      if (item) labels.push(getDisplayName(item));
     }
 
-    return `${selectedIds.length} item${selectedIds.length !== 1 ? 's' : ''} selected`;
+    if (labels.length > 0 && labels.length <= 2) return labels.join(', ');
+    return `${totalCount} item${totalCount !== 1 ? 's' : ''} selected`;
   };
 
   if (!collectionId) {
@@ -171,11 +173,20 @@ function ReferenceItemsSelector({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-(--radix-dropdown-menu-trigger-width) min-w-50 max-h-60 overflow-y-auto" align="start">
+        {currentPageItem && (
+          <DropdownMenuCheckboxItem
+            checked={currentPageItem.checked}
+            onCheckedChange={(checked) => currentPageItem.onChange(checked === true)}
+            onSelect={(e) => e.preventDefault()}
+          >
+            Current page item
+          </DropdownMenuCheckboxItem>
+        )}
         {loading ? (
           <div className="flex items-center justify-center py-4">
             <Spinner />
           </div>
-        ) : items.length === 0 ? (
+        ) : items.length === 0 && !currentPageItem ? (
           <div className="text-center py-4 text-xs text-muted-foreground">
             No items in this collection
           </div>
@@ -294,6 +305,15 @@ export default function CollectionFiltersSettings({
     return null;
   }
 
+  // Build a fresh "self" condition (filters by the item's own ID).
+  const buildSelfCondition = (id: string): VisibilityCondition => ({
+    id,
+    source: 'self',
+    operator: 'is_one_of',
+    value: '[]',
+    includesCurrentPageItem: true,
+  });
+
   // Handle adding a new condition group for a collection field
   const handleAddFieldConditionGroup = (field: CollectionField) => {
     const newCondition: VisibilityCondition = {
@@ -314,6 +334,14 @@ export default function CollectionFiltersSettings({
     updateGroups([...groups, newGroup]);
   };
 
+  const handleAddSelfConditionGroup = () => {
+    const newGroup: VisibilityConditionGroup = {
+      id: Date.now().toString(),
+      conditions: [buildSelfCondition(`${Date.now()}-1`)],
+    };
+    updateGroups([...groups, newGroup]);
+  };
+
   // Handle adding a condition to an existing group (OR logic)
   const handleAddConditionFromOr = (groupId: string, field: CollectionField) => {
     const newGroups = groups.map(group => {
@@ -330,6 +358,19 @@ export default function CollectionFiltersSettings({
         return {
           ...group,
           conditions: [...group.conditions, newCondition],
+        };
+      }
+      return group;
+    });
+    updateGroups(newGroups);
+  };
+
+  const handleAddSelfConditionFromOr = (groupId: string) => {
+    const newGroups = groups.map(group => {
+      if (group.id === groupId) {
+        return {
+          ...group,
+          conditions: [...group.conditions, buildSelfCondition(`${groupId}-${Date.now()}`)],
         };
       }
       return group;
@@ -457,10 +498,16 @@ export default function CollectionFiltersSettings({
 
   // Render the dropdown content for adding conditions
   const renderAddConditionDropdown = (
-    onFieldSelect: (field: CollectionField) => void
+    onFieldSelect: (field: CollectionField) => void,
+    onSelfSelect: () => void,
   ) => (
     <DropdownMenuContent align="end" className="max-h-75! overflow-y-auto">
-      {/* Collection Fields Section */}
+      <DropdownMenuLabel className="text-xs text-muted-foreground">Item</DropdownMenuLabel>
+      <DropdownMenuItem onClick={onSelfSelect} className="flex items-center gap-2">
+        <Icon name="database" className="size-3 opacity-60" />
+        Item ID
+      </DropdownMenuItem>
+
       {fields && fields.length > 0 && (
         <>
           <DropdownMenuLabel className="text-xs text-muted-foreground">
@@ -477,13 +524,6 @@ export default function CollectionFiltersSettings({
             </DropdownMenuItem>
           ))}
         </>
-      )}
-
-      {/* Empty State */}
-      {(!fields || fields.length === 0) && (
-        <div className="px-2 py-4 text-xs text-muted-foreground text-center">
-          No fields available
-        </div>
       )}
     </DropdownMenuContent>
   );
@@ -502,7 +542,68 @@ export default function CollectionFiltersSettings({
   };
 
   // Render a single condition
+  // Render a `source: 'self'` condition (filter the collection by item identity).
+  const renderSelfCondition = (
+    condition: VisibilityCondition,
+    group: VisibilityConditionGroup,
+    index: number,
+  ) => (
+    <React.Fragment key={condition.id}>
+      {index > 0 && (
+        <li className="flex items-center gap-2 h-6">
+          <Label variant="muted" className="text-[10px]">Or</Label>
+          <hr className="flex-1" />
+        </li>
+      )}
+      <li className="*:w-full flex flex-col gap-2">
+        <header className="flex items-center gap-1.5">
+          <div className="size-5 flex items-center justify-center rounded-[6px] bg-secondary/50 hover:bg-secondary">
+            <Icon name="database" className="size-2.5 opacity-60" />
+          </div>
+          <Label variant="muted" className="truncate">Item ID</Label>
+          <span
+            role="button"
+            tabIndex={0}
+            className="ml-auto -my-1 -mr-0.5 shrink-0 p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
+            onClick={() => handleRemoveCondition(group.id, condition.id)}
+          >
+            <Icon name="x" className="size-2.5" />
+          </span>
+        </header>
+
+        <Select
+          value={condition.operator}
+          onValueChange={(value) => patchCondition(group.id, condition.id, { operator: value as VisibilityOperator })}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Select..." />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {SELF_OPERATORS.map((op) => (
+                <SelectItem key={op.value} value={op.value}>{op.label}</SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+
+        <ReferenceItemsSelector
+          collectionId={collectionId}
+          value={condition.value || '[]'}
+          onChange={(value) => handleValueChange(group.id, condition.id, value)}
+          currentPageItem={{
+            checked: !!condition.includesCurrentPageItem,
+            onChange: (checked) => patchCondition(group.id, condition.id, { includesCurrentPageItem: checked }),
+          }}
+        />
+      </li>
+    </React.Fragment>
+  );
+
   const renderCondition = (condition: VisibilityCondition, group: VisibilityConditionGroup, index: number) => {
+    if (condition.source === 'self') {
+      return renderSelfCondition(condition, group, index);
+    }
     const fieldType = condition.fieldType || getFieldType(condition.fieldId || '');
     const operators = getOperatorsForFieldType(fieldType);
     const icon = getFieldIcon(fieldType);
@@ -805,7 +906,7 @@ export default function CollectionFiltersSettings({
               <Icon name="plus" />
             </Button>
           </DropdownMenuTrigger>
-          {renderAddConditionDropdown(handleAddFieldConditionGroup)}
+          {renderAddConditionDropdown(handleAddFieldConditionGroup, handleAddSelfConditionGroup)}
         </DropdownMenu>
       }
     >
@@ -845,7 +946,8 @@ export default function CollectionFiltersSettings({
                         </Button>
                       </DropdownMenuTrigger>
                       {renderAddConditionDropdown(
-                        (field) => handleAddConditionFromOr(group.id, field)
+                        (field) => handleAddConditionFromOr(group.id, field),
+                        () => handleAddSelfConditionFromOr(group.id),
                       )}
                     </DropdownMenu>
                   </li>

--- a/app/(builder)/ycode/components/ConditionalVisibilitySettings.tsx
+++ b/app/(builder)/ycode/components/ConditionalVisibilitySettings.tsx
@@ -34,7 +34,6 @@ import {
   DropdownMenuTrigger,
   DropdownMenuCheckboxItem,
 } from '@/components/ui/dropdown-menu';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Spinner } from '@/components/ui/spinner';
 import {
   getFieldIcon,
@@ -48,8 +47,9 @@ import {
   COMPARE_OPERATORS,
   PAGE_COLLECTION_OPERATORS,
   isDateFieldType,
+  SELF_OPERATORS,
 } from '@/lib/collection-field-utils';
-import { findAllCollectionLayers, CollectionLayerInfo } from '@/lib/layer-utils';
+import { findAllCollectionLayers, findAllParentCollectionLayers, getCollectionVariable, CollectionLayerInfo } from '@/lib/layer-utils';
 import { usePagesStore } from '@/stores/usePagesStore';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { useComponentsStore } from '@/stores/useComponentsStore';
@@ -72,10 +72,16 @@ function ReferenceItemsSelector({
   collectionId,
   value,
   onChange,
+  currentPageItem,
 }: {
   collectionId: string;
   value: string; // JSON array of item IDs
   onChange: (value: string) => void;
+  /** When provided, renders a "Current page item" entry above the items list. */
+  currentPageItem?: {
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+  };
 }) {
   const [open, setOpen] = useState(false);
   const [items, setItems] = useState<CollectionItemWithValues[]>([]);
@@ -137,23 +143,18 @@ function ReferenceItemsSelector({
 
   // Get display text for closed state
   const getDisplayText = () => {
-    if (selectedIds.length === 0) return 'Select items...';
+    const totalCount = selectedIds.length + (currentPageItem?.checked ? 1 : 0);
+    if (totalCount === 0) return 'Select items...';
 
-    // Find display names for selected items
-    const selectedNames = selectedIds
-      .map(id => {
-        const item = items.find(i => i.id === id);
-        return item ? getDisplayName(item) : null;
-      })
-      .filter(Boolean);
-
-    if (selectedNames.length > 0) {
-      return selectedNames.length <= 2
-        ? selectedNames.join(', ')
-        : `${selectedNames.length} items selected`;
+    const labels: string[] = [];
+    if (currentPageItem?.checked) labels.push('Current page item');
+    for (const id of selectedIds) {
+      const item = items.find(i => i.id === id);
+      if (item) labels.push(getDisplayName(item));
     }
 
-    return `${selectedIds.length} item${selectedIds.length !== 1 ? 's' : ''} selected`;
+    if (labels.length > 0 && labels.length <= 2) return labels.join(', ');
+    return `${totalCount} item${totalCount !== 1 ? 's' : ''} selected`;
   };
 
   if (!collectionId) {
@@ -173,11 +174,20 @@ function ReferenceItemsSelector({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-(--radix-dropdown-menu-trigger-width) min-w-50 max-h-60 overflow-y-auto" align="start">
+        {currentPageItem && (
+          <DropdownMenuCheckboxItem
+            checked={currentPageItem.checked}
+            onCheckedChange={(checked) => currentPageItem.onChange(checked === true)}
+            onSelect={(e) => e.preventDefault()}
+          >
+            Current page item
+          </DropdownMenuCheckboxItem>
+        )}
         {loading ? (
           <div className="flex items-center justify-center py-4">
             <Spinner />
           </div>
-        ) : items.length === 0 ? (
+        ) : items.length === 0 && !currentPageItem ? (
           <div className="text-center py-4 text-xs text-muted-foreground">
             No items in this collection
           </div>
@@ -216,24 +226,34 @@ export default function ConditionalVisibilitySettings({
   const editingComponentVariantId = useEditorStore((state) => state.editingComponentVariantId);
   const componentDrafts = useComponentsStore((state) => state.componentDrafts);
 
-  // Get all collection layers on the page
-  const pageCollectionLayers = useMemo((): CollectionLayerInfo[] => {
+  // Resolve the layer tree currently being edited (page or component variant).
+  const currentLayers = useMemo((): Layer[] => {
     if (!currentPageId) return [];
-
-    let layers: Layer[] = [];
     if (editingComponentId) {
       const variantDrafts = componentDrafts[editingComponentId];
       const variantId = (editingComponentVariantId && variantDrafts?.[editingComponentVariantId])
         ? editingComponentVariantId
         : (variantDrafts ? Object.keys(variantDrafts)[0] : null);
-      layers = (variantId && variantDrafts) ? variantDrafts[variantId] || [] : [];
-    } else {
-      const draft = draftsByPageId[currentPageId];
-      layers = draft ? draft.layers : [];
+      return (variantId && variantDrafts) ? variantDrafts[variantId] || [] : [];
     }
-
-    return findAllCollectionLayers(layers);
+    const draft = draftsByPageId[currentPageId];
+    return draft ? draft.layers : [];
   }, [currentPageId, editingComponentId, editingComponentVariantId, componentDrafts, draftsByPageId]);
+
+  // Get all collection layers on the page
+  const pageCollectionLayers = useMemo((): CollectionLayerInfo[] => {
+    return currentLayers.length > 0 ? findAllCollectionLayers(currentLayers) : [];
+  }, [currentLayers]);
+
+  // The closest enclosing collection for the layer being styled — used as the
+  // pool the user picks static items from when configuring a `self` condition.
+  const selfReferenceCollectionId = useMemo((): string | undefined => {
+    if (!layer) return undefined;
+    const parents = findAllParentCollectionLayers(currentLayers, layer.id);
+    const closest = parents[0];
+    const closestId = closest ? getCollectionVariable(closest)?.id : undefined;
+    return closestId ?? pageCollectionLayers[0]?.collectionId;
+  }, [layer, currentLayers, pageCollectionLayers]);
 
   // Initialize groups from layer data
   const groups: VisibilityConditionGroup[] = useMemo(() => {
@@ -257,7 +277,7 @@ export default function ConditionalVisibilitySettings({
   }, [layer, onLayerUpdate]);
 
   const hasConditions = groups.length > 0;
-  const hasAvailableSources = allFieldsFromGroups.length > 0 || pageCollectionLayers.length > 0;
+  const hasAvailableSources = allFieldsFromGroups.length > 0 || pageCollectionLayers.length > 0 || !!selfReferenceCollectionId;
 
   if (!layer || (!hasConditions && !hasAvailableSources)) {
     return null;
@@ -299,6 +319,37 @@ export default function ConditionalVisibilitySettings({
     };
 
     updateGroups([...groups, newGroup]);
+  };
+
+  // Build a fresh "self" condition (visibility filter by enclosing item identity).
+  const buildSelfCondition = (id: string): VisibilityCondition => ({
+    id,
+    source: 'self',
+    operator: 'is_one_of',
+    value: '[]',
+    includesCurrentPageItem: true,
+    referenceCollectionId: selfReferenceCollectionId,
+  });
+
+  const handleAddSelfConditionGroup = () => {
+    const newGroup: VisibilityConditionGroup = {
+      id: Date.now().toString(),
+      conditions: [buildSelfCondition(`${Date.now()}-1`)],
+    };
+    updateGroups([...groups, newGroup]);
+  };
+
+  const handleAddSelfConditionFromOr = (groupId: string) => {
+    const newGroups = groups.map(group => {
+      if (group.id === groupId) {
+        return {
+          ...group,
+          conditions: [...group.conditions, buildSelfCondition(`${groupId}-${Date.now()}`)],
+        };
+      }
+      return group;
+    });
+    updateGroups(newGroups);
   };
 
   // Handle removing a condition group
@@ -483,13 +534,23 @@ export default function ConditionalVisibilitySettings({
   // Render the dropdown content for adding conditions
   const renderAddConditionDropdown = (
     onFieldSelect: (field: CollectionField) => void,
-    onPageCollectionSelect: (layer: CollectionLayerInfo) => void
+    onPageCollectionSelect: (layer: CollectionLayerInfo) => void,
+    onSelfSelect: () => void,
   ) => (
     <DropdownMenuContent align="end" className="max-h-75! overflow-y-auto">
-      {/* Collection Fields Section - render each group */}
+      {selfReferenceCollectionId && (
+        <>
+          <DropdownMenuLabel className="text-xs text-muted-foreground">Item</DropdownMenuLabel>
+          <DropdownMenuItem onClick={onSelfSelect} className="flex items-center gap-2">
+            <Icon name="database" className="size-3 opacity-60" />
+            Item ID
+          </DropdownMenuItem>
+        </>
+      )}
+
       {fieldGroups?.map((group, groupIndex) => group.fields.length > 0 && (
         <React.Fragment key={groupIndex}>
-          {groupIndex > 0 && <DropdownMenuSeparator />}
+          {(groupIndex > 0 || selfReferenceCollectionId) && <DropdownMenuSeparator />}
           <DropdownMenuLabel className="text-xs text-muted-foreground">
             {group.label || 'Collection Fields'}
           </DropdownMenuLabel>
@@ -527,7 +588,7 @@ export default function ConditionalVisibilitySettings({
       )}
 
       {/* Empty State */}
-      {allFieldsFromGroups.length === 0 && pageCollectionLayers.length === 0 && (
+      {allFieldsFromGroups.length === 0 && pageCollectionLayers.length === 0 && !selfReferenceCollectionId && (
         <div className="px-2 py-4 text-xs text-muted-foreground text-center">
           No fields or collections available
         </div>
@@ -548,8 +609,87 @@ export default function ConditionalVisibilitySettings({
     return undefined;
   };
 
+  // Apply an arbitrary patch to a single condition (used by self conditions
+  // that have fields beyond operator/value, e.g. includesCurrentPageItem).
+  const patchCondition = (groupId: string, conditionId: string, patch: Partial<VisibilityCondition>) => {
+    const newGroups = groups.map(group => {
+      if (group.id !== groupId) return group;
+      return {
+        ...group,
+        conditions: group.conditions.map(c => c.id === conditionId ? { ...c, ...patch } : c),
+      };
+    });
+    updateGroups(newGroups);
+  };
+
+  // Render a `source: 'self'` condition (hide/show based on the enclosing item's identity).
+  const renderSelfCondition = (
+    condition: VisibilityCondition,
+    group: VisibilityConditionGroup,
+    index: number,
+  ) => {
+    const referenceCollectionId = condition.referenceCollectionId ?? selfReferenceCollectionId;
+    return (
+      <React.Fragment key={condition.id}>
+        {index > 0 && (
+          <li className="flex items-center gap-2 h-6">
+            <Label variant="muted" className="text-[10px]">Or</Label>
+            <hr className="flex-1" />
+          </li>
+        )}
+        <li className="*:w-full flex flex-col gap-2">
+          <header className="flex items-center gap-1.5">
+            <div className="size-5 flex items-center justify-center rounded-[6px] bg-secondary/50 hover:bg-secondary">
+              <Icon name="database" className="size-2.5 opacity-60" />
+            </div>
+            <Label variant="muted" className="truncate">Item ID</Label>
+            <span
+              role="button"
+              tabIndex={0}
+              className="ml-auto -my-1 -mr-0.5 shrink-0 p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
+              onClick={() => handleRemoveCondition(group.id, condition.id)}
+            >
+              <Icon name="x" className="size-2.5" />
+            </span>
+          </header>
+
+          <Select
+            value={condition.operator}
+            onValueChange={(value) => patchCondition(group.id, condition.id, { operator: value as VisibilityOperator })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {SELF_OPERATORS.map((op) => (
+                  <SelectItem key={op.value} value={op.value}>{op.label}</SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+
+          {referenceCollectionId && (
+            <ReferenceItemsSelector
+              collectionId={referenceCollectionId}
+              value={condition.value || '[]'}
+              onChange={(value) => handleValueChange(group.id, condition.id, value)}
+              currentPageItem={{
+                checked: !!condition.includesCurrentPageItem,
+                onChange: (checked) => patchCondition(group.id, condition.id, { includesCurrentPageItem: checked }),
+              }}
+            />
+          )}
+        </li>
+      </React.Fragment>
+    );
+  };
+
   // Render a single condition
   const renderCondition = (condition: VisibilityCondition, group: VisibilityConditionGroup, index: number) => {
+    if (condition.source === 'self') {
+      return renderSelfCondition(condition, group, index);
+    }
     const isPageCollection = condition.source === 'page_collection';
     const fieldType = isPageCollection ? undefined : condition.fieldType || getFieldType(condition.fieldId || '');
     const operators = isPageCollection ? PAGE_COLLECTION_OPERATORS : getOperatorsForFieldType(fieldType);
@@ -713,7 +853,8 @@ export default function ConditionalVisibilitySettings({
           </DropdownMenuTrigger>
           {renderAddConditionDropdown(
             handleAddFieldConditionGroup,
-            handleAddPageCollectionConditionGroup
+            handleAddPageCollectionConditionGroup,
+            handleAddSelfConditionGroup,
           )}
         </DropdownMenu>
       }
@@ -750,7 +891,8 @@ export default function ConditionalVisibilitySettings({
                       </DropdownMenuTrigger>
                       {renderAddConditionDropdown(
                         (field) => handleAddConditionFromOr(group.id, field),
-                        (layer) => handleAddPageCollectionConditionFromOr(group.id, layer)
+                        (layer) => handleAddPageCollectionConditionFromOr(group.id, layer),
+                        () => handleAddSelfConditionFromOr(group.id),
                       )}
                     </DropdownMenu>
                   </li>

--- a/components/FilterableCollection.tsx
+++ b/components/FilterableCollection.tsx
@@ -184,7 +184,15 @@ export default function FilterableCollection({
   );
 
   const buildApiFilters = useCallback(() => {
-    type FilterItem = { fieldId: string; operator: string; value: string; value2?: string; fieldType?: string };
+    type FilterItem = {
+      fieldId: string;
+      operator: string;
+      value: string;
+      value2?: string;
+      fieldType?: string;
+      source?: 'collection_field' | 'self';
+      includesCurrentPageItem?: boolean;
+    };
     const operatorsWithoutValue = new Set([
       'is_present',
       'is_empty',
@@ -201,6 +209,21 @@ export default function FilterableCollection({
       const activeInGroup: FilterItem[] = [];
 
       for (const condition of group.conditions) {
+        // Self conditions compare against the item's own ID — no fieldId needed,
+        // and they're forwarded verbatim so the server resolves the current page item.
+        if (condition.source === 'self') {
+          const hasStaticIds = !!condition.value && condition.value !== '[]';
+          if (!hasStaticIds && !condition.includesCurrentPageItem) continue;
+          activeInGroup.push({
+            fieldId: '',
+            operator: condition.operator,
+            value: condition.value || '[]',
+            source: 'self',
+            includesCurrentPageItem: condition.includesCurrentPageItem,
+          });
+          continue;
+        }
+
         if (!condition.fieldId) continue;
 
         let value = condition.inputLayerId ? '' : (condition.value || '');
@@ -533,7 +556,15 @@ export default function FilterableCollection({
   // --- Fetch logic ---
 
   const fetchFiltered = useCallback((
-    filterGroups: Array<Array<{ fieldId: string; operator: string; value: string; value2?: string; fieldType?: string }>>,
+    filterGroups: Array<Array<{
+      fieldId: string;
+      operator: string;
+      value: string;
+      value2?: string;
+      fieldType?: string;
+      source?: 'collection_field' | 'self';
+      includesCurrentPageItem?: boolean;
+    }>>,
     offset: number,
     append: boolean,
   ) => {

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1341,8 +1341,10 @@ const LayerItemImpl: React.FC<{
         items = items.filter(item =>
           evaluateVisibility(effectiveFilters, {
             collectionLayerData: item.values,
-            pageCollectionData: null,
+            pageCollectionData: pageCollectionItemData ?? null,
             pageCollectionCounts: {},
+            currentItemId: item.id,
+            pageCollectionItemId,
           })
         );
       }
@@ -1710,6 +1712,8 @@ const LayerItemImpl: React.FC<{
       collectionLayerData,
       pageCollectionData: pageCollectionItemData,
       pageCollectionCounts,
+      currentItemId: collectionLayerItemId,
+      pageCollectionItemId,
     });
     if (!isVisible) {
       return null;

--- a/lib/collection-field-utils.ts
+++ b/lib/collection-field-utils.ts
@@ -166,6 +166,12 @@ export const PAGE_COLLECTION_OPERATORS: OperatorOption[] = [
   { value: 'has_no_items', label: 'has no items' },
 ];
 
+/** Operators available when filtering an item against its own ID (source: 'self'). */
+export const SELF_OPERATORS: OperatorOption[] = [
+  { value: 'is_one_of', label: 'is one of' },
+  { value: 'is_not_one_of', label: 'is not one of' },
+];
+
 export const COMPARE_OPERATORS: { value: string; label: string }[] = [
   { value: 'eq', label: 'equals' },
   { value: 'lt', label: 'less than' },
@@ -223,6 +229,21 @@ export function operatorRequiresItemSelection(operator: VisibilityOperator): boo
   return ['is_one_of', 'is_not_one_of', 'contains_all_of', 'contains_exactly'].includes(
     operator
   );
+}
+
+/**
+ * Parse a JSON-stringified array of item IDs (used by reference / self conditions).
+ * Returns an empty array for unset, malformed, or non-array values so callers
+ * can always `for…of` the result without extra guards.
+ */
+export function parseItemIdList(value: string | undefined | null): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
+  } catch {
+    return [];
+  }
 }
 
 /** Check if operator requires a second value (for date ranges) */

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -10,7 +10,7 @@ import { getCmsFieldBinding } from '@/lib/tiptap-utils';
 import { applyComponentOverrides } from '@/lib/resolve-components';
 import { getComponentVariantLayers } from '@/lib/component-variant-utils';
 import { resolveFieldFromSources } from '@/lib/cms-variables-utils';
-import { compareDateFilter, isDateFieldType, isDatePreset, resolveDateFilterValue } from '@/lib/collection-field-utils';
+import { compareDateFilter, isDateFieldType, isDatePreset, parseItemIdList, resolveDateFilterValue } from '@/lib/collection-field-utils';
 import { parseMultiReferenceValue, normalizeBooleanValue } from '@/lib/collection-utils';
 import { getInheritedValue } from '@/lib/tailwind-class-mapper';
 import cloneDeep from 'lodash/cloneDeep';
@@ -1941,6 +1941,10 @@ export interface VisibilityContext {
   pageCollectionCounts?: Record<string, number>;
   /** Field definitions for type-aware comparison */
   collectionFields?: CollectionField[];
+  /** ID of the item currently being evaluated (used by `source: 'self'` conditions). */
+  currentItemId?: string;
+  /** ID of the dynamic page's collection item, when on a dynamic page. */
+  pageCollectionItemId?: string | null;
 }
 
 /**
@@ -1953,7 +1957,24 @@ function evaluateCondition(
   condition: import('@/types').VisibilityCondition,
   context: VisibilityContext
 ): boolean {
-  const { collectionLayerData, pageCollectionData, pageCollectionCounts } = context;
+  const { collectionLayerData, pageCollectionData, pageCollectionCounts, currentItemId, pageCollectionItemId } = context;
+
+  // Self conditions: compare the item being evaluated against a set of item
+  // IDs (statically picked and/or the current dynamic page item). Used for
+  // patterns like "only show the current item" or "exclude the current item
+  // from a related list". If we don't know the current item, the condition
+  // can't be evaluated meaningfully — fall through to `true` to avoid hiding
+  // everything by accident (matches the default behaviour of unset conditions).
+  if (condition.source === 'self') {
+    if (!currentItemId) return true;
+    const compareIds = new Set<string>();
+    for (const id of parseItemIdList(condition.value)) compareIds.add(id);
+    if (condition.includesCurrentPageItem && pageCollectionItemId) {
+      compareIds.add(pageCollectionItemId);
+    }
+    const matches = compareIds.has(currentItemId);
+    return condition.operator === 'is_not_one_of' ? !matches : matches;
+  }
 
   if (condition.source === 'page_collection') {
     // Page collection conditions

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -596,7 +596,7 @@ async function fetchPageByPathInternal(
             // Pass enhanced values so nested collections can filter based on dynamic page data
             // Pass collectionItem.id so inverse reference layers can query by parent item
             let resolvedLayers = layersWithInjectedData.length > 0
-              ? await resolveCollectionLayers(layersWithInjectedData, isPublished, enhancedItemValues, paginationContext, translations, collectionItem.id, timezone)
+              ? await resolveCollectionLayers(layersWithInjectedData, isPublished, enhancedItemValues, paginationContext, translations, collectionItem.id, timezone, collectionItem.id)
               : [];
 
             // Resolve collections inside rich text embedded components
@@ -2112,6 +2112,11 @@ export async function resolveCollectionLayers(
   translations?: Record<string, Translation>,
   parentCollectionItemId?: string,
   timezone?: string,
+  // The dynamic page's collection item ID. Distinct from `parentCollectionItemId`
+  // (which advances as nested collections recurse) because `self` filters always
+  // resolve "current page item" against the outermost page item, never the
+  // nearest enclosing collection.
+  pageCollectionItemId?: string,
 ): Promise<Layer[]> {
   // Reuse caller-provided timezone, or fetch once for the entire tree
   if (!timezone) {
@@ -2347,8 +2352,10 @@ export async function resolveCollectionLayers(
               items = items.filter(item =>
                 evaluateVisibility(staticFilters, {
                   collectionLayerData: item.values,
-                  pageCollectionData: null,
+                  pageCollectionData: parentItemValues ?? null,
                   pageCollectionCounts: {},
+                  currentItemId: item.id,
+                  pageCollectionItemId: pageCollectionItemId ?? parentCollectionItemId,
                 })
               );
             }
@@ -2788,7 +2795,7 @@ export async function resolveCollectionLayers(
   // Third pass: Filter layers by conditional visibility
   // We need to compute collection counts first, then filter
   // parentItemValues is the page collection data for dynamic pages
-  const filteredResult = filterByVisibility(resultWithPagination, undefined, parentItemValues);
+  const filteredResult = filterByVisibility(resultWithPagination, undefined, parentItemValues, pageCollectionItemId ?? parentCollectionItemId);
 
   return filteredResult;
 }
@@ -2877,21 +2884,25 @@ function getFilterableCollectionTarget(
  * @param layers - Layer tree to filter
  * @param collectionLayerData - Current collection layer item values for field conditions
  * @param pageCollectionData - Page collection data for dynamic pages
+ * @param pageCollectionItemId - ID of the dynamic page's collection item, when on a dynamic page
  * @returns Filtered layer tree with hidden layers removed
  */
 function filterByVisibility(
   layers: Layer[],
   collectionLayerData?: Record<string, string>,
-  pageCollectionData?: Record<string, string> | null
+  pageCollectionData?: Record<string, string> | null,
+  pageCollectionItemId?: string | null,
 ): Layer[] {
   const pageCollectionCounts = computeCollectionCounts(layers);
   const filterableCollectionIds = findFilterableCollectionIds(layers);
 
   function filterLayer(
     layer: Layer,
-    currentCollectionLayerData?: Record<string, string>
+    currentCollectionLayerData?: Record<string, string>,
+    currentItemId?: string,
   ): Layer | null {
     const effectiveCollectionLayerData = layer._collectionItemValues || currentCollectionLayerData;
+    const effectiveCurrentItemId = layer._collectionItemId || currentItemId;
 
     const conditionalVisibility = layer.variables?.conditionalVisibility;
     if (conditionalVisibility && conditionalVisibility.groups?.length > 0) {
@@ -2899,6 +2910,8 @@ function filterByVisibility(
         collectionLayerData: effectiveCollectionLayerData,
         pageCollectionData,
         pageCollectionCounts,
+        currentItemId: effectiveCurrentItemId,
+        pageCollectionItemId,
       });
       const filterTarget = getFilterableCollectionTarget(conditionalVisibility, filterableCollectionIds);
       if (filterTarget) {
@@ -2923,7 +2936,7 @@ function filterByVisibility(
           attributes,
           children: layer.children
             ? layer.children
-              .map(child => filterLayer(child, effectiveCollectionLayerData))
+              .map(child => filterLayer(child, effectiveCollectionLayerData, effectiveCurrentItemId))
               .filter((child): child is Layer => child !== null)
             : undefined,
         };
@@ -2935,7 +2948,7 @@ function filterByVisibility(
 
     if (layer.children) {
       const filteredChildren = layer.children
-        .map(child => filterLayer(child, effectiveCollectionLayerData))
+        .map(child => filterLayer(child, effectiveCollectionLayerData, effectiveCurrentItemId))
         .filter((child): child is Layer => child !== null);
 
       return {
@@ -2948,7 +2961,7 @@ function filterByVisibility(
   }
 
   return layers
-    .map(layer => filterLayer(layer, collectionLayerData))
+    .map(layer => filterLayer(layer, collectionLayerData, pageCollectionItemId ?? undefined))
     .filter((layer): layer is Layer => layer !== null);
 }
 
@@ -3260,6 +3273,7 @@ export async function renderCollectionItemsToHtml(
         undefined,
         item.id,
         htmlTimezone,
+        pageLinkContext?.pageCollectionItemId,
       );
 
       // Resolve all AssetVariables to URLs server-side
@@ -3315,7 +3329,7 @@ export async function renderCollectionItemsToHtml(
       }
 
       // Apply conditional visibility based on this item's field values
-      resolvedLayers = filterByVisibility(resolvedLayers, item.values);
+      resolvedLayers = filterByVisibility(resolvedLayers, item.values, undefined, pageLinkContext?.pageCollectionItemId);
 
       // Preferred path: rebuild a full clone of the collection layer just
       // like SSR does (link/action/attributes preserved). Renders one HTML

--- a/types/index.ts
+++ b/types/index.ts
@@ -1348,6 +1348,9 @@ export type BooleanOperator = 'is';
 export type ReferenceOperator = 'is_one_of' | 'is_not_one_of' | 'exists' | 'does_not_exist';
 export type MultiReferenceOperator = 'is_one_of' | 'is_not_one_of' | 'contains_all_of' | 'contains_exactly' | 'item_count' | 'has_items' | 'has_no_items';
 export type PageCollectionOperator = 'item_count' | 'has_items' | 'has_no_items';
+// Self filter: compare the item's own ID against a set of IDs (statically picked
+// and/or the current dynamic page item). Mirrors reference field semantics.
+export type SelfOperator = 'is_one_of' | 'is_not_one_of';
 
 export type VisibilityOperator =
   | TextOperator
@@ -1356,11 +1359,12 @@ export type VisibilityOperator =
   | BooleanOperator
   | ReferenceOperator
   | MultiReferenceOperator
-  | PageCollectionOperator;
+  | PageCollectionOperator
+  | SelfOperator;
 
 export interface VisibilityCondition {
   id: string;
-  source: 'collection_field' | 'page_collection';
+  source: 'collection_field' | 'page_collection' | 'self';
   // For collection_field source
   fieldId?: string;
   fieldType?: CollectionFieldType;
@@ -1373,6 +1377,9 @@ export interface VisibilityCondition {
   collectionLayerName?: string; // Display name for the layer
   compareOperator?: 'eq' | 'lt' | 'lte' | 'gt' | 'gte'; // For 'item_count' operator
   compareValue?: number; // For 'item_count' operator
+  // For self source: when true, the current dynamic page item ID is injected
+  // into the comparison set alongside any statically picked IDs in `value`.
+  includesCurrentPageItem?: boolean;
   // For linking filter value to an input layer inside a Filter
   inputLayerId?: string;
   inputLayerId2?: string; // For second bound (e.g. 'is_between')


### PR DESCRIPTION
## Summary

Adds a `source: 'self'` condition type for collection filters and conditional visibility, letting users show/hide layers or filter collection items based on whether the enclosing item matches a static set of IDs and/or the current dynamic page item. This replaces the legacy `r_id` / `fieldType: 'self'` pseudo-field with a first-class concept that doesn't require a stored field as a pivot.

## Changes

- Extend `VisibilityCondition` with `'self'` source, `SelfOperator`, and `includesCurrentPageItem` flag
- Add `SELF_OPERATORS` and `parseItemIdList` helpers in `collection-field-utils`
- Thread `currentItemId` / `pageCollectionItemId` through `VisibilityContext`, `resolveCollectionLayers`, `filterByVisibility`, and `LayerRenderer` (both SSR and edit-mode paths)
- Handle `source: 'self'` in the collection filter API route via an in-memory matcher (no DB roundtrip)
- Forward self conditions in `FilterableCollection.buildApiFilters`
- Add an "Item ID" entry in the add-condition dropdowns of both `CollectionFiltersSettings` and `ConditionalVisibilitySettings`
- Render the static-IDs picker with an integrated "Current page item" checkbox option

## Test plan

- [ ] On a dynamic page, add a collection filter with `Item ID is one of` + Current page item enabled; verify only the current page's item is rendered
- [ ] Switch the operator to `is not one of` with Current page item enabled; verify the current page item is excluded from the list
- [ ] Combine static picks + Current page item in the dropdown; verify both contribute to the match set
- [ ] Add a conditional visibility rule of `Item ID is one of` + Current page item on a layer inside a related-items collection; verify it shows only for the current page item
- [ ] Confirm legacy pages migrated from `r_id` / `fieldType: 'self'` render correctly (no more `invalid input syntax for type uuid: "r_id"` console error)