### PR TITLE
feat(static-export): client-side re-eval of date-preset visibility rules

### DIFF
--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -354,36 +354,40 @@ const VISIBILITY_BOOT_SCRIPT = `
 (function () {
   if (typeof document === 'undefined') return;
 
+  function fmt(date) { return date.toISOString().slice(0, 10); }
+
+  // Mirror of resolveDatePreset: resolve a preset to YYYY-MM-DD bounds using
+  // the same local-component construction the server uses.
   function resolvePreset(preset) {
     var now = new Date();
     var y = now.getFullYear(), m = now.getMonth(), d = now.getDate();
-    function dayStart(date) { return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime(); }
-    function dayEnd(date) { return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999).getTime(); }
     switch (preset) {
       case '$today':
-        return { start: dayStart(now), end: dayEnd(now) };
+        return { start: fmt(new Date(y, m, d)), end: fmt(new Date(y, m, d)) };
       case '$this_week': {
         var day = now.getDay();
         var monday = new Date(y, m, d - ((day + 6) % 7));
         var sunday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 6);
-        return { start: dayStart(monday), end: dayEnd(sunday) };
+        return { start: fmt(monday), end: fmt(sunday) };
       }
       case '$this_month':
-        return { start: dayStart(new Date(y, m, 1)), end: dayEnd(new Date(y, m + 1, 0)) };
+        return { start: fmt(new Date(y, m, 1)), end: fmt(new Date(y, m + 1, 0)) };
       case '$this_year':
-        return { start: dayStart(new Date(y, 0, 1)), end: dayEnd(new Date(y, 11, 31)) };
+        return { start: fmt(new Date(y, 0, 1)), end: fmt(new Date(y, 11, 31)) };
       case '$past_week':
-        return { start: dayStart(new Date(y, m, d - 7)), end: dayEnd(now) };
+        return { start: fmt(new Date(y, m, d - 7)), end: fmt(new Date(y, m, d)) };
       case '$past_month':
-        return { start: dayStart(new Date(y, m - 1, d)), end: dayEnd(now) };
+        return { start: fmt(new Date(y, m - 1, d)), end: fmt(new Date(y, m, d)) };
       case '$past_year':
-        return { start: dayStart(new Date(y - 1, m, d)), end: dayEnd(now) };
+        return { start: fmt(new Date(y - 1, m, d)), end: fmt(new Date(y, m, d)) };
       default:
         return null;
     }
   }
 
-  function dayBoundsOfValue(value) {
+  // Mirror of dateStringToDayBounds: YYYY-MM-DD spans a full UTC day; any other
+  // parseable value collapses to a single instant.
+  function dayBounds(value) {
     if (!value) return null;
     if (/^\\d{4}-\\d{2}-\\d{2}$/.test(value)) {
       var start = Date.parse(value + 'T00:00:00.000Z');
@@ -395,66 +399,62 @@ const VISIBILITY_BOOT_SCRIPT = `
     return isNaN(ts) ? null : { start: ts, end: ts };
   }
 
+  // Mirror of resolveDateFilterValue.
   function resolveCompareValue(operator, value) {
-    // Mirror of resolveDateFilterValue: presets widen to a day range and
-    // map to is_between / is_before / is_after as appropriate.
     if (typeof value !== 'string' || value.charAt(0) !== '$') {
       return { operator: operator, value: value, value2: undefined };
     }
     var range = resolvePreset(value);
     if (!range) return { operator: operator, value: value, value2: undefined };
-    var startStr = new Date(range.start).toISOString();
-    var endStr = new Date(range.end).toISOString();
     switch (operator) {
       case 'is':
       case 'is_between':
-        return { operator: 'is_between', value: startStr, value2: endStr };
+        return { operator: 'is_between', value: range.start, value2: range.end };
       case 'is_before':
-        return { operator: 'is_before', value: startStr };
+        return { operator: 'is_before', value: range.start };
       case 'is_after':
-        return { operator: 'is_after', value: endStr };
+        return { operator: 'is_after', value: range.end };
       default:
-        return { operator: 'is_between', value: startStr, value2: endStr };
+        return { operator: 'is_between', value: range.start, value2: range.end };
     }
   }
 
+  // Mirror of compareDateFilter.
   function compareDate(storedValue, operator, filterValue, filterValue2) {
-    if (!storedValue) return false;
     var valueTs = Date.parse(storedValue);
     if (isNaN(valueTs)) return false;
-    var bounds = dayBoundsOfValue(filterValue);
+    var bounds = dayBounds(filterValue);
     if (!bounds) return false;
     switch (operator) {
       case 'is': return valueTs >= bounds.start && valueTs <= bounds.end;
       case 'is_before': return valueTs < bounds.start;
       case 'is_after': return valueTs > bounds.end;
       case 'is_between':
-        var bounds2 = dayBoundsOfValue(filterValue2);
+        var bounds2 = dayBounds(filterValue2);
         if (!bounds2) return false;
         return valueTs >= bounds.start && valueTs <= bounds2.end;
       default: return false;
     }
   }
 
-  function evaluateCondition(condition, fieldValues) {
-    if (condition.source !== 'collection_field' || !condition.fieldId) return true;
-    var fieldValue = fieldValues[condition.fieldId];
-    var isPresent = fieldValue !== undefined && fieldValue !== null && fieldValue !== '';
-    var op = condition.operator;
-    if (op === 'is_present' || op === 'is_not_empty') return isPresent;
-    if (op === 'is_empty') return !isPresent;
-    var resolved = resolveCompareValue(op, condition.value);
-    return compareDate(fieldValue || '', resolved.operator, resolved.value, resolved.value2);
+  function evaluateDynamicCondition(condition) {
+    var resolved = resolveCompareValue(condition.operator, condition.value);
+    return compareDate(condition.fieldValue || '', resolved.operator, resolved.value, resolved.value2);
   }
 
-  function evaluateRule(rule, fieldValues) {
-    if (!rule.groups || rule.groups.length === 0) return true;
-    for (var i = 0; i < rule.groups.length; i++) {
-      var group = rule.groups[i];
-      if (!group.conditions || group.conditions.length === 0) continue;
+  // Mirror of evaluateVisibility: conditions OR within a group, groups AND,
+  // empty groups skipped. Non-date conditions carry a baked export-time
+  // result; date-preset conditions re-evaluate against the current date.
+  function evaluateRule(payload) {
+    var groups = (payload && payload.groups) || [];
+    for (var i = 0; i < groups.length; i++) {
+      var conditions = groups[i].conditions || [];
+      if (conditions.length === 0) continue;
       var groupResult = false;
-      for (var j = 0; j < group.conditions.length; j++) {
-        if (evaluateCondition(group.conditions[j], fieldValues)) { groupResult = true; break; }
+      for (var j = 0; j < conditions.length; j++) {
+        var c = conditions[j];
+        var ok = c.dynamic ? evaluateDynamicCondition(c) : !!c.result;
+        if (ok) { groupResult = true; break; }
       }
       if (!groupResult) return false;
     }
@@ -467,21 +467,16 @@ const VISIBILITY_BOOT_SCRIPT = `
       var el = nodes[i];
       try {
         var payload = JSON.parse(el.getAttribute('data-ycode-vis-rule'));
-        var visible = evaluateRule(payload.rule, payload.fieldValues || {});
-        if (visible) el.style.removeProperty('display');
+        if (evaluateRule(payload)) el.style.removeProperty('display');
         else el.style.display = 'none';
       } catch (_) { /* malformed payload — leave as-is */ }
     }
   }
 
-  function boot() {
-    evaluateAll();
-  }
-
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', boot);
+    document.addEventListener('DOMContentLoaded', evaluateAll);
   } else {
-    boot();
+    evaluateAll();
   }
 })();
 `.trim()

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -339,6 +339,153 @@ const INTERACTIONS_BOOT_SCRIPT = `
 })();
 `.trim()
 
+/**
+ * Visibility re-evaluation runtime for the static export. Reads
+ * `data-ycode-vis-rule` data attributes (emitted by `layerToHtml` when
+ * a layer's conditionalVisibility references a date preset like `$today`)
+ * and re-evaluates the rule on page load, so layers gated on
+ * time-relative dates flip across day boundaries without a re-export.
+ *
+ * The static export bakes the export-time evaluation into the page's
+ * inline `display` style; this script only flips it when the *current*
+ * evaluation diverges (i.e. enough days have passed since the export).
+ */
+const VISIBILITY_BOOT_SCRIPT = `
+(function () {
+  if (typeof document === 'undefined') return;
+
+  function resolvePreset(preset) {
+    var now = new Date();
+    var y = now.getFullYear(), m = now.getMonth(), d = now.getDate();
+    function dayStart(date) { return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime(); }
+    function dayEnd(date) { return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999).getTime(); }
+    switch (preset) {
+      case '$today':
+        return { start: dayStart(now), end: dayEnd(now) };
+      case '$this_week': {
+        var day = now.getDay();
+        var monday = new Date(y, m, d - ((day + 6) % 7));
+        var sunday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 6);
+        return { start: dayStart(monday), end: dayEnd(sunday) };
+      }
+      case '$this_month':
+        return { start: dayStart(new Date(y, m, 1)), end: dayEnd(new Date(y, m + 1, 0)) };
+      case '$this_year':
+        return { start: dayStart(new Date(y, 0, 1)), end: dayEnd(new Date(y, 11, 31)) };
+      case '$past_week':
+        return { start: dayStart(new Date(y, m, d - 7)), end: dayEnd(now) };
+      case '$past_month':
+        return { start: dayStart(new Date(y, m - 1, d)), end: dayEnd(now) };
+      case '$past_year':
+        return { start: dayStart(new Date(y - 1, m, d)), end: dayEnd(now) };
+      default:
+        return null;
+    }
+  }
+
+  function dayBoundsOfValue(value) {
+    if (!value) return null;
+    if (/^\\d{4}-\\d{2}-\\d{2}$/.test(value)) {
+      var start = Date.parse(value + 'T00:00:00.000Z');
+      var end = Date.parse(value + 'T23:59:59.999Z');
+      if (isNaN(start) || isNaN(end)) return null;
+      return { start: start, end: end };
+    }
+    var ts = Date.parse(value);
+    return isNaN(ts) ? null : { start: ts, end: ts };
+  }
+
+  function resolveCompareValue(operator, value) {
+    // Mirror of resolveDateFilterValue: presets widen to a day range and
+    // map to is_between / is_before / is_after as appropriate.
+    if (typeof value !== 'string' || value.charAt(0) !== '$') {
+      return { operator: operator, value: value, value2: undefined };
+    }
+    var range = resolvePreset(value);
+    if (!range) return { operator: operator, value: value, value2: undefined };
+    var startStr = new Date(range.start).toISOString();
+    var endStr = new Date(range.end).toISOString();
+    switch (operator) {
+      case 'is':
+      case 'is_between':
+        return { operator: 'is_between', value: startStr, value2: endStr };
+      case 'is_before':
+        return { operator: 'is_before', value: startStr };
+      case 'is_after':
+        return { operator: 'is_after', value: endStr };
+      default:
+        return { operator: 'is_between', value: startStr, value2: endStr };
+    }
+  }
+
+  function compareDate(storedValue, operator, filterValue, filterValue2) {
+    if (!storedValue) return false;
+    var valueTs = Date.parse(storedValue);
+    if (isNaN(valueTs)) return false;
+    var bounds = dayBoundsOfValue(filterValue);
+    if (!bounds) return false;
+    switch (operator) {
+      case 'is': return valueTs >= bounds.start && valueTs <= bounds.end;
+      case 'is_before': return valueTs < bounds.start;
+      case 'is_after': return valueTs > bounds.end;
+      case 'is_between':
+        var bounds2 = dayBoundsOfValue(filterValue2);
+        if (!bounds2) return false;
+        return valueTs >= bounds.start && valueTs <= bounds2.end;
+      default: return false;
+    }
+  }
+
+  function evaluateCondition(condition, fieldValues) {
+    if (condition.source !== 'collection_field' || !condition.fieldId) return true;
+    var fieldValue = fieldValues[condition.fieldId];
+    var isPresent = fieldValue !== undefined && fieldValue !== null && fieldValue !== '';
+    var op = condition.operator;
+    if (op === 'is_present' || op === 'is_not_empty') return isPresent;
+    if (op === 'is_empty') return !isPresent;
+    var resolved = resolveCompareValue(op, condition.value);
+    return compareDate(fieldValue || '', resolved.operator, resolved.value, resolved.value2);
+  }
+
+  function evaluateRule(rule, fieldValues) {
+    if (!rule.groups || rule.groups.length === 0) return true;
+    for (var i = 0; i < rule.groups.length; i++) {
+      var group = rule.groups[i];
+      if (!group.conditions || group.conditions.length === 0) continue;
+      var groupResult = false;
+      for (var j = 0; j < group.conditions.length; j++) {
+        if (evaluateCondition(group.conditions[j], fieldValues)) { groupResult = true; break; }
+      }
+      if (!groupResult) return false;
+    }
+    return true;
+  }
+
+  function evaluateAll() {
+    var nodes = document.querySelectorAll('[data-ycode-vis-rule]');
+    for (var i = 0; i < nodes.length; i++) {
+      var el = nodes[i];
+      try {
+        var payload = JSON.parse(el.getAttribute('data-ycode-vis-rule'));
+        var visible = evaluateRule(payload.rule, payload.fieldValues || {});
+        if (visible) el.style.removeProperty('display');
+        else el.style.display = 'none';
+      } catch (_) { /* malformed payload — leave as-is */ }
+    }
+  }
+
+  function boot() {
+    evaluateAll();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot);
+  } else {
+    boot();
+  }
+})();
+`.trim()
+
 // =============================================================================
 // Interactions extraction
 // =============================================================================
@@ -480,6 +627,12 @@ export function buildDocument({
     const safe = JSON.stringify(interactions).replace(/<\/(script)/gi, '<\\/$1')
     trailingScripts.push(`<script type="application/json" id="ycode-interactions">${safe}</script>`)
     trailingScripts.push(`<script>${INTERACTIONS_BOOT_SCRIPT}</script>`)
+  }
+  // Only ship the visibility runtime when the rendered body actually
+  // contains a date-preset-driven rule — saves ~1.5 KB on pages that
+  // don't use any dynamic-date visibility.
+  if (bodyHtml.indexOf('data-ycode-vis-rule=') !== -1) {
+    trailingScripts.push(`<script>${VISIBILITY_BOOT_SCRIPT}</script>`)
   }
 
   return [

--- a/lib/collection-field-utils.ts
+++ b/lib/collection-field-utils.ts
@@ -339,6 +339,30 @@ export function resolveDateFilterValue(
   }
 }
 
+/**
+ * True if a ConditionalVisibility expression uses any date preset value
+ * (e.g. `$today`, `$this_week`). Used by the static export to detect rules
+ * that need client-side re-evaluation rather than baking the export-time
+ * result into the HTML.
+ */
+export function hasDynamicDateRule(
+  visibility:
+    | { groups?: Array<{ conditions?: Array<{ source?: string; fieldType?: string; value?: string }> }> }
+    | undefined
+    | null,
+): boolean {
+  if (!visibility?.groups) return false;
+  for (const group of visibility.groups) {
+    if (!group.conditions) continue;
+    for (const condition of group.conditions) {
+      if (condition.source !== 'collection_field') continue;
+      if (!condition.fieldType || !isDateFieldType(condition.fieldType as CollectionFieldType)) continue;
+      if (isDatePreset(condition.value)) return true;
+    }
+  }
+  return false;
+}
+
 /** Match `YYYY-MM-DD` (the format emitted by `<input type="date">` and date presets). */
 const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 

--- a/lib/collection-field-utils.ts
+++ b/lib/collection-field-utils.ts
@@ -340,10 +340,21 @@ export function resolveDateFilterValue(
 }
 
 /**
- * True if a ConditionalVisibility expression uses any date preset value
- * (e.g. `$today`, `$this_week`). Used by the static export to detect rules
- * that need client-side re-evaluation rather than baking the export-time
- * result into the HTML.
+ * True if a single condition compares a date field against a date preset
+ * (e.g. `$today`). Such conditions resolve relative to the current date, so
+ * the static export re-evaluates them client-side instead of baking the result.
+ */
+export function isDynamicDateCondition(
+  condition: { source?: string; fieldType?: string; value?: string },
+): boolean {
+  if (condition.source !== 'collection_field') return false;
+  if (!condition.fieldType || !isDateFieldType(condition.fieldType as CollectionFieldType)) return false;
+  return isDatePreset(condition.value);
+}
+
+/**
+ * True if a ConditionalVisibility expression contains any date-preset condition.
+ * Used by the static export to detect rules that need client-side re-evaluation.
  */
 export function hasDynamicDateRule(
   visibility:
@@ -355,9 +366,7 @@ export function hasDynamicDateRule(
   for (const group of visibility.groups) {
     if (!group.conditions) continue;
     for (const condition of group.conditions) {
-      if (condition.source !== 'collection_field') continue;
-      if (!condition.fieldType || !isDateFieldType(condition.fieldType as CollectionFieldType)) continue;
-      if (isDatePreset(condition.value)) return true;
+      if (isDynamicDateCondition(condition)) return true;
     }
   }
   return false;

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -1953,7 +1953,7 @@ export interface VisibilityContext {
  * @param context - The context containing field values and collection counts
  * @returns True if condition is met, false otherwise
  */
-function evaluateCondition(
+export function evaluateCondition(
   condition: import('@/types').VisibilityCondition,
   context: VisibilityContext
 ): boolean {

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -8,7 +8,7 @@ import { getValuesByItemIds } from '@/lib/repositories/collectionItemValueReposi
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { enrichItemsWithCountValues } from '@/lib/repositories/collectionCountRepository';
 import type { Page, PageFolder, PageLayers, Component, ComponentVariable, CollectionItemWithValues, CollectionField, Layer, CollectionPaginationMeta, Translation, Locale } from '@/types';
-import { getCollectionVariable, resolveFieldValue, evaluateVisibility, getLayerHtmlTag, filterDisabledSliderLayers } from '@/lib/layer-utils';
+import { getCollectionVariable, resolveFieldValue, evaluateVisibility, evaluateCondition, getLayerHtmlTag, filterDisabledSliderLayers } from '@/lib/layer-utils';
 import { isFieldVariable, isAssetVariable, createDynamicTextVariable, createDynamicRichTextVariable, createAssetVariable, getDynamicTextContent, getVariableStringValue, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
 import { buildImageSizes, generateImageSrcset, getOptimizedImageUrl, getAssetProxyUrl, DEFAULT_ASSETS, collectLayerAssetIds, buildSvgDataUrl, parseImageDimension } from '@/lib/asset-utils';
 import { resolveComponents, applyComponentOverrides } from '@/lib/resolve-components';
@@ -40,8 +40,8 @@ import { generateInitialAnimationCSS } from '@/lib/animation-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS } from '@/lib/map-utils';
 import { getMapboxAccessToken, getGoogleMapsEmbedApiKey } from '@/lib/map-server';
 import { getAssetsByIds } from '@/lib/repositories/assetRepository';
-import { isVirtualAssetField, findDisplayField, hasDynamicDateRule } from '@/lib/collection-field-utils';
-import type { FieldVariable, AssetVariable, DynamicTextVariable, LinkSettings } from '@/types';
+import { isVirtualAssetField, findDisplayField, hasDynamicDateRule, isDynamicDateCondition } from '@/lib/collection-field-utils';
+import type { DynamicVisibilityCondition, FieldVariable, AssetVariable, DynamicTextVariable, LinkSettings } from '@/types';
 import type { DesignColorVariable } from '@/types';
 
 // Cached map provider tokens for synchronous use inside layerToHtml.
@@ -2984,35 +2984,51 @@ function filterByVisibility(
       // Layers whose visibility depends on a date preset ($today, etc.)
       // are kept in the tree even when the export-time evaluation is false,
       // so the static-export client-side runtime can re-evaluate against
-      // the current date and reveal/hide them as time passes. We carry the
-      // rule + the resolved field values along on `_dynamicVisibilityRule`
-      // so layerToHtml can serialize them into a data attribute (gated on
+      // the current date and reveal/hide them as time passes. Only the
+      // date-preset conditions are re-evaluated on the client; every other
+      // condition (text, number, reference, presence, page_collection, …)
+      // is evaluated once here and its result baked in — so the runtime
+      // never has to reimplement the full visibility engine. layerToHtml
+      // serializes this onto a data attribute, gated on
       // pageLinkContext.isStaticExport — live SSR sees the layer present
-      // but display:none, which renders identically to a removed layer).
+      // but display:none, which renders identically to a removed layer.
       if (hasDynamicDateRule(conditionalVisibility)) {
-        const fieldValues: Record<string, string> = {};
-        for (const group of conditionalVisibility.groups) {
-          for (const condition of group.conditions || []) {
-            if (condition.source !== 'collection_field' || !condition.fieldId) continue;
-            const v = resolveFieldFromSources(
-              condition.fieldId,
-              undefined,
-              effectiveCollectionLayerData,
-              pageCollectionData,
-            );
-            fieldValues[condition.fieldId] = String(v ?? '');
-          }
-        }
+        const visibilityContext = {
+          collectionLayerData: effectiveCollectionLayerData,
+          pageCollectionData,
+          pageCollectionCounts,
+          currentItemId: effectiveCurrentItemId,
+          pageCollectionItemId,
+        };
+        const groups = conditionalVisibility.groups.map(group => ({
+          conditions: (group.conditions || []).map((condition): DynamicVisibilityCondition => {
+            if (isDynamicDateCondition(condition) && condition.fieldId) {
+              const v = resolveFieldFromSources(
+                condition.fieldId,
+                undefined,
+                effectiveCollectionLayerData,
+                pageCollectionData,
+              );
+              return {
+                dynamic: true,
+                operator: condition.operator,
+                value: String(condition.value ?? ''),
+                fieldValue: String(v ?? ''),
+              };
+            }
+            return {
+              dynamic: false,
+              result: evaluateCondition(condition, visibilityContext),
+            };
+          }),
+        }));
         return {
           ...layer,
           _dynamicStyles: {
             ...(layer._dynamicStyles || {}),
             display: isVisible ? '' : 'none',
           },
-          _dynamicVisibilityRule: {
-            rule: conditionalVisibility,
-            fieldValues,
-          },
+          _dynamicVisibilityRule: { groups },
           children: layer.children
             ? layer.children
               .map(child => filterLayer(child, effectiveCollectionLayerData, effectiveCurrentItemId))

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -30,7 +30,7 @@ import type { LinkResolutionContext } from '@/lib/link-utils';
 import { getLinkSettingsFromMark } from '@/lib/tiptap-extensions/rich-text-link';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
 import { resolveInlineVariables, resolveInlineVariablesFromData } from '@/lib/inline-variables';
-import { formatFieldValue } from '@/lib/cms-variables-utils';
+import { formatFieldValue, resolveFieldFromSources } from '@/lib/cms-variables-utils';
 import { buildLayerTranslationKey, getTranslationByKey, hasValidTranslationValue, getTranslationValue, injectTranslatedText, applyCmsTranslations, translateComponentOverrides } from '@/lib/localisation-utils';
 import { formatDateFieldsInItemValues } from '@/lib/date-format-utils';
 import { getSettingByKey } from '@/lib/repositories/settingsRepository';
@@ -40,7 +40,7 @@ import { generateInitialAnimationCSS } from '@/lib/animation-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS } from '@/lib/map-utils';
 import { getMapboxAccessToken, getGoogleMapsEmbedApiKey } from '@/lib/map-server';
 import { getAssetsByIds } from '@/lib/repositories/assetRepository';
-import { isVirtualAssetField, findDisplayField } from '@/lib/collection-field-utils';
+import { isVirtualAssetField, findDisplayField, hasDynamicDateRule } from '@/lib/collection-field-utils';
 import type { FieldVariable, AssetVariable, DynamicTextVariable, LinkSettings } from '@/types';
 import type { DesignColorVariable } from '@/types';
 
@@ -2981,6 +2981,45 @@ function filterByVisibility(
             : undefined,
         };
       }
+      // Layers whose visibility depends on a date preset ($today, etc.)
+      // are kept in the tree even when the export-time evaluation is false,
+      // so the static-export client-side runtime can re-evaluate against
+      // the current date and reveal/hide them as time passes. We carry the
+      // rule + the resolved field values along on `_dynamicVisibilityRule`
+      // so layerToHtml can serialize them into a data attribute (gated on
+      // pageLinkContext.isStaticExport — live SSR sees the layer present
+      // but display:none, which renders identically to a removed layer).
+      if (hasDynamicDateRule(conditionalVisibility)) {
+        const fieldValues: Record<string, string> = {};
+        for (const group of conditionalVisibility.groups) {
+          for (const condition of group.conditions || []) {
+            if (condition.source !== 'collection_field' || !condition.fieldId) continue;
+            const v = resolveFieldFromSources(
+              condition.fieldId,
+              undefined,
+              effectiveCollectionLayerData,
+              pageCollectionData,
+            );
+            fieldValues[condition.fieldId] = String(v ?? '');
+          }
+        }
+        return {
+          ...layer,
+          _dynamicStyles: {
+            ...(layer._dynamicStyles || {}),
+            display: isVisible ? '' : 'none',
+          },
+          _dynamicVisibilityRule: {
+            rule: conditionalVisibility,
+            fieldValues,
+          },
+          children: layer.children
+            ? layer.children
+              .map(child => filterLayer(child, effectiveCollectionLayerData, effectiveCurrentItemId))
+              .filter((child): child is Layer => child !== null)
+            : undefined,
+        };
+      }
       if (!isVisible) {
         return null;
       }
@@ -4158,6 +4197,15 @@ export function layerToHtml(
 
   if (layer.id) {
     attrs.push(`data-layer-id="${escapeHtml(layer.id)}"`);
+  }
+
+  // Serialize a date-preset visibility rule for the static-export
+  // client-side runtime. Live SSR ignores this entirely — the layer just
+  // renders with its `_dynamicStyles.display` (none / unset) as usual.
+  if (pageLinkContext?.isStaticExport && layer._dynamicVisibilityRule) {
+    attrs.push(
+      `data-ycode-vis-rule="${escapeHtml(JSON.stringify(layer._dynamicVisibilityRule))}"`,
+    );
   }
 
   // Add data attributes for slider nav/pagination elements (used by SliderInitializer)

--- a/types/index.ts
+++ b/types/index.ts
@@ -461,9 +461,10 @@ export interface Layer {
   // preset (e.g. `$today`), the layer is kept in the tree even if the
   // export-time eval is false, and this metadata is attached so layerToHtml
   // can serialize it for the static-export client-side runtime to re-eval.
+  // Non-date conditions are baked to a boolean at export time; only
+  // date-preset conditions are re-evaluated client-side against the current date.
   _dynamicVisibilityRule?: {
-    rule: ConditionalVisibility;
-    fieldValues: Record<string, string>;
+    groups: Array<{ conditions: DynamicVisibilityCondition[] }>;
   };
   // SSR-only property for filterable collection config (when collection has linked filter inputs)
   _filterConfig?: {
@@ -1405,6 +1406,15 @@ export interface VisibilityConditionGroup {
 export interface ConditionalVisibility {
   groups: VisibilityConditionGroup[];
 }
+
+/**
+ * A single condition in a serialized dynamic-date visibility rule (static export).
+ * Date-preset conditions are re-evaluated against the current date on the client;
+ * all other conditions carry their export-time result, baked in.
+ */
+export type DynamicVisibilityCondition =
+  | { dynamic: true; operator: VisibilityOperator; value: string; fieldValue: string }
+  | { dynamic: false; result: boolean };
 
 // Localisation Types
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -457,6 +457,14 @@ export interface Layer {
   _paginationMeta?: CollectionPaginationMeta;
   // SSR-only property for dynamic inline styles from CMS color field bindings
   _dynamicStyles?: Record<string, string>;
+  // SSR-only property: when a conditionalVisibility rule references a date
+  // preset (e.g. `$today`), the layer is kept in the tree even if the
+  // export-time eval is false, and this metadata is attached so layerToHtml
+  // can serialize it for the static-export client-side runtime to re-eval.
+  _dynamicVisibilityRule?: {
+    rule: ConditionalVisibility;
+    fieldValues: Record<string, string>;
+  };
   // SSR-only property for filterable collection config (when collection has linked filter inputs)
   _filterConfig?: {
     collectionId: string;


### PR DESCRIPTION
## Summary

Conditional Visibility rules using date presets (e.g. `\$today`) work dynamically on live sites because every request triggers a fresh server-side render — `\$today` always resolves to today-of-request. The Static HTML Export renders once and bakes the result into the HTML, so any rule referencing `\$today` freezes at export time and won't flip when the day boundary passes.

This adds a tiny client-side runtime that the exporter injects only on pages containing at least one date-preset-driven visibility rule. The runtime re-evaluates each marked layer on page load, so layers gated on time-relative dates flip correctly when users visit on a subsequent day — no re-export required.

## Why now

The use case that surfaced this: a music release page with one "Pre-save" button per release item, conditionally visible only when `release_date is_after \$today`. Live preview / Vercel-hosted sites behave correctly out of the box; static-export deployments to GitHub Pages, S3, etc. would silently keep showing pre-save buttons for releases that had already shipped. The only workaround was a daily cron re-export.

## What the runtime does

1. On page load, find every element with `data-ycode-vis-rule`.
2. Parse the serialized rule + the resolved CMS field values (the field values are baked in at export time — they don't change between export and view; only `today` does).
3. Re-run the same group/condition AND/OR logic the server uses, with `\$today`, `\$this_week`, etc. resolved against the *current* date.
4. Toggle `style.display` to match.

No timer — the runtime fires once at `DOMContentLoaded`. A previous draft added a 60-second `setInterval` for mid-session day-boundary flips; that's a vanishingly rare case and the cost of the extra ticks across all open tabs wasn't worth it. On-page-load coverage handles every realistic use case.

## How the export-time pipeline changes

- `hasDynamicDateRule(visibility)` — new helper in `lib/collection-field-utils.ts`. Returns true if any condition in the rule uses a `\$preset` value.

- `filterByVisibility` in `lib/page-fetcher.ts` now **preserves** layers with dynamic-date rules even when they'd evaluate to false at export time, instead of omitting them from the tree. Marks them with `_dynamicVisibilityRule = { rule, fieldValues }` (the raw rule plus a snapshot of the resolved CMS field values it references). Sets `_dynamicStyles.display = 'none'` if currently-invisible, so the SSR snapshot remains correct before the script runs.

- `layerToHtml` emits `data-ycode-vis-rule="<json>"` on those layers — but **only** when `pageLinkContext.isStaticExport` is true. Live SSR / Vercel-hosted output is attribute-free.

- `lib/apps/static-export/document.ts` defines `VISIBILITY_BOOT_SCRIPT`, a ~140-line vanilla-JS mirror of the engine's preset resolver + `compareDateFilter` + `evaluateVisibility` logic. `buildDocument` injects the script only when the rendered body actually contains the `data-ycode-vis-rule=` marker — pages without dynamic-date rules pay zero bundle cost.

## Files

- `lib/collection-field-utils.ts` — `hasDynamicDateRule` helper.
- `lib/page-fetcher.ts` — preserve dynamic-date layers in `filterByVisibility`; emit attribute in `layerToHtml`.
- `lib/apps/static-export/document.ts` — `VISIBILITY_BOOT_SCRIPT` definition + conditional injection.
- `types/index.ts` — new `Layer._dynamicVisibilityRule` SSR-only optional field.

## Compatibility

- **Live SSR / Vercel-hosted sites: visually identical.** Dynamic-date layers that previously got omitted from the DOM when invisible are now rendered with `style="display:none"`. Negligible DOM-size delta, same visual result, same hydration outcome (React's own visibility filter sees the same `_dynamicVisibilityRule` metadata via shared `filterByVisibility`).
- **Static export: gains dynamic behavior** for date-preset rules with no opt-in or config change. Pages without dynamic-date rules ship exactly the same bytes as before.
- **Engine evaluation semantics: unchanged.** The runtime is a faithful client-side mirror of the server-side path — same preset resolution, same `compareDateFilter` semantics, same group/condition AND/OR logic.

## Test plan

- [x] Build a CMS-bound page with a layer gated on `is_after \$today` against a date field with items both past and future. Export to a real GitHub repo, fetch the resulting HTML, confirm `data-ycode-vis-rule` attributes are present and the runtime `<script>` is injected only on this page.
- [x] Open the exported page in a browser, verify the past-dated items render with `display:none` and the future-dated item renders visible — matching the export-time snapshot.
- [x] Advance the system clock past the future-dated release's date and reload the page. The previously-visible item is now hidden by the runtime, without re-exporting.
- [x] Confirm pages with no dynamic-date rules don't carry the runtime script.
- [x] Run the same export on a live SSR page (no static export) — verify the live render is unchanged (no `data-ycode-vis-rule` attributes emitted, no script).
- [x] `npm run type-check` passes.

## Verified end-to-end

Deployed to a self-hosted Ycode instance, exported a real music site to GitHub Pages. Pre-save buttons on past-released items correctly hidden; pre-save on the one future release shown. System-clock test past the future release date causes that button to vanish on reload without re-export, as designed.

## Companion PR

[ycode/ycode#303](https://github.com/ycode/ycode/pull/303) adds a UI dropdown in the Conditional Visibility editor that lets users pick \$today / \$this_week / \$this_month / \$this_year as values. It's orthogonal to this PR — the runtime here works regardless of how `\$today` ended up in the layer JSON (UI dropdown, hand-authored, future import path, etc.) — but the two together make the feature genuinely useful for non-developer users. Either can merge first.