### PR TITLE
feat(visibility): support dynamic date presets in conditional visibility

### DIFF
--- a/app/(builder)/ycode/components/ConditionalVisibilitySettings.tsx
+++ b/app/(builder)/ycode/components/ConditionalVisibilitySettings.tsx
@@ -47,6 +47,8 @@ import {
   COMPARE_OPERATORS,
   PAGE_COLLECTION_OPERATORS,
   isDateFieldType,
+  isDatePreset,
+  DATE_PRESET_OPTIONS,
   SELF_OPERATORS,
 } from '@/lib/collection-field-utils';
 import { findAllCollectionLayers, findAllParentCollectionLayers, getCollectionVariable, CollectionLayerInfo } from '@/lib/layer-utils';
@@ -801,11 +803,39 @@ export default function ConditionalVisibilitySettings({
                   </SelectContent>
                 </Select>
               ) : isDateFieldType(fieldType) ? (
-                <Input
-                  type="date"
-                  value={condition.value || ''}
-                  onChange={(e) => handleValueChange(group.id, condition.id, e.target.value)}
-                />
+                <div className="flex flex-col gap-1.5">
+                  <Select
+                    value={isDatePreset(condition.value) ? condition.value : '_custom'}
+                    onValueChange={(v) => {
+                      if (v === '_custom') {
+                        handleValueChange(group.id, condition.id, '');
+                      } else {
+                        handleValueChange(group.id, condition.id, v);
+                      }
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectItem value="_custom">Custom date...</SelectItem>
+                        {DATE_PRESET_OPTIONS
+                          .filter((opt) => !opt.value.startsWith('$past_'))
+                          .map((opt) => (
+                            <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                          ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                  {!isDatePreset(condition.value) && (
+                    <Input
+                      type="date"
+                      value={condition.value || ''}
+                      onChange={(e) => handleValueChange(group.id, condition.id, e.target.value)}
+                    />
+                  )}
+                </div>
               ) : fieldType === 'number' ? (
                 <Input
                   type="number"


### PR DESCRIPTION
## Summary

Conditional Visibility rules on date CMS fields could only compare against a **fixed picked date**, so rules like _"show this button if release date is after today"_ had to be re-picked every day to stay accurate. The engine already had full support for date presets (`\$today`, `\$this_week`, `\$this_month`, `\$this_year`) — they just weren't exposed in the Conditional Visibility editor's UI.

This brings the visibility editor in line with the Collection Filters editor, which already exposes the same presets.

## What was missing

`evaluateCondition` in `lib/layer-utils.ts` resolves date presets at render time:

```ts
if (isDateFieldType(fieldType) && isDatePreset(compareValue)) {
  const resolved = resolveDateFilterValue(effectiveOperator, compareValue, compareValue2);
  // ...
}
```

…but the visibility editor's date input was a bare `<input type="date">`, which can only produce `YYYY-MM-DD` strings. Users had no way to enter `\$today` short of editing the layer JSON by hand.

## Fix

`ConditionalVisibilitySettings.tsx` — replace the bare date input for date fields with a Select + date-picker pair, mirroring the shape used in `CollectionFiltersSettings.tsx`. Wired to the same shared `DATE_PRESET_OPTIONS` constant in `lib/collection-field-utils.ts` — no engine changes, no new shared constants.

### UX choices

- **Picker visible by default.** The Select defaults to "Custom date..." with the date picker rendered immediately below. Picking a date stays a single interaction — same as before the change. Adding a preset is one extra click via the dropdown.
- **Past-week / past-month / past-year omitted from the visibility dropdown.** They're functionally equivalent to `is_before` + a relative reference, and the visibility use case is dominated by present/future comparisons (\"show CTA until launch date\", \"hide after sale ends\"). They remain in the shared `DATE_PRESET_OPTIONS` constant so the Collection Filters editor (where _past N_ ranges genuinely matter for filtering recent items) is unaffected.
- **Second value field (for \`is_between\`) stays a plain date picker.** The engine's `resolveDateFilterValue` collapses preset+\`is_between\` to the preset's own start/end range, so a preset on \`value2\` would be silently ignored — exposing it in the UI would be misleading.

## Changes

- `app/(builder)/ycode/components/ConditionalVisibilitySettings.tsx` — date field branch swapped from bare `<Input type=\"date\">` to Select + conditional date picker. +30 lines.

## Compatibility

- **Engine: unchanged.** No new logic, no migration. The preset resolution path has been in place since the Collection Filters work.
- **Existing rules: unchanged.** Conditions with hand-picked `YYYY-MM-DD` values continue to render in the date picker with "Custom date..." selected in the Select — no migration needed for their stored values.
- **Collection Filters editor: unchanged.** Same shared constants, no edits to that component.

## Test plan

- [x] On a layer with a date-field conditional visibility rule, pick `is after` + `Today` from the new dropdown. Confirm the layer shows when the field's value is later than today's end-of-day, hides otherwise.
- [x] Pick `is between` + `This month`. Confirm only items dated within the current month satisfy the rule.
- [x] Pick `is after` + `Custom date...` and enter a date manually. Confirm behavior matches the pre-PR baseline.
- [x] Load an existing layer with a hand-picked date value. Confirm UI renders "Custom date..." + the existing date pre-filled in the picker.
- [x] `npm run type-check` passes.
- [x] Collection Filters editor unaffected: presets list there still shows the full set including past_week / past_month / past_year.

## Verified end-to-end

Deployed to a self-hosted Ycode instance, real CMS with release dates spanning past + future. Buttons gated on \"release date is after Today\" appear and disappear at the day boundary as expected, no manual re-edit required.