### PR TITLE
fix: render multi-reference inverse-reference collections in SSR

### DIFF
--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -2301,7 +2301,15 @@ export async function resolveCollectionLayers(
               .filter(item => {
                 const val = item.values[sourceFieldId!];
                 if (!val) return false;
-                return val === parentItemId || (typeof val === 'string' && val.includes(`"${parentItemId}"`));
+                // Single reference: bare UUID string. Multi-reference: castValue already
+                // JSON-parses the stored array into a JS array, so check membership
+                // directly. The legacy `val.includes('"id"')` substring check is kept as
+                // a fallback for any value that arrives un-parsed.
+                if (Array.isArray(val)) return val.includes(parentItemId);
+                if (typeof val === 'string') {
+                  return val === parentItemId || val.includes(`"${parentItemId}"`);
+                }
+                return false;
               })
               .map(item => item.id);
           } else if (sourceFieldId && itemValues) {


### PR DESCRIPTION
## Summary

A collection layer sourced via `inverse_reference` from a `multi_reference` field rendered zero items on the server because the in-memory filter still treated the source value as a string. `castValue` JSON-parses any value starting with `[`, so multi_reference values arrive as a JS array and the substring check (`val.includes('"<id>"')`) silently fails.

Symptom: a Nav menu showed its 6 section headers but none of the items underneath in the live/preview page, even though the canvas/client renderer displayed them correctly (the client already uses `parseMultiReferenceValue`).

Regression introduced when SSR inverse-reference filtering was moved off the DB-side `getItemIdsByFieldValue` (which uses SQL `LIKE` on the raw JSON string) onto an in-memory check over already-parsed cache values.

## Changes

- In `resolveCollectionLayers`, handle the array case explicitly when filtering inverse references; keep the string fallback for any value that still arrives un-parsed.

## Test plan

- [ ] Render a page that uses a multi-reference + inverse-reference pair (e.g. Nav menu sections → sub-items) and confirm all items appear in the live/preview output, not just the parent groups.
- [ ] Confirm single-reference inverse references still resolve (bare UUID string case).
- [ ] Confirm canvas/client rendering is unchanged.