### PR TITLE
fix: respect apply-style choice on intro animations

### DIFF
--- a/app/(builder)/ycode/components/InteractionsPanel.tsx
+++ b/app/(builder)/ycode/components/InteractionsPanel.tsx
@@ -81,7 +81,7 @@ import {
 import type { TriggerType, PropertyType, ParsedAnimationValue } from '@/lib/animation-utils';
 
 // 4. Types
-import type { Layer, LayerInteraction, InteractionTimeline, InteractionTween, TweenProperties, Breakpoint } from '@/types';
+import type { ApplyStyles, Layer, LayerInteraction, InteractionTimeline, InteractionTween, TweenProperties, Breakpoint } from '@/types';
 import { BREAKPOINTS, BREAKPOINT_VALUES } from '@/lib/breakpoint-utils';
 import { useColorVariablesStore } from '@/stores/useColorVariablesStore';
 import { Badge } from '@/components/ui/badge';
@@ -2292,14 +2292,15 @@ export default function InteractionsPanel({
                       return (
                         <div key={prop.key} className="flex items-center gap-1.25">
                           {!prop.toOnly && (() => {
-                            const effectiveApplyStyle = selectedInteraction
-                              ? getEffectiveApplyStyle(selectedInteraction.trigger, prop.key, selectedTween.apply_styles)
-                              : (selectedTween.apply_styles?.[prop.key] || 'on-trigger');
-                            // Intro triggers (load, scroll-into-view) are implicitly on-load
-                            // to prevent flicker — lock the toggle in that case.
-                            const isImplicitOnLoad = selectedInteraction
-                              ? (selectedInteraction.trigger === 'load' || selectedInteraction.trigger === 'scroll-into-view')
-                              : false;
+                            // SplitText tweens target child .word/.char/.line elements that
+                            // only exist after SplitText runs client-side, so the on-load /
+                            // on-trigger toggle is a no-op — they always behave as on-trigger.
+                            const isNoOpForSplitText = !!selectedTween.splitText;
+                            const effectiveApplyStyle: ApplyStyles = isNoOpForSplitText
+                              ? 'on-trigger'
+                              : selectedInteraction
+                                ? getEffectiveApplyStyle(selectedInteraction.trigger, prop.key, selectedTween.apply_styles)
+                                : (selectedTween.apply_styles?.[prop.key] || 'on-trigger');
                             const isOnLoad = effectiveApplyStyle === 'on-load';
 
                             return (
@@ -2310,13 +2311,12 @@ export default function InteractionsPanel({
                                       size="xs"
                                       variant="secondary"
                                       className="size-7 p-0 shrink-0 transition-none"
-                                      disabled={isFromCurrent || isImplicitOnLoad}
+                                      disabled={isFromCurrent || isNoOpForSplitText}
                                       onClick={() => {
-                                        const currentValue = selectedTween.apply_styles?.[prop.key] || 'on-trigger';
                                         handleUpdateTween(selectedTween.id, {
                                           apply_styles: {
                                             ...selectedTween.apply_styles,
-                                            [prop.key]: currentValue === 'on-load' ? 'on-trigger' : 'on-load',
+                                            [prop.key]: isOnLoad ? 'on-trigger' : 'on-load',
                                           },
                                         });
                                       }}
@@ -2325,8 +2325,8 @@ export default function InteractionsPanel({
                                     </Button>
                                   </TooltipTrigger>
                                   <TooltipContent side="top" align="start">
-                                    {isImplicitOnLoad
-                                      ? 'Always applied on page load for this trigger'
+                                    {isNoOpForSplitText
+                                      ? 'Text animations always apply styles on trigger'
                                       : isOnLoad
                                         ? 'Apply property style on page load'
                                         : 'Apply property style on trigger'}

--- a/lib/animation-utils.ts
+++ b/lib/animation-utils.ts
@@ -12,18 +12,20 @@ import { BREAKPOINTS } from '@/lib/breakpoint-utils';
 const IMPLICIT_ON_LOAD_TRIGGERS: ReadonlyArray<LayerInteraction['trigger']> = ['load', 'scroll-into-view'];
 
 /**
- * Returns the effective apply mode for a tween property, treating intro
- * triggers (load, scroll-into-view) as implicit `on-load` so the initial
- * state is painted server-side. Stops `to`-state flashes before the
- * timeline starts.
+ * Returns the effective apply mode for a tween property. Honors an explicit
+ * `apply_styles` choice; otherwise falls back to `on-load` for intro
+ * triggers (load, scroll-into-view) so new intro animations stay
+ * flicker-free, and `on-trigger` for everything else.
  */
 export function getEffectiveApplyStyle(
   trigger: LayerInteraction['trigger'],
   propertyKey: TweenPropertyKey,
   applyStyles: InteractionTween['apply_styles'] | undefined
 ): ApplyStyles {
+  const explicit = applyStyles?.[propertyKey];
+  if (explicit) return explicit;
   if (IMPLICIT_ON_LOAD_TRIGGERS.includes(trigger)) return 'on-load';
-  return applyStyles?.[propertyKey] || 'on-trigger';
+  return 'on-trigger';
 }
 
 /**
@@ -696,6 +698,11 @@ export function generateInitialAnimationCSS(layers: Layer[]): InitialAnimationRe
           const breakpointValue = interaction.timeline?.breakpoints?.join(' ') || null;
 
           (interaction.tweens || []).forEach((tween) => {
+            // SplitText tweens target child elements (.word/.char/.line) created at
+            // run-time, not the parent layer. Painting the `from` state on the parent
+            // would offset/hide the whole element and never be cleared.
+            if (tween.splitText) return;
+
             const styles: string[] = [];
             const transforms: string[] = [];
             const filterValues: Partial<Record<FilterPropertyKey, string>> = {};


### PR DESCRIPTION
## Summary

Intro triggers (`load`, `scroll-into-view`) were unconditionally treated as `on-load`, overriding any explicit `on-trigger` setting on a tween property. Existing animations that intentionally kept an element visible until the trigger fired stopped working, and the UI toggle was locked so users couldn't even revert the override.

## Changes

- Honor an explicit `apply_styles` choice in `getEffectiveApplyStyle`; only fall back to `on-load` for intro triggers when no value is set
- Unlock the apply-style toggle in `InteractionsPanel` for `load` / `scroll-into-view` triggers
- Disable the toggle for `splitText` tweens — the choice is a no-op there because the `from` state targets child `.word` / `.char` / `.line` elements that only exist after `SplitText` runs client-side
- New intro animations still default to `on-load` (via `getDefaultApplyStyles`), so flicker-free defaults are preserved out of the box

## Test plan

- [ ] Open an existing animation with `scroll-into-view` trigger and `apply_styles: on-trigger` — element stays visible from initial render and only animates when triggered
- [ ] Create a new intro animation — defaults to `on-load`, element starts in the `from` state, no flicker
- [ ] Toggle a property between `on-load` and `on-trigger` on a `scroll-into-view` trigger — button is interactive, both modes work
- [ ] On a `splitText` tween, confirm the toggle is disabled and the tooltip reads "Text animations always apply styles on trigger"