### PR TITLE
fix: paginated collections, filters, and animations

### DIFF
--- a/app/(builder)/ycode/api/collections/[id]/items/load-more/route.ts
+++ b/app/(builder)/ycode/api/collections/[id]/items/load-more/route.ts
@@ -8,6 +8,7 @@ import { getAllPages } from '@/lib/repositories/pageRepository';
 import { getAllPageFolders } from '@/lib/repositories/pageFolderRepository';
 import { renderCollectionItemsToHtml, loadTranslationsForLocale } from '@/lib/page-fetcher';
 import { noCache } from '@/lib/api-response';
+import { fetchAllRows } from '@/lib/supabase-constants';
 import type { Layer, CollectionItem, CollectionItemWithValues } from '@/types';
 
 export const dynamic = 'force-dynamic';
@@ -39,20 +40,24 @@ async function getAllItemIdsForCollection(
   const client = await getSupabaseAdmin();
   if (!client) throw new Error('Supabase client not configured');
 
-  let query = client
-    .from('collection_items')
-    .select('id')
-    .eq('collection_id', collectionId)
-    .eq('is_published', isPublished)
-    .is('deleted_at', null);
+  // Page past Supabase's 1000-row default cap so collections with more items
+  // report accurate `total` / `hasMore` instead of stalling at the cap.
+  // Match SSR's ordering so any `maxTotal` slice picks the same items.
+  const rows = await fetchAllRows<{ id: string }>((from, to) => {
+    let q = client
+      .from('collection_items')
+      .select('id')
+      .eq('collection_id', collectionId)
+      .eq('is_published', isPublished)
+      .is('deleted_at', null)
+      .order('manual_order', { ascending: true })
+      .order('created_at', { ascending: false })
+      .range(from, to);
+    if (isPublished) q = q.eq('is_publishable', true);
+    return q;
+  });
 
-  if (isPublished) {
-    query = query.eq('is_publishable', true);
-  }
-
-  const { data, error } = await query;
-  if (error) throw new Error(`Failed to fetch item IDs: ${error.message}`);
-  return data?.map(d => d.id) || [];
+  return rows.map(r => r.id);
 }
 
 async function getFieldValuesForItems(
@@ -123,6 +128,7 @@ export async function POST(
       isPreview = false,
       pageCollectionItemId,
       pageCollectionSortedItemIds,
+      maxTotal,
     } = body;
 
     if (!layerTemplate || !Array.isArray(layerTemplate)) {
@@ -136,10 +142,16 @@ export async function POST(
     const pageLimit = isNaN(limit) || limit < 1 ? 10 : Math.min(limit, 100);
 
     // Pool of candidate ids: either the explicit list (multi-reference filter)
-    // or every item in the collection.
-    const candidateIds = Array.isArray(itemIds) && itemIds.length > 0
+    // or every item in the collection. When SSR enforced a `maxTotal` cap
+    // (from `collection.limit` with pagination enabled), clamp the pool so
+    // `hasMore` and offset-based paging stop at the same boundary.
+    let candidateIds = Array.isArray(itemIds) && itemIds.length > 0
       ? itemIds
       : await getAllItemIdsForCollection(collectionId, published);
+
+    if (typeof maxTotal === 'number' && maxTotal > 0 && candidateIds.length > maxTotal) {
+      candidateIds = candidateIds.slice(0, maxTotal);
+    }
 
     const total = candidateIds.length;
 

--- a/components/AnimationInitializer.tsx
+++ b/components/AnimationInitializer.tsx
@@ -68,6 +68,25 @@ function getElement(layerId: string): HTMLElement | null {
 }
 
 /**
+ * Pre-paint each tween's `from` state so the element rests in its intended
+ * initial appearance before the trigger fires. CSS via generateInitialAnimationCSS()
+ * only covers intro triggers (load, scroll-into-view); for hover/click we apply
+ * inline styles here so the layer's CSS default doesn't bleed through as the
+ * `to` state.
+ */
+function applyInitialFromState(interaction: LayerInteraction): void {
+  (interaction.tweens || []).forEach(tween => {
+    if (tween.splitText) return;
+    const el = getElement(tween.layer_id);
+    if (!el) return;
+    const { from } = buildGsapProps(tween);
+    if (Object.keys(from).length > 0) {
+      gsap.set(el, from);
+    }
+  });
+}
+
+/**
  * Collect info about elements that should start hidden based on interactions
  * Returns a map of layerId -> breakpoints (null means all breakpoints)
  */
@@ -316,6 +335,13 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
   // `-fc-${itemId}` suffix that mirrors the server-side filter renderer.
   const [extrasByCollection, setExtrasByCollection] = useState<Record<string, Layer[]>>({});
 
+  // Forces the bind effect to re-run when tracked DOM elements get remounted
+  // (e.g. when dynamic-imported wrappers like LoadMoreCollection finish loading
+  // and React replaces the Suspense fallback with their real subtree). Without
+  // this, gsap.set() and listeners attached on first paint die with the old
+  // nodes and the new ones never animate until the next state change.
+  const [rebindTick, setRebindTick] = useState(0);
+
   useEffect(() => {
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<ItemsInjectedDetail>).detail;
@@ -425,6 +451,16 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
       if (!triggerElement) return;
 
       const { trigger } = interaction;
+
+      // Intro triggers (load, scroll-into-view) get their `from` state via
+      // server-emitted CSS. For hover/click, paint the `from` state inline so
+      // the resting appearance matches the author's intent instead of the
+      // layer's CSS default.
+      if (trigger === 'hover' || trigger === 'click') {
+        if (shouldRunOnBreakpoint(interaction, currentBreakpoint)) {
+          applyInitialFromState(interaction);
+        }
+      }
 
       // Helper to get or create timeline (always lazy to avoid GSAP setting inline styles)
       // Initial styles are handled by CSS via generateInitialAnimationCSS()
@@ -562,16 +598,64 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
       }
     });
 
+    // Watch for tracked elements being remounted (e.g. dynamic chunk loading
+    // for LoadMoreCollection/FilterableCollection replaces the Suspense fallback
+    // with the real subtree). When a node carrying a tracked data-layer-id
+    // appears in the DOM, bump rebindTick to re-run this effect against the
+    // fresh nodes — re-applying gsap.set() and rebinding listeners.
+    const trackedLayerIds = new Set<string>();
+    collectedInteractions.forEach(({ triggerLayerId, interaction }) => {
+      trackedLayerIds.add(triggerLayerId);
+      (interaction.tweens || []).forEach(t => trackedLayerIds.add(t.layer_id));
+    });
+
+    let rebindTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleRebind = () => {
+      if (rebindTimer) return;
+      rebindTimer = setTimeout(() => {
+        rebindTimer = null;
+        setRebindTick(t => t + 1);
+      }, 50);
+    };
+
+    const containsTrackedId = (node: Node): boolean => {
+      if (!(node instanceof Element)) return false;
+      const id = node.getAttribute('data-layer-id');
+      if (id && trackedLayerIds.has(id)) return true;
+      // Check descendants — items often nest deeply
+      const descendants = node.querySelectorAll('[data-layer-id]');
+      for (const el of descendants) {
+        const cid = el.getAttribute('data-layer-id');
+        if (cid && trackedLayerIds.has(cid)) return true;
+      }
+      return false;
+    };
+
+    const remountObserver = new MutationObserver(mutations => {
+      for (const m of mutations) {
+        if (m.type !== 'childList') continue;
+        for (const n of m.addedNodes) {
+          if (containsTrackedId(n)) {
+            scheduleRebind();
+            return;
+          }
+        }
+      }
+    });
+    remountObserver.observe(document.body, { childList: true, subtree: true });
+
     // Capture ref values for cleanup
     const cleanups = cleanupRef.current;
     const timelines = timelinesRef.current;
 
     return () => {
+      if (rebindTimer) clearTimeout(rebindTimer);
+      remountObserver.disconnect();
       cleanups.forEach((cleanup) => cleanup());
       timelines.forEach((tl) => tl.kill());
       ScrollTrigger.getAll().forEach((st) => st.kill());
     };
-  }, [effectiveLayers, currentBreakpoint]);
+  }, [effectiveLayers, currentBreakpoint, rebindTick]);
 
   return null;
 }

