### PR TITLE
fix: reset animations section when selecting a new layer

### DIFF
--- a/app/(builder)/ycode/components/InteractionsPanel.tsx
+++ b/app/(builder)/ycode/components/InteractionsPanel.tsx
@@ -847,6 +847,20 @@ export default function InteractionsPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedInteractionId]);
 
+  // Reverse sync: when the trigger is locked (event selected) and the selected layer
+  // changes, select the matching animated layer in the Animations section, or clear
+  // the selection when the layer is not animated
+  useEffect(() => {
+    if (!selectedInteractionId) return;
+    const interaction = interactions.find((i) => i.id === selectedInteractionId);
+    const tweens = interaction?.tweens || [];
+    // Keep current selection if it already targets the layer (supports multiple tweens per layer)
+    const currentTween = tweens.find((t) => t.id === selectedTweenId);
+    if (currentTween && currentTween.layer_id === selectedLayerId) return;
+    const matchingTween = tweens.find((t) => t.layer_id === selectedLayerId);
+    setSelectedTweenId(matchingTween ? matchingTween.id : null);
+  }, [selectedLayerId, selectedInteractionId, selectedTweenId, interactions]);
+
   // Notify parent about state changes
   useEffect(() => {
     onStateChange?.({
@@ -1709,6 +1723,11 @@ export default function InteractionsPanel({
               <Button
                 size="xs"
                 variant="secondary"
+                className={cn(
+                  selectedLayerId &&
+                    !(selectedInteraction.tweens || []).some((t) => t.layer_id === selectedLayerId) &&
+                    'bg-teal-500/50 text-white hover:bg-teal-500/60'
+                )}
                 onClick={handleAddTween}
                 disabled={!selectedLayerId}
               >


### PR DESCRIPTION
## Summary

When editing interactions, the Animations section did not react to the
layer selected on canvas. This makes the panel keep stale selections and
forces users to edit animations for the wrong layer. Now, while a trigger
event is selected (trigger layer locked), selecting a layer syncs the
Animations section to that layer.

Closes #284

## Changes

- Auto-select the matching animated layer in the Animations section when the selected layer is animated
- Clear the animated layer selection when the selected layer is not animated
- Highlight the add (+) button (teal) when the selected layer can be added as an animation

## Test plan

- [ ] Open Interactions, create an event on a layer (trigger gets locked)
- [ ] Add an animation targeting a child layer
- [ ] Select that animated layer on canvas/tree — its animation is selected in the Animations section
- [ ] Select a non-animated layer — no animation is selected, add button turns teal
- [ ] Select an already-animated layer — add button stays default