### PR TITLE
feat: make MCP translations reliable end-to-end

### DIFF
--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -520,10 +520,34 @@ Example: \`search_google_fonts({ query: "playfair" })\` → \`add_font({ family:
 Multi-language support:
 - Use list_locales to see configured languages
 - Use create_locale with ISO 639-1 code (e.g. "fr", "de", "ja")
+- Use list_translatable_content FIRST to discover exactly what can be translated for a page/component/cms collection — it returns the precise source_type/source_id/content_key/content_type plus the current source value (and existing translation when locale_id is passed). Don't guess content keys.
 - Use set_translation to translate plain-text content for a locale
-- Use set_rich_text_translation with structured blocks for richText fields (skips hand-assembling Tiptap JSON)
-- Use batch_set_translations for bulk translations
+- Use set_rich_text_translation with structured blocks for rich_text fields (skips hand-assembling Tiptap JSON)
+- Use batch_set_translations for bulk plain-text translations
 - Each translation targets a source (page/component/cms) + content_key
+
+**IMPORTANT — completion & publishing:**
+- Translations are marked complete by default (\`is_completed: true\`). Only pass \`is_completed: false\` for work-in-progress drafts — incomplete translations are saved but NEVER appear on the live site.
+- Translations are drafts until published. After translating, call \`publish\`. \`get_unpublished_changes\` reports pending translation/locale counts.
+
+**Finding what to translate (content_key formats):**
+- **Pages/components — layer text:** \`content_key = "layer:<layerId>:text"\`. Get layer IDs from get_layers. source_type "page" or "component", source_id = page/component ID.
+- **Page slug / SEO:** \`content_key\` = "slug", "seo:title", or "seo:description". source_type "page".
+- **CMS fields:** source_type "cms", source_id = collection ITEM id. content_key = \`"field:key:<fieldKey>"\` (e.g. "field:key:content", "field:key:title"), or \`"field:id:<fieldId>"\` when the field has no key. Use list_collection_items to get item IDs plus each field's key and type. Only \`text\` and \`rich_text\` fields are translatable.
+- **CMS rich_text fields (e.g. a blog post "content" body):** these store Tiptap JSON, not plain text. Use \`set_rich_text_translation\` with content_key \`"field:key:content"\` (content_type is set to "richtext" automatically). Do NOT send plain text via set_translation for rich_text fields — it will not render and will appear empty in the editor.
+
+Example — translate a blog post body into Russian:
+\`\`\`
+list_collection_items({ collection_id: "<posts collection>" })
+  → find the item id and the "content" field (type: rich_text, key: "content")
+set_rich_text_translation({
+  locale_id: "<ru locale>", source_type: "cms", source_id: "<item id>",
+  content_key: "field:key:content",
+  blocks: [{ type: "paragraph", text: "Переведённый текст..." }],
+  is_completed: true
+})
+publish()
+\`\`\`
 
 ### Page Folders
 
@@ -554,8 +578,8 @@ Global site configuration:
 ### Publishing
 
 All changes are drafts until published:
-- Use get_unpublished_changes to see what needs publishing (pages, styles, components, collections, fonts, assets)
-- Use publish to make everything live
+- Use get_unpublished_changes to see what needs publishing (pages, styles, components, collections, fonts, assets, translations, locales)
+- Use publish to make everything live (this also publishes locales and translations)
 
 ---
 

--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -535,6 +535,7 @@ Multi-language support:
 - **Page slug / SEO:** \`content_key\` = "slug", "seo:title", or "seo:description". source_type "page".
 - **CMS fields:** source_type "cms", source_id = collection ITEM id. content_key = \`"field:key:<fieldKey>"\` (e.g. "field:key:content", "field:key:title"), or \`"field:id:<fieldId>"\` when the field has no key. Use list_collection_items to get item IDs plus each field's key and type. Only \`text\` and \`rich_text\` fields are translatable.
 - **CMS rich_text fields (e.g. a blog post "content" body):** these store Tiptap JSON, not plain text. Use \`set_rich_text_translation\` with content_key \`"field:key:content"\` (content_type is set to "richtext" automatically). Do NOT send plain text via set_translation for rich_text fields — it will not render and will appear empty in the editor.
+- **Component instance overrides:** when a component instance overrides text/image on a specific page, that override is translated PER PAGE (not on the component). content_key = \`"layer:<instanceLayerId>:override:<type>:<variableId>"\` where type is \`text\`, \`rich_text\`, \`image_src\`, or \`image_alt\`; source_type "page", source_id = page ID. These are easy to miss — call \`list_translatable_content({ source_type: "page", source_id })\` to get them with clear "Component › Variable" labels.
 
 Example — translate a blog post body into Russian:
 \`\`\`

--- a/lib/mcp/tools/locales.ts
+++ b/lib/mcp/tools/locales.ts
@@ -15,7 +15,7 @@ import {
   upsertTranslations,
 } from '@/lib/repositories/translationRepository';
 import { getPageById } from '@/lib/repositories/pageRepository';
-import { getComponentById } from '@/lib/repositories/componentRepository';
+import { getAllComponents, getComponentById } from '@/lib/repositories/componentRepository';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { getItemsWithValues } from '@/lib/repositories/collectionItemRepository';
 import { getCachedLayers } from '@/lib/mcp/page-layers';
@@ -300,7 +300,10 @@ export function registerLocaleTools(server: McpServer) {
           return { content: [{ type: 'text' as const, text: `Error: Page "${source_id}" not found.` }], isError: true };
         }
         const layers = await getCachedLayers(source_id);
-        items = extractPageTranslatableItems(page, layers);
+        // Pass components so per-instance override rows get rich
+        // "Component › Variable" labels instead of falling back to layer names.
+        const components = await getAllComponents(false).catch(() => []);
+        items = extractPageTranslatableItems(page, layers, undefined, components);
       } else if (source_type === 'component') {
         const component = await getComponentById(source_id);
         if (!component) {

--- a/lib/mcp/tools/locales.ts
+++ b/lib/mcp/tools/locales.ts
@@ -14,8 +14,21 @@ import {
   deleteTranslation,
   upsertTranslations,
 } from '@/lib/repositories/translationRepository';
-import { buildTiptapDoc } from '@/lib/mcp/utils';
+import { getPageById } from '@/lib/repositories/pageRepository';
+import { getComponentById } from '@/lib/repositories/componentRepository';
+import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
+import { getItemsWithValues } from '@/lib/repositories/collectionItemRepository';
+import { getCachedLayers } from '@/lib/mcp/page-layers';
+import {
+  extractPageTranslatableItems,
+  extractComponentTranslatableItems,
+  extractCmsTranslatableItems,
+} from '@/lib/localisation-utils';
+import type { TranslatableItem } from '@/lib/localisation-utils';
+import { getTranslatableKey } from '@/lib/locale-runtime';
+import { buildTiptapDoc, validateTranslationContent } from '@/lib/mcp/utils';
 import type { RichTextBlock } from '@/lib/mcp/utils';
+import type { ComponentVariant, Layer } from '@/types';
 
 const richTextBlockSchema = z.object({
   type: z.enum(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'codeBlock', 'horizontalRule']),
@@ -153,17 +166,22 @@ export function registerLocaleTools(server: McpServer) {
       content_key: z.string().describe('Content key identifying what is being translated (e.g. layer ID or field name)'),
       content_type: z.enum(['text', 'richtext', 'asset_id']).optional().describe('Type of content. Defaults to "text".'),
       content_value: z.string().describe('The translated content'),
-      is_completed: z.boolean().optional().describe('Mark translation as complete. Defaults to false.'),
+      is_completed: z.boolean().optional().describe('Mark translation as complete. Defaults to true. Incomplete translations are saved as drafts but never shown on the live site.'),
     },
     async ({ locale_id, source_type, source_id, content_key, content_type, content_value, is_completed }) => {
+      const resolvedType = content_type || 'text';
+      const validation = validateTranslationContent(resolvedType, content_value);
+      if (!validation.valid) {
+        return { content: [{ type: 'text' as const, text: `Error: ${validation.error}` }], isError: true };
+      }
       const translation = await createTranslation({
         locale_id,
         source_type,
         source_id,
         content_key,
-        content_type: content_type || 'text',
+        content_type: resolvedType,
         content_value,
-        is_completed,
+        is_completed: is_completed ?? true,
       });
       return {
         content: [{
@@ -196,8 +214,25 @@ export function registerLocaleTools(server: McpServer) {
         content_key: t.content_key,
         content_type: (t.content_type || 'text') as 'text' | 'richtext' | 'asset_id',
         content_value: t.content_value,
-        is_completed: t.is_completed,
+        is_completed: t.is_completed ?? true,
       }));
+
+      // Validate every entry up front so a malformed item doesn't partially
+      // apply the batch — report each failure with its index and key.
+      const errors = data
+        .map((t, i) => ({ i, key: t.content_key, result: validateTranslationContent(t.content_type, t.content_value) }))
+        .filter((e) => !e.result.valid)
+        .map((e) => `[${e.i}] "${e.key}": ${(e.result as { error: string }).error}`);
+      if (errors.length > 0) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error: ${errors.length} translation(s) have an invalid format and none were saved. Fix and retry:\n${errors.join('\n')}`,
+          }],
+          isError: true,
+        };
+      }
+
       const result = await upsertTranslations(data);
       return {
         content: [{
@@ -246,6 +281,89 @@ export function registerLocaleTools(server: McpServer) {
   );
 
   server.tool(
+    'list_translatable_content',
+    `Discover exactly what can be translated for a page, component, or CMS collection — and the precise source_type/source_id/content_key/content_type to use with set_translation. Use this BEFORE translating so you never have to guess keys. Pass locale_id to also see which items already have a translation and their current value.`,
+    {
+      source_type: z.enum(['page', 'component', 'cms']).describe('What to inspect: a page, a component, or a CMS collection'),
+      source_id: z.string().describe('Page ID, component ID, or collection ID (for cms)'),
+      locale_id: z.string().optional().describe('Optional locale ID to annotate each item with its existing translation status/value'),
+      search: z.string().optional().describe('CMS only: filter collection items by search term'),
+      limit: z.number().optional().describe('CMS only: max collection items to scan (default 25)'),
+    },
+    async ({ source_type, source_id, locale_id, search, limit }) => {
+      let items: TranslatableItem[] = [];
+      let total: number | undefined;
+
+      if (source_type === 'page') {
+        const page = await getPageById(source_id);
+        if (!page) {
+          return { content: [{ type: 'text' as const, text: `Error: Page "${source_id}" not found.` }], isError: true };
+        }
+        const layers = await getCachedLayers(source_id);
+        items = extractPageTranslatableItems(page, layers);
+      } else if (source_type === 'component') {
+        const component = await getComponentById(source_id);
+        if (!component) {
+          return { content: [{ type: 'text' as const, text: `Error: Component "${source_id}" not found.` }], isError: true };
+        }
+        const variants = component.variants as ComponentVariant[] | undefined;
+        const layers = (variants?.[0]?.layers || (component.layers as Layer[]) || []);
+        items = extractComponentTranslatableItems({ id: component.id, name: component.name }, layers);
+      } else {
+        const fields = await getFieldsByCollectionId(source_id);
+        const { items: collectionItems, total: itemTotal } = await getItemsWithValues(
+          source_id,
+          false,
+          search ? { search } : undefined,
+        );
+        total = itemTotal;
+        const scoped = collectionItems.slice(0, limit ?? 25);
+        for (const item of scoped) {
+          items.push(...extractCmsTranslatableItems(
+            { id: item.id, collection_id: source_id, values: item.values },
+            fields,
+          ));
+        }
+      }
+
+      // Annotate with existing translations for the given locale, if requested.
+      let existingByKey: Map<string, { value: string; is_completed: boolean }> | null = null;
+      if (locale_id) {
+        const translations = await getTranslationsByLocale(locale_id);
+        existingByKey = new Map(
+          translations.map((t) => [getTranslatableKey(t), { value: t.content_value, is_completed: t.is_completed }]),
+        );
+      }
+
+      const result = items.map((item) => {
+        const existing = existingByKey?.get(item.key);
+        return {
+          source_type: item.source_type,
+          source_id: item.source_id,
+          content_key: item.content_key,
+          content_type: item.content_type,
+          label: item.info?.label,
+          source_value: item.content_value,
+          ...(locale_id
+            ? { has_translation: !!existing, is_completed: existing?.is_completed ?? false, translated_value: existing?.value }
+            : {}),
+        };
+      });
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            count: result.length,
+            ...(total !== undefined ? { collection_items_total: total, scanned_items: Math.min(total, limit ?? 25) } : {}),
+            items: result,
+          }, null, 2),
+        }],
+      };
+    },
+  );
+
+  server.tool(
     'set_rich_text_translation',
     `Translate a rich-text content key by passing structured blocks. The blocks are converted
 to the Tiptap JSON shape that Ycode expects for richtext translations and stored as
@@ -260,7 +378,7 @@ orderedList, codeBlock, horizontalRule. Text supports **bold**, *italic*, [link]
       source_id: z.string().describe('ID of the source (page ID, component ID, etc.)'),
       content_key: z.string().describe('Content key identifying the rich-text field (e.g. layer ID or "richtext:<field id>")'),
       blocks: z.array(richTextBlockSchema).min(1).describe('Rich-text blocks describing the translated content'),
-      is_completed: z.boolean().optional().describe('Mark translation as complete. Defaults to false.'),
+      is_completed: z.boolean().optional().describe('Mark translation as complete. Defaults to true. Incomplete translations are saved as drafts but never shown on the live site.'),
     },
     async ({ locale_id, source_type, source_id, content_key, blocks, is_completed }) => {
       const doc = buildTiptapDoc(blocks as RichTextBlock[]);
@@ -271,7 +389,7 @@ orderedList, codeBlock, horizontalRule. Text supports **bold**, *italic*, [link]
         content_key,
         content_type: 'richtext',
         content_value: JSON.stringify(doc),
-        is_completed,
+        is_completed: is_completed ?? true,
       });
       return {
         content: [{

--- a/lib/mcp/tools/publishing.ts
+++ b/lib/mcp/tools/publishing.ts
@@ -7,6 +7,8 @@ import { getItemsByCollectionId } from '@/lib/repositories/collectionItemReposit
 import { getUnpublishedAssets, publishAssets, hardDeleteSoftDeletedAssets } from '@/lib/repositories/assetRepository';
 import { getUnpublishedAssetFolders, publishAssetFolders, hardDeleteSoftDeletedAssetFolders } from '@/lib/repositories/assetFolderRepository';
 import { getUnpublishedFonts, publishFonts } from '@/lib/repositories/fontRepository';
+import { getAllLocales } from '@/lib/repositories/localeRepository';
+import { getUnpublishedTranslationsCount } from '@/lib/repositories/translationRepository';
 import { publishPages } from '@/lib/services/pageService';
 import { publishCollectionWithItems } from '@/lib/services/collectionService';
 import { publishLocalisation } from '@/lib/services/localisationService';
@@ -15,13 +17,23 @@ import { publishCSS, savePublishedAt } from '@/lib/services/settingsService';
 import { generateAndSaveDraftCSS } from '@/lib/server/cssGenerator';
 import { clearAllCache } from '@/lib/services/cacheService';
 
+/** Count draft locales not yet present in the published set (new languages awaiting publish). */
+async function countUnpublishedLocales(): Promise<number> {
+  const [draft, published] = await Promise.all([
+    getAllLocales(false),
+    getAllLocales(true),
+  ]);
+  const publishedIds = new Set(published.map((l) => l.id));
+  return draft.filter((l) => !publishedIds.has(l.id)).length;
+}
+
 export function registerPublishingTools(server: McpServer) {
   server.tool(
     'get_unpublished_changes',
-    'Check what changes are pending and need to be published. Reports unpublished pages, styles, components, collections, fonts, and assets.',
+    'Check what changes are pending and need to be published. Reports unpublished pages, styles, components, collections, fonts, assets, translations, and locales.',
     {},
     async () => {
-      const [pages, styles, components, collections, fonts, assets, assetFolders] = await Promise.all([
+      const [pages, styles, components, collections, fonts, assets, assetFolders, translations, locales] = await Promise.all([
         getUnpublishedPages().catch(() => []),
         getUnpublishedLayerStyles().catch(() => []),
         getUnpublishedComponents().catch(() => []),
@@ -29,10 +41,13 @@ export function registerPublishingTools(server: McpServer) {
         getUnpublishedFonts().catch(() => []),
         getUnpublishedAssets().catch(() => []),
         getUnpublishedAssetFolders().catch(() => []),
+        getUnpublishedTranslationsCount().catch(() => 0),
+        countUnpublishedLocales().catch(() => 0),
       ]);
 
       const hasChanges = pages.length > 0 || styles.length > 0 || components.length > 0
-        || collections.length > 0 || fonts.length > 0 || assets.length > 0 || assetFolders.length > 0;
+        || collections.length > 0 || fonts.length > 0 || assets.length > 0 || assetFolders.length > 0
+        || translations > 0 || locales > 0;
 
       return {
         content: [{
@@ -46,6 +61,8 @@ export function registerPublishingTools(server: McpServer) {
             unpublished_fonts: fonts.map((f) => ({ id: f.id, family: f.family })),
             unpublished_assets: assets.length,
             unpublished_asset_folders: assetFolders.length,
+            unpublished_translations: translations,
+            unpublished_locales: locales,
           }, null, 2),
         }],
       };

--- a/lib/mcp/utils.ts
+++ b/lib/mcp/utils.ts
@@ -119,6 +119,51 @@ export function getTiptapTextContent(text: string): TiptapDoc {
   };
 }
 
+/** True when value is a Tiptap document node: `{ type: 'doc', content: [...] }`. */
+export function isTiptapDoc(value: unknown): value is TiptapDoc {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && (value as TiptapDoc).type === 'doc'
+    && Array.isArray((value as TiptapDoc).content)
+  );
+}
+
+/**
+ * Validate a translation's content_value against its content_type so malformed
+ * data is rejected before it reaches the database. Returns an actionable error
+ * the AI can use to correct and retry.
+ */
+export function validateTranslationContent(
+  contentType: 'text' | 'richtext' | 'asset_id',
+  contentValue: string,
+): { valid: true } | { valid: false; error: string } {
+  if (contentType === 'richtext') {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(contentValue);
+    } catch {
+      return {
+        valid: false,
+        error: 'richtext content_value must be a JSON-stringified Tiptap document like {"type":"doc","content":[...]}. Prefer the set_rich_text_translation tool, which builds the JSON from simple blocks.',
+      };
+    }
+    if (!isTiptapDoc(parsed)) {
+      return {
+        valid: false,
+        error: 'richtext content_value parsed as JSON but is not a Tiptap document. It must have the shape {"type":"doc","content":[...]}. Prefer the set_rich_text_translation tool.',
+      };
+    }
+    return { valid: true };
+  }
+
+  if (contentType === 'asset_id' && !contentValue.trim()) {
+    return { valid: false, error: 'asset_id content_value must be a non-empty asset ID.' };
+  }
+
+  return { valid: true };
+}
+
 /**
  * Build a Tiptap document from a simplified block array.
  * Accepts an array of block descriptors and produces valid Tiptap JSON.

--- a/lib/repositories/translationRepository.ts
+++ b/lib/repositories/translationRepository.ts
@@ -353,6 +353,9 @@ export async function upsertTranslations(
     content_key: t.content_key,
     content_type: t.content_type,
     content_value: t.content_value,
+    // Without this, the DB default (false) keeps batch translations hidden on
+    // the live site, which only renders completed translations.
+    is_completed: t.is_completed ?? false,
     is_published: false,
     deleted_at: null, // Restore if previously deleted
   }));


### PR DESCRIPTION
## Summary

Translating content through the MCP server (e.g. Claude) was unreliable: translations saved in the editor wouldn't go live, and the CMS rich-text "content" field often wasn't translated at all. This makes the MCP translation flow work end-to-end — discovery, validation, completion, and publishing.

## Changes

- Report pending translations and locales in `get_unpublished_changes` so the agent knows there's something to publish (previously omitted, so it often skipped publishing)
- Default MCP-set translations to completed (matching the editor) and persist `is_completed` in batch upserts, so translations actually render on the live site after publish
- Validate `content_value` against its `content_type` before insert, returning an actionable error for malformed rich-text instead of silently storing unrenderable data
- Add a `list_translatable_content` tool so the agent discovers the exact source/key/type (including the CMS rich-text "content" field and per-page component override translations) instead of guessing
- Document the i18n workflow, CMS rich-text handling, and per-page component overrides in the agent instructions

## Test plan

- [x] `tools/list` exposes `list_translatable_content` and translation tools
- [x] `get_unpublished_changes` reports `unpublished_translations` / `unpublished_locales`
- [x] `list_translatable_content` returns correct keys/types/labels and existing-translation status for a page
- [x] Malformed rich-text is rejected with an actionable error
- [x] `set_rich_text_translation` stores valid Tiptap JSON as a completed draft (verified in DB) and is detected as unpublished
- [x] `delete_translation` soft-deletes correctly
- [ ] Publish a translated locale and confirm it renders on the live site