--- a/components/FilterableCollection.tsx
+++ b/components/FilterableCollection.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react';
 import { useFilterStore } from '@/stores/useFilterStore';
+import { LOAD_MORE_APPENDED_ATTR } from '@/components/LoadMoreCollection';
 import type { ConditionalVisibility, Layer } from '@/types';
 import { isDateFieldType, isDatePreset, resolveDateFilterValue } from '@/lib/collection-field-utils';
 
@@ -95,6 +96,7 @@ export default function FilterableCollection({
   const ssrNextClassRef = useRef<string | null>(null);
   const ssrCountTextRef = useRef<string | null>(null);
   const ssrLoadMoreBtnDisplayRef = useRef<string | null>(null);
+  const ssrWrapperHadHiddenRef = useRef<boolean | null>(null);
   const strippedPaginationParamRef = useRef(false);
 
   const strippedId = collectionLayerId.startsWith('lyr-')
@@ -109,17 +111,23 @@ export default function FilterableCollection({
     return markerRef.current?.parentElement as HTMLElement | null;
   }, []);
 
-  const hideSSR = useCallback(() => {
+  const setSsrItemsDisplay = useCallback((display: '' | 'none') => {
     ssrChildrenRef.current.forEach(el => {
-      (el as HTMLElement).style.display = 'none';
+      (el as HTMLElement).style.display = display;
     });
-  }, []);
+    // Items previously appended by LoadMoreCollection live alongside the SSR
+    // children but aren't captured by `ssrChildrenRef` (they're added after
+    // mount). Toggle them in tandem so a runtime filter doesn't leave stale
+    // load-more rows visible underneath the filtered results.
+    const parent = getParent();
+    if (!parent) return;
+    parent.querySelectorAll(`[${LOAD_MORE_APPENDED_ATTR}]`).forEach(el => {
+      (el as HTMLElement).style.display = display;
+    });
+  }, [getParent]);
 
-  const showSSR = useCallback(() => {
-    ssrChildrenRef.current.forEach(el => {
-      (el as HTMLElement).style.display = '';
-    });
-  }, []);
+  const hideSSR = useCallback(() => setSsrItemsDisplay('none'), [setSsrItemsDisplay]);
+  const showSSR = useCallback(() => setSsrItemsDisplay(''), [setSsrItemsDisplay]);
 
   const clearFilteredDOM = useCallback(() => {
     const parent = getParent();
@@ -376,9 +384,18 @@ export default function FilterableCollection({
     ) as HTMLElement | null;
   }, [collectionLayerId]);
 
+  const toggleSsrWrapperHidden = useCallback((wrapper: HTMLElement, hide: boolean) => {
+    if (ssrWrapperHadHiddenRef.current === null) {
+      ssrWrapperHadHiddenRef.current = wrapper.classList.contains('hidden');
+    }
+    wrapper.classList.toggle('hidden', hide);
+  }, []);
+
   const updateSsrPaginationDisplay = useCallback((page: number, totalPages: number) => {
     const wrapper = getSsrPaginationWrapper();
     if (!wrapper) return;
+
+    toggleSsrWrapperHidden(wrapper, totalPages <= 0);
 
     const infoEl = wrapper.querySelector(`[data-layer-id$="-pagination-info"]`) as HTMLElement | null;
     if (infoEl) {
@@ -417,11 +434,13 @@ export default function FilterableCollection({
         nextBtn.classList.add('cursor-pointer');
       }
     }
-  }, [getSsrPaginationWrapper]);
+  }, [getSsrPaginationWrapper, toggleSsrWrapperHidden]);
 
   const updateSsrLoadMoreDisplay = useCallback((loaded: number, total: number, hasMore: boolean) => {
     const wrapper = getSsrPaginationWrapper();
     if (!wrapper) return;
+
+    toggleSsrWrapperHidden(wrapper, total <= 0);
 
     const countEl = wrapper.querySelector(`[data-layer-id$="-pagination-count"]`) as HTMLElement | null;
     if (countEl) {
@@ -474,6 +493,11 @@ export default function FilterableCollection({
       const loadMoreBtn = wrapper.querySelector(`[data-pagination-action="load_more"]`) as HTMLElement | null;
       if (loadMoreBtn) loadMoreBtn.style.display = ssrLoadMoreBtnDisplayRef.current;
       ssrLoadMoreBtnDisplayRef.current = null;
+    }
+
+    if (ssrWrapperHadHiddenRef.current !== null) {
+      wrapper.classList.toggle('hidden', ssrWrapperHadHiddenRef.current);
+      ssrWrapperHadHiddenRef.current = null;
     }
   }, [getSsrPaginationWrapper]);
 

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -933,8 +933,81 @@ const LayerItemImpl: React.FC<{
     };
   }, [isFilterLayer, filterOnChange, isEditMode, layer.id]);
 
+  // Canvas-only: identify pagination sibling/wrapper layers so we can
+  // substitute dynamic text and hide the wrapper when the linked collection
+  // is empty. Published mode handles this server-side via
+  // `updatePaginationLayerWithMeta` in page-fetcher.
+  const paginationContextTarget = useMemo<{ collectionLayerId: string; kind: 'count' | 'info' | 'wrapper' } | null>(() => {
+    if (!isEditMode || !layer.id) return null;
+    if (layer.id.endsWith('-pagination-count')) {
+      return { collectionLayerId: layer.id.replace(/-pagination-count$/, ''), kind: 'count' };
+    }
+    if (layer.id.endsWith('-pagination-info')) {
+      return { collectionLayerId: layer.id.replace(/-pagination-info$/, ''), kind: 'info' };
+    }
+    const paginationFor = layer.attributes?.['data-pagination-for'];
+    if (typeof paginationFor === 'string' && paginationFor) {
+      return { collectionLayerId: paginationFor, kind: 'wrapper' };
+    }
+    return null;
+  }, [isEditMode, layer.id, layer.attributes]);
+
+  const paginationLinkedCollectionLayer = usePagesStore((state) => {
+    if (!paginationContextTarget || !pageId) return null;
+    const draft = state.draftsByPageId[pageId];
+    if (!draft) return null;
+    return findLayerById(draft.layers, paginationContextTarget.collectionLayerId);
+  });
+
+  const paginationLinkedLayerTotal = useCollectionLayerStore((state) =>
+    paginationContextTarget ? state.layerTotal[paginationContextTarget.collectionLayerId] : undefined
+  );
+
+  /**
+   * Resolves the displayed total for the linked paginated collection.
+   * Returns `undefined` while data is loading (don't flash "0 of 0") or when
+   * pagination isn't applicable to this layer.
+   */
+  const paginationDisplayTotal = useMemo<number | undefined>(() => {
+    if (!paginationContextTarget || !paginationLinkedCollectionLayer) return undefined;
+    const linkedCollection = getCollectionVariable(paginationLinkedCollectionLayer);
+    if (!linkedCollection?.pagination?.enabled) return undefined;
+    if (paginationLinkedLayerTotal === undefined) return undefined;
+    const maxTotal = typeof linkedCollection.limit === 'number' && linkedCollection.limit > 0
+      ? linkedCollection.limit
+      : undefined;
+    return maxTotal != null
+      ? Math.min(paginationLinkedLayerTotal, maxTotal)
+      : paginationLinkedLayerTotal;
+  }, [paginationContextTarget, paginationLinkedCollectionLayer, paginationLinkedLayerTotal]);
+
+  const isPaginationWrapperEmpty = paginationContextTarget?.kind === 'wrapper'
+    && paginationDisplayTotal !== undefined
+    && paginationDisplayTotal <= 0;
+
+  const computedPaginationText = useMemo<string | undefined>(() => {
+    if (!paginationContextTarget || paginationContextTarget.kind === 'wrapper') return undefined;
+    if (paginationDisplayTotal === undefined) return undefined;
+    if (paginationDisplayTotal <= 0) return '';
+    const pagination = getCollectionVariable(paginationLinkedCollectionLayer!)?.pagination;
+    const itemsPerPage = pagination?.items_per_page || 10;
+    if (paginationContextTarget.kind === 'count') {
+      const shown = Math.min(itemsPerPage, paginationDisplayTotal);
+      return `Showing ${shown} of ${paginationDisplayTotal}`;
+    }
+    const totalPages = Math.max(1, Math.ceil(paginationDisplayTotal / itemsPerPage));
+    return `Page 1 of ${totalPages}`;
+  }, [paginationContextTarget, paginationLinkedCollectionLayer, paginationDisplayTotal]);
+
   // Resolve text and image URLs with field binding support
   const textContent = (() => {
+    // Canvas pagination overlay: when this layer is the count/info sibling of
+    // a paginated collection, replace the placeholder content with the same
+    // dynamic text SSR would render.
+    if (computedPaginationText !== undefined) {
+      return computedPaginationText;
+    }
+
     // Special handling for locale selector label.
     // Runs in both edit and runtime modes so the builder canvas reflects the
     // active locale chosen via the header dropdown — otherwise the label
@@ -1350,10 +1423,20 @@ const LayerItemImpl: React.FC<{
       }
     }
 
-    // Mirror SSR semantics: when static filters are present we fetch all items
-    // (no API limit/offset) so filtering happens on the full set. Re-apply the
-    // configured limit/offset here so the canvas shows the same items as preview.
-    if (hasStaticFilters) {
+    // Mirror SSR semantics: pagination (when enabled) overrides legacy
+    // `limit`/`offset`, showing only `items_per_page` items — same as the
+    // first page of preview. Without pagination, fall back to legacy
+    // `limit`/`offset`. We slice unconditionally for paginated layers, and
+    // when static filters are present for non-paginated ones (the API
+    // returns the configured limit when there are no static filters, so no
+    // re-slicing is needed there).
+    const pagination = collectionVariable?.pagination;
+    const isPaginated = !!pagination?.enabled && (pagination.mode === 'pages' || pagination.mode === 'load_more');
+
+    if (isPaginated) {
+      const itemsPerPage = pagination!.items_per_page || 10;
+      items = items.slice(0, itemsPerPage);
+    } else if (hasStaticFilters) {
       const offset = collectionVariable?.offset ?? 0;
       const limit = collectionVariable?.limit;
       if (offset || limit) {
@@ -1362,7 +1445,7 @@ const LayerItemImpl: React.FC<{
     }
 
     return items;
-  }, [collectionId, allCollectionItems, sourceFieldId, sourceFieldType, sourceFieldSource, collectionLayerData, pageCollectionItemData, collectionLayerItemId, pageCollectionItemId, getAsset, collectionVariable?.filters, collectionVariable?.limit, collectionVariable?.offset, isEditMode]);
+  }, [collectionId, allCollectionItems, sourceFieldId, sourceFieldType, sourceFieldSource, collectionLayerData, pageCollectionItemData, collectionLayerItemId, pageCollectionItemId, getAsset, collectionVariable?.filters, collectionVariable?.limit, collectionVariable?.offset, collectionVariable?.pagination, isEditMode]);
 
   const optionsSourceSort = layer.settings?.optionsSource;
 
@@ -1427,14 +1510,29 @@ const LayerItemImpl: React.FC<{
     const hasStaticFilters = !!collectionVariable.filters?.groups?.some(
       g => g.conditions.some(c => !c.inputLayerId)
     );
+    const pagination = collectionVariable.pagination;
+    const isPaginated = !!pagination?.enabled && (pagination.mode === 'pages' || pagination.mode === 'load_more');
+
+    let fetchLimit: number | undefined;
+    let fetchOffset: number | undefined;
+    if (hasStaticFilters) {
+      fetchLimit = FILTERED_FETCH_LIMIT;
+      fetchOffset = 0;
+    } else if (isPaginated) {
+      fetchLimit = pagination!.items_per_page || 10;
+      fetchOffset = 0;
+    } else {
+      fetchLimit = collectionVariable.limit;
+      fetchOffset = collectionVariable.offset;
+    }
 
     fetchLayerData(
       layer.id,
       collectionVariable.id,
       sortBy,
       sortOrder,
-      hasStaticFilters ? FILTERED_FETCH_LIMIT : collectionVariable.limit,
-      hasStaticFilters ? 0 : collectionVariable.offset
+      fetchLimit,
+      fetchOffset
     );
   }, [
     isEditMode,
@@ -1447,6 +1545,7 @@ const LayerItemImpl: React.FC<{
     collectionVariable?.limit,
     collectionVariable?.offset,
     collectionVariable?.filters,
+    collectionVariable?.pagination,
     optionsSourceSort?.sortFieldId,
     optionsSourceSort?.sortOrder,
     sortByInputDefaultValue,
@@ -1685,6 +1784,7 @@ const LayerItemImpl: React.FC<{
     isDragging && 'opacity-30',
     showProjection && 'outline outline-1 outline-dashed outline-blue-400 bg-blue-50/10',
     isLockedByOther && 'opacity-90 pointer-events-none select-none',
+    isPaginationWrapperEmpty && 'hidden',
     'ycode-layer'
   ) : clsx(classesString, paragraphClasses, SWIPER_CLASS_MAP[layer.name], isSlideChild && 'swiper-slide', buttonNeedsFit && 'w-fit', buttonNeedsTextCenter && 'text-center');
 

--- a/components/LoadMoreCollection.tsx
+++ b/components/LoadMoreCollection.tsx
@@ -31,7 +31,7 @@ interface LoadMoreCollectionProps {
   collectionLayer?: Omit<Layer, 'children'>;
 }
 
-const LOAD_MORE_APPENDED_ATTR = 'data-lm-appended';
+export const LOAD_MORE_APPENDED_ATTR = 'data-lm-appended';
 
 export default function LoadMoreCollection({
   children,
@@ -44,7 +44,7 @@ export default function LoadMoreCollection({
   pageCollectionSortedItemIds,
   collectionLayer,
 }: LoadMoreCollectionProps) {
-  const { totalItems, itemsPerPage, collectionId, isPublished, sortBy, sortOrder } = paginationMeta;
+  const { totalItems, itemsPerPage, collectionId, isPublished, sortBy, sortOrder, maxTotal } = paginationMeta;
   const markerRef = useRef<HTMLSpanElement>(null);
 
   const [loadedCount, setLoadedCount] = useState(itemsPerPage);
@@ -80,6 +80,7 @@ export default function LoadMoreCollection({
             pageCollectionItemId,
             pageCollectionSortedItemIds,
             collectionLayer,
+            maxTotal,
           }),
         }
       );
@@ -138,6 +139,7 @@ export default function LoadMoreCollection({
     pageCollectionItemId,
     pageCollectionSortedItemIds,
     collectionLayer,
+    maxTotal,
   ]);
 
   useEffect(() => {
@@ -155,15 +157,20 @@ export default function LoadMoreCollection({
   }, [collectionLayerId, loadMore]);
 
   useEffect(() => {
-    const countElement = document.querySelector(
-      `[data-pagination-for="${collectionLayerId}"] [data-layer-id$="-pagination-count"]`
-    );
+    const wrapper = document.querySelector(
+      `[data-pagination-for="${collectionLayerId}"]`
+    ) as HTMLElement | null;
+
+    // Hide the whole wrapper when there are no results.
+    if (wrapper) wrapper.classList.toggle('hidden', totalItems <= 0);
+
+    const countElement = wrapper?.querySelector(`[data-layer-id$="-pagination-count"]`);
     if (countElement) {
       countElement.textContent = `Showing ${loadedCount} of ${totalItems}`;
     }
 
-    const loadMoreButton = document.querySelector(
-      `[data-pagination-for="${collectionLayerId}"] [data-pagination-action="load_more"]`
+    const loadMoreButton = wrapper?.querySelector(
+      `[data-pagination-action="load_more"]`
     ) as HTMLElement | null;
     if (loadMoreButton) {
       loadMoreButton.style.display = hasMore ? '' : 'none';

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -1959,28 +1959,38 @@ async function buildCollectionCache(
   // Items are fetched per-collection because a single `.in('collection_id', [...])`
   // query is bounded by Supabase/PostgREST's `db-max-rows` setting (often 1000),
   // so a large collection can starve smaller ones in the same page.
+  // We chunk via `.range()` past the 1000-row cap, stopping once we hit
+  // PER_COLLECTION_LIMIT or run out of rows.
   const allCollIds = [...ids, ...refCollectionIds];
   const PER_COLLECTION_LIMIT = 5000;
+  const ITEMS_PAGE_SIZE = 1000;
 
-  const buildItemsQuery = (collectionId: string) => {
-    let q = client
-      .from('collection_items')
-      .select('*')
-      .eq('collection_id', collectionId)
-      .eq('is_published', isPublished)
-      .is('deleted_at', null)
-      .order('manual_order', { ascending: true })
-      .order('created_at', { ascending: false })
-      .limit(PER_COLLECTION_LIMIT);
-    if (isPublished) q = q.eq('is_publishable', true);
-    return q;
+  const fetchItemsForCollection = async (collectionId: string) => {
+    const all: any[] = [];
+    for (let from = 0; from < PER_COLLECTION_LIMIT; from += ITEMS_PAGE_SIZE) {
+      const to = Math.min(from + ITEMS_PAGE_SIZE - 1, PER_COLLECTION_LIMIT - 1);
+      let q = client
+        .from('collection_items')
+        .select('*')
+        .eq('collection_id', collectionId)
+        .eq('is_published', isPublished)
+        .is('deleted_at', null)
+        .order('manual_order', { ascending: true })
+        .order('created_at', { ascending: false })
+        .range(from, to);
+      if (isPublished) q = q.eq('is_publishable', true);
+      const { data, error } = await q;
+      if (error) throw new Error(`Failed to fetch items: ${error.message}`);
+      if (!data || data.length === 0) break;
+      all.push(...data);
+      if (data.length < (to - from + 1)) break;
+    }
+    return all;
   };
 
-  const itemsPromise = Promise.all(allCollIds.map(buildItemsQuery))
-    .then(results => ({
-      data: results.flatMap(r => r.data || []),
-      error: results.find(r => r.error)?.error,
-    }));
+  const itemsPromise = Promise.all(allCollIds.map(fetchItemsForCollection))
+    .then(results => ({ data: results.flat(), error: null as unknown }))
+    .catch(error => ({ data: [] as any[], error }));
 
   const refFieldsPromise = refCollectionIds.length > 0
     ? client.from('collection_fields').select('*')
@@ -2326,6 +2336,51 @@ export async function resolveCollectionLayers(
             filteredItems = filteredItems.filter(i => allowedSet.has(i.id));
           }
 
+          // Apply static collection filters early so totalItems, pagination
+          // slicing, and the `itemIds` we hand off to load_more all reflect
+          // the same constrained set. Input-linked conditions are skipped
+          // here — they run client-side via FilterableCollection.
+          const collectionFilters = collectionVariable.filters;
+          const staticFilters = collectionFilters?.groups?.length ? {
+            ...collectionFilters,
+            groups: collectionFilters.groups.map(group => ({
+              ...group,
+              conditions: group.conditions.filter(c => !c.inputLayerId),
+            })).filter(group => group.conditions.length > 0),
+          } : null;
+          const hasStaticFilters = !!staticFilters && staticFilters.groups.length > 0;
+
+          if (hasStaticFilters) {
+            filteredItems = filteredItems.filter(item =>
+              evaluateVisibility(staticFilters!, {
+                collectionLayerData: item.values,
+                pageCollectionData: parentItemValues ?? null,
+                pageCollectionCounts: {},
+                currentItemId: item.id,
+                pageCollectionItemId: pageCollectionItemId ?? parentCollectionItemId,
+              })
+            );
+          }
+
+          // When pagination is enabled, `collectionVariable.limit` acts as a
+          // hard cap on the total — both for the displayed count and for how
+          // far `load_more` can page. Without pagination, the legacy slice
+          // below applies it as a per-page limit instead.
+          const maxTotal = isPaginated && typeof collectionVariable.limit === 'number' && collectionVariable.limit > 0
+            ? collectionVariable.limit
+            : undefined;
+          if (maxTotal != null && filteredItems.length > maxTotal) {
+            filteredItems = filteredItems.slice(0, maxTotal);
+          }
+
+          // Static filters shrink the candidate pool — propagate the final
+          // ID list so the load_more API uses it as its candidate pool
+          // (otherwise it falls back to all collection items and bypasses
+          // the layer's static filters).
+          if (hasStaticFilters) {
+            allowedItemIds = filteredItems.map(item => item.id);
+          }
+
           const totalItems = filteredItems.length;
 
           // For non-field-sort, apply limit/offset in-memory (mirrors DB pagination)
@@ -2335,30 +2390,6 @@ export async function resolveCollectionLayers(
             items = filteredItems.slice(start, limit ? start + limit : undefined);
           } else {
             items = filteredItems;
-          }
-
-          // Apply static collection filters (evaluate against each item's own values)
-          const collectionFilters = collectionVariable.filters;
-          if (collectionFilters?.groups?.length) {
-            const staticFilters = {
-              ...collectionFilters,
-              groups: collectionFilters.groups.map(group => ({
-                ...group,
-                conditions: group.conditions.filter(c => !c.inputLayerId),
-              })).filter(group => group.conditions.length > 0),
-            };
-
-            if (staticFilters.groups.length > 0) {
-              items = items.filter(item =>
-                evaluateVisibility(staticFilters, {
-                  collectionLayerData: item.values,
-                  pageCollectionData: parentItemValues ?? null,
-                  pageCollectionCounts: {},
-                  currentItemId: item.id,
-                  pageCollectionItemId: pageCollectionItemId ?? parentCollectionItemId,
-                })
-              );
-            }
           }
 
           // Apply sorting if specified (since API doesn't handle sortBy yet)
@@ -2495,6 +2526,7 @@ export async function resolveCollectionLayers(
               isPublished,
               sortBy: collectionVariable.sort_by,
               sortOrder: collectionVariable.sort_order,
+              maxTotal,
             };
           }
 
@@ -2977,9 +3009,16 @@ function updatePaginationLayerWithMeta(layer: Layer, meta: CollectionPaginationM
   // Deep clone to avoid mutation
   const updatedLayer: Layer = JSON.parse(JSON.stringify(layer));
 
+  // No results: hide the entire pagination wrapper rather than rendering
+  // controls with empty/zero text.
+  if (totalItems <= 0) {
+    updatedLayer.classes = Array.isArray(updatedLayer.classes)
+      ? [...updatedLayer.classes, 'hidden']
+      : `${updatedLayer.classes || ''} hidden`.trim();
+  }
+
   // Helper to recursively update layers
   function updateLayerRecursive(l: Layer): void {
-    // Update page info text (for 'pages' mode)
     if (l.id?.endsWith('-pagination-info')) {
       l.variables = {
         ...l.variables,
@@ -2990,7 +3029,6 @@ function updatePaginationLayerWithMeta(layer: Layer, meta: CollectionPaginationM
       };
     }
 
-    // Update items count text (for 'load_more' mode)
     if (l.id?.endsWith('-pagination-count')) {
       const shownItems = Math.min(itemsPerPage, totalItems);
       l.variables = {

--- a/stores/useCollectionLayerStore.ts
+++ b/stores/useCollectionLayerStore.ts
@@ -13,6 +13,7 @@ import type { CollectionItemWithValues, CollectionPaginationMeta } from '@/types
 
 interface CollectionLayerState {
   layerData: Record<string, CollectionItemWithValues[]>; // keyed by layerId
+  layerTotal: Record<string, number>; // Total matching rows in the collection (from server count), keyed by layerId
   loading: Record<string, boolean>; // loading state per layer
   error: Record<string, string | null>; // error state per layer
   layerConfig: Record<string, { collectionId: string; sortBy?: string; sortOrder?: 'asc' | 'desc'; limit?: number; offset?: number; filters?: Array<{ fieldId: string; operator: string; value: string }> }>; // Track config per layer
@@ -52,6 +53,7 @@ type CollectionLayerStore = CollectionLayerState & CollectionLayerActions;
 export const useCollectionLayerStore = create<CollectionLayerStore>((set, get) => ({
   // Initial state
   layerData: {},
+  layerTotal: {},
   loading: {},
   error: {},
   layerConfig: {},
@@ -199,10 +201,12 @@ export const useCollectionLayerStore = create<CollectionLayerStore>((set, get) =
       }
 
       const items = response.data?.items || [];
+      const total = typeof response.data?.total === 'number' ? response.data.total : items.length;
 
       // Store fetched data keyed by layerId
       set((state) => ({
         layerData: { ...state.layerData, [layerId]: items },
+        layerTotal: { ...state.layerTotal, [layerId]: total },
         loading: { ...state.loading, [layerId]: false },
         layerConfig: {
           ...state.layerConfig,
@@ -223,11 +227,13 @@ export const useCollectionLayerStore = create<CollectionLayerStore>((set, get) =
   clearLayerData: (layerId: string) => {
     set((state) => {
       const { [layerId]: _, ...restLayerData } = state.layerData;
+      const { [layerId]: _t, ...restLayerTotal } = state.layerTotal;
       const { [layerId]: __, ...restLoading } = state.loading;
       const { [layerId]: ___, ...restError } = state.error;
 
       return {
         layerData: restLayerData,
+        layerTotal: restLayerTotal,
         loading: restLoading,
         error: restError,
       };
@@ -238,6 +244,7 @@ export const useCollectionLayerStore = create<CollectionLayerStore>((set, get) =
   clearAllLayerData: () => {
     set({
       layerData: {},
+      layerTotal: {},
       loading: {},
       error: {},
       referencedItems: {},
@@ -306,9 +313,11 @@ export const useCollectionLayerStore = create<CollectionLayerStore>((set, get) =
           });
 
           if (!response.error && response.data?.items) {
+            const total = typeof response.data.total === 'number' ? response.data.total : response.data.items.length;
             // Update data silently (no loading state change)
             set((state) => ({
               layerData: { ...state.layerData, [layerId]: response.data!.items },
+              layerTotal: { ...state.layerTotal, [layerId]: total },
             }));
           }
         } catch (error) {

--- a/types/index.ts
+++ b/types/index.ts
@@ -1336,6 +1336,10 @@ export interface CollectionPaginationMeta {
   // paging will return overlapping (duplicate) items.
   sortBy?: string;
   sortOrder?: 'asc' | 'desc';
+  // Optional cap from `collectionVariable.limit` when pagination is enabled.
+  // Treated as a max total: clamps `totalItems` and stops `load_more` once
+  // reached, even if the underlying collection has more matching rows.
+  maxTotal?: number;
 }
 
 // Conditional Visibility Types


### PR DESCRIPTION
## Summary

Fixes a cluster of issues around paginated collections, static filters, and animations on collection items — including counts capped at 1000, "Showing 0 of 0" on empty results, filters being bypassed by load-more, and hover/click animations not playing on the initial SSR-rendered items.

## Changes

- Page past Supabase's 1000-row default cap when fetching collection items and item ids, so paginated counts and `hasMore` reflect every matching row instead of stalling at 1000.
- Apply static collection filters before computing totals and slicing, and pass the filtered id pool to the load-more API so static conditions are honored across paging and filter input changes.
- Treat `collection.limit` as a hard total cap when pagination is enabled — load-more stops at the cap and counts clamp to it.
- Hide the entire pagination wrapper when there are no results instead of rendering "Showing 0 of 0" / "Page 1 of 1". Restored on cleanup.
- Show real "Showing X of Y" / "Page X of Y" text on the builder canvas (mirrors what SSR renders for preview/published).
- Pre-paint each tween's `from` state for hover/click triggers so the element rests in its authored initial appearance instead of the layer's CSS default (previously: newly-injected items appeared "already hovered").
- Re-bind animations when tracked layers get remounted: `next/dynamic` chunks for `LoadMoreCollection` / `FilterableCollection` finishing their load replaces the Suspense fallback with the real subtree, which previously orphaned the `gsap.set` and listeners attached on first paint — initial SSR items never animated until the next state change. A scoped `MutationObserver` now triggers a re-bind when nodes with tracked `data-layer-id`s are re-added to the DOM.

## Test plan

- [ ] Collection with > 1000 items shows the real total in "Showing X of Y" and load-more keeps loading past 1000.
- [ ] Set `collection.limit` to e.g. 180 with pagination enabled — load-more stops at 180, the count caps at 180.
- [ ] Static filter on a collection with load-more: clicking load-more keeps the filter applied (no unfiltered items leak in).
- [ ] Filter input (search/select) on a collection with load-more: results match the filter; previously-loaded rows aren't left visible.
- [ ] Empty filter result hides the pagination wrapper entirely; clearing the filter restores it.
- [ ] Builder canvas shows the same "Showing X of Y" / "Page X of Y" text as preview.
- [ ] Hover/click animation on a collection item — initial 8 SSR items animate on reload (not stuck in the "to" state).
- [ ] Click load-more — newly-loaded items animate correctly and don't appear "already hovered".
- [ ] Breakpoint resize on a page with collection-item animations still works.