### PR TITLE
feat: add OAuth to MCP for Claude.ai web/ChatGPT

### DIFF
--- a/app/(builder)/ycode/YCodeLayoutClient.tsx
+++ b/app/(builder)/ycode/YCodeLayoutClient.tsx
@@ -61,7 +61,7 @@ function YCodeLayoutInner({ children }: { children: React.ReactNode }) {
 
   // Exclude standalone routes from YCodeBuilder
   // These routes should render independently without the editor UI
-  const prefixRoutes = ['/ycode/preview', '/ycode/devtools/'];
+  const prefixRoutes = ['/ycode/preview', '/ycode/devtools/', '/ycode/oauth/'];
   const exactRoutes = ['/ycode/welcome', '/ycode/accept-invite'];
 
   if (

--- a/app/(builder)/ycode/api/oauth/authorize/route.ts
+++ b/app/(builder)/ycode/api/oauth/authorize/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAuthUser } from '@/lib/supabase-auth';
+import { getClient } from '@/lib/repositories/mcpOAuthClientRepository';
+import { createCode } from '@/lib/repositories/mcpOAuthCodeRepository';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * POST /ycode/api/oauth/authorize
+ *
+ * Called by the consent page (`/ycode/oauth/authorize`) when the user
+ * approves or denies an OAuth request. Validates the session, client,
+ * and PKCE parameters; on approve issues a single-use code and 302s
+ * back to `redirect_uri`.
+ *
+ * Returns JSON for fetch() callers and uses 302 only for direct form posts.
+ */
+
+interface AuthorizeBody {
+  client_id?: unknown;
+  redirect_uri?: unknown;
+  code_challenge?: unknown;
+  code_challenge_method?: unknown;
+  state?: unknown;
+  scope?: unknown;
+  decision?: unknown; // 'approve' | 'deny'
+}
+
+function redirectWithError(
+  redirectUri: string,
+  error: string,
+  state: string | null,
+  description?: string,
+): NextResponse {
+  const url = new URL(redirectUri);
+  url.searchParams.set('error', error);
+  if (description) url.searchParams.set('error_description', description);
+  if (state) url.searchParams.set('state', state);
+  return NextResponse.redirect(url, { status: 302 });
+}
+
+export async function POST(request: NextRequest) {
+  let body: AuthorizeBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: 'invalid_request', error_description: 'Request body must be JSON' },
+      { status: 400 },
+    );
+  }
+
+  const clientId = typeof body.client_id === 'string' ? body.client_id : null;
+  const redirectUri = typeof body.redirect_uri === 'string' ? body.redirect_uri : null;
+  const codeChallenge = typeof body.code_challenge === 'string' ? body.code_challenge : null;
+  const codeChallengeMethod = typeof body.code_challenge_method === 'string'
+    ? body.code_challenge_method
+    : null;
+  const state = typeof body.state === 'string' ? body.state : null;
+  const scope = typeof body.scope === 'string' ? body.scope : null;
+  const decision = typeof body.decision === 'string' ? body.decision : null;
+
+  if (!clientId || !redirectUri || !codeChallenge || !codeChallengeMethod) {
+    return NextResponse.json(
+      { error: 'invalid_request', error_description: 'Missing required parameters' },
+      { status: 400 },
+    );
+  }
+
+  if (codeChallengeMethod !== 'S256') {
+    return NextResponse.json(
+      {
+        error: 'invalid_request',
+        error_description: 'Only S256 PKCE method is supported',
+      },
+      { status: 400 },
+    );
+  }
+
+  if (decision !== 'approve' && decision !== 'deny') {
+    return NextResponse.json(
+      { error: 'invalid_request', error_description: 'decision must be approve or deny' },
+      { status: 400 },
+    );
+  }
+
+  const auth = await getAuthUser();
+  if (!auth) {
+    return NextResponse.json({ error: 'login_required' }, { status: 401 });
+  }
+
+  const client = await getClient(clientId);
+  if (!client) {
+    return NextResponse.json(
+      { error: 'invalid_client', error_description: 'Unknown client_id' },
+      { status: 400 },
+    );
+  }
+
+  if (!client.redirect_uris.includes(redirectUri)) {
+    return NextResponse.json(
+      { error: 'invalid_request', error_description: 'redirect_uri not registered' },
+      { status: 400 },
+    );
+  }
+
+  if (decision === 'deny') {
+    const url = redirectWithError(redirectUri, 'access_denied', state).headers.get('location')!;
+    return NextResponse.json({ redirect_to: url });
+  }
+
+  try {
+    const code = await createCode({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      code_challenge: codeChallenge,
+      code_challenge_method: codeChallengeMethod,
+      scope,
+      user_id: auth.user.id,
+    });
+
+    const url = new URL(redirectUri);
+    url.searchParams.set('code', code);
+    if (state) url.searchParams.set('state', state);
+
+    return NextResponse.json({ redirect_to: url.toString() });
+  } catch (error) {
+    console.error('[oauth/authorize] Failed to issue code:', error);
+    return NextResponse.json(
+      {
+        error: 'server_error',
+        error_description: error instanceof Error ? error.message : 'Failed to issue code',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/(builder)/ycode/api/oauth/register/route.ts
+++ b/app/(builder)/ycode/api/oauth/register/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest } from 'next/server';
+import { registerClient } from '@/lib/repositories/mcpOAuthClientRepository';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * POST /ycode/api/oauth/register
+ *
+ * RFC 7591 — OAuth 2.0 Dynamic Client Registration.
+ *
+ * Public endpoint (no auth required). PKCE is the actual security mechanism
+ * for the issued tokens; the returned `client_id` is opaque and not a secret.
+ * We persist the `client_name` so the consent screen can show it to the user,
+ * and the `redirect_uris` so /authorize can validate them on every request.
+ */
+
+interface RegisterBody {
+  client_name?: unknown;
+  redirect_uris?: unknown;
+  grant_types?: unknown;
+  response_types?: unknown;
+  token_endpoint_auth_method?: unknown;
+}
+
+function jsonError(status: number, error: string, description?: string): Response {
+  return new Response(
+    JSON.stringify(description ? { error, error_description: description } : { error }),
+    {
+      status,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+        'Access-Control-Allow-Origin': '*',
+      },
+    },
+  );
+}
+
+export async function POST(request: NextRequest) {
+  let body: RegisterBody;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, 'invalid_client_metadata', 'Request body must be valid JSON');
+  }
+
+  const clientName = typeof body.client_name === 'string' && body.client_name.trim() !== ''
+    ? body.client_name.trim()
+    : 'MCP Client';
+
+  const redirectUris = Array.isArray(body.redirect_uris)
+    ? body.redirect_uris.filter((u): u is string => typeof u === 'string' && u.length > 0)
+    : [];
+
+  if (redirectUris.length === 0) {
+    return jsonError(
+      400,
+      'invalid_redirect_uri',
+      'At least one redirect_uri is required',
+    );
+  }
+
+  for (const uri of redirectUris) {
+    try {
+      const parsed = new URL(uri);
+      if (parsed.protocol !== 'https:'
+        && parsed.hostname !== 'localhost'
+        && parsed.hostname !== '127.0.0.1') {
+        return jsonError(
+          400,
+          'invalid_redirect_uri',
+          `redirect_uri must use HTTPS (or be localhost): ${uri}`,
+        );
+      }
+    } catch {
+      return jsonError(400, 'invalid_redirect_uri', `Malformed redirect_uri: ${uri}`);
+    }
+  }
+
+  try {
+    const client = await registerClient({
+      client_name: clientName,
+      redirect_uris: redirectUris,
+    });
+
+    const issuedAt = Math.floor(new Date(client.created_at).getTime() / 1000);
+
+    return new Response(
+      JSON.stringify({
+        client_id: client.client_id,
+        client_id_issued_at: issuedAt,
+        client_name: client.client_name,
+        redirect_uris: client.redirect_uris,
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+      }),
+      {
+        status: 201,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+          'Access-Control-Allow-Origin': '*',
+        },
+      },
+    );
+  } catch (error) {
+    console.error('[oauth/register] Failed:', error);
+    return jsonError(
+      500,
+      'server_error',
+      error instanceof Error ? error.message : 'Failed to register client',
+    );
+  }
+}
+
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  });
+}

--- a/app/(builder)/ycode/api/oauth/token/route.ts
+++ b/app/(builder)/ycode/api/oauth/token/route.ts
@@ -1,0 +1,200 @@
+import { NextRequest } from 'next/server';
+import { consumeCode, cleanupExpired } from '@/lib/repositories/mcpOAuthCodeRepository';
+import { getClient } from '@/lib/repositories/mcpOAuthClientRepository';
+import {
+  createOAuthToken,
+  rotateRefreshToken,
+  type OAuthTokenPair,
+} from '@/lib/repositories/mcpTokenRepository';
+import { verifyPkce } from '@/lib/oauth/pkce';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * POST /ycode/api/oauth/token
+ *
+ * Public token endpoint supporting two grant types:
+ *
+ *  - `authorization_code`: consume a single-use code issued by /authorize,
+ *     verify the PKCE code_verifier matches the stored code_challenge, and
+ *     issue an access + refresh token pair.
+ *
+ *  - `refresh_token`: rotate a refresh token, revoking the old one and
+ *     issuing a fresh access + refresh pair.
+ */
+
+interface FormBody {
+  grant_type?: string;
+  code?: string;
+  redirect_uri?: string;
+  client_id?: string;
+  code_verifier?: string;
+  refresh_token?: string;
+}
+
+function jsonError(status: number, error: string, description?: string): Response {
+  return new Response(
+    JSON.stringify(description ? { error, error_description: description } : { error }),
+    {
+      status,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+        'Access-Control-Allow-Origin': '*',
+      },
+    },
+  );
+}
+
+function jsonTokens(pair: OAuthTokenPair): Response {
+  return new Response(
+    JSON.stringify({
+      access_token: pair.access_token,
+      token_type: 'Bearer',
+      expires_in: pair.expires_in,
+      refresh_token: pair.refresh_token,
+      scope: 'mcp',
+    }),
+    {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+        'Pragma': 'no-cache',
+        'Access-Control-Allow-Origin': '*',
+      },
+    },
+  );
+}
+
+async function parseBody(request: NextRequest): Promise<FormBody | null> {
+  const contentType = request.headers.get('content-type') || '';
+
+  try {
+    if (contentType.includes('application/x-www-form-urlencoded')) {
+      const text = await request.text();
+      const params = new URLSearchParams(text);
+      return {
+        grant_type: params.get('grant_type') ?? undefined,
+        code: params.get('code') ?? undefined,
+        redirect_uri: params.get('redirect_uri') ?? undefined,
+        client_id: params.get('client_id') ?? undefined,
+        code_verifier: params.get('code_verifier') ?? undefined,
+        refresh_token: params.get('refresh_token') ?? undefined,
+      };
+    }
+
+    if (contentType.includes('application/json')) {
+      const json = await request.json();
+      return json as FormBody;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  const body = await parseBody(request);
+  if (!body || !body.grant_type) {
+    return jsonError(400, 'invalid_request', 'Missing or unparseable request body');
+  }
+
+  // Best-effort cleanup of expired codes ~10% of the time.
+  if (Math.random() < 0.1) {
+    cleanupExpired().catch(() => {});
+  }
+
+  if (body.grant_type === 'authorization_code') {
+    return handleAuthorizationCode(body);
+  }
+
+  if (body.grant_type === 'refresh_token') {
+    return handleRefreshToken(body);
+  }
+
+  return jsonError(400, 'unsupported_grant_type', `Unknown grant_type: ${body.grant_type}`);
+}
+
+async function handleAuthorizationCode(body: FormBody): Promise<Response> {
+  const { code, redirect_uri: redirectUri, client_id: clientId, code_verifier: codeVerifier } = body;
+
+  if (!code || !redirectUri || !clientId || !codeVerifier) {
+    return jsonError(
+      400,
+      'invalid_request',
+      'authorization_code grant requires code, redirect_uri, client_id, code_verifier',
+    );
+  }
+
+  const stored = await consumeCode(code);
+  if (!stored) {
+    return jsonError(400, 'invalid_grant', 'Code is invalid, expired, or already used');
+  }
+
+  if (stored.client_id !== clientId) {
+    return jsonError(400, 'invalid_grant', 'client_id mismatch');
+  }
+
+  if (stored.redirect_uri !== redirectUri) {
+    return jsonError(400, 'invalid_grant', 'redirect_uri mismatch');
+  }
+
+  const pkceOk = await verifyPkce(codeVerifier, stored.code_challenge, stored.code_challenge_method);
+  if (!pkceOk) {
+    return jsonError(400, 'invalid_grant', 'PKCE verification failed');
+  }
+
+  const client = await getClient(stored.client_id);
+  if (!client) {
+    return jsonError(400, 'invalid_client', 'Client no longer exists');
+  }
+
+  try {
+    const pair = await createOAuthToken({
+      user_id: stored.user_id,
+      oauth_client_id: stored.client_id,
+      name: client.client_name,
+    });
+    return jsonTokens(pair);
+  } catch (error) {
+    console.error('[oauth/token] createOAuthToken failed:', error);
+    return jsonError(
+      500,
+      'server_error',
+      error instanceof Error ? error.message : 'Failed to issue token',
+    );
+  }
+}
+
+async function handleRefreshToken(body: FormBody): Promise<Response> {
+  const { refresh_token: refreshToken, client_id: clientId } = body;
+
+  if (!refreshToken) {
+    return jsonError(400, 'invalid_request', 'refresh_token is required');
+  }
+
+  if (!clientId) {
+    return jsonError(400, 'invalid_request', 'client_id is required');
+  }
+
+  const pair = await rotateRefreshToken(refreshToken);
+  if (!pair) {
+    return jsonError(400, 'invalid_grant', 'Refresh token is invalid, expired, or already rotated');
+  }
+
+  return jsonTokens(pair);
+}
+
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  });
+}

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -21,7 +21,7 @@
 // 1. React/Next.js
 import { useEffect, useState, useMemo, useRef, useCallback, Suspense, lazy } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 // 2. Internal components
 import CenterCanvas from '../components/CenterCanvas';
 import HeaderBar from '../components/HeaderBar';
@@ -97,6 +97,7 @@ interface YCodeBuilderProps {
 
 export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCodeBuilderProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { routeType, resourceId, sidebarTab, navigateToLayers, navigateToCollection, navigateToCollections, navigateToComponent, urlState, updateQueryParams } = useEditorUrl();
 
   // Role-based access
@@ -485,6 +486,17 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
       document.documentElement.classList.add('dark');
     }
   }, [user]);
+
+  // After login, honor `?next=` (used by the OAuth consent flow to bounce
+  // unauthenticated users through `/ycode` and back). Only same-origin
+  // paths starting with `/ycode` are accepted to prevent open redirects.
+  useEffect(() => {
+    if (!user || !authInitialized) return;
+    const next = searchParams?.get('next');
+    if (!next) return;
+    if (!next.startsWith('/ycode')) return;
+    router.replace(next);
+  }, [user, authInitialized, searchParams, router]);
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/app/(builder)/ycode/integrations/mcp/page.tsx
+++ b/app/(builder)/ycode/integrations/mcp/page.tsx
@@ -30,6 +30,8 @@ interface McpToken {
   is_active: boolean;
   last_used_at: string | null;
   created_at: string;
+  oauth_client_id: string | null;
+  expires_at: string | null;
 }
 
 export default function McpPage() {
@@ -43,9 +45,11 @@ export default function McpPage() {
   const [generatedToken, setGeneratedToken] = useState<McpToken | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [mcpBearerUrl, setMcpBearerUrl] = useState('/ycode/mcp');
 
   useEffect(() => {
     fetchTokens();
+    setMcpBearerUrl(`${window.location.origin}/ycode/mcp`);
   }, []);
 
   const fetchTokens = async () => {
@@ -127,6 +131,16 @@ export default function McpPage() {
     return formatDate(dateString);
   };
 
+  const isOAuthToken = (token: McpToken) => Boolean(token.oauth_client_id);
+
+  const tokenStatusLabel = (token: McpToken) => {
+    if (!isOAuthToken(token)) return 'URL token';
+    if (token.expires_at && new Date(token.expires_at).getTime() < Date.now()) {
+      return 'OAuth (expired)';
+    }
+    return 'OAuth';
+  };
+
   return (
     <div className="p-8">
       <div className="max-w-3xl mx-auto">
@@ -164,9 +178,15 @@ export default function McpPage() {
                     <code className="text-xs text-muted-foreground bg-secondary px-1.5 py-0.5 rounded font-mono">
                       {token.token_prefix}...
                     </code>
+                    <span className="text-xs text-muted-foreground bg-secondary px-1.5 py-0.5 rounded">
+                      {tokenStatusLabel(token)}
+                    </span>
                   </div>
                   <div className="text-xs text-muted-foreground">
                     Created {formatDate(token.created_at)} · Last used: {formatLastUsed(token.last_used_at)}
+                    {isOAuthToken(token) && token.expires_at
+                      ? <> · Expires {formatDate(token.expires_at)}</>
+                      : null}
                   </div>
                 </div>
 
@@ -224,6 +244,18 @@ export default function McpPage() {
             <p className="text-muted-foreground">
               Any AI tool that supports the MCP Streamable HTTP transport can connect using the URL.
               No API key is needed — the URL contains the authentication token.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="font-medium mb-2">Claude.ai web / ChatGPT (OAuth)</h3>
+            <p className="text-muted-foreground">
+              These clients connect via OAuth. Add a custom connector pointing to{' '}
+              <code className="text-xs bg-secondary px-1.5 py-0.5 rounded font-mono">
+                {mcpBearerUrl}
+              </code>{' '}
+              and you&apos;ll be prompted to approve access from this page. OAuth-issued tokens appear in the
+              list above and can be revoked at any time.
             </p>
           </section>
         </div>

--- a/app/(builder)/ycode/mcp/[token]/route.ts
+++ b/app/(builder)/ycode/mcp/[token]/route.ts
@@ -1,245 +1,34 @@
 import { NextRequest } from 'next/server';
-import { randomUUID } from 'crypto';
-import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { validateToken } from '@/lib/repositories/mcpTokenRepository';
-import { createMcpServer } from '@/lib/mcp/server';
+import {
+  authenticateToken,
+  handleMcpPost,
+  handleMcpGet,
+  handleMcpDelete,
+  addCorsHeaders,
+  unauthorizedJson,
+} from '@/lib/mcp/handler';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-interface McpSession {
-  transport: WebStandardStreamableHTTPServerTransport;
-  server: McpServer;
-  lastActivity: number;
-}
-
-const sessions = new Map<string, McpSession>();
-
-const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
-
-function cleanupStaleSessions() {
-  const now = Date.now();
-  for (const [id, session] of sessions) {
-    if (now - session.lastActivity > SESSION_TIMEOUT_MS) {
-      session.transport.close().catch(() => {});
-      sessions.delete(id);
-    }
-  }
-}
-
 /**
- * Token validation cache. AI agents make many requests per minute and each
- * was previously hitting Supabase to revalidate the same token. Cache hits
- * for 60s (revocations propagate within a minute, fine for agent use).
- * Misses cache for 5s so a token flip from invalid→valid recovers quickly.
+ * Legacy URL-token MCP endpoint.
+ *
+ * Used by Cursor, Windsurf, Claude Desktop, and Claude Code — clients that
+ * accept an MCP URL with the auth token embedded in the path. Claude.ai web
+ * and ChatGPT use the sibling `/ycode/mcp` route, which authenticates via
+ * `Authorization: Bearer <token>` headers issued by the OAuth flow.
  */
-interface TokenCacheEntry {
-  valid: boolean;
-  expires: number;
-}
-const tokenCache = new Map<string, TokenCacheEntry>();
-const TOKEN_CACHE_TTL_VALID_MS = 60_000;
-const TOKEN_CACHE_TTL_INVALID_MS = 5_000;
-
-async function authenticateToken(token: string): Promise<boolean> {
-  const now = Date.now();
-  const cached = tokenCache.get(token);
-  if (cached && cached.expires > now) {
-    return cached.valid;
-  }
-
-  let valid = false;
-  try {
-    const result = await validateToken(token);
-    valid = result !== null;
-  } catch {
-    valid = false;
-  }
-
-  const ttl = valid ? TOKEN_CACHE_TTL_VALID_MS : TOKEN_CACHE_TTL_INVALID_MS;
-  tokenCache.set(token, { valid, expires: now + ttl });
-  return valid;
-}
-
-function addCorsHeaders(response: Response): Response {
-  const headers = new Headers(response.headers);
-  headers.set('Access-Control-Allow-Origin', '*');
-  headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-  headers.set('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id, mcp-protocol-version');
-  headers.set('Access-Control-Expose-Headers', 'mcp-session-id');
-
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
-}
-
-function createSessionTransport() {
-  const server = createMcpServer();
-  const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
-    enableJsonResponse: true,
-    onsessioninitialized: (newSessionId) => {
-      sessions.set(newSessionId, { transport, server, lastActivity: Date.now() });
-    },
-  });
-
-  transport.onclose = () => {
-    if (transport.sessionId) {
-      sessions.delete(transport.sessionId);
-    }
-  };
-
-  return { server, transport };
-}
-
-/**
- * Auto-initialize a fresh server+transport so it can handle non-init requests.
- * This is needed on serverless (Vercel) where in-memory sessions are lost
- * between requests that hit different instances.
- */
-async function autoInitialize(
-  transport: WebStandardStreamableHTTPServerTransport,
-  url: string,
-): Promise<void> {
-  const initReq = new Request(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json, text/event-stream',
-    },
-  });
-
-  await transport.handleRequest(initReq, {
-    parsedBody: {
-      jsonrpc: '2.0',
-      id: '_auto_init',
-      method: 'initialize',
-      params: {
-        protocolVersion: '2025-03-26',
-        capabilities: {},
-        clientInfo: { name: 'ycode-auto', version: '1.0.0' },
-      },
-    },
-  });
-
-  const notifReq = new Request(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json, text/event-stream',
-      'mcp-session-id': transport.sessionId!,
-    },
-  });
-
-  await transport.handleRequest(notifReq, {
-    parsedBody: { jsonrpc: '2.0', method: 'notifications/initialized' },
-  });
-}
-
-/**
- * Ensure the Accept header includes both required MIME types.
- * Some MCP clients (e.g., Claude Code) don't send text/event-stream,
- * but the SDK enforces it even when enableJsonResponse is true.
- */
-function ensureAcceptHeader(request: Request): Request {
-  const accept = request.headers.get('accept') || '';
-  if (accept.includes('application/json') && accept.includes('text/event-stream')) {
-    return request;
-  }
-
-  const headers = new Headers(request.headers);
-  headers.set('Accept', 'application/json, text/event-stream');
-  return new Request(request.url, {
-    method: request.method,
-    headers,
-    body: request.body,
-    // @ts-expect-error duplex is needed for streaming body but not in all TS defs
-    duplex: 'half',
-  });
-}
-
-async function handleMcpRequest(request: Request): Promise<Response> {
-  const normalized = ensureAcceptHeader(request);
-  const sessionId = normalized.headers.get('mcp-session-id');
-
-  if (sessionId && sessions.has(sessionId)) {
-    const session = sessions.get(sessionId)!;
-    session.lastActivity = Date.now();
-    return session.transport.handleRequest(normalized);
-  }
-
-  if (normalized.method !== 'POST') {
-    return new Response(JSON.stringify({
-      jsonrpc: '2.0',
-      error: { code: -32000, message: 'Session expired. Send a new initialize request.' },
-      id: null,
-    }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-
-  const body = await normalized.json();
-  const isInit = !Array.isArray(body) && body.method === 'initialize';
-
-  const { server, transport } = createSessionTransport();
-  await server.connect(transport);
-
-  if (isInit) {
-    const req = new Request(normalized.url, {
-      method: 'POST',
-      headers: normalized.headers,
-    });
-    return transport.handleRequest(req, { parsedBody: body });
-  }
-
-  // Session was lost (serverless instance recycled) — auto-initialize
-  await autoInitialize(transport, normalized.url);
-
-  const actualReq = new Request(normalized.url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json, text/event-stream',
-      'mcp-session-id': transport.sessionId!,
-    },
-  });
-
-  return transport.handleRequest(actualReq, { parsedBody: body });
-}
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ token: string }> },
 ) {
   const { token } = await params;
-
-  try {
-    const isValid = await authenticateToken(token);
-    if (!isValid) {
-      return new Response(JSON.stringify({ error: 'Invalid MCP token' }), {
-        status: 401,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
-
-    cleanupStaleSessions();
-    const response = await handleMcpRequest(request);
-    return addCorsHeaders(response);
-  } catch (error) {
-    console.error('[MCP POST] Error:', error);
-    return addCorsHeaders(new Response(JSON.stringify({
-      jsonrpc: '2.0',
-      error: { code: -32603, message: error instanceof Error ? error.message : 'Internal server error' },
-      id: null,
-    }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    }));
+  if (!(await authenticateToken(token))) {
+    return unauthorizedJson('Invalid MCP token');
   }
+  return handleMcpPost(request);
 }
 
 export async function GET(
@@ -247,43 +36,10 @@ export async function GET(
   { params }: { params: Promise<{ token: string }> },
 ) {
   const { token } = await params;
-
-  try {
-    const isValid = await authenticateToken(token);
-    if (!isValid) {
-      return new Response(JSON.stringify({ error: 'Invalid MCP token' }), {
-        status: 401,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
-
-    const sessionId = request.headers.get('mcp-session-id');
-    if (!sessionId || !sessions.has(sessionId)) {
-      return addCorsHeaders(new Response(JSON.stringify({
-        jsonrpc: '2.0',
-        error: { code: -32000, message: 'Session not found. Send a POST initialize first.' },
-        id: null,
-      }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }));
-    }
-
-    const session = sessions.get(sessionId)!;
-    session.lastActivity = Date.now();
-    const response = await session.transport.handleRequest(request);
-    return addCorsHeaders(response);
-  } catch (error) {
-    console.error('[MCP GET] Error:', error);
-    return addCorsHeaders(new Response(JSON.stringify({
-      jsonrpc: '2.0',
-      error: { code: -32603, message: error instanceof Error ? error.message : 'Internal server error' },
-      id: null,
-    }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    }));
+  if (!(await authenticateToken(token))) {
+    return unauthorizedJson('Invalid MCP token');
   }
+  return handleMcpGet(request);
 }
 
 export async function DELETE(
@@ -291,29 +47,10 @@ export async function DELETE(
   { params }: { params: Promise<{ token: string }> },
 ) {
   const { token } = await params;
-
-  try {
-    const isValid = await authenticateToken(token);
-    if (!isValid) {
-      return new Response(JSON.stringify({ error: 'Invalid MCP token' }), {
-        status: 401,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
-
-    const sessionId = request.headers.get('mcp-session-id');
-    if (sessionId && sessions.has(sessionId)) {
-      const session = sessions.get(sessionId)!;
-      await session.transport.close();
-      sessions.delete(sessionId);
-      return addCorsHeaders(new Response(null, { status: 204 }));
-    }
-
-    return addCorsHeaders(new Response(null, { status: 204 }));
-  } catch (error) {
-    console.error('[MCP DELETE] Error:', error);
-    return addCorsHeaders(new Response(null, { status: 204 }));
+  if (!(await authenticateToken(token))) {
+    return unauthorizedJson('Invalid MCP token');
   }
+  return handleMcpDelete(request);
 }
 
 export async function OPTIONS() {

--- a/app/(builder)/ycode/mcp/route.ts
+++ b/app/(builder)/ycode/mcp/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from 'next/server';
+import {
+  authenticateToken,
+  handleMcpPost,
+  handleMcpGet,
+  handleMcpDelete,
+  addCorsHeaders,
+  buildWwwAuthenticateHeader,
+} from '@/lib/mcp/handler';
+import { getBaseUrl } from '@/lib/oauth/metadata';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * OAuth Bearer-token MCP endpoint.
+ *
+ * Used by clients that authenticate per the MCP authorization spec
+ * (Claude.ai web, ChatGPT). Returns 401 with a `WWW-Authenticate` header
+ * pointing to the protected-resource metadata so unauthenticated clients
+ * can discover the OAuth flow.
+ *
+ * The shared session/transport logic lives in `lib/mcp/handler.ts` and is
+ * also used by the legacy URL-token endpoint at `/ycode/mcp/[token]`.
+ */
+
+function extractBearerToken(request: NextRequest): string | null {
+  const header = request.headers.get('authorization') || request.headers.get('Authorization');
+  if (!header) return null;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : null;
+}
+
+function unauthorizedWithChallenge(request: NextRequest, message: string): Response {
+  const baseUrl = getBaseUrl(request);
+  const response = new Response(JSON.stringify({ error: message }), {
+    status: 401,
+    headers: {
+      'Content-Type': 'application/json',
+      'WWW-Authenticate': buildWwwAuthenticateHeader(baseUrl),
+    },
+  });
+  return addCorsHeaders(response);
+}
+
+async function authorize(request: NextRequest): Promise<Response | null> {
+  const token = extractBearerToken(request);
+  if (!token) {
+    return unauthorizedWithChallenge(request, 'Authorization required');
+  }
+
+  const valid = await authenticateToken(token);
+  if (!valid) {
+    return unauthorizedWithChallenge(request, 'Invalid or expired access token');
+  }
+
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  const denied = await authorize(request);
+  if (denied) return denied;
+  return handleMcpPost(request);
+}
+
+export async function GET(request: NextRequest) {
+  const denied = await authorize(request);
+  if (denied) return denied;
+  return handleMcpGet(request);
+}
+
+export async function DELETE(request: NextRequest) {
+  const denied = await authorize(request);
+  if (denied) return denied;
+  return handleMcpDelete(request);
+}
+
+export async function OPTIONS() {
+  return addCorsHeaders(new Response(null, { status: 204 }));
+}

--- a/app/(builder)/ycode/oauth/authorize/ConsentForm.tsx
+++ b/app/(builder)/ycode/oauth/authorize/ConsentForm.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+interface ConsentFormProps {
+  clientName: string;
+  userEmail: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  scope: string | null;
+  state: string | null;
+}
+
+export default function ConsentForm(props: ConsentFormProps) {
+  const [submitting, setSubmitting] = useState<'approve' | 'deny' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.documentElement.classList.add('dark');
+    return () => {
+      document.documentElement.classList.remove('dark');
+    };
+  }, []);
+
+  const handleDecision = async (decision: 'approve' | 'deny') => {
+    setSubmitting(decision);
+    setError(null);
+
+    try {
+      const response = await fetch('/ycode/api/oauth/authorize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          decision,
+          client_id: props.clientId,
+          redirect_uri: props.redirectUri,
+          code_challenge: props.codeChallenge,
+          code_challenge_method: props.codeChallengeMethod,
+          scope: props.scope,
+          state: props.state,
+        }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok || !result.redirect_to) {
+        setError(result.error_description || result.error || 'Failed to process decision');
+        setSubmitting(null);
+        return;
+      }
+
+      window.location.href = result.redirect_to;
+    } catch (err) {
+      console.error('Consent submission failed:', err);
+      setError('Network error. Please try again.');
+      setSubmitting(null);
+    }
+  };
+
+  let hostname = props.redirectUri;
+  try {
+    hostname = new URL(props.redirectUri).host;
+  } catch {
+    // keep raw value on parse failure
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-neutral-950 p-6">
+      <div className="w-full max-w-md flex flex-col gap-6 p-8 rounded-lg border border-white/10 bg-neutral-900">
+
+        <div className="flex flex-col gap-1">
+          <h1 className="text-base font-medium">Connect {props.clientName}</h1>
+          <p className="text-sm text-white/60">
+            Signed in as <span className="text-white/85">{props.userEmail}</span>
+          </p>
+        </div>
+
+        <div className="text-sm text-white/80 leading-relaxed">
+          <p>
+            <span className="font-medium text-white">{props.clientName}</span> is requesting
+            access to your YCode project through the Model Context Protocol.
+          </p>
+          <p className="mt-3 text-white/60">
+            If you approve, this application will be able to read and modify your pages,
+            collections, assets, and other project data on your behalf.
+          </p>
+        </div>
+
+        <div className="text-xs text-white/50 bg-white/5 px-3 py-2 rounded">
+          Redirecting to <span className="text-white/80 font-mono">{hostname}</span>
+        </div>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="flex gap-2 justify-end">
+          <Button
+            variant="secondary"
+            onClick={() => handleDecision('deny')}
+            disabled={submitting !== null}
+          >
+            {submitting === 'deny' ? 'Denying…' : 'Deny'}
+          </Button>
+          <Button
+            onClick={() => handleDecision('approve')}
+            disabled={submitting !== null}
+          >
+            {submitting === 'approve' ? 'Approving…' : `Approve ${props.clientName}`}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(builder)/ycode/oauth/authorize/page.tsx
+++ b/app/(builder)/ycode/oauth/authorize/page.tsx
@@ -1,0 +1,146 @@
+import { redirect } from 'next/navigation';
+import { getAuthUser } from '@/lib/supabase-auth';
+import { getClient } from '@/lib/repositories/mcpOAuthClientRepository';
+import ConsentForm from './ConsentForm';
+
+/**
+ * OAuth Consent Page
+ *
+ * Server component that validates the OAuth request server-side:
+ *  - Requires a logged-in YCode user (redirects to login with ?next= otherwise).
+ *  - Looks up the registered client by `client_id`.
+ *  - Validates the supplied `redirect_uri` was registered at DCR time.
+ *  - Enforces the MCP-required PKCE method (S256).
+ *
+ * On a valid request, renders the client-side `<ConsentForm />` which
+ * posts the approve/deny decision to `/ycode/api/oauth/authorize`.
+ */
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+interface SearchParams {
+  [key: string]: string | string[] | undefined;
+}
+
+function asString(value: string | string[] | undefined): string | null {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value) && value.length > 0) return value[0];
+  return null;
+}
+
+function buildLoginRedirect(searchParams: SearchParams): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (typeof value === 'string') {
+      params.set(key, value);
+    } else if (Array.isArray(value) && value.length > 0) {
+      params.set(key, value[0]);
+    }
+  }
+  const next = `/ycode/oauth/authorize?${params.toString()}`;
+  return `/ycode?next=${encodeURIComponent(next)}`;
+}
+
+function ErrorPanel({ title, message }: { title: string; message: string }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-neutral-950 p-6">
+      <div className="w-full max-w-md flex flex-col gap-3 p-8 rounded-lg border border-white/10 bg-neutral-900">
+        <h1 className="text-base font-medium">{title}</h1>
+        <p className="text-sm text-white/60">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+export default async function AuthorizePage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const params = await searchParams;
+
+  const responseType = asString(params.response_type);
+  const clientId = asString(params.client_id);
+  const redirectUri = asString(params.redirect_uri);
+  const codeChallenge = asString(params.code_challenge);
+  const codeChallengeMethod = asString(params.code_challenge_method);
+  const scope = asString(params.scope);
+  const state = asString(params.state);
+
+  if (!responseType || !clientId || !redirectUri || !codeChallenge || !codeChallengeMethod) {
+    return (
+      <ErrorPanel
+        title="Invalid authorization request"
+        message="The request is missing one or more required OAuth parameters."
+      />
+    );
+  }
+
+  if (responseType !== 'code') {
+    return (
+      <ErrorPanel
+        title="Unsupported response type"
+        message="Only the authorization code flow is supported."
+      />
+    );
+  }
+
+  if (codeChallengeMethod !== 'S256') {
+    return (
+      <ErrorPanel
+        title="Unsupported PKCE method"
+        message="Only the S256 code challenge method is supported."
+      />
+    );
+  }
+
+  const auth = await getAuthUser();
+  if (!auth) {
+    redirect(buildLoginRedirect(params));
+  }
+
+  let client;
+  try {
+    client = await getClient(clientId);
+  } catch (error) {
+    console.error('[oauth/authorize page] getClient failed:', error);
+    return (
+      <ErrorPanel
+        title="Authorization unavailable"
+        message="Could not look up the OAuth client. Please try again later."
+      />
+    );
+  }
+
+  if (!client) {
+    return (
+      <ErrorPanel
+        title="Unknown client"
+        message="The application requesting access has not been registered with this YCode instance."
+      />
+    );
+  }
+
+  if (!client.redirect_uris.includes(redirectUri)) {
+    return (
+      <ErrorPanel
+        title="Invalid redirect URI"
+        message="The redirect URI does not match any registered for this client."
+      />
+    );
+  }
+
+  return (
+    <ConsentForm
+      clientName={client.client_name}
+      userEmail={auth.user.email || ''}
+      clientId={clientId}
+      redirectUri={redirectUri}
+      codeChallenge={codeChallenge}
+      codeChallengeMethod={codeChallengeMethod}
+      scope={scope}
+      state={state}
+    />
+  );
+}

--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,37 @@
+import type { NextRequest } from 'next/server';
+import { getBaseUrl, jsonMetadataResponse, optionsResponse } from '@/lib/oauth/metadata';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * RFC 8414 — OAuth 2.0 Authorization Server Metadata.
+ *
+ * Advertises the authorize, token, and registration endpoints, plus the
+ * supported response types, grant types, and PKCE methods. MCP clients
+ * (Claude.ai web, ChatGPT) fetch this to discover the OAuth flow.
+ *
+ * `client_id_metadata_document_supported: true` is advertised so clients
+ * may eventually skip DCR by hosting a client metadata document, but for
+ * now DCR via /register is the only registration mechanism we accept.
+ */
+export async function GET(request: NextRequest) {
+  const baseUrl = getBaseUrl(request);
+
+  return jsonMetadataResponse({
+    issuer: baseUrl,
+    authorization_endpoint: `${baseUrl}/ycode/oauth/authorize`,
+    token_endpoint: `${baseUrl}/ycode/api/oauth/token`,
+    registration_endpoint: `${baseUrl}/ycode/api/oauth/register`,
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['none'],
+    scopes_supported: ['mcp'],
+    client_id_metadata_document_supported: true,
+  });
+}
+
+export async function OPTIONS() {
+  return optionsResponse();
+}

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,27 @@
+import type { NextRequest } from 'next/server';
+import { getBaseUrl, jsonMetadataResponse, optionsResponse } from '@/lib/oauth/metadata';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * RFC 9728 — Protected Resource Metadata.
+ *
+ * Tells OAuth-aware MCP clients which authorization server protects this
+ * deployment. Returned URL is absolute so it works behind reverse proxies
+ * and on any host (Vercel preview, custom domain, localhost).
+ */
+export async function GET(request: NextRequest) {
+  const baseUrl = getBaseUrl(request);
+
+  return jsonMetadataResponse({
+    resource: `${baseUrl}/ycode/mcp`,
+    authorization_servers: [baseUrl],
+    bearer_methods_supported: ['header'],
+    resource_documentation: 'https://github.com/ycode/ycode',
+  });
+}
+
+export async function OPTIONS() {
+  return optionsResponse();
+}

--- a/app/.well-known/oauth-protected-resource/ycode/mcp/route.ts
+++ b/app/.well-known/oauth-protected-resource/ycode/mcp/route.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from 'next/server';
+import { getBaseUrl, jsonMetadataResponse, optionsResponse } from '@/lib/oauth/metadata';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * RFC 9728 — Protected Resource Metadata, scoped to the `/ycode/mcp` endpoint.
+ *
+ * This is the URL returned in the `WWW-Authenticate: Bearer resource_metadata=...`
+ * header on 401 responses from the MCP endpoint.
+ */
+export async function GET(request: NextRequest) {
+  const baseUrl = getBaseUrl(request);
+
+  return jsonMetadataResponse({
+    resource: `${baseUrl}/ycode/mcp`,
+    authorization_servers: [baseUrl],
+    bearer_methods_supported: ['header'],
+    resource_documentation: 'https://github.com/ycode/ycode',
+  });
+}
+
+export async function OPTIONS() {
+  return optionsResponse();
+}

--- a/database/migrations/20260528000001_add_mcp_oauth_support.ts
+++ b/database/migrations/20260528000001_add_mcp_oauth_support.ts
@@ -1,0 +1,144 @@
+import type { Knex } from 'knex';
+
+/**
+ * Migration: Add OAuth 2.1 + Dynamic Client Registration support to the MCP server.
+ *
+ * Adds two new tables and extends `mcp_tokens` with OAuth-related columns so that
+ * Claude.ai web and ChatGPT custom connectors (which require OAuth + PKCE per the
+ * MCP authorization spec 2025-06-18) can authenticate against the YCode MCP server.
+ *
+ * The existing URL-token flow (`/ycode/mcp/[token]`) remains unchanged for
+ * backward compatibility with Cursor, Windsurf, Claude Desktop, and Claude Code.
+ */
+
+export async function up(knex: Knex): Promise<void> {
+  // --- mcp_oauth_clients (DCR registrations) ---
+  const hasClientsTable = await knex.schema.hasTable('mcp_oauth_clients');
+  if (!hasClientsTable) {
+    await knex.schema.createTable('mcp_oauth_clients', (table) => {
+      table.uuid('id').defaultTo(knex.raw('gen_random_uuid()')).primary();
+      table.string('client_id', 128).notNullable().unique();
+      table.string('client_name', 255).notNullable();
+      table.specificType('redirect_uris', 'text[]').notNullable();
+      table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
+    });
+
+    await knex.schema.raw(
+      'CREATE INDEX IF NOT EXISTS idx_mcp_oauth_clients_client_id ON mcp_oauth_clients(client_id)',
+    );
+
+    await knex.schema.raw('ALTER TABLE mcp_oauth_clients ENABLE ROW LEVEL SECURITY');
+
+    await knex.schema.raw(`
+      CREATE POLICY "OAuth clients are viewable by authenticated users"
+        ON mcp_oauth_clients FOR SELECT
+        USING ((SELECT auth.uid()) IS NOT NULL)
+    `);
+  }
+
+  // --- mcp_oauth_codes (short-lived authorization codes) ---
+  const hasCodesTable = await knex.schema.hasTable('mcp_oauth_codes');
+  if (!hasCodesTable) {
+    await knex.schema.createTable('mcp_oauth_codes', (table) => {
+      table.string('code', 128).primary();
+      table.string('client_id', 128).notNullable();
+      table.string('redirect_uri', 1024).notNullable();
+      table.string('code_challenge', 256).notNullable();
+      table.string('code_challenge_method', 16).notNullable();
+      table.string('scope', 256).nullable();
+      table.uuid('user_id').notNullable();
+      table.timestamp('expires_at', { useTz: true })
+        .notNullable()
+        .defaultTo(knex.raw("(NOW() + INTERVAL '10 minutes')"));
+      table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
+    });
+
+    await knex.schema.raw(
+      'CREATE INDEX IF NOT EXISTS idx_mcp_oauth_codes_expires_at ON mcp_oauth_codes(expires_at)',
+    );
+
+    await knex.schema.raw('ALTER TABLE mcp_oauth_codes ENABLE ROW LEVEL SECURITY');
+  }
+
+  // --- Extend mcp_tokens with OAuth-related columns ---
+  const hasOauthClientId = await knex.schema.hasColumn('mcp_tokens', 'oauth_client_id');
+  if (!hasOauthClientId) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.string('oauth_client_id', 128).nullable();
+    });
+  }
+
+  const hasExpiresAt = await knex.schema.hasColumn('mcp_tokens', 'expires_at');
+  if (!hasExpiresAt) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.timestamp('expires_at', { useTz: true }).nullable();
+    });
+  }
+
+  const hasRefreshToken = await knex.schema.hasColumn('mcp_tokens', 'refresh_token');
+  if (!hasRefreshToken) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.string('refresh_token', 128).nullable().unique();
+    });
+  }
+
+  const hasRefreshExpiresAt = await knex.schema.hasColumn('mcp_tokens', 'refresh_expires_at');
+  if (!hasRefreshExpiresAt) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.timestamp('refresh_expires_at', { useTz: true }).nullable();
+    });
+  }
+
+  const hasUserId = await knex.schema.hasColumn('mcp_tokens', 'user_id');
+  if (!hasUserId) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.uuid('user_id').nullable();
+    });
+  }
+
+  // Partial index to quickly find active, non-expired tokens (covers both flows)
+  await knex.schema.raw(`
+    CREATE INDEX IF NOT EXISTS idx_mcp_tokens_oauth_client_id
+    ON mcp_tokens(oauth_client_id) WHERE oauth_client_id IS NOT NULL
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasUserId = await knex.schema.hasColumn('mcp_tokens', 'user_id');
+  if (hasUserId) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.dropColumn('user_id');
+    });
+  }
+
+  const hasRefreshExpiresAt = await knex.schema.hasColumn('mcp_tokens', 'refresh_expires_at');
+  if (hasRefreshExpiresAt) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.dropColumn('refresh_expires_at');
+    });
+  }
+
+  const hasRefreshToken = await knex.schema.hasColumn('mcp_tokens', 'refresh_token');
+  if (hasRefreshToken) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.dropColumn('refresh_token');
+    });
+  }
+
+  const hasExpiresAt = await knex.schema.hasColumn('mcp_tokens', 'expires_at');
+  if (hasExpiresAt) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.dropColumn('expires_at');
+    });
+  }
+
+  const hasOauthClientId = await knex.schema.hasColumn('mcp_tokens', 'oauth_client_id');
+  if (hasOauthClientId) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.dropColumn('oauth_client_id');
+    });
+  }
+
+  await knex.schema.dropTableIfExists('mcp_oauth_codes');
+  await knex.schema.dropTableIfExists('mcp_oauth_clients');
+}

--- a/database/migrations/20260528000002_hash_mcp_refresh_tokens.ts
+++ b/database/migrations/20260528000002_hash_mcp_refresh_tokens.ts
@@ -1,0 +1,58 @@
+import type { Knex } from 'knex';
+
+/**
+ * Migration: Hash MCP refresh tokens at rest.
+ *
+ * Refresh tokens were initially stored as plaintext in `mcp_tokens.refresh_token`.
+ * That's unsafe — a database leak would let an attacker rotate every active
+ * session. This migration mirrors the `api_keys` pattern: store only a SHA-256
+ * hash of the refresh token and look it up by hash at rotation time. The
+ * plaintext value is only ever returned to the OAuth client once at issue time.
+ *
+ * Steps (all guarded so the migration is idempotent and safe on template data):
+ *   1. Add `refresh_token_hash TEXT UNIQUE NULL`.
+ *   2. Backfill the hash from any existing plaintext rows.
+ *   3. Drop the plaintext `refresh_token` column.
+ */
+
+export async function up(knex: Knex): Promise<void> {
+  const hasHash = await knex.schema.hasColumn('mcp_tokens', 'refresh_token_hash');
+  if (!hasHash) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.string('refresh_token_hash', 128).nullable().unique();
+    });
+  }
+
+  const hasPlaintext = await knex.schema.hasColumn('mcp_tokens', 'refresh_token');
+  if (hasPlaintext) {
+    // Backfill hashes for any rows that still have a plaintext refresh token
+    // and haven't been migrated yet. Uses pgcrypto's `digest` to compute the
+    // SHA-256 hash in-place.
+    await knex.raw(`
+      UPDATE mcp_tokens
+      SET refresh_token_hash = encode(digest(refresh_token, 'sha256'), 'hex')
+      WHERE refresh_token IS NOT NULL
+        AND refresh_token_hash IS NULL;
+    `);
+
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.dropColumn('refresh_token');
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasPlaintext = await knex.schema.hasColumn('mcp_tokens', 'refresh_token');
+  if (!hasPlaintext) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.string('refresh_token', 128).nullable().unique();
+    });
+  }
+
+  const hasHash = await knex.schema.hasColumn('mcp_tokens', 'refresh_token_hash');
+  if (hasHash) {
+    await knex.schema.alterTable('mcp_tokens', (table) => {
+      table.dropColumn('refresh_token_hash');
+    });
+  }
+}

--- a/lib/mcp/handler.ts
+++ b/lib/mcp/handler.ts
@@ -1,0 +1,271 @@
+import { randomUUID } from 'crypto';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { validateToken } from '@/lib/repositories/mcpTokenRepository';
+import { createMcpServer } from '@/lib/mcp/server';
+import { getCachedToken, setCachedToken } from '@/lib/mcp/token-cache';
+
+/**
+ * Shared MCP HTTP handler used by both the URL-token endpoint
+ * (`/ycode/mcp/[token]`) and the OAuth Bearer-token endpoint
+ * (`/ycode/mcp`).
+ *
+ * Authentication is the only thing that differs between the two — once a
+ * token is validated, the request body, session lifecycle, transport, and
+ * CORS handling are identical.
+ */
+
+interface McpSession {
+  transport: WebStandardStreamableHTTPServerTransport;
+  server: McpServer;
+  lastActivity: number;
+}
+
+const sessions = new Map<string, McpSession>();
+
+const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+
+function cleanupStaleSessions() {
+  const now = Date.now();
+  for (const [id, session] of sessions) {
+    if (now - session.lastActivity > SESSION_TIMEOUT_MS) {
+      session.transport.close().catch(() => {});
+      sessions.delete(id);
+    }
+  }
+}
+
+export async function authenticateToken(token: string): Promise<boolean> {
+  const cached = getCachedToken(token);
+  if (cached) {
+    return cached.valid;
+  }
+
+  let valid = false;
+  try {
+    const result = await validateToken(token);
+    valid = result !== null;
+  } catch {
+    valid = false;
+  }
+
+  setCachedToken(token, valid);
+  return valid;
+}
+
+export function addCorsHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set('Access-Control-Allow-Origin', '*');
+  headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  headers.set('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id, mcp-protocol-version, Authorization');
+  headers.set('Access-Control-Expose-Headers', 'mcp-session-id');
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function createSessionTransport() {
+  const server = createMcpServer();
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+    enableJsonResponse: true,
+    onsessioninitialized: (newSessionId) => {
+      sessions.set(newSessionId, { transport, server, lastActivity: Date.now() });
+    },
+  });
+
+  transport.onclose = () => {
+    if (transport.sessionId) {
+      sessions.delete(transport.sessionId);
+    }
+  };
+
+  return { server, transport };
+}
+
+/**
+ * Auto-initialize a fresh server+transport so it can handle non-init requests.
+ * Needed on serverless (Vercel) where in-memory sessions are lost between
+ * requests that hit different instances.
+ */
+async function autoInitialize(
+  transport: WebStandardStreamableHTTPServerTransport,
+  url: string,
+): Promise<void> {
+  const initReq = new Request(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+    },
+  });
+
+  await transport.handleRequest(initReq, {
+    parsedBody: {
+      jsonrpc: '2.0',
+      id: '_auto_init',
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'ycode-auto', version: '1.0.0' },
+      },
+    },
+  });
+
+  const notifReq = new Request(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      'mcp-session-id': transport.sessionId!,
+    },
+  });
+
+  await transport.handleRequest(notifReq, {
+    parsedBody: { jsonrpc: '2.0', method: 'notifications/initialized' },
+  });
+}
+
+/**
+ * Some MCP clients (e.g., Claude Code) don't send text/event-stream,
+ * but the SDK enforces it even when enableJsonResponse is true.
+ */
+function ensureAcceptHeader(request: Request): Request {
+  const accept = request.headers.get('accept') || '';
+  if (accept.includes('application/json') && accept.includes('text/event-stream')) {
+    return request;
+  }
+
+  const headers = new Headers(request.headers);
+  headers.set('Accept', 'application/json, text/event-stream');
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body: request.body,
+    // @ts-expect-error duplex is needed for streaming body but not in all TS defs
+    duplex: 'half',
+  });
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  const normalized = ensureAcceptHeader(request);
+  const sessionId = normalized.headers.get('mcp-session-id');
+
+  if (sessionId && sessions.has(sessionId)) {
+    const session = sessions.get(sessionId)!;
+    session.lastActivity = Date.now();
+    return session.transport.handleRequest(normalized);
+  }
+
+  const body = await normalized.json();
+  const isInit = !Array.isArray(body) && body.method === 'initialize';
+
+  const { server, transport } = createSessionTransport();
+  await server.connect(transport);
+
+  if (isInit) {
+    const req = new Request(normalized.url, {
+      method: 'POST',
+      headers: normalized.headers,
+    });
+    return transport.handleRequest(req, { parsedBody: body });
+  }
+
+  await autoInitialize(transport, normalized.url);
+
+  const actualReq = new Request(normalized.url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      'mcp-session-id': transport.sessionId!,
+    },
+  });
+
+  return transport.handleRequest(actualReq, { parsedBody: body });
+}
+
+export async function handleMcpPost(request: Request): Promise<Response> {
+  cleanupStaleSessions();
+  try {
+    const response = await handlePost(request);
+    return addCorsHeaders(response);
+  } catch (error) {
+    console.error('[MCP POST] Error:', error);
+    return addCorsHeaders(new Response(JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code: -32603, message: error instanceof Error ? error.message : 'Internal server error' },
+      id: null,
+    }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+  }
+}
+
+export async function handleMcpGet(request: Request): Promise<Response> {
+  try {
+    const sessionId = request.headers.get('mcp-session-id');
+    if (!sessionId || !sessions.has(sessionId)) {
+      return addCorsHeaders(new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Session not found. Send a POST initialize first.' },
+        id: null,
+      }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }
+
+    const session = sessions.get(sessionId)!;
+    session.lastActivity = Date.now();
+    const response = await session.transport.handleRequest(request);
+    return addCorsHeaders(response);
+  } catch (error) {
+    console.error('[MCP GET] Error:', error);
+    return addCorsHeaders(new Response(JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code: -32603, message: error instanceof Error ? error.message : 'Internal server error' },
+      id: null,
+    }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+  }
+}
+
+export async function handleMcpDelete(request: Request): Promise<Response> {
+  try {
+    const sessionId = request.headers.get('mcp-session-id');
+    if (sessionId && sessions.has(sessionId)) {
+      const session = sessions.get(sessionId)!;
+      await session.transport.close();
+      sessions.delete(sessionId);
+    }
+    return addCorsHeaders(new Response(null, { status: 204 }));
+  } catch (error) {
+    console.error('[MCP DELETE] Error:', error);
+    return addCorsHeaders(new Response(null, { status: 204 }));
+  }
+}
+
+export function unauthorizedJson(message: string): Response {
+  return addCorsHeaders(new Response(JSON.stringify({ error: message }), {
+    status: 401,
+    headers: { 'Content-Type': 'application/json' },
+  }));
+}
+
+/**
+ * Build the `WWW-Authenticate` header value used by the bearer-token MCP
+ * endpoint. Includes the absolute URL of the protected-resource metadata
+ * document so OAuth-aware clients can discover the auth server.
+ */
+export function buildWwwAuthenticateHeader(baseUrl: string): string {
+  const resourceMetadata = `${baseUrl}/.well-known/oauth-protected-resource/ycode/mcp`;
+  return `Bearer realm="ycode", resource_metadata="${resourceMetadata}"`;
+}

--- a/lib/mcp/token-cache.ts
+++ b/lib/mcp/token-cache.ts
@@ -1,0 +1,43 @@
+/**
+ * In-memory cache for MCP token validation results.
+ *
+ * AI agents make many requests per minute and each was previously hitting
+ * Supabase to revalidate the same token. Cache hits live for 60s (revocations
+ * propagate within a minute, fine for static URL tokens). Misses cache for 5s
+ * so a token flip from invalid→valid recovers quickly.
+ *
+ * The cache lives in its own module so both `lib/mcp/handler.ts` and the
+ * repository can read/invalidate it without creating a circular import.
+ * Rotated/deleted tokens are explicitly invalidated so the old access token
+ * stops working immediately, not after the cache TTL expires.
+ */
+
+interface TokenCacheEntry {
+  valid: boolean;
+  expires: number;
+}
+
+const cache = new Map<string, TokenCacheEntry>();
+
+export const TOKEN_CACHE_TTL_VALID_MS = 60_000;
+export const TOKEN_CACHE_TTL_INVALID_MS = 5_000;
+
+export function getCachedToken(token: string): TokenCacheEntry | undefined {
+  const entry = cache.get(token);
+  if (entry && entry.expires > Date.now()) {
+    return entry;
+  }
+  if (entry) {
+    cache.delete(token);
+  }
+  return undefined;
+}
+
+export function setCachedToken(token: string, valid: boolean): void {
+  const ttl = valid ? TOKEN_CACHE_TTL_VALID_MS : TOKEN_CACHE_TTL_INVALID_MS;
+  cache.set(token, { valid, expires: Date.now() + ttl });
+}
+
+export function invalidateToken(token: string): void {
+  cache.delete(token);
+}

--- a/lib/oauth/metadata.ts
+++ b/lib/oauth/metadata.ts
@@ -1,0 +1,38 @@
+import type { NextRequest } from 'next/server';
+
+/**
+ * Shared helpers for building absolute URLs in OAuth metadata documents.
+ *
+ * We derive the public base URL from the request headers so that the
+ * advertised endpoints work regardless of deployment host (Vercel preview,
+ * custom domain, localhost).
+ */
+
+export function getBaseUrl(request: NextRequest | Request): string {
+  const host = request.headers.get('host') || 'localhost:3000';
+  const forwardedProto = request.headers.get('x-forwarded-proto');
+  const protocol = forwardedProto || (host.startsWith('localhost') ? 'http' : 'https');
+  return `${protocol}://${host}`;
+}
+
+export function jsonMetadataResponse(payload: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(payload, null, 2), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}
+
+export function optionsResponse(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  });
+}

--- a/lib/oauth/pkce.ts
+++ b/lib/oauth/pkce.ts
@@ -1,0 +1,38 @@
+/**
+ * PKCE (RFC 7636) helpers for the MCP OAuth flow.
+ *
+ * We only support the S256 transformation — `plain` is rejected up front
+ * because the MCP authorization spec (2025-06-18) mandates S256.
+ */
+
+function base64UrlEncode(bytes: ArrayBuffer): string {
+  const b64 = Buffer.from(bytes).toString('base64');
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export async function deriveS256Challenge(codeVerifier: string): Promise<string> {
+  const data = new TextEncoder().encode(codeVerifier);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return base64UrlEncode(digest);
+}
+
+/**
+ * Verify that the supplied `code_verifier` matches the stored `code_challenge`
+ * under the given method. Returns false for any unsupported method.
+ */
+export async function verifyPkce(
+  codeVerifier: string,
+  codeChallenge: string,
+  method: string,
+): Promise<boolean> {
+  if (method !== 'S256') {
+    return false;
+  }
+
+  if (!codeVerifier || codeVerifier.length < 43 || codeVerifier.length > 128) {
+    return false;
+  }
+
+  const derived = await deriveS256Challenge(codeVerifier);
+  return derived === codeChallenge;
+}

--- a/lib/repositories/mcpOAuthClientRepository.ts
+++ b/lib/repositories/mcpOAuthClientRepository.ts
@@ -1,0 +1,75 @@
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { randomBytes } from 'crypto';
+
+/**
+ * MCP OAuth Client Repository
+ *
+ * Stores RFC 7591 Dynamic Client Registration entries. The `client_id` itself
+ * is not a secret (PKCE is the actual security mechanism) but we persist the
+ * client name so the consent screen can display "Allow [Client Name]…" and
+ * the registered redirect URIs so we can validate them at /authorize time.
+ */
+
+export interface McpOAuthClient {
+  id: string;
+  client_id: string;
+  client_name: string;
+  redirect_uris: string[];
+  created_at: string;
+}
+
+export interface RegisterClientData {
+  client_name: string;
+  redirect_uris: string[];
+}
+
+function generateClientId(): string {
+  return 'mcp_client_' + randomBytes(24).toString('hex');
+}
+
+export async function registerClient(data: RegisterClientData): Promise<McpOAuthClient> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    throw new Error('Supabase not configured');
+  }
+
+  const clientId = generateClientId();
+
+  const { data: row, error } = await client
+    .from('mcp_oauth_clients')
+    .insert({
+      client_id: clientId,
+      client_name: data.client_name,
+      redirect_uris: data.redirect_uris,
+      created_at: new Date().toISOString(),
+    })
+    .select('id, client_id, client_name, redirect_uris, created_at')
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to register OAuth client: ${error.message}`);
+  }
+
+  return row;
+}
+
+export async function getClient(clientId: string): Promise<McpOAuthClient | null> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    throw new Error('Supabase not configured');
+  }
+
+  const { data, error } = await client
+    .from('mcp_oauth_clients')
+    .select('id, client_id, client_name, redirect_uris, created_at')
+    .eq('client_id', clientId)
+    .single();
+
+  if (error && error.code !== 'PGRST116') {
+    throw new Error(`Failed to fetch OAuth client: ${error.message}`);
+  }
+
+  return data;
+}

--- a/lib/repositories/mcpOAuthCodeRepository.ts
+++ b/lib/repositories/mcpOAuthCodeRepository.ts
@@ -1,0 +1,113 @@
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { randomBytes } from 'crypto';
+
+/**
+ * MCP OAuth Code Repository
+ *
+ * Stores short-lived (10 minute) authorization codes issued at the consent
+ * step. Codes are single-use: `consumeCode` deletes the row atomically so a
+ * replayed code is rejected even on concurrent requests.
+ */
+
+export interface McpOAuthCode {
+  code: string;
+  client_id: string;
+  redirect_uri: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  scope: string | null;
+  user_id: string;
+  expires_at: string;
+  created_at: string;
+}
+
+export interface CreateCodeData {
+  client_id: string;
+  redirect_uri: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  scope?: string | null;
+  user_id: string;
+}
+
+function generateCode(): string {
+  return 'mcp_code_' + randomBytes(32).toString('hex');
+}
+
+export async function createCode(data: CreateCodeData): Promise<string> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    throw new Error('Supabase not configured');
+  }
+
+  const code = generateCode();
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+
+  const { error } = await client
+    .from('mcp_oauth_codes')
+    .insert({
+      code,
+      client_id: data.client_id,
+      redirect_uri: data.redirect_uri,
+      code_challenge: data.code_challenge,
+      code_challenge_method: data.code_challenge_method,
+      scope: data.scope ?? null,
+      user_id: data.user_id,
+      expires_at: expiresAt,
+      created_at: new Date().toISOString(),
+    });
+
+  if (error) {
+    throw new Error(`Failed to create OAuth code: ${error.message}`);
+  }
+
+  return code;
+}
+
+/**
+ * Atomically consume an authorization code: fetch it and delete it in the
+ * same operation. Returns null if the code was already consumed, expired,
+ * or never existed.
+ */
+export async function consumeCode(code: string): Promise<McpOAuthCode | null> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    throw new Error('Supabase not configured');
+  }
+
+  const { data, error } = await client
+    .from('mcp_oauth_codes')
+    .delete()
+    .eq('code', code)
+    .select('code, client_id, redirect_uri, code_challenge, code_challenge_method, scope, user_id, expires_at, created_at')
+    .single();
+
+  if (error || !data) {
+    return null;
+  }
+
+  if (new Date(data.expires_at).getTime() < Date.now()) {
+    return null;
+  }
+
+  return data;
+}
+
+/**
+ * Best-effort cleanup of expired codes. Safe to call from any request path;
+ * we only schedule it occasionally to avoid load.
+ */
+export async function cleanupExpired(): Promise<void> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    return;
+  }
+
+  await client
+    .from('mcp_oauth_codes')
+    .delete()
+    .lt('expires_at', new Date().toISOString());
+}

--- a/lib/repositories/mcpTokenRepository.ts
+++ b/lib/repositories/mcpTokenRepository.ts
@@ -1,5 +1,6 @@
 import { getSupabaseAdmin } from '@/lib/supabase-server';
-import { randomBytes } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
+import { invalidateToken } from '@/lib/mcp/token-cache';
 
 export interface McpToken {
   id: string;
@@ -9,14 +10,48 @@ export interface McpToken {
   last_used_at: string | null;
   created_at: string;
   updated_at: string;
+  oauth_client_id: string | null;
+  expires_at: string | null;
+  user_id: string | null;
 }
 
 export interface McpTokenWithPlainToken extends McpToken {
   token: string;
 }
 
+export interface OAuthTokenPair {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  refresh_expires_in: number;
+}
+
+export interface CreateOAuthTokenData {
+  user_id: string;
+  oauth_client_id: string;
+  name: string;
+  access_token_ttl_seconds?: number;
+  refresh_token_ttl_seconds?: number;
+}
+
+const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 60 * 60; // 1 hour
+const DEFAULT_REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
 function generateToken(): string {
   return 'ymc_' + randomBytes(24).toString('hex');
+}
+
+function generateRefreshToken(): string {
+  return 'ymr_' + randomBytes(32).toString('hex');
+}
+
+/**
+ * Hash a refresh token with SHA-256 before storing. We only ever hand the
+ * plaintext value back to the OAuth client once at issue time; the database
+ * keeps the hash so a DB leak can't be replayed against `/oauth/token`.
+ */
+function hashRefreshToken(refreshToken: string): string {
+  return createHash('sha256').update(refreshToken).digest('hex');
 }
 
 export async function getAllTokens(): Promise<McpToken[]> {
@@ -28,7 +63,7 @@ export async function getAllTokens(): Promise<McpToken[]> {
 
   const { data, error } = await client
     .from('mcp_tokens')
-    .select('id, name, token_prefix, is_active, last_used_at, created_at, updated_at')
+    .select('id, name, token_prefix, is_active, last_used_at, created_at, updated_at, oauth_client_id, expires_at, user_id')
     .order('created_at', { ascending: false });
 
   if (error) {
@@ -57,7 +92,7 @@ export async function createToken(name: string): Promise<McpTokenWithPlainToken>
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     })
-    .select('id, name, token, token_prefix, is_active, last_used_at, created_at, updated_at')
+    .select('id, name, token, token_prefix, is_active, last_used_at, created_at, updated_at, oauth_client_id, expires_at, user_id')
     .single();
 
   if (error) {
@@ -68,7 +103,7 @@ export async function createToken(name: string): Promise<McpTokenWithPlainToken>
 }
 
 /**
- * Validate a token and return the record if active.
+ * Validate a token and return the record if active and not expired.
  * Updates last_used_at in the background.
  */
 export async function validateToken(token: string): Promise<McpToken | null> {
@@ -80,12 +115,16 @@ export async function validateToken(token: string): Promise<McpToken | null> {
 
   const { data, error } = await client
     .from('mcp_tokens')
-    .select('id, name, token_prefix, is_active, last_used_at, created_at, updated_at')
+    .select('id, name, token_prefix, is_active, last_used_at, created_at, updated_at, oauth_client_id, expires_at, user_id')
     .eq('token', token)
     .eq('is_active', true)
     .single();
 
   if (error || !data) {
+    return null;
+  }
+
+  if (data.expires_at && new Date(data.expires_at).getTime() < Date.now()) {
     return null;
   }
 
@@ -104,6 +143,12 @@ export async function deleteToken(id: string): Promise<void> {
     throw new Error('Supabase not configured');
   }
 
+  const { data: existing } = await client
+    .from('mcp_tokens')
+    .select('token')
+    .eq('id', id)
+    .single();
+
   const { error } = await client
     .from('mcp_tokens')
     .delete()
@@ -111,6 +156,10 @@ export async function deleteToken(id: string): Promise<void> {
 
   if (error) {
     throw new Error(`Failed to delete MCP token: ${error.message}`);
+  }
+
+  if (existing?.token) {
+    invalidateToken(existing.token);
   }
 }
 
@@ -123,7 +172,7 @@ export async function getTokenById(id: string): Promise<McpToken | null> {
 
   const { data, error } = await client
     .from('mcp_tokens')
-    .select('id, name, token_prefix, is_active, last_used_at, created_at, updated_at')
+    .select('id, name, token_prefix, is_active, last_used_at, created_at, updated_at, oauth_client_id, expires_at, user_id')
     .eq('id', id)
     .single();
 
@@ -132,4 +181,104 @@ export async function getTokenById(id: string): Promise<McpToken | null> {
   }
 
   return data;
+}
+
+/**
+ * Issue an OAuth-bound MCP token pair (access + refresh).
+ * Both tokens are random opaque strings stored alongside their TTLs.
+ */
+export async function createOAuthToken(
+  data: CreateOAuthTokenData,
+): Promise<OAuthTokenPair> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    throw new Error('Supabase not configured');
+  }
+
+  const accessTtl = data.access_token_ttl_seconds ?? DEFAULT_ACCESS_TOKEN_TTL_SECONDS;
+  const refreshTtl = data.refresh_token_ttl_seconds ?? DEFAULT_REFRESH_TOKEN_TTL_SECONDS;
+
+  const token = generateToken();
+  const refreshToken = generateRefreshToken();
+  const now = Date.now();
+  const expiresAt = new Date(now + accessTtl * 1000).toISOString();
+  const refreshExpiresAt = new Date(now + refreshTtl * 1000).toISOString();
+  const tokenPrefix = token.substring(0, 12);
+
+  const { error } = await client
+    .from('mcp_tokens')
+    .insert({
+      name: data.name,
+      token,
+      token_prefix: tokenPrefix,
+      oauth_client_id: data.oauth_client_id,
+      user_id: data.user_id,
+      expires_at: expiresAt,
+      refresh_token_hash: hashRefreshToken(refreshToken),
+      refresh_expires_at: refreshExpiresAt,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+  if (error) {
+    throw new Error(`Failed to create OAuth MCP token: ${error.message}`);
+  }
+
+  return {
+    access_token: token,
+    refresh_token: refreshToken,
+    expires_in: accessTtl,
+    refresh_expires_in: refreshTtl,
+  };
+}
+
+/**
+ * Rotate a refresh token: validate the old one, issue a fresh access+refresh
+ * pair, and revoke the old token row. Returns null if the refresh token is
+ * unknown, revoked, or expired.
+ */
+export async function rotateRefreshToken(
+  refreshToken: string,
+  options?: { access_token_ttl_seconds?: number; refresh_token_ttl_seconds?: number },
+): Promise<OAuthTokenPair | null> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    throw new Error('Supabase not configured');
+  }
+
+  const { data: existing, error: fetchError } = await client
+    .from('mcp_tokens')
+    .select('id, name, token, oauth_client_id, user_id, refresh_expires_at, is_active')
+    .eq('refresh_token_hash', hashRefreshToken(refreshToken))
+    .eq('is_active', true)
+    .single();
+
+  if (fetchError || !existing) {
+    return null;
+  }
+
+  if (!existing.refresh_expires_at
+      || new Date(existing.refresh_expires_at).getTime() < Date.now()) {
+    return null;
+  }
+
+  if (!existing.oauth_client_id || !existing.user_id) {
+    return null;
+  }
+
+  // Revoke the old token first so a leaked refresh token can't be reused.
+  await client.from('mcp_tokens').delete().eq('id', existing.id);
+  if (existing.token) {
+    invalidateToken(existing.token);
+  }
+
+  return createOAuthToken({
+    user_id: existing.user_id,
+    oauth_client_id: existing.oauth_client_id,
+    name: existing.name,
+    access_token_ttl_seconds: options?.access_token_ttl_seconds,
+    refresh_token_ttl_seconds: options?.refresh_token_ttl_seconds,
+  });
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -20,6 +20,8 @@ const PUBLIC_COLLECTION_ITEM_SUFFIXES = ['/items/filter', '/items/load-more'];
 
 const PUBLIC_API_EXACT = [
   '/ycode/api/revalidate', // Cache revalidation — has own secret token auth
+  '/ycode/api/oauth/register', // RFC 7591 Dynamic Client Registration — anonymous
+  '/ycode/api/oauth/token',    // OAuth token exchange — auth is via PKCE/refresh
 ];
 
 /**
@@ -126,9 +128,11 @@ async function verifyApiAuth(request: NextRequest): Promise<NextResponse | null>
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // MCP endpoint uses its own token-based authentication — skip session auth.
-  // Cloud overlay proxies MUST also exempt this path to avoid login redirects.
-  if (pathname.startsWith('/ycode/mcp/')) {
+  // MCP endpoints use their own token-based authentication — skip session auth.
+  // Cloud overlay proxies MUST also exempt these paths to avoid login redirects.
+  //   - `/ycode/mcp/<token>`: legacy URL-token endpoint (Cursor, Windsurf, etc.)
+  //   - `/ycode/mcp`: OAuth Bearer-token endpoint (Claude.ai web, ChatGPT)
+  if (pathname === '/ycode/mcp' || pathname.startsWith('/ycode/mcp/')) {
     const response = NextResponse.next();
     response.headers.set('x-pathname', pathname);
     return response;


### PR DESCRIPTION
## Summary

The MCP server at `/ycode/mcp/[token]` currently uses URL-embedded tokens, which works in Cursor, Windsurf, Claude Desktop, and Claude Code — but Claude.ai web and ChatGPT custom connectors require OAuth 2.1 with Dynamic Client Registration. This PR adds full OAuth support (PKCE S256, DCR, rotating refresh tokens) at a sibling `/ycode/mcp` endpoint while keeping the existing URL-token flow untouched for backward compatibility. Closes #289.

## Changes

- Add `POST /ycode/api/oauth/register` (RFC 7591 dynamic client registration) and validate that registered `redirect_uri`s are HTTPS or localhost
- Add `POST /ycode/api/oauth/token` supporting both `authorization_code` (with PKCE S256) and `refresh_token` grants
- Add server-rendered consent page at `/ycode/oauth/authorize` that validates client, redirect URI, and PKCE params before showing approve/deny
- Add bearer-token MCP endpoint at `/ycode/mcp` that returns `401` with `WWW-Authenticate: Bearer resource_metadata=…` so OAuth clients can discover the auth flow
- Publish the three required well-known metadata documents (`/.well-known/oauth-protected-resource`, the scoped variant, and `/.well-known/oauth-authorization-server`) advertising S256 PKCE, DCR, and the `authorization_code` + `refresh_token` grants
- Issue 1h access tokens + 30d refresh tokens; rotate the refresh token on every use and revoke the old pair atomically
- Store refresh tokens as SHA-256 hashes (mirroring `apiKeyRepository`); plaintext only exists in transit
- Extract the shared MCP session/transport/CORS logic into `lib/mcp/handler.ts` so the legacy URL-token route and the new bearer route share one implementation; back it with a token cache that's invalidated on rotation/deletion so revocation is immediate
- Plumb `?next=` through sign-in so users hitting the consent page unauthenticated land back on it after logging in
- Update the integrations MCP page to badge OAuth vs URL tokens, show expiry, and document the bearer endpoint for Claude.ai/ChatGPT
- Two idempotent Knex migrations: one to add the OAuth schema (`mcp_oauth_clients`, `mcp_oauth_codes`, OAuth columns on `mcp_tokens`); one to swap the plaintext `refresh_token` column for a backfilled `refresh_token_hash`

## Test plan

- [ ] Run pending migrations (`POST /ycode/api/setup/migrate`) and confirm both new migrations execute cleanly
- [ ] `curl /.well-known/oauth-protected-resource`, the scoped variant, and `/.well-known/oauth-authorization-server` — verify each returns absolute URLs for the current host
- [ ] `POST /ycode/mcp` with no token — expect 401 with `WWW-Authenticate: Bearer realm="ycode", resource_metadata="…/.well-known/oauth-protected-resource/ycode/mcp"`
- [ ] Register a client via `POST /ycode/api/oauth/register` with a valid `redirect_uri`, then again with `http://evil.example.com/cb` and `[]` — expect 201 and two 400s
- [ ] Visit `/ycode/oauth/authorize?response_type=code&client_id=…&redirect_uri=…&code_challenge=…&code_challenge_method=S256` logged out — expect redirect to `/ycode?next=…`, then back to the consent page after sign-in
- [ ] Visit the consent page with an unknown `client_id` or unregistered `redirect_uri` — expect the dedicated error panels
- [ ] Approve consent, exchange the code at `/ycode/api/oauth/token` with the correct PKCE verifier — expect `access_token` + `refresh_token`; replay the same code — expect `invalid_grant`; exchange with a wrong verifier — expect `invalid_grant`
- [ ] Call `POST /ycode/mcp` with the issued `Authorization: Bearer …` and a JSON-RPC `initialize` — expect a 200 MCP response
- [ ] Rotate the refresh token at `/ycode/api/oauth/token` (`grant_type=refresh_token`), then replay the old refresh token — expect 200 then `invalid_grant`
- [ ] Confirm the old access token is rejected immediately after rotation (cache invalidation works)
- [ ] Generate a manual URL token via `/ycode/integrations/mcp` and confirm the legacy `/ycode/mcp/[token]` endpoint still serves MCP requests
- [ ] On `/ycode/integrations/mcp`, verify OAuth-issued tokens show an `OAuth` badge + expiry date and URL tokens show a `URL token` badge

Made with [Cursor](https://cursor.com)