### PR TITLE
fix(static-export): render code-block HTML inline instead of in an iframe

### DIFF
--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -77,7 +77,7 @@ export function renderPageBody(
         ctx.components,
         undefined, // ancestorComponentIds
         false, // isSlideChild
-        undefined, // pageLinkContext
+        { isStaticExport: true }, // pageLinkContext — opt out of iframe htmlEmbed wrapping
       ),
     )
     .filter(Boolean)

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -3999,6 +3999,13 @@ export interface PageLinkContext {
   pageCollectionItemId?: string;
   pageCollectionSortedItemIds?: string[];
   isPreview?: boolean;
+  /**
+   * Set by the static export to opt out of the iframe-wrapped htmlEmbed
+   * SSR fallback. The live site relies on React hydration to replace the
+   * SSR iframe with an inline `HtmlEmbedRenderer`; the static export has
+   * no hydration, so an iframe with no `height` clips the user's content.
+   */
+  isStaticExport?: boolean;
 }
 
 /** Build an `assetMap`-backed `getAsset` callback compatible with `generateLinkHref`. */
@@ -4393,6 +4400,18 @@ export function layerToHtml(
   // Handle Code Embed layers - render as iframe for SSR
   if (layer.name === 'htmlEmbed') {
     const htmlEmbedCode = layer.settings?.htmlEmbed?.code || '<div>Add your custom code here</div>';
+
+    // Static export has no React hydration to replace the SSR iframe with
+    // an inline HtmlEmbedRenderer mount, and iframes default to ~150px
+    // tall with no `height` set — clipping the user's content. Emit the
+    // code inline so it renders at natural height, matching the editor.
+    // <script> tags in initial document HTML are executed by the browser,
+    // so user-pasted scripts run exactly as authored.
+    if (pageLinkContext?.isStaticExport) {
+      attrs.push('data-html-embed="true"');
+      const inlineAttrsStr = attrs.length > 0 ? ' ' + attrs.join(' ') : '';
+      return `<div${inlineAttrsStr}>${htmlEmbedCode}</div>`;
+    }
 
     // Create a complete HTML document for iframe srcdoc
     const iframeContent = `<!DOCTYPE html>


### PR DESCRIPTION
## Summary

Code Embed (htmlEmbed) layers render correctly in the builder and live preview, but break in the **Static HTML Export** — the user's pasted HTML is clipped to ~150px because it's wrapped in an iframe with no height set.

## Why this happens

`layerToHtml`'s `htmlEmbed` branch emits:

```html
<iframe data-html-embed="true" srcdoc="<doc with body{overflow:hidden}>"
        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
        style="width: 100%; border: none; display: block;"
        title="Code Embed …"></iframe>
```

On the live Vercel-hosted site this is fine — React hydrates over the iframe and `HtmlEmbedRenderer` replaces it with an inline mount, injecting the user's HTML into a `<div>` and re-creating `<script>` tags so they execute. The user sees the iframe for a few frames at most.

The static export has no hydration. The iframe is the final output. It defaults to ~150px tall and `body { overflow: hidden }` means it can't scroll either — so any content past the first ~150px is permanently invisible. Concretely: a contact form with a heading, intro paragraph, three fields, Turnstile widget, and submit button shows just the heading and the first line of the intro.

## Fix

Adds an opt-in `isStaticExport?: boolean` to `PageLinkContext` and, when set, emits the user's HTML inline in a `<div data-html-embed="true">` instead of the iframe. The static export passes the flag; nothing else does.

Browsers execute `<script>` tags they parse during initial document load, so user-pasted scripts run exactly as authored — matching the editor's `HtmlEmbedRenderer.tsx` behavior (which re-creates script tags after `innerHTML`).

## Changes

- `lib/page-fetcher.ts` — add `isStaticExport?: boolean` to `PageLinkContext`; in the `htmlEmbed` branch, return inline `<div>${code}</div>` when the flag is set, otherwise fall through to the existing iframe path.
- `lib/apps/static-export/document.ts` — pass `{ isStaticExport: true }` as the `pageLinkContext` arg to `layerToHtml` in `renderPageBody`.

## Compatibility

- **Live Vercel / dynamic sites: zero behavior change.** Every existing caller of `layerToHtml` passes `pageLinkContext` either as `undefined` or with only the legacy fields (`pageCollectionItemId`, `pageCollectionSortedItemIds`, `isPreview`). With the flag falsy, the new branch is skipped and SSR output is byte-identical to today. Hydration → inline render still works as before.
- **Editor / preview: unchanged.** Those use the React `HtmlEmbedRenderer` directly, not `layerToHtml`.
- **Static export: now matches the editor.** User HTML/CSS/JS render at natural height with scripts executing as authored.
- Security: the iframe was sandboxed with `allow-scripts allow-same-origin allow-forms` already — effectively a same-origin frame. The inline version exposes the same surface in the same origin. No new security boundary crossed.

## Test plan

- [x] Build a page with a Code Embed containing a non-trivial form (heading + several fields + external script). Verify in builder: renders fine.
- [x] Verify in live preview: renders fine.
- [x] Run Export Now, open the exported HTML in a browser: form now renders at full height with working inline `<script>` execution. Before this change: clipped to ~150px iframe.
- [x] Repeat with a multi-page export to confirm no regression on non-htmlEmbed pages.
- [x] `npm run type-check` clean.
- [x] grep confirms `isStaticExport` is only set in `lib/apps/static-export/document.ts:79`. No accidental wiring to SSR.

## Verified end-to-end

Deployed to a self-hosted Ycode instance built from this branch, exported a real contact page with a Cloudflare Turnstile widget. The form, captcha, and submit button now render and submit correctly. Same site exported from `develop` immediately before this change showed only the heading.