### PR TITLE
fix: resolve dynamic page link slugs across collections in CMS

### DIFF
--- a/app/(builder)/ycode/api/collections/items/slugs/route.ts
+++ b/app/(builder)/ycode/api/collections/items/slugs/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from 'next/server';
+import { getSlugsByItemIds } from '@/lib/repositories/collectionItemRepository';
+import { noCache } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * POST /ycode/api/collections/items/slugs
+ *
+ * Returns a `{ itemId: slug }` map for the given collection item IDs.
+ * Used by the CMS editor to resolve cross-collection / cross-page link
+ * references where the referenced item is not part of the currently
+ * loaded collection items.
+ *
+ * Body:
+ *  - itemIds: string[]
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { itemIds } = body;
+
+    if (!itemIds || !Array.isArray(itemIds)) {
+      return noCache({ error: 'itemIds must be an array' }, 400);
+    }
+
+    if (itemIds.length === 0) {
+      return noCache({ data: { slugs: {} } });
+    }
+
+    const slugs = await getSlugsByItemIds(itemIds, false);
+    return noCache({ data: { slugs } });
+  } catch (error) {
+    console.error('Error fetching item slugs:', error);
+    return noCache(
+      { error: error instanceof Error ? error.message : 'Failed to fetch item slugs' },
+      500
+    );
+  }
+}

--- a/app/(builder)/ycode/components/CMS.tsx
+++ b/app/(builder)/ycode/components/CMS.tsx
@@ -40,7 +40,7 @@ import { parseMultiAssetFieldValue } from '@/lib/multi-asset-utils';
 import { type FieldType, findDisplayField, getItemDisplayName, getFieldIcon, isMultipleAssetField, findStatusFieldId, isDateFieldType } from '@/lib/collection-field-utils';
 import { CollectionStatusPill, parseStatusValue } from './CollectionStatusPill';
 import { extractPlainTextFromTiptap } from '@/lib/tiptap-utils';
-import { parseCollectionLinkValue, resolveCollectionLinkValue } from '@/lib/link-utils';
+import { extractCrossCollectionItemIds, parseCollectionLinkValue, resolveCollectionLinkValue } from '@/lib/link-utils';
 import { useEditorUrl } from '@/hooks/use-editor-url';
 import { useRole } from '@/hooks/use-role';
 import FieldsDropdown from './FieldsDropdown';
@@ -474,6 +474,9 @@ const CMS = React.memo(function CMS() {
   const totalItems = selectedCollectionId ? (itemsTotalCount[selectedCollectionId] || 0) : 0;
 
   // Build slug map across ALL loaded collections for cross-collection link resolution
+  const crossCollectionSlugs = useCollectionsStore((state) => state.crossCollectionSlugs);
+  const loadMissingItemSlugs = useCollectionsStore((state) => state.loadMissingItemSlugs);
+
   const allCollectionItemSlugs = useMemo(() => {
     const slugs: Record<string, string> = {};
     for (const collectionId of Object.keys(items)) {
@@ -487,8 +490,35 @@ const CMS = React.memo(function CMS() {
         }
       }
     }
+    // Merge in slugs resolved for items not loaded in any collection
+    // (cross-collection refs, or items on a different page of the current one).
+    for (const [itemId, slug] of Object.entries(crossCollectionSlugs)) {
+      if (slug && !slugs[itemId]) {
+        slugs[itemId] = slug;
+      }
+    }
     return slugs;
-  }, [items, fields]);
+  }, [items, fields, crossCollectionSlugs]);
+
+  // Resolve slug values for collection items referenced by link fields in the
+  // currently displayed items but missing from `allCollectionItemSlugs`. Without
+  // this the Page-link column would render `/{slug}` placeholders until the
+  // referenced collection happens to be loaded.
+  useEffect(() => {
+    if (!selectedCollectionId) return;
+    const currentItems = items[selectedCollectionId];
+    const currentFields = fields[selectedCollectionId];
+    if (!currentItems?.length || !currentFields?.length) return;
+
+    const linkFieldIds = currentFields.filter(f => f.type === 'link').map(f => f.id);
+    if (linkFieldIds.length === 0) return;
+
+    const missingIds = extractCrossCollectionItemIds(currentItems, linkFieldIds, allCollectionItemSlugs)
+      .filter(id => !(id in crossCollectionSlugs));
+    if (missingIds.length === 0) return;
+
+    loadMissingItemSlugs(missingIds);
+  }, [selectedCollectionId, items, fields, allCollectionItemSlugs, crossCollectionSlugs, loadMissingItemSlugs]);
 
   // Drag and drop sensors
   const sensors = useSensors(

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -571,6 +571,13 @@ export const collectionsApi = {
     return apiRequest<CollectionItemWithValues>(`/ycode/api/collections/${collectionId}/items/${itemId}`);
   },
 
+  async getItemSlugs(itemIds: string[]): Promise<ApiResponse<{ slugs: Record<string, string> }>> {
+    return apiRequest<{ slugs: Record<string, string> }>('/ycode/api/collections/items/slugs', {
+      method: 'POST',
+      body: JSON.stringify({ itemIds }),
+    });
+  },
+
   async createItem(collectionId: string, values: Record<string, any>, statusAction?: StatusAction): Promise<ApiResponse<CollectionItemWithValues>> {
     return apiRequest<CollectionItemWithValues>(`/ycode/api/collections/${collectionId}/items`, {
       method: 'POST',

--- a/lib/link-utils.ts
+++ b/lib/link-utils.ts
@@ -320,6 +320,8 @@ export interface ResolveFieldLinkOptions {
 /**
  * Extract collection_item_ids referenced by link field values that point to
  * dynamic pages. Used to pre-fetch slugs for cross-collection link resolution.
+ * Skips dynamic-resolution keywords (`current-page`, `ref-*`, etc.) since those
+ * are resolved at render time and don't map to a concrete item id.
  */
 export function extractCrossCollectionItemIds(
   items: { values: Record<string, string> }[],
@@ -332,12 +334,14 @@ export function extractCrossCollectionItemIds(
       const rawValue = item.values[fieldId];
       if (!rawValue) continue;
       const linkValue = parseCollectionLinkValue(rawValue);
-      if (linkValue?.type === 'page' && linkValue.page?.collection_item_id) {
-        const refItemId = linkValue.page.collection_item_id;
-        if (!existingSlugs?.[refItemId]) {
-          itemIds.add(refItemId);
-        }
-      }
+      if (linkValue?.type !== 'page' || !linkValue.page?.collection_item_id) continue;
+
+      const refItemId = linkValue.page.collection_item_id;
+      if (isCollectionItemKeyword(refItemId)) continue;
+      if (refItemId.startsWith(REF_PAGE_PREFIX) || refItemId.startsWith(REF_COLLECTION_PREFIX)) continue;
+      if (existingSlugs?.[refItemId]) continue;
+
+      itemIds.add(refItemId);
     }
   }
   return Array.from(itemIds);

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -3,7 +3,7 @@ import { escapeHtml } from '@/lib/escape-html';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { getKnexClient } from '@/lib/knex-client';
 import { buildSlugPath, buildDynamicPageUrl, buildLocalizedSlugPath, buildLocalizedDynamicPageUrl, detectLocaleFromPath, matchPageWithTranslatedSlugs, matchDynamicPageWithTranslatedSlugs } from '@/lib/page-utils';
-import { getItemWithValues, getItemsWithValues, getItemsWithValuesByIds, getItemIdsByFieldValue, getItemsByCollectionId } from '@/lib/repositories/collectionItemRepository';
+import { getItemWithValues, getItemsWithValues, getItemsWithValuesByIds, getItemIdsByFieldValue, getItemsByCollectionId, getSlugsByItemIds } from '@/lib/repositories/collectionItemRepository';
 import { getValuesByItemIds } from '@/lib/repositories/collectionItemValueRepository';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { enrichItemsWithCountValues } from '@/lib/repositories/collectionCountRepository';
@@ -3160,24 +3160,8 @@ async function enrichSlugsFromLinkFields(
   const missingItemIds = extractCrossCollectionItemIds(items, linkFieldIds, existingSlugs);
   if (missingItemIds.length === 0) return;
 
-  const refItems = await getItemsWithValuesByIds(missingItemIds, isPublished);
-  const refCollectionIds = new Set(Object.values(refItems).map(i => i.collection_id));
-
-  const fieldsByCollection = new Map<string, CollectionField[]>();
-  await Promise.all(
-    Array.from(refCollectionIds).map(async (collId) => {
-      const fields = await getFieldsByCollectionId(collId, isPublished);
-      fieldsByCollection.set(collId, fields);
-    })
-  );
-
-  for (const refItem of Object.values(refItems)) {
-    const fields = fieldsByCollection.get(refItem.collection_id);
-    const slugField = fields?.find(f => f.key === 'slug');
-    if (slugField && refItem.values[slugField.id]) {
-      existingSlugs[refItem.id] = refItem.values[slugField.id];
-    }
-  }
+  const refSlugs = await getSlugsByItemIds(missingItemIds, isPublished);
+  Object.assign(existingSlugs, refSlugs);
 }
 
 /**

--- a/lib/repositories/collectionItemRepository.ts
+++ b/lib/repositories/collectionItemRepository.ts
@@ -1,7 +1,7 @@
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { getKnexClient } from '@/lib/knex-client';
 import { SUPABASE_QUERY_LIMIT } from '@/lib/supabase-constants';
-import type { CollectionItem, CollectionItemWithValues } from '@/types';
+import type { CollectionField, CollectionItem, CollectionItemWithValues } from '@/types';
 import { randomUUID } from 'crypto';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { getValuesByFieldId, getValuesByItemIds, getValuesByItemId } from '@/lib/repositories/collectionItemValueRepository';
@@ -673,6 +673,42 @@ export async function getItemsWithValuesByIds(
     result[item.id] = { ...item, values: valuesByItem[item.id] || {} };
   }
   return result;
+}
+
+/**
+ * Batch fetch slug values for arbitrary item IDs across collections.
+ * Returns a map keyed by item ID. Only items whose owning collection has a
+ * `slug` field with a non-empty value are included.
+ */
+export async function getSlugsByItemIds(
+  ids: string[],
+  is_published: boolean = false
+): Promise<Record<string, string>> {
+  if (ids.length === 0) return {};
+
+  const itemsByIds = await getItemsWithValuesByIds(ids, is_published);
+  const itemList = Object.values(itemsByIds);
+  if (itemList.length === 0) return {};
+
+  const refCollectionIds = Array.from(new Set(itemList.map(i => i.collection_id)));
+  const fieldsByCollection = new Map<string, CollectionField[]>();
+  await Promise.all(
+    refCollectionIds.map(async (collId) => {
+      const fields = await getFieldsByCollectionId(collId, is_published);
+      fieldsByCollection.set(collId, fields);
+    })
+  );
+
+  const slugs: Record<string, string> = {};
+  for (const item of itemList) {
+    const fields = fieldsByCollection.get(item.collection_id);
+    const slugField = fields?.find(f => f.key === 'slug');
+    const slugValue = slugField ? item.values[slugField.id] : undefined;
+    if (slugValue) {
+      slugs[item.id] = slugValue;
+    }
+  }
+  return slugs;
 }
 
 /**

--- a/stores/useCollectionsStore.ts
+++ b/stores/useCollectionsStore.ts
@@ -28,6 +28,13 @@ interface CollectionsState {
   itemsTotalCount: Record<string, number>; // keyed by collection_id (UUID) - total count for pagination
   lastItemsQuery: Record<string, ItemsQueryParams>; // keyed by collection_id — last loadItems params
   selectedCollectionId: string | null; // UUID
+  /**
+   * Slugs of items referenced by link fields but not present in the currently
+   * loaded `items` (e.g. cross-collection refs or items on a different page).
+   * Keyed by item ID. `null` marks an item id we already tried to resolve and
+   * found no slug for — prevents repeated fetch attempts.
+   */
+  crossCollectionSlugs: Record<string, string | null>;
   isLoading: boolean;
   error: string | null;
 }
@@ -55,6 +62,7 @@ interface CollectionsActions {
   getDropdownItems: (collectionId: string) => Promise<Array<{ id: string; label: string }>>;
   searchAndMergeItems: (collectionId: string, query: string, limit?: number) => Promise<Array<{ id: string; label: string }>>;
   ensureItemLoaded: (collectionId: string, itemId: string) => Promise<void>;
+  loadMissingItemSlugs: (itemIds: string[]) => Promise<void>;
   createItem: (collectionId: string, values: Record<string, any>, statusAction?: StatusAction) => Promise<CollectionItemWithValues>;
   updateItem: (collectionId: string, itemId: string, values: Record<string, any>) => Promise<void>;
   deleteItem: (collectionId: string, itemId: string) => Promise<void>;
@@ -84,6 +92,7 @@ export const useCollectionsStore = create<CollectionsStore>((set, get) => ({
   itemsTotalCount: {},
   lastItemsQuery: {},
   selectedCollectionId: null,
+  crossCollectionSlugs: {},
   isLoading: false,
   error: null,
 
@@ -1292,6 +1301,32 @@ export const useCollectionsStore = create<CollectionsStore>((set, get) => ({
       });
     } catch (error) {
       console.error('Failed to hydrate collection item:', error);
+    }
+  },
+
+  loadMissingItemSlugs: async (itemIds: string[]) => {
+    if (itemIds.length === 0) return;
+
+    const { crossCollectionSlugs } = get();
+    const idsToFetch = itemIds.filter(id => !(id in crossCollectionSlugs));
+    if (idsToFetch.length === 0) return;
+
+    try {
+      const response = await collectionsApi.getItemSlugs(idsToFetch);
+      if (response.error || !response.data) return;
+
+      const fetchedSlugs = response.data.slugs;
+      set(state => {
+        const next: Record<string, string | null> = { ...state.crossCollectionSlugs };
+        // Mark every requested id so we never re-fetch — items without a slug
+        // are recorded as null instead of being omitted from the cache.
+        for (const id of idsToFetch) {
+          next[id] = fetchedSlugs[id] ?? null;
+        }
+        return { crossCollectionSlugs: next };
+      });
+    } catch (error) {
+      console.error('Failed to load missing item slugs:', error);
     }
   },
 }));


### PR DESCRIPTION
## Summary

In the CMS items list, page-link cells rendered as `/{slug}` when the referenced item belonged to a different collection (or sat on a different pagination page of the current one) because the editor only resolved slugs from items already loaded in the collections store. Opening the item sheet hydrated the related item and masked the bug.

This PR mirrors the SSR `enrichSlugsFromLinkFields` pattern for the editor: extract referenced item ids from loaded items, fetch the missing slugs in one round-trip, and merge them into the slug map used by the table.

## Changes

- Add shared `getSlugsByItemIds` repository helper and reuse it from `page-fetcher`'s `enrichSlugsFromLinkFields` (drops duplicated field/slug lookup logic).
- Expose `POST /ycode/api/collections/items/slugs` so the editor can resolve slugs by item id without loading whole referenced collections.
- Cache cross-collection slugs in `useCollectionsStore` (including `null` markers) so each id is fetched at most once per session.
- Wire the CMS list to extract referenced ids from link fields and request missing slugs after items load; merged into the existing `allCollectionItemSlugs` memo.
- Skip dynamic-resolution keywords (`current-page`, `ref-*`, etc.) in `extractCrossCollectionItemIds` so we don't try to resolve sentinels as concrete item ids.

## Test plan

- [ ] Open a CMS collection whose items have Page link fields pointing to another collection's items — cells now show the resolved URL instead of `/{slug}`.
- [ ] Same check with pages on a different pagination page of the current collection.
- [ ] Open the item sheet to confirm the link still resolves correctly there.
- [ ] Verify a link to a static (non-dynamic) page still renders as before.
- [ ] Verify no extra requests when the linked item is already part of a loaded collection.