### PR TITLE
fix: sync Airtable URL fields as proper link values

### DIFF
--- a/lib/apps/airtable/field-mapping.ts
+++ b/lib/apps/airtable/field-mapping.ts
@@ -5,7 +5,7 @@
  * transforms Airtable field values into CMS-compatible strings.
  */
 
-import type { CollectionFieldType } from '@/types';
+import type { CollectionFieldType, CollectionLinkValue } from '@/types';
 import type { AirtableFieldType } from './types';
 import { markdownToTiptapJson } from './markdown-to-tiptap';
 
@@ -232,16 +232,38 @@ export function transformFieldValue(
         ? (value as Record<string, unknown>).text as string ?? null
         : String(value);
 
+    case 'url':
+      // CMS 'link' fields store a CollectionLinkValue JSON object, not a raw URL.
+      return cmsType === 'link' ? toLinkValueJson(value, airtableType) : String(value);
+
     case 'button': {
       if (typeof value !== 'object' || value === null) return null;
       const btn = value as Record<string, unknown>;
-      if (cmsType === 'link') return btn.url as string ?? null;
+      if (cmsType === 'link') return toLinkValueJson(value, airtableType);
       return btn.label as string ?? null;
     }
 
     default:
+      // singleLineText / formula mapped to a 'link' field need link-value JSON.
+      if (cmsType === 'link') return toLinkValueJson(value, airtableType);
       return typeof value === 'object' ? JSON.stringify(value) : String(value);
   }
+}
+
+/** Wrap a link-compatible Airtable value into a CollectionLinkValue JSON string */
+function toLinkValueJson(value: unknown, airtableType: AirtableFieldType): string | null {
+  let url: string | null = null;
+  if (airtableType === 'button') {
+    const btnUrl = typeof value === 'object' && value !== null
+      ? (value as Record<string, unknown>).url
+      : null;
+    url = typeof btnUrl === 'string' && btnUrl.trim() ? btnUrl.trim() : null;
+  } else if (typeof value !== 'object') {
+    url = String(value).trim() || null;
+  }
+  if (!url) return null;
+  const linkValue: CollectionLinkValue = { type: 'url', url };
+  return JSON.stringify(linkValue);
 }
 
 function extractAttachmentUrl(value: unknown): string | null {


### PR DESCRIPTION
## Summary

Airtable URL (and button) fields mapped to a Ycode CMS `link` field were being stored as raw URL strings. The `link` field type expects a `CollectionLinkValue` JSON object, so synced links appeared empty in the builder CMS table and link picker. This wraps link-bound values into the correct shape.

## Changes

- Wrap Airtable `url`, `button`, `singleLineText`, and `formula` values into a `CollectionLinkValue` (`{ type: 'url', url }`) when the target CMS field is `link`
- Add a `toLinkValueJson` helper to extract the URL from each source type
- Leave non-link mappings unchanged (URLs still stored as plain strings for text fields)

## Test plan

- [ ] Map an Airtable URL field to a CMS link field and sync — link shows correctly in the CMS table and is editable in the item editor
- [ ] Verify the link resolves to the correct href on the published page
- [ ] Map an Airtable button field to a link field — uses the button URL
- [ ] Re-sync unchanged records — no spurious updates
- [ ] Re-sync records previously stored as plain URL strings — values self-heal to the link-value shape
- [ ] Empty URL / button without URL — field stays unset (shows `-`)