### PR TITLE
feat: make component override values translatable

### DIFF
--- a/app/(builder)/ycode/components/LocalizationContent.tsx
+++ b/app/(builder)/ycode/components/LocalizationContent.tsx
@@ -33,6 +33,9 @@ interface LocalizationContentProps {
   children: React.ReactNode;
 }
 
+// Minimum number of characters before a search query is applied.
+const MIN_SEARCH_LENGTH = 2;
+
 interface ModalState {
   isOpen: boolean;
   isEditMode: boolean;
@@ -124,6 +127,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
   const [searchQuery, setSearchQuery] = useState<string>(() => {
     return searchParams?.get('search') || '';
   });
+  const isSearchActive = searchQuery.trim().length >= MIN_SEARCH_LENGTH;
   const [expandedPages, setExpandedPages] = useState<Set<string>>(new Set());
   // Local input values for immediate UI feedback (keyed by item.key)
   const [localInputValues, setLocalInputValues] = useState<Record<string, string>>({});
@@ -240,8 +244,8 @@ export default function LocalizationContent({ children }: LocalizationContentPro
         }
       }
 
-      // Filter by search query
-      if (searchQuery.trim()) {
+      // Filter by search query (requires a minimum query length)
+      if (isSearchActive) {
         const query = searchQuery.toLowerCase().trim();
         const originalContent = item.content_value?.toLowerCase() || '';
         const label = item.info?.label?.toLowerCase() || '';
@@ -334,12 +338,51 @@ export default function LocalizationContent({ children }: LocalizationContentPro
     });
   }, [storeFolders]);
 
-  // Initialize expanded pages when pages change
-  useEffect(() => {
-    if (sortedPages.length > 0 && expandedPages.size === 0) {
-      setExpandedPages(new Set(sortedPages.map(p => p.id)));
+  // Ordered ids of the collapsible sections for the active content type.
+  // Pages and CMS items share the same accordion/expansion behaviour.
+  const sectionIds = useMemo(() => {
+    if (selectedContentType === 'cms') {
+      return collections.flatMap(collection =>
+        (items[collection.id] || [])
+          .filter(item => !item.is_published)
+          .map(item => item.id)
+      );
     }
-  }, [sortedPages, expandedPages.size]);
+    return sortedPages.map(p => p.id);
+  }, [selectedContentType, collections, items, sortedPages]);
+
+  // Expand only the first section by default — rendering every section's
+  // translation rows at once slows the page considerably. Re-initialises when
+  // the content type changes (so switching to CMS expands its first item),
+  // but collapsing sections within a type doesn't re-trigger the auto-expand.
+  const initializedExpandedType = useRef<string | null>(null);
+  useEffect(() => {
+    if (initializedExpandedType.current === selectedContentType) return;
+    if (sectionIds.length === 0) return;
+    // Respect a deep-linked search: expand all when active, else first only.
+    setExpandedPages(
+      isSearchActive ? new Set(sectionIds) : new Set([sectionIds[0]])
+    );
+    initializedExpandedType.current = selectedContentType;
+  }, [selectedContentType, sectionIds, isSearchActive]);
+
+  // Update the search query and adjust section expansion in the SAME batched
+  // update. Doing this in a follow-up effect would briefly render an
+  // intermediate state (search inactive but all sections still expanded ⇒
+  // every section's items rendered at once), which is very slow on large sites.
+  // While searching, expand all sections so matches are visible; when search
+  // drops below the threshold, collapse back to just the first (accordion).
+  const handleSearchChange = (value: string) => {
+    const nowActive = value.trim().length >= MIN_SEARCH_LENGTH;
+    if (nowActive !== isSearchActive) {
+      setExpandedPages(
+        nowActive
+          ? new Set(sectionIds)
+          : new Set(sectionIds.length > 0 ? [sectionIds[0]] : [])
+      );
+    }
+    setSearchQuery(value);
+  };
 
   // Build full page path segments for display
   const getPagePathSegments = (page: typeof sortedPages[0]): string[] => {
@@ -348,17 +391,51 @@ export default function LocalizationContent({ children }: LocalizationContentPro
     return [...folderSegments, page.name];
   };
 
+  // Refs for scrolling a freshly-expanded section to the top of the viewport.
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const sectionRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const pendingScrollPageId = useRef<string | null>(null);
+
   const togglePageExpansion = (pageId: string) => {
     setExpandedPages(prev => {
       const next = new Set(prev);
       if (next.has(pageId)) {
         next.delete(pageId);
       } else {
+        // Accordion: only one section open at a time, unless a search is
+        // active (then matching sections can stay expanded together).
+        if (!isSearchActive) {
+          next.clear();
+        }
         next.add(pageId);
+        // Scroll this section to the top once it's expanded (and others
+        // collapsed) — handled in an effect after the layout settles.
+        pendingScrollPageId.current = pageId;
       }
       return next;
     });
   };
+
+  // After expansion changes, scroll the just-expanded section's header just
+  // below the sticky toolbar. rAF waits for the collapse/expand layout shift.
+  useEffect(() => {
+    const pageId = pendingScrollPageId.current;
+    if (!pageId) return;
+    pendingScrollPageId.current = null;
+
+    const container = scrollContainerRef.current;
+    const section = sectionRefs.current.get(pageId);
+    if (!container || !section) return;
+
+    requestAnimationFrame(() => {
+      const TOOLBAR_HEIGHT = 64; // sticky toolbar (h-16)
+      const delta =
+        section.getBoundingClientRect().top -
+        container.getBoundingClientRect().top -
+        TOOLBAR_HEIGHT;
+      container.scrollTo({ top: container.scrollTop + delta, behavior: 'smooth' });
+    });
+  }, [expandedPages]);
 
   // Helper functions for managing local input values
   const handleLocalValueChange = (key: string, value: string) => {
@@ -543,7 +620,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 overflow-y-auto">
+      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
         {selectedLocale ? (
           <div className="flex flex-col min-h-full">
             <div className="sticky top-0 z-10 h-16 bg-background p-4 flex items-center gap-2 border-b">
@@ -580,7 +657,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                   <InputGroupInput
                     placeholder="Search..."
                     value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onChange={(e) => handleSearchChange(e.target.value)}
                   />
                   <InputGroupAddon>
                     <Icon name="search" className="size-3" />
@@ -638,7 +715,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                         const draft = draftsByPageId[page.id];
                         const layers = draft?.layers || [];
                         const selectedLocale = locales.find(l => l.id === selectedLocaleId);
-                        const translatableItems = extractPageTranslatableItems(page, layers, selectedLocale);
+                        const translatableItems = extractPageTranslatableItems(page, layers, selectedLocale, storeComponents);
                         const filteredItems = filterTranslatableItems(translatableItems);
 
                         if (filteredItems.length === 0) {
@@ -648,9 +725,15 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                         const isExpanded = expandedPages.has(page.id);
 
                         return (
-                          <div key={page.id}>
+                          <div
+                            key={page.id}
+                            ref={(el) => {
+                              if (el) sectionRefs.current.set(page.id, el);
+                              else sectionRefs.current.delete(page.id);
+                            }}
+                          >
                             <header
-                              className="sticky top-16 z-[5] border-b cursor-pointer bg-background"
+                              className="sticky top-16 z-5 border-b cursor-pointer bg-background"
                               onClick={() => togglePageExpansion(page.id)}
                             >
                               <div className="p-4 flex items-center gap-1.5 bg-secondary/10 hover:bg-secondary/35 transition-colors">
@@ -666,7 +749,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                                   <Icon name={getPageIcon(page)} className="size-3 opacity-60" />
                                 </div>
 
-                                <Label className="flex items-center gap-1">
+                                <Label className="flex items-center gap-1 cursor-pointer">
                                   {getPagePathSegments(page).map((segment, index, array) => (
                                     <React.Fragment key={index}>
                                       <span>{segment}</span>
@@ -739,7 +822,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
 
                           return (
                           <div key={folder.id}>
-                            <header className="sticky top-16 z-[5] border-b bg-background">
+                            <header className="sticky top-16 z-5 border-b bg-background">
                               <div className="p-4 flex items-center gap-1.5 bg-secondary/10">
                                 <div className="size-5.5 flex items-center justify-center rounded-[6px] bg-secondary/50">
                                   <Icon name="folder" className="size-3 opacity-60" />
@@ -820,7 +903,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
 
                         return (
                           <div key={component.id}>
-                            <header className="sticky top-16 z-[5] border-b bg-background">
+                            <header className="sticky top-16 z-5 border-b bg-background">
                               <div className="p-4 flex items-center gap-1.5 bg-secondary/10">
                                 <div className="size-5.5 flex items-center justify-center rounded-[6px] bg-secondary/50">
                                   <Icon name="component" className="size-3 opacity-60" />
@@ -900,15 +983,34 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                           const nameField = collectionFields.find(f => f.type === 'text' && f.fillable);
                           const itemName = nameField ? item.values[nameField.id] || item.id.substring(0, 8) : item.id.substring(0, 8);
 
+                          const isExpanded = expandedPages.has(item.id);
+
                           return (
-                            <div key={item.id}>
-                              <header className="sticky top-16 z-[5] border-b bg-background">
-                                <div className="p-4 flex items-center gap-1.5 bg-secondary/10">
+                            <div
+                              key={item.id}
+                              ref={(el) => {
+                                if (el) sectionRefs.current.set(item.id, el);
+                                else sectionRefs.current.delete(item.id);
+                              }}
+                            >
+                              <header
+                                className="sticky top-16 z-5 border-b cursor-pointer bg-background"
+                                onClick={() => togglePageExpansion(item.id)}
+                              >
+                                <div className="p-4 flex items-center gap-1.5 bg-secondary/10 hover:bg-secondary/35 transition-colors">
+                                  <Icon
+                                    name="chevronRight"
+                                    className={cn(
+                                      'size-3 transition-transform',
+                                      isExpanded && 'rotate-90'
+                                    )}
+                                  />
+
                                   <div className="size-5.5 flex items-center justify-center rounded-[6px] bg-secondary/50">
                                     <Icon name="database" className="size-3 opacity-60" />
                                   </div>
 
-                                  <Label>{collection.name} <span className="text-muted-foreground">›</span> {itemName}</Label>
+                                  <Label className="cursor-pointer">{collection.name} <span className="text-muted-foreground">›</span> {itemName}</Label>
 
                                   <span className="flex items-center gap-1.5 ml-auto text-xs text-muted-foreground">
                                   <span>{defaultLocale?.label}</span>
@@ -917,29 +1019,32 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                                 </span>
                                 </div>
                               </header>
-                              <ul className="border-b px-4 py-5 flex flex-col gap-5">
-                                {filteredItems.map((transItem) => (
-                                  <TranslationRow
-                                    key={transItem.key}
-                                    item={transItem}
-                                    selectedLocaleId={selectedLocaleId}
-                                    localInputValues={localInputValues}
-                                    onLocalValueChange={handleLocalValueChange}
-                                    onLocalValueClear={handleLocalValueClear}
-                                    getTranslationByKey={getTranslationByKey}
-                                    createTranslation={createTranslation}
-                                    updateTranslation={updateTranslation}
-                                    updateTranslationValue={updateTranslationValue}
-                                    updateTranslationStatus={updateTranslationStatus}
-                                    deleteTranslation={deleteTranslation}
-                                    allFields={allFields}
-                                    collections={collections}
-                                    pages={storePages}
-                                    folders={storeFolders}
-                                    sourceItem={undefined}
-                                  />
-                                ))}
-                              </ul>
+
+                              {isExpanded && (
+                                <ul className="border-b px-4 py-5 flex flex-col gap-5">
+                                  {filteredItems.map((transItem) => (
+                                    <TranslationRow
+                                      key={transItem.key}
+                                      item={transItem}
+                                      selectedLocaleId={selectedLocaleId}
+                                      localInputValues={localInputValues}
+                                      onLocalValueChange={handleLocalValueChange}
+                                      onLocalValueClear={handleLocalValueClear}
+                                      getTranslationByKey={getTranslationByKey}
+                                      createTranslation={createTranslation}
+                                      updateTranslation={updateTranslation}
+                                      updateTranslationValue={updateTranslationValue}
+                                      updateTranslationStatus={updateTranslationStatus}
+                                      deleteTranslation={deleteTranslation}
+                                      allFields={allFields}
+                                      collections={collections}
+                                      pages={storePages}
+                                      folders={storeFolders}
+                                      sourceItem={undefined}
+                                    />
+                                  ))}
+                                </ul>
+                              )}
                             </div>
                           );
                         }).filter(Boolean);

--- a/app/(builder)/ycode/components/TranslationRow.tsx
+++ b/app/(builder)/ycode/components/TranslationRow.tsx
@@ -9,6 +9,8 @@ import RichTextEditorSheet from './RichTextEditorSheet';
 import type { FieldGroup } from './CollectionFieldSelector';
 import FileManagerDialog from './FileManagerDialog';
 import { sanitizeSlug, checkDuplicatePageSlug, checkDuplicateFolderSlug, type ValidationResult } from '@/lib/page-utils';
+import { looksLikeTiptapJson } from '@/lib/localisation-utils';
+import { tiptapDocToCanonicalString } from '@/lib/tiptap-utils';
 import { parseValueToContent } from '@/lib/cms-variables-utils';
 import { flattenFieldGroups, SIMPLE_TEXT_FIELD_TYPES } from '@/lib/collection-field-utils';
 import type { TranslatableItem } from '@/lib/localisation-utils';
@@ -112,10 +114,16 @@ export default function TranslationRow({
     }
   }
 
-  // Use local value if available, otherwise use store value
-  const translationValue = localInputValues[item.key] !== undefined
+  // Use local value if available, otherwise use store value.
+  // Guard against content_type/value-shape mismatches: a plain-text item may
+  // carry a legacy translation stored as a Tiptap JSON doc string — flatten it
+  // to plain text so the cell shows readable content instead of raw JSON.
+  const rawTranslationValue = localInputValues[item.key] !== undefined
     ? localInputValues[item.key]
     : storeValue;
+  const translationValue = !isRichText && looksLikeTiptapJson(rawTranslationValue)
+    ? tiptapDocToCanonicalString(JSON.parse(rawTranslationValue))
+    : rawTranslationValue;
 
   // For rich text, parse JSON string to Tiptap JSON object for RichTextEditor
   let translationValueForEditor: string | any = translationValue;
@@ -500,7 +508,7 @@ export default function TranslationRow({
 
     return (
       <>
-        <div className={`size-8 rounded overflow-hidden flex-shrink-0 flex items-center justify-center relative`}>
+        <div className={`size-8 rounded overflow-hidden shrink-0 flex items-center justify-center relative isolate`}>
           {/* Checkerboard pattern for transparency - only for images and icons */}
           {showCheckerboard
             ? <div className="absolute inset-0 opacity-10 bg-checkerboard" />
@@ -543,11 +551,29 @@ export default function TranslationRow({
     <li key={item.key} className="flex flex-col gap-1.5">
       {/* Item header */}
       <div className="flex items-center gap-1.75">
-        <div className="size-5 flex items-center justify-center rounded-[6px] bg-secondary/50">
-          <Icon name={item.info.icon} className="shrink-0 size-2.5 opacity-50" />
-        </div>
+        {item.info.segments && item.info.segments.length > 0 ? (
+          <div className="flex items-center gap-1.25">
+            {item.info.segments.map((segment, index) => (
+              <React.Fragment key={index}>
+                {index > 0 && (
+                  <Icon name="chevronRight" className="shrink-0 size-2.5 opacity-40" />
+                )}
+                <div className="size-5 flex items-center justify-center rounded-[6px] bg-secondary/50">
+                  <Icon name={segment.icon} className="shrink-0 size-2.5 opacity-50" />
+                </div>
+                <span className="text-xs font-medium opacity-60">{segment.label}</span>
+              </React.Fragment>
+            ))}
+          </div>
+        ) : (
+          <>
+            <div className="size-5 flex items-center justify-center rounded-[6px] bg-secondary/50">
+              <Icon name={item.info.icon} className="shrink-0 size-2.5 opacity-50" />
+            </div>
 
-        <span className="text-xs font-medium opacity-60">{item.info.label}</span>
+            <span className="text-xs font-medium opacity-60">{item.info.label}</span>
+          </>
+        )}
 
         {item.info.description && (
           <>
@@ -621,7 +647,7 @@ export default function TranslationRow({
                 onClick={() => setIsRichTextSheetOpen(true)}
               >
                 {isRichTextTranslationEmpty ? (
-                  <div className="min-h-[28px] px-2.5 py-1 flex items-center">
+                  <div className="min-h-7 px-2.5 py-1 flex items-center">
                     <span className="text-muted-foreground/50 text-xs">
                       {translation?.is_completed === true ? '(Using original)' : 'Click to edit...'}
                     </span>
@@ -652,7 +678,7 @@ export default function TranslationRow({
                     ? '(Using original)'
                     : (originalPreviewText || 'Enter translation...')
                 }
-                className={`min-h-[28px] [&_.ProseMirror]:py-1 [&_.ProseMirror]:px-2.5 [&_.ProseMirror]:!bg-transparent`}
+                className={`min-h-7 [&_.ProseMirror]:py-1 [&_.ProseMirror]:px-2.5 [&_.ProseMirror]:bg-transparent!`}
                 fieldGroups={fieldGroups}
                 allFields={allFields}
                 collections={collections}
@@ -670,8 +696,8 @@ export default function TranslationRow({
                     ? '(Using original)'
                     : (originalPreviewText || 'Enter translation...')
                 }
-                className={`min-h-[28px] [&_.ProseMirror]:py-1 [&_.ProseMirror]:px-2.5 [&_.ProseMirror]:!bg-transparent ${
-                  validationError ? '[&_.ProseMirror]:!border-destructive' : ''
+                className={`min-h-7 [&_.ProseMirror]:py-1 [&_.ProseMirror]:px-2.5 [&_.ProseMirror]:bg-transparent! ${
+                  validationError ? '[&_.ProseMirror]:border-destructive!' : ''
                 }`}
                 fieldGroups={fieldGroups}
                 allFields={allFields}
@@ -686,8 +712,10 @@ export default function TranslationRow({
         </div>
       </div>
 
-      {/* Asset Picker Dialog */}
-      {isAsset && (
+      {/* Asset Picker Dialog — only mount when open. FileManagerDialog fetches
+          the asset list on mount regardless of `open`, so keeping one mounted
+          per asset row would fire a redundant request for every row. */}
+      {isAsset && isAssetPickerOpen && (
         <FileManagerDialog
           open={isAssetPickerOpen}
           onOpenChange={setIsAssetPickerOpen}

--- a/lib/localisation-utils.ts
+++ b/lib/localisation-utils.ts
@@ -1,4 +1,4 @@
-import type { Layer, Page, Translation, Locale, LocaleOption, CollectionField } from '@/types';
+import type { Layer, Page, Translation, Locale, LocaleOption, CollectionField, Component, ComponentVariable, DynamicTextVariable, DynamicRichTextVariable } from '@/types';
 import { getLayerIcon, getLayerName } from '@/lib/layer-display-utils';
 import {
   buildLayerTranslationKey,
@@ -9,6 +9,7 @@ import {
 import { createDynamicTextVariable, createDynamicRichTextVariable, createDynamicRichTextVariableFromPlainText, createAssetVariable } from '@/lib/variable-utils';
 import { castValue } from '@/lib/collection-utils';
 import { tiptapDocHasFormatting, tiptapDocToCanonicalString, hasVariableNode, hasAnyTextOrVariable } from '@/lib/tiptap-utils';
+import { stringToTiptapContent } from '@/lib/text-format-utils';
 import { isRichTextLayer } from '@/lib/layer-utils';
 import { looksLikeFormattedHtml } from '@/lib/translation-classification';
 import type { IconProps } from '@/components/ui/icon';
@@ -282,6 +283,9 @@ export interface TranslatableItem {
     icon: IconProps['name']; // Icon name for the item
     label: string; // Item label (e.g., "SEO Title", "Heading")
     description?: string; // Optional item description
+    // Optional breadcrumb segments rendered inline (icon + label, › separated).
+    // Used by component override rows: "[component] Name › [type] Variable".
+    segments?: Array<{ icon: IconProps['name']; label: string }>;
   }
 }
 
@@ -321,23 +325,17 @@ export function extractImageAltText(layer: Layer): string | null {
  * format for `text` content, and the JSON-stringified Tiptap doc for
  * `richtext` content, so downstream rendering is unambiguous.
  */
-function classifyLayerTextForTranslation(
-  layer: Layer
+function classifyTextVariableForTranslation(
+  textVariable: DynamicTextVariable | DynamicRichTextVariable | undefined | null,
+  isRichSource: boolean
 ): { contentType: 'text' | 'richtext'; value: string; openInSheet: boolean } | null {
-  const textVariable = layer.variables?.text;
   if (!textVariable) return null;
-
-  // Only true rich-text layers (block-level editor with paragraphs/headings/
-  // lists) open in the doc-style sheet. Simple text/heading layers flatten
-  // multi-paragraph content to line breaks on canvas, so the translation
-  // editor should stay inline and compact to match.
-  const isRichLayer = isRichTextLayer(layer);
 
   if (textVariable.type === 'dynamic_text') {
     const text = textVariable.data.content;
     if (!text || typeof text !== 'string' || !text.trim()) return null;
     if (looksLikeFormattedHtml(text) || text.includes('<ycode-inline-variable>')) {
-      return { contentType: 'richtext', value: text.trim(), openInSheet: isRichLayer };
+      return { contentType: 'richtext', value: text.trim(), openInSheet: isRichSource };
     }
     return { contentType: 'text', value: text.trim(), openInSheet: false };
   }
@@ -349,7 +347,7 @@ function classifyLayerTextForTranslation(
     if (tiptapDocHasFormatting(doc) || hasVariableNode(doc)) {
       const json = JSON.stringify(doc);
       if (!hasAnyTextOrVariable(doc)) return null;
-      return { contentType: 'richtext', value: json, openInSheet: isRichLayer };
+      return { contentType: 'richtext', value: json, openInSheet: isRichSource };
     }
 
     const canonical = tiptapDocToCanonicalString(doc).trim();
@@ -358,6 +356,16 @@ function classifyLayerTextForTranslation(
   }
 
   return null;
+}
+
+function classifyLayerTextForTranslation(
+  layer: Layer
+): { contentType: 'text' | 'richtext'; value: string; openInSheet: boolean } | null {
+  // Only true rich-text layers (block-level editor with paragraphs/headings/
+  // lists) open in the doc-style sheet. Simple text/heading layers flatten
+  // multi-paragraph content to line breaks on canvas, so the translation
+  // editor should stay inline and compact to match.
+  return classifyTextVariableForTranslation(layer.variables?.text as any, isRichTextLayer(layer));
 }
 
 /**
@@ -445,13 +453,117 @@ function extractMediaTranslatableItems(
 }
 
 /**
- * Recursively extract all translatable text items from layers
+ * Extract translatable items from a component instance's `componentOverrides`.
+ *
+ * Per-instance overrides are page-scoped: each instance can be translated
+ * independently. Keys mirror what `translateComponentOverrides` consumes at
+ * render time:
+ *   - `layer:<instanceId>:override:text:<varId>`
+ *   - `layer:<instanceId>:override:rich_text:<varId>`
+ *   - `layer:<instanceId>:override:image_src:<varId>`
+ *   - `layer:<instanceId>:override:image_alt:<varId>`
+ */
+function extractComponentOverrideTranslatableItems(
+  layer: Layer,
+  pageId: string,
+  componentsById: Map<string, Component> | undefined,
+  items: TranslatableItem[]
+): void {
+  const overrides = layer.componentOverrides;
+  if (!overrides || !layer.componentId) return;
+
+  const component = componentsById?.get(layer.componentId);
+  const componentName = component?.name || getLayerName(layer);
+  const getVar = (varId: string): ComponentVariable | undefined =>
+    component?.variables?.find(v => v.id === varId);
+
+  // Build the item `info`: a flattened label (for search) plus inline
+  // breadcrumb segments "[component] Name › [type] Variable".
+  const buildInfo = (
+    variableLabel: string,
+    typeIcon: IconProps['name']
+  ): TranslatableItem['info'] => ({
+    icon: 'component',
+    label: `${componentName} › ${variableLabel}`,
+    segments: [
+      { icon: 'component', label: componentName },
+      { icon: typeIcon, label: variableLabel },
+    ],
+  });
+
+  // Text and rich-text overrides
+  for (const category of ['text', 'rich_text'] as const) {
+    const catOverrides = overrides[category];
+    if (!catOverrides) continue;
+
+    for (const [varId, value] of Object.entries(catOverrides)) {
+      const classification = classifyTextVariableForTranslation(
+        value as DynamicTextVariable | DynamicRichTextVariable,
+        category === 'rich_text'
+      );
+      if (!classification) continue;
+
+      const variableName = getVar(varId)?.name || getLayerName(layer);
+      items.push({
+        key: `page:${pageId}:layer:${layer.id}:override:${category}:${varId}`,
+        source_type: 'page',
+        source_id: pageId,
+        content_key: `layer:${layer.id}:override:${category}:${varId}`,
+        content_type: classification.contentType,
+        content_value: classification.value,
+        open_in_sheet: classification.openInSheet,
+        info: buildInfo(variableName, classification.contentType === 'richtext' ? 'type' : 'text'),
+      });
+    }
+  }
+
+  // Image overrides (source asset + alt text)
+  const imageOverrides = overrides.image;
+  if (imageOverrides) {
+    for (const [varId, value] of Object.entries(imageOverrides)) {
+      const imageValue = value as any;
+      const variableName = getVar(varId)?.name || getLayerName(layer);
+
+      const src = imageValue?.src;
+      if (src && src.type === 'asset' && src.data?.asset_id) {
+        items.push({
+          key: `page:${pageId}:layer:${layer.id}:override:image_src:${varId}`,
+          source_type: 'page',
+          source_id: pageId,
+          content_key: `layer:${layer.id}:override:image_src:${varId}`,
+          content_type: 'asset_id',
+          content_value: src.data.asset_id,
+          info: buildInfo(`${variableName} (source)`, 'image'),
+        });
+      }
+
+      const alt = imageValue?.alt;
+      if (alt && alt.type === 'dynamic_text' && typeof alt.data?.content === 'string' && alt.data.content.trim()) {
+        items.push({
+          key: `page:${pageId}:layer:${layer.id}:override:image_alt:${varId}`,
+          source_type: 'page',
+          source_id: pageId,
+          content_key: `layer:${layer.id}:override:image_alt:${varId}`,
+          content_type: 'text',
+          content_value: alt.data.content.trim(),
+          info: buildInfo(`${variableName} (alt text)`, 'text'),
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Recursively extract all translatable text items from layers.
+ * When `componentsById` is provided (page context only), per-instance
+ * component overrides are surfaced as page-scoped translatable items.
  */
 function extractLayerTranslatableItems(
   layers: Layer[],
   sourceType: 'page' | 'component',
   sourceId: string,
-  items: TranslatableItem[]
+  items: TranslatableItem[],
+  componentsById?: Map<string, Component>
 ): void {
   for (const layer of layers) {
     // The locale-selector label renders the active locale name dynamically and
@@ -480,8 +592,13 @@ function extractLayerTranslatableItems(
 
     extractMediaTranslatableItems(layer, sourceType, sourceId, items);
 
+    // Component instance overrides are page-scoped and translated per instance.
+    if (sourceType === 'page' && layer.componentId && layer.componentOverrides) {
+      extractComponentOverrideTranslatableItems(layer, sourceId, componentsById, items);
+    }
+
     if (layer.children && Array.isArray(layer.children) && layer.children.length > 0) {
-      extractLayerTranslatableItems(layer.children, sourceType, sourceId, items);
+      extractLayerTranslatableItems(layer.children, sourceType, sourceId, items, componentsById);
     }
   }
 }
@@ -547,7 +664,8 @@ function extractSeoItems(
 export function extractPageTranslatableItems(
   page: Page,
   layers: Layer[],
-  locale?: Locale
+  locale?: Locale,
+  components?: Component[]
 ): TranslatableItem[] {
   const items: TranslatableItem[] = [];
 
@@ -572,9 +690,12 @@ export function extractPageTranslatableItems(
   // 2. Extract SEO items (second)
   extractSeoItems(page.id, page.settings?.seo, items);
 
-  // 3. Extract layer texts (third)
+  // 3. Extract layer texts (third), including per-instance component overrides
   if (layers && Array.isArray(layers) && layers.length > 0) {
-    extractLayerTranslatableItems(layers, 'page', page.id, items);
+    const componentsById = components
+      ? new Map(components.map(c => [c.id, c]))
+      : undefined;
+    extractLayerTranslatableItems(layers, 'page', page.id, items, componentsById);
   }
 
   return items;
@@ -800,12 +921,20 @@ export function injectTranslatedText(
       // Tiptap JSON into a `dynamic_text` variable would render as literal JSON.
       // The renderer handles `dynamic_rich_text` on simple text/heading layers
       // by flattening paragraphs into the layer's single tag.
-      if (textTranslation?.content_type === 'richtext') {
+      // Drive the injected variable type off the actual value shape, not the
+      // stored `content_type` — legacy/mismatched rows can disagree (a `text`
+      // row holding a Tiptap JSON doc, or a `richtext` row holding plain text).
+      // This keeps generated pages correct regardless of the stored type.
+      if (looksLikeTiptapJson(textValue)) {
+        // Serialized Tiptap doc → rich content. The renderer flattens it for
+        // simple text/heading layers, so this is safe even when the source is
+        // a `dynamic_text` layer. Avoids rendering raw JSON as visible text.
         (variableUpdates as any).text = createDynamicRichTextVariable(textValue);
       } else if (layer.variables?.text?.type === 'dynamic_rich_text') {
-        // Plain-text translation for a rich-text source: avoid noisy JSON.parse.
+        // Plain-text value for a rich-text source: convert without JSON.parse.
         (variableUpdates as any).text = createDynamicRichTextVariableFromPlainText(textValue);
       } else {
+        // Plain-text value for a simple text source.
         (variableUpdates as any).text = createDynamicTextVariable(textValue);
       }
     }
@@ -932,10 +1061,18 @@ export function translateComponentOverrides(
         const next: Record<string, any> = {};
         for (const [varId, value] of Object.entries(catOverrides)) {
           const v = lookup(`layer:${layer.id}:override:${category}:${varId}`);
-          if (v !== undefined && value && typeof value === 'object' && 'data' in (value as any)) {
-            const isRich = category === 'rich_text';
-            const content = isRich ? safeParseJson(v) : v;
-            next[varId] = { ...(value as any), data: { ...(value as any).data, content } };
+          const val = value as any;
+          if (v !== undefined && val && typeof val === 'object' && 'data' in val) {
+            // The stored override value's own type dictates the content shape,
+            // NOT the override category: text overrides are persisted as
+            // `dynamic_rich_text` (a Tiptap doc) even for plain `text`
+            // variables. Writing a bare string into a `dynamic_rich_text`
+            // value would render as empty, so convert plain translations into
+            // a Tiptap doc and parse serialized docs.
+            const content = val.type === 'dynamic_rich_text'
+              ? (looksLikeTiptapJson(v) ? safeParseJson(v) : stringToTiptapContent(v))
+              : v;
+            next[varId] = { ...val, data: { ...val.data, content } };
             categoryMutated = true;
           } else {
             next[varId] = value;
@@ -992,6 +1129,23 @@ function safeParseJson(value: string): unknown {
     return JSON.parse(value);
   } catch {
     return value;
+  }
+}
+
+/**
+ * Whether a translation value string looks like a serialized Tiptap document
+ * (rich text). Used to decide between JSON-parsing and treating the value as
+ * plain text, guarding against content_type / value-shape mismatches.
+ */
+export function looksLikeTiptapJson(value: string | null | undefined): boolean {
+  if (!value || typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return false;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return !!parsed && typeof parsed === 'object';
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary

Component instances can override their master component's content (text, rich text, images), but those overridden values weren't translatable. This makes them translatable end-to-end and improves the localization page UX for large sites.

## Changes

- Extract translatable items from page-scoped component overrides (text, rich text, image source/alt), labelled as `component › variable` with matching icons
- Drive text/rich-text injection by content shape so plain strings and Tiptap JSON are both handled — fixes a `JSON.parse` crash when switching locale on the canvas, and applies on generated/exported pages too
- Flatten stray Tiptap JSON to plain text in non-rich-text rows so raw JSON never shows in the UI
- Add accordion expansion to Pages and CMS items: only the first section opens by default, one section open at a time, smooth scroll-to-top on expand, and a 2-character minimum search that expands matches
- Mount the asset picker dialog only when open to stop a flood of asset requests
- Isolate the asset preview so its image no longer paints over sticky section headers

## Test plan

- [ ] Override text/rich-text/image on a component instance, then translate those values in the localization page and verify they render on canvas and generated pages
- [ ] Switch to a non-default locale on the canvas — no `JSON.parse` error
- [ ] Confirm no raw JSON appears in translation rows
- [ ] Pages and CMS tabs: only first section expanded by default, expanding one collapses the other and scrolls to top
- [ ] Search with 2+ chars expands matches; dropping to 1 char collapses back
- [ ] Open the asset picker and confirm assets load only then
- [ ] Scroll a section with image translations — preview stays under the sticky header