### PR TITLE
feat: allow renaming components

### DIFF
--- a/app/(builder)/ycode/components/ComponentCard.tsx
+++ b/app/(builder)/ycode/components/ComponentCard.tsx
@@ -17,6 +17,8 @@ interface ComponentCardProps {
   /** Optional actions rendered to the right of the name (e.g. dropdown menu) */
   actions?: React.ReactNode;
   className?: string;
+  /** Triggered by double-clicking the name (e.g. to start renaming) */
+  onStartRename?: () => void;
 }
 
 export default function ComponentCard({
@@ -26,6 +28,7 @@ export default function ComponentCard({
   disabled = false,
   actions,
   className,
+  onStartRename,
 }: ComponentCardProps) {
   return (
     <div className={cn('group flex flex-col gap-1.5', className)}>
@@ -58,6 +61,7 @@ export default function ComponentCard({
         <span
           className="flex-1 truncate text-xs font-medium"
           title={component.name}
+          onDoubleClick={onStartRename}
         >
           {component.name}
         </span>

--- a/app/(builder)/ycode/components/ElementLibrary.tsx
+++ b/app/(builder)/ycode/components/ElementLibrary.tsx
@@ -39,6 +39,7 @@ import { toast } from 'sonner';
 import { componentsApi } from '@/lib/api';
 import type { Layer } from '@/types';
 import ComponentCard from './ComponentCard';
+import RenameComponentDialog from './RenameComponentDialog';
 import SaveLayoutDialog from './SaveLayoutDialog';
 import { usePagesStore } from '@/stores/usePagesStore';
 import { useEditorStore } from '@/stores/useEditorStore';
@@ -300,6 +301,7 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
   const componentDrafts = useComponentsStore((s) => s.componentDrafts);
   const updateComponentDraft = useComponentsStore((s) => s.updateComponentDraft);
   const deleteComponent = useComponentsStore((s) => s.deleteComponent);
+  const renameComponent = useComponentsStore((s) => s.renameComponent);
   const getDeletePreview = useComponentsStore((s) => s.getDeletePreview);
   const loadComponentDraft = useComponentsStore((s) => s.loadComponentDraft);
   const getComponentById = useComponentsStore((s) => s.getComponentById);
@@ -321,6 +323,8 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
     return 'elements';
   });
   const [componentSearch, setComponentSearch] = useState('');
+  const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [componentToRename, setComponentToRename] = useState<Component | null>(null);
   const tabRefs = React.useRef<Record<string, HTMLDivElement | null>>({});
 
   const circularComponentIds = useMemo(() => {
@@ -1380,6 +1384,24 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
     onClose();
   };
 
+  const handleStartRename = (component: Component) => {
+    setComponentToRename(component);
+    setRenameDialogOpen(true);
+  };
+
+  const handleConfirmRename = async (newName: string) => {
+    if (!componentToRename) return;
+
+    const trimmed = newName.trim();
+    if (!trimmed || trimmed === componentToRename.name) return;
+
+    try {
+      await renameComponent(componentToRename.id, trimmed);
+    } catch (error) {
+      console.error('Failed to rename component:', error);
+    }
+  };
+
   const handleDeleteClick = async (component: Component, e: React.MouseEvent) => {
     e.stopPropagation();
     setComponentToDelete(component);
@@ -1642,6 +1664,7 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
                           circularComponentIds.has(component.id) && 'opacity-40 pointer-events-none',
                           isHidden && 'hidden',
                         )}
+                        onStartRename={() => handleStartRename(component)}
                         onClick={() => handleAddComponent(component.id)}
                         onMouseDown={(e) => {
                           if (e.button !== 0) return;
@@ -1683,6 +1706,7 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
                               <DropdownMenuItem onClick={(e) => handleEditComponent(component, e)}>Edit</DropdownMenuItem>
+                              <DropdownMenuItem onSelect={() => handleStartRename(component)}>Rename</DropdownMenuItem>
                               <DropdownMenuItem onClick={(e) => handleDeleteClick(component, e)}>Delete</DropdownMenuItem>
                             </DropdownMenuContent>
                           </DropdownMenu>
@@ -1695,6 +1719,13 @@ export default function ElementLibrary({ isOpen, onClose, liveLayerUpdates }: El
             )}
           </TabsContent>
         </Tabs>
+
+        <RenameComponentDialog
+          open={renameDialogOpen}
+          onOpenChange={setRenameDialogOpen}
+          onConfirm={handleConfirmRename}
+          currentName={componentToRename?.name}
+        />
 
         <SaveLayoutDialog
           open={isEditLayoutDialogOpen}

--- a/app/(builder)/ycode/components/RenameComponentDialog.tsx
+++ b/app/(builder)/ycode/components/RenameComponentDialog.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+/**
+ * Rename Component Dialog
+ *
+ * Dialog for renaming an existing component. Mirrors CreateComponentDialog.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface RenameComponentDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (componentName: string) => void;
+  currentName?: string;
+}
+
+export default function RenameComponentDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  currentName,
+}: RenameComponentDialogProps) {
+  const [componentName, setComponentName] = useState(currentName || '');
+
+  // Sync the input with the component being renamed each time the dialog opens
+  useEffect(() => {
+    if (open) setComponentName(currentName || '');
+  }, [open, currentName]);
+
+  const handleConfirm = () => {
+    if (!componentName.trim()) return;
+
+    // Persist optimistically and close immediately — the store updates the
+    // name in place and rolls back if the request fails.
+    onConfirm(componentName.trim());
+    onOpenChange(false);
+  };
+
+  const handleCancel = () => {
+    onOpenChange(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && componentName.trim()) {
+      handleConfirm();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        width="320px"
+        className="gap-0"
+        aria-describedby={undefined}
+      >
+        <DialogHeader>
+          <DialogTitle>Rename component</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4.5">
+          <div className="flex flex-col gap-2">
+            <Input
+              id="component-name"
+              placeholder="Name"
+              value={componentName}
+              onChange={(e) => setComponentName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              autoFocus
+            />
+          </div>
+
+          <DialogFooter className="grid grid-cols-2 mt-1">
+            <Button
+              variant="secondary"
+              onClick={handleCancel}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleConfirm}
+              disabled={!componentName.trim()}
+            >
+              Rename
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/stores/useComponentsStore.ts
+++ b/stores/useComponentsStore.ts
@@ -768,9 +768,36 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
       });
     },
 
-    // Rename a component (convenience method)
+    // Rename a component with optimistic update (rolls back on failure)
     renameComponent: async (id, newName) => {
-      await get().updateComponent(id, { name: newName });
+      const previousName = get().components.find((c) => c.id === id)?.name;
+
+      set((state) => ({
+        components: state.components.map((c) => (c.id === id ? { ...c, name: newName } : c)),
+      }));
+
+      try {
+        const response = await fetch(`/ycode/api/components/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: newName }),
+        });
+
+        const result = await response.json();
+        if (result.error) throw new Error(result.error);
+
+        set((state) => ({
+          components: state.components.map((c) => (c.id === id ? result.data : c)),
+        }));
+      } catch (error) {
+        console.error('Failed to rename component:', error);
+        if (previousName !== undefined) {
+          set((state) => ({
+            components: state.components.map((c) => (c.id === id ? { ...c, name: previousName } : c)),
+            error: 'Failed to rename component',
+          }));
+        }
+      }
     },
 
     // Get component by ID (convenience method)


### PR DESCRIPTION
## Summary

Brings back the ability to rename components shown in the Element Library, a feature that existed in the legacy editor but was missing in the new version. Renaming is exposed through a dialog and updates optimistically.

## Changes

- Add `RenameComponentDialog` (mirrors the create-component dialog) pre-filled with the current name
- Add a "Rename" action to each component's dropdown in the Element Library, plus double-click on the name to rename
- Make `renameComponent` in the components store optimistic — updates the name immediately and rolls back if the save fails

## Test plan

- [ ] Open the Element Library → Components tab
- [ ] Rename a component via the ⋯ dropdown → confirm the name updates instantly and persists after refresh
- [ ] Double-click a component name → rename dialog opens pre-filled
- [ ] Cancel / empty name / unchanged name → no change is saved
- [ ] Simulate a failed save → name rolls back to the original