### PR TITLE
fix: strip stray slashes from page slug segments

### DIFF
--- a/lib/page-utils.ts
+++ b/lib/page-utils.ts
@@ -53,6 +53,15 @@ export function isHomepage(page: Page): boolean {
 }
 
 /**
+ * Strip leading/trailing slashes from a single slug segment so it doesn't
+ * collapse into an empty path or introduce double slashes when joined.
+ * Preserves interior slashes (legacy nested slugs like `foo/bar`).
+ */
+export function normalizeSlugSegment(slug: string | null | undefined): string {
+  return (slug ?? '').replace(/^\/+|\/+$/g, '');
+}
+
+/**
  * Build the full slug path for a page or folder
  * Returns the full URL path starting with "/"
  *
@@ -93,7 +102,9 @@ export function buildSlugPath(
     }
   }
 
-  return '/' + slugParts.filter(Boolean).join('/');
+  // Legacy data sometimes stores an index page slug as the literal `/`. Without
+  // normalisation that produces paths like `/blog//` when concatenated.
+  return '/' + slugParts.map(normalizeSlugSegment).filter(Boolean).join('/');
 }
 
 /**
@@ -224,7 +235,7 @@ export function buildLocalizedSlugPath(
   }
 
   // Add locale code prefix
-  const pathWithoutLocale = '/' + slugParts.filter(Boolean).join('/');
+  const pathWithoutLocale = '/' + slugParts.map(normalizeSlugSegment).filter(Boolean).join('/');
   return `/${locale.code}${pathWithoutLocale}`;
 }
 
@@ -343,7 +354,7 @@ export function matchPageWithTranslatedSlugs(
     slugParts.push(translatedSlug);
   }
 
-  const constructedPath = '/' + slugParts.filter(Boolean).join('/');
+  const constructedPath = '/' + slugParts.map(normalizeSlugSegment).filter(Boolean).join('/');
   return constructedPath === targetPath;
 }
 
@@ -381,7 +392,7 @@ export function matchDynamicPageWithTranslatedSlugs(
   // Add {slug} placeholder for dynamic page
   slugParts.push('{slug}');
 
-  const patternPath = '/' + slugParts.filter(Boolean).join('/');
+  const patternPath = '/' + slugParts.map(normalizeSlugSegment).filter(Boolean).join('/');
 
   // Replace {slug} with regex capture group
   const patternRegex = patternPath.replace(/\{slug\}/g, '([^/]+)');

--- a/lib/services/cacheService.ts
+++ b/lib/services/cacheService.ts
@@ -1,7 +1,7 @@
 import { revalidateTag, revalidatePath } from 'next/cache';
 import { invalidateByTag } from '@vercel/functions';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
-import { buildSlugPath } from '@/lib/page-utils';
+import { buildSlugPath, normalizeSlugSegment } from '@/lib/page-utils';
 import type { Page, PageFolder } from '@/types';
 import type {
   ChangedLocale,
@@ -195,7 +195,7 @@ export async function getRoutePathsForPages(pageIds: string[]): Promise<string[]
           slugParts.push(localeTranslations[pageKey] || page.slug);
         }
 
-        const localePath = slugParts.filter(Boolean).join('/');
+        const localePath = slugParts.map(normalizeSlugSegment).filter(Boolean).join('/');
         if (localePath) routePaths.push(localePath);
       }
     }
@@ -291,7 +291,7 @@ async function resolveDynamicPageRoutes(
         slugParts.push(...folderSegments);
         slugParts.push(itemSlug);
 
-        const localePath = slugParts.filter(Boolean).join('/');
+        const localePath = slugParts.map(normalizeSlugSegment).filter(Boolean).join('/');
         if (localePath) routes.push(localePath);
       }
     }
@@ -357,7 +357,7 @@ export async function getRoutePathsForDeletedCollectionItems(
           }
           slugParts.push(...folderSegments);
           slugParts.push(itemSlug);
-          const localePath = slugParts.filter(Boolean).join('/');
+          const localePath = slugParts.map(normalizeSlugSegment).filter(Boolean).join('/');
           if (localePath) routes.push(localePath);
         }
       }


### PR DESCRIPTION
## Summary

Page URLs occasionally rendered with a double slash (e.g. `/blog//`) when a folder-index page slug was stored as the literal `/` — a legacy convention that the new schema expresses with `is_index = true` + empty slug. Normalise each slug segment before joining so leading/trailing slashes never leak into the final URL.

## Changes

- Add `normalizeSlugSegment` helper in `lib/page-utils.ts` that strips leading/trailing slashes while preserving interior ones (so legacy `foo/bar` slugs still work)
- Apply it in every slug-path builder/matcher: `buildSlugPath`, `buildLocalizedSlugPath`, `matchPageWithTranslatedSlugs`, `matchDynamicPageWithTranslatedSlugs`
- Apply it in the 3 locale-path builders in `lib/services/cacheService.ts` so cache warming/invalidation uses the same canonical paths

## Test plan

- [ ] A page link targeting a folder-index page (e.g. Blog Index with slug stored as `/`) resolves to `/blog`, not `/blog//`
- [ ] Regular pages (slug `about`) still resolve to `/about`
- [ ] Dynamic page URLs with collection item slug substitution still resolve correctly
- [ ] Localised paths (`/fr/blog`) match without trailing or double slashes
- [ ] Cache invalidation after publish hits the correct route tags