### PR TITLE
fix: correct Safari canvas selection and layers tree

### DIFF
--- a/app/(builder)/ycode/components/LayersTree.tsx
+++ b/app/(builder)/ycode/components/LayersTree.tsx
@@ -224,11 +224,16 @@ function VirtualLayerRow({ nodeId, isRenaming, isLocalizing, translateY, childre
       <div
         style={{
           position: 'absolute',
-          top: 0,
+          // Position rows with `top` rather than `transform: translateY`. A
+          // transformed ancestor becomes the containing block for the row's
+          // `position: sticky` background, which Safari composites incorrectly
+          // in a virtualized list — promoting stale, oversized GPU layers that
+          // paint the blue selection over (and far beyond) the row, hiding the
+          // layer names. Using `top` avoids the transform entirely.
+          top: translateY,
           left: 0,
           width: '100%',
           height: ROW_HEIGHT,
-          transform: `translateY(${translateY}px)`,
         }}
       >
         {children}
@@ -468,7 +473,7 @@ const LayerRow = React.memo(function LayerRow({
     return (
       <div className="relative flex" style={{ width: '100%', minWidth: '100%' }}>
         {/* Background layer - stays fixed */}
-        <div className="absolute inset-0 pointer-events-none">
+        <div className="absolute inset-0 pointer-events-none z-0">
           <div
             className={cn(
               'sticky left-0 h-full',
@@ -485,7 +490,7 @@ const LayerRow = React.memo(function LayerRow({
         </div>
 
         {/* Content layer */}
-        <div className="relative flex w-full min-w-full flex-1">
+        <div className="relative z-10 flex w-full min-w-full flex-1">
           {node.depth > 0 && (
             <>
               {Array.from({ length: node.depth }).map((_, i) => (
@@ -565,7 +570,7 @@ const LayerRow = React.memo(function LayerRow({
         style={{ width: '100%', minWidth: '100%' }}
       >
         {/* Background layer - stays fixed when scrolling horizontally */}
-        <div className="absolute inset-0 pointer-events-none">
+        <div className="absolute inset-0 pointer-events-none z-0">
           <div
             className={cn(
               'sticky left-0 h-full bg-(--row-bg) group-hover/row:bg-(--row-hover-bg)',
@@ -594,7 +599,7 @@ const LayerRow = React.memo(function LayerRow({
         )}
 
         {/* Content layer - scrolls horizontally */}
-        <div className="relative flex w-full min-w-full flex-1">
+        <div className="relative z-10 flex w-full min-w-full flex-1">
           {/* Vertical connector lines */}
           {node.depth > 0 && (
             <>
@@ -1472,20 +1477,43 @@ export default function LayersTree({
     }
   }, [shouldScrollToSelected]);
 
-  // Virtualizer: discover the nearest scroll-container ancestor
-  const scrollContainerRef = useRef<HTMLElement | null>(null);
+  // Virtualizer: discover the nearest scroll-container ancestor.
+  // Held in state (not a ref) so resolving it triggers a re-render — the
+  // virtualizer only rebinds its scroll element on render, and a ref write
+  // alone leaves it stuck with a null element (blank tree, intermittently
+  // on Safari where the rescue re-render often loses the timing race).
+  const [scrollContainer, setScrollContainer] = useState<HTMLElement | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     let el = wrapperRef.current?.parentElement ?? null;
     while (el) {
       const style = getComputedStyle(el);
-      if (style.overflowY === 'auto' || style.overflowY === 'scroll') {
-        scrollContainerRef.current = el;
-        return;
-      }
+      if (style.overflowY === 'auto' || style.overflowY === 'scroll') break;
       el = el.parentElement;
     }
+    const scroller = el;
+    if (!scroller) return;
+
+    // Bind the virtualizer's scroll element only once it has a measurable
+    // height. The virtualizer reads the viewport height once on bind; if that
+    // read is 0 (Safari before layout settles, or while the Layers tab is
+    // hidden), it computes an empty range and renders no rows — and if the
+    // 0→height ResizeObserver tick is missed (a Safari quirk) the tree stays
+    // blank with just the selection bar. Waiting for a non-zero height makes
+    // the first viewport read reliable across browsers.
+    if (scroller.clientHeight > 0) {
+      setScrollContainer(scroller);
+      return;
+    }
+    const ro = new ResizeObserver(() => {
+      if (scroller.clientHeight > 0) {
+        setScrollContainer(scroller);
+        ro.disconnect();
+      }
+    });
+    ro.observe(scroller);
+    return () => ro.disconnect();
   }, []);
 
   const treeAvailableWidth = leftSidebarWidth - 32;
@@ -1493,7 +1521,7 @@ export default function LayersTree({
 
   const virtualizer = useVirtualizer({
     count: flattenedNodes.length,
-    getScrollElement: () => scrollContainerRef.current,
+    getScrollElement: () => scrollContainer,
     estimateSize: () => ROW_HEIGHT,
     overscan: 20,
   });
@@ -1505,7 +1533,7 @@ export default function LayersTree({
     const idx = flattenedNodes.findIndex(n => n.id === selectedLayerId);
     if (idx < 0) return;
 
-    const scrollEl = scrollContainerRef.current;
+    const scrollEl = scrollContainer;
     if (!scrollEl) {
       virtualizer.scrollToIndex(idx, { align: 'center', behavior: 'smooth' });
       return;
@@ -1555,7 +1583,7 @@ export default function LayersTree({
     }, 100);
 
     return () => clearTimeout(timeout);
-  }, [shouldScrollToSelected, selectedLayerId, flattenedNodes, virtualizer]);
+  }, [shouldScrollToSelected, selectedLayerId, flattenedNodes, virtualizer, scrollContainer]);
 
   const setHoveredLayerIdFromStore = useEditorStore((s) => s.setHoveredLayerId);
 

--- a/components/SelectionOverlay.tsx
+++ b/components/SelectionOverlay.tsx
@@ -113,6 +113,18 @@ export function SelectionOverlay({
     const iframeRect = iframeElement.getBoundingClientRect();
     const containerRect = containerElement.getBoundingClientRect();
 
+    // Derive the scale that maps the iframe's INNER coordinate space (where
+    // element rects are measured) to OUTER screen pixels, instead of trusting
+    // zoom/100. The canvas is scaled with CSS `zoom` on a wrapper, and Safari
+    // propagates that zoom into the iframe's own getBoundingClientRect/offset
+    // measurements (so inner rects come back already scaled), while
+    // Chrome/Firefox report inner rects unscaled. Comparing the painted iframe
+    // width to the inner root width — both via getBoundingClientRect — yields
+    // the correct multiplier in every browser (≈zoom in Chrome, ≈1 in Safari)
+    // and prevents the double-scaling that pushed outlines off on Safari.
+    const innerRootWidth = iframeDoc.documentElement.getBoundingClientRect().width;
+    const effectiveScale = innerRootWidth > 0 ? iframeRect.width / innerRootWidth : scale;
+
     // Ensure we have the right number of child outline divs
     while (container.children.length < targetElements.length) {
       const div = document.createElement('div');
@@ -139,10 +151,10 @@ export function SelectionOverlay({
         height = iframeRect.height;
       } else {
         const elementRect = targetElement.getBoundingClientRect();
-        top = iframeRect.top - containerRect.top + (elementRect.top * scale);
-        left = iframeRect.left - containerRect.left + (elementRect.left * scale);
-        width = elementRect.width * scale;
-        height = elementRect.height * scale;
+        top = iframeRect.top - containerRect.top + (elementRect.top * effectiveScale);
+        left = iframeRect.left - containerRect.left + (elementRect.left * effectiveScale);
+        width = elementRect.width * effectiveScale;
+        height = elementRect.height * effectiveScale;
       }
 
       child.className = `absolute ${outlineClass}`;

--- a/lib/iframe-utils.ts
+++ b/lib/iframe-utils.ts
@@ -7,21 +7,44 @@
  */
 
 /**
- * Get the current scale factor applied to the iframe (via its parent wrapper).
- * The zoom is applied as CSS zoom on the wrapper div, not the iframe itself.
+ * Get the scale factor that maps the iframe's INNER coordinate system to OUTER
+ * window pixels. The canvas is scaled with CSS `zoom` on a wrapper div.
+ *
+ * Preferred path derives the scale from geometry — the painted iframe width
+ * divided by the inner root width, both measured via getBoundingClientRect.
+ * This is robust across browsers: Safari propagates the wrapper's `zoom` into
+ * the iframe's own measurements (inner rects come back already scaled), while
+ * Chrome/Firefox report inner rects unscaled. The ratio yields the correct
+ * multiplier in every browser (≈zoom in Chrome, ≈1 in Safari) and avoids the
+ * double-scaling that misaligned canvas overlays/drag math on Safari.
+ *
+ * Falls back to reading CSS `zoom` / `transform: scale()` from an ancestor
+ * wrapper when the iframe document isn't accessible yet (e.g. before load).
  */
 export function getIframeScale(iframe: HTMLIFrameElement): number {
-  const wrapper = iframe.parentElement;
-  // Read from CSS zoom property
-  const zoomValue = wrapper?.style.zoom;
-  if (zoomValue) {
-    const parsed = parseFloat(zoomValue);
-    if (!isNaN(parsed) && parsed > 0) return parsed;
+  const innerRoot = iframe.contentDocument?.documentElement;
+  if (innerRoot) {
+    const innerWidth = innerRoot.getBoundingClientRect().width;
+    const outerWidth = iframe.getBoundingClientRect().width;
+    if (innerWidth > 0 && outerWidth > 0) {
+      return outerWidth / innerWidth;
+    }
   }
-  // Fallback to transform scale
-  const transform = wrapper?.style.transform || '';
-  const match = transform.match(/scale\(([\d.]+)\)/);
-  return match ? parseFloat(match[1]) : 1;
+
+  // Fallback: walk up ancestors for the CSS zoom / transform scale. The zoom
+  // wrapper is not always the direct parent, so we don't stop at the first.
+  let el: HTMLElement | null = iframe.parentElement;
+  while (el) {
+    const zoomValue = el.style.zoom;
+    if (zoomValue) {
+      const parsed = parseFloat(zoomValue);
+      if (!isNaN(parsed) && parsed > 0) return parsed;
+    }
+    const match = (el.style.transform || '').match(/scale\(([\d.]+)\)/);
+    if (match) return parseFloat(match[1]);
+    el = el.parentElement;
+  }
+  return 1;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes two Safari-only bugs in the editor: the blue selection outline on the canvas was offset from the actual layer, and the layers tree intermittently hid layer names behind the blue selection (or rendered as one oversized block).

## Changes

- **Canvas selection alignment**: Derive an effective scale from the painted iframe width vs. its inner document width instead of trusting `zoom / 100`. Safari propagates the outer CSS `zoom` into the iframe's inner `getBoundingClientRect` measurements, which double-scaled the overlay. Applied the same geometry-based scale in `lib/iframe-utils.ts`.
- **Layers tree paint bug**: Position virtual rows with `top` instead of `transform: translateY`. A transformed ancestor became the containing block for each row's `position: sticky` background, which Safari composited into stale, oversized GPU layers that painted the blue selection over the layer names.
- Layer the row content explicitly above the background (`z-10` / `z-0`) rather than relying on implicit paint order.
- Bind the virtualizer's scroll element only once it has a measurable height, preventing an empty/partial tree when Safari reports a zero-height viewport at mount.

## Test plan

- [ ] In Safari, select layers on the canvas — the blue outline aligns with the layer at various zoom levels
- [ ] In Safari, select layers in the tree — the blue highlight is one row tall and the layer name stays visible
- [ ] Switch between the Layers and Pages tabs, reload — the tree always renders fully with names
- [ ] Confirm no regression in Chrome/Firefox for selection outline and tree rendering
- [ ] Verify horizontal scrolling of a deeply nested tree keeps the row highlight pinned

Made with [Cursor](https://cursor.com)