### PR TITLE
fix: make collection date filters respect the project timezone

### DIFF
--- a/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
+++ b/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { getSettingByKey } from '@/lib/repositories/settingsRepository';
 import { getItemsByCollectionId } from '@/lib/repositories/collectionItemRepository';
 import { getValuesByItemIds } from '@/lib/repositories/collectionItemValueRepository';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
@@ -88,9 +89,11 @@ async function getIdsMatchingFilter(
   filter: FilterCondition,
   isPublished: boolean,
   allItemIds: string[],
+  timezone: string,
 ): Promise<Set<string>> {
   const { fieldId, operator, value } = filter;
   const allSet = new Set(allItemIds);
+  const isDateOnly = filter.fieldType === 'date_only';
 
   const selectIds = (chunk: string[]) =>
     client
@@ -138,7 +141,7 @@ async function getIdsMatchingFilter(
         );
         const result = new Set<string>();
         for (const row of data) {
-          if (compareDateFilter(String(row.value), 'is', value)) result.add(row.item_id);
+          if (compareDateFilter(String(row.value), 'is', value, undefined, timezone, isDateOnly)) result.add(row.item_id);
         }
         return result;
       }
@@ -191,7 +194,7 @@ async function getIdsMatchingFilter(
         );
         const matchIds = new Set<string>();
         for (const row of data) {
-          if (compareDateFilter(String(row.value), 'is', value)) matchIds.add(row.item_id);
+          if (compareDateFilter(String(row.value), 'is', value, undefined, timezone, isDateOnly)) matchIds.add(row.item_id);
         }
         return new Set([...allSet].filter(id => !matchIds.has(id)));
       }
@@ -262,7 +265,7 @@ async function getIdsMatchingFilter(
       );
       const result = new Set<string>();
       for (const row of data) {
-        if (compareDateFilter(String(row.value), 'is_before', value)) result.add(row.item_id);
+        if (compareDateFilter(String(row.value), 'is_before', value, undefined, timezone, isDateOnly)) result.add(row.item_id);
       }
       return result;
     }
@@ -273,7 +276,7 @@ async function getIdsMatchingFilter(
       );
       const result = new Set<string>();
       for (const row of data) {
-        if (compareDateFilter(String(row.value), 'is_after', value)) result.add(row.item_id);
+        if (compareDateFilter(String(row.value), 'is_after', value, undefined, timezone, isDateOnly)) result.add(row.item_id);
       }
       return result;
     }
@@ -291,11 +294,11 @@ async function getIdsMatchingFilter(
         const storedValue = String(row.value);
         // Open-ended ranges fall back to the relevant single-bound operator.
         if (startRaw && endRaw) {
-          if (compareDateFilter(storedValue, 'is_between', startRaw, endRaw)) result.add(row.item_id);
+          if (compareDateFilter(storedValue, 'is_between', startRaw, endRaw, timezone, isDateOnly)) result.add(row.item_id);
         } else if (startRaw) {
-          if (!compareDateFilter(storedValue, 'is_before', startRaw)) result.add(row.item_id);
+          if (!compareDateFilter(storedValue, 'is_before', startRaw, undefined, timezone, isDateOnly)) result.add(row.item_id);
         } else if (endRaw) {
-          if (!compareDateFilter(storedValue, 'is_after', endRaw)) result.add(row.item_id);
+          if (!compareDateFilter(storedValue, 'is_after', endRaw, undefined, timezone, isDateOnly)) result.add(row.item_id);
         }
       }
       return result;
@@ -443,6 +446,7 @@ async function getFilteredItemIds(
   collectionId: string,
   isPublished: boolean,
   filterGroups: FilterCondition[][],
+  timezone: string,
   pageCollectionItemId?: string,
 ): Promise<{ matchingIds: string[]; total: number }> {
   const client = await getSupabaseAdmin();
@@ -468,12 +472,12 @@ async function getFilteredItemIds(
         continue;
       }
       if (isDateFieldType(filter.fieldType) && isDatePreset(filter.value)) {
-        const resolved = resolveDateFilterValue(filter.operator, filter.value, filter.value2);
+        const resolved = resolveDateFilterValue(filter.operator, filter.value, filter.value2, timezone);
         if (resolved) {
           filter = { ...filter, operator: resolved.operator, value: resolved.value, value2: resolved.value2 };
         }
       }
-      const matchingForFilter = await getIdsMatchingFilter(client, filter, isPublished, [...currentIds]);
+      const matchingForFilter = await getIdsMatchingFilter(client, filter, isPublished, [...currentIds], timezone);
       currentIds = new Set([...currentIds].filter(id => matchingForFilter.has(id)));
     }
 
@@ -574,10 +578,13 @@ export async function POST(
       return noCache({ error: 'collectionLayerId is required' }, 400);
     }
 
+    const timezone = (await getSettingByKey('timezone') as string | null) || 'UTC';
+
     const { matchingIds, total: filteredTotal } = await getFilteredItemIds(
       collectionId,
       isPublished,
       filterGroups,
+      timezone,
       pageCollectionItemId,
     );
 

--- a/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
+++ b/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
@@ -421,11 +421,17 @@ export default function CollectionFiltersSettings({
 
   const handleOperatorChange = (groupId: string, conditionId: string, operator: VisibilityOperator) => {
     const needsSecondValue = operatorRequiresSecondValue(operator);
+    const existing = groups.find(g => g.id === groupId)?.conditions.find(c => c.id === conditionId);
+    // `is between` has no preset options, so drop a stale preset value carried
+    // over from a single-bound operator.
+    const value = operatorRequiresValue(operator)
+      ? (needsSecondValue && isDatePreset(existing?.value) ? '' : existing?.value)
+      : undefined;
     patchCondition(groupId, conditionId, {
       operator,
-      value: operatorRequiresValue(operator) ? groups.find(g => g.id === groupId)?.conditions.find(c => c.id === conditionId)?.value : undefined,
-      value2: needsSecondValue ? groups.find(g => g.id === groupId)?.conditions.find(c => c.id === conditionId)?.value2 : undefined,
-      inputLayerId2: needsSecondValue ? groups.find(g => g.id === groupId)?.conditions.find(c => c.id === conditionId)?.inputLayerId2 : undefined,
+      value,
+      value2: needsSecondValue ? existing?.value2 : undefined,
+      inputLayerId2: needsSecondValue ? existing?.inputLayerId2 : undefined,
     });
   };
 
@@ -615,6 +621,9 @@ export default function CollectionFiltersSettings({
     // to a linked input for conditions saved before `dateInput` existed.
     const isDateInputMode = isDateFieldType(fieldType)
       && (condition.dateInput === true || !!condition.inputLayerId);
+    // Same mode tracking for the second bound (`is_between`).
+    const isDateInputMode2 = isDateFieldType(fieldType)
+      && (condition.dateInput2 === true || !!condition.inputLayerId2);
 
     return (
       <React.Fragment key={condition.id}>
@@ -796,7 +805,9 @@ export default function CollectionFiltersSettings({
                           <SelectContent>
                             <SelectGroup>
                               <SelectItem value="_custom">Custom date</SelectItem>
-                              {DATE_PRESET_OPTIONS.map((opt) => (
+                              {/* Presets resolve to a single day/range, so they only
+                                  apply to single-bound operators — not `is between`. */}
+                              {!operatorRequiresSecondValue(condition.operator) && DATE_PRESET_OPTIONS.map((opt) => (
                                 <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
                               ))}
                               <SelectItem value="_input">Filter form input</SelectItem>
@@ -848,52 +859,79 @@ export default function CollectionFiltersSettings({
                 </div>
               )}
 
-              {/* Second value for date between */}
+              {/* Second value for date between — mirrors the primary date UI:
+                  a Custom date / Filter form input select, with the date input
+                  (custom) or the link-to-input target icon (input mode). */}
               {operatorRequiresSecondValue(condition.operator) && (
                 <>
                   <Label variant="muted" className="text-[10px] text-center">and</Label>
                   {condition.inputLayerId2 ? (
-                    <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/40 px-2 py-1.5 text-xs">
-                      <Icon name="filter" className="size-3 text-muted-foreground shrink-0" />
-                      <span className="truncate text-foreground">{getLinkedInputName(condition.inputLayerId2)}</span>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            className="ml-auto shrink-0 text-muted-foreground hover:text-foreground"
-                            onClick={() => handleUnlinkSecondInput(group.id, condition.id)}
-                          >
-                            <Icon name="unlink" className="size-3" />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent>Unlink second filter input</TooltipContent>
-                      </Tooltip>
+                    <div className="flex items-center gap-1">
+                      <Input
+                        value={getLinkedInputName(condition.inputLayerId2)}
+                        disabled
+                      />
+                      <div className="shrink-0">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button variant="secondary" onClick={() => handleUnlinkSecondInput(group.id, condition.id)}>
+                              <Icon name="x" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Unlink second filter input</TooltipContent>
+                        </Tooltip>
+                      </div>
                     </div>
                   ) : (
                     <div className="flex items-center gap-1">
-                      <div className="flex-1">
-                        <Input
-                          type="date"
-                          value={condition.value2 || ''}
-                          onChange={(e) => patchCondition(group.id, condition.id, { value2: clampDateInputValue(e.target.value) })}
-                        />
+                      <div className="flex-1 flex flex-col gap-1.5">
+                        <Select
+                          value={isDateInputMode2 ? '_input' : '_custom'}
+                          onValueChange={(v) => {
+                            if (v === '_input') {
+                              patchCondition(group.id, condition.id, { dateInput2: true, value2: '' });
+                            } else {
+                              patchCondition(group.id, condition.id, { dateInput2: false, value2: '' });
+                            }
+                          }}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select..." />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              <SelectItem value="_custom">Custom date</SelectItem>
+                              <SelectItem value="_input">Filter form input</SelectItem>
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                        {!isDateInputMode2 && (
+                          <Input
+                            type="date"
+                            value={condition.value2 || ''}
+                            onChange={(e) => patchCondition(group.id, condition.id, { value2: clampDateInputValue(e.target.value) })}
+                          />
+                        )}
                       </div>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="secondary"
-                            onClick={(e) => {
-                              const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-                              handlePickSecondInputForCondition(group.id, condition.id, {
-                                x: rect.left + rect.width / 2,
-                                y: rect.top + rect.height / 2,
-                              });
-                            }}
-                          >
-                            <Icon name="crosshair" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Link second filter input</TooltipContent>
-                      </Tooltip>
+                      {isDateInputMode2 && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="secondary"
+                              onClick={(e) => {
+                                const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                                handlePickSecondInputForCondition(group.id, condition.id, {
+                                  x: rect.left + rect.width / 2,
+                                  y: rect.top + rect.height / 2,
+                                });
+                              }}
+                            >
+                              <Icon name="crosshair" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Link second filter input</TooltipContent>
+                        </Tooltip>
+                      )}
                     </div>
                   )}
                 </>

--- a/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
+++ b/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
@@ -51,6 +51,7 @@ import {
   isDateFieldType,
   SELF_OPERATORS,
 } from '@/lib/collection-field-utils';
+import { clampDateInputValue } from '@/lib/date-format-utils';
 import { getCollectionVariable, isInputInsideFilter, resolveFilterInputId, findLayerById } from '@/lib/layer-utils';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { usePagesStore } from '@/stores/usePagesStore';
@@ -609,6 +610,11 @@ export default function CollectionFiltersSettings({
     const icon = getFieldIcon(fieldType);
     const displayName = getFieldName(condition.fieldId || '');
     const referenceCollectionId = getReferenceCollectionId(condition);
+    // Date fields use a dropdown for value mode; the "Filter form input" option
+    // is the only place that reveals the link-to-input target icon. Falls back
+    // to a linked input for conditions saved before `dateInput` existed.
+    const isDateInputMode = isDateFieldType(fieldType)
+      && (condition.dateInput === true || !!condition.inputLayerId);
 
     return (
       <React.Fragment key={condition.id}>
@@ -773,12 +779,14 @@ export default function CollectionFiltersSettings({
                     ) : isDateFieldType(fieldType) ? (
                       <div className="flex flex-col gap-1.5">
                         <Select
-                          value={isDatePreset(condition.value) ? condition.value : (condition.value ? '_custom' : '')}
+                          value={isDatePreset(condition.value) ? condition.value : (isDateInputMode ? '_input' : '_custom')}
                           onValueChange={(v) => {
-                            if (v === '_custom') {
-                              handleValueChange(group.id, condition.id, '');
+                            if (v === '_input') {
+                              patchCondition(group.id, condition.id, { dateInput: true, value: '' });
+                            } else if (v === '_custom') {
+                              patchCondition(group.id, condition.id, { dateInput: false, value: '' });
                             } else {
-                              handleValueChange(group.id, condition.id, v);
+                              patchCondition(group.id, condition.id, { dateInput: false, value: v });
                             }
                           }}
                         >
@@ -787,18 +795,19 @@ export default function CollectionFiltersSettings({
                           </SelectTrigger>
                           <SelectContent>
                             <SelectGroup>
+                              <SelectItem value="_custom">Custom date</SelectItem>
                               {DATE_PRESET_OPTIONS.map((opt) => (
                                 <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
                               ))}
-                              <SelectItem value="_custom">Custom date...</SelectItem>
+                              <SelectItem value="_input">Filter form input</SelectItem>
                             </SelectGroup>
                           </SelectContent>
                         </Select>
-                        {!isDatePreset(condition.value) && (
+                        {!isDatePreset(condition.value) && !isDateInputMode && (
                           <Input
                             type="date"
                             value={condition.value || ''}
-                            onChange={(e) => handleValueChange(group.id, condition.id, e.target.value)}
+                            onChange={(e) => patchCondition(group.id, condition.id, { value: clampDateInputValue(e.target.value) })}
                           />
                         )}
                       </div>
@@ -817,23 +826,25 @@ export default function CollectionFiltersSettings({
                       />
                     )}
                   </div>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="secondary"
-                        onClick={(e) => {
-                          const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-                          handlePickInputForCondition(group.id, condition.id, {
-                            x: rect.left + rect.width / 2,
-                            y: rect.top + rect.height / 2,
-                          });
-                        }}
-                      >
-                        <Icon name="crosshair" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>Link to filter input</TooltipContent>
-                  </Tooltip>
+                  {(!isDateFieldType(fieldType) || isDateInputMode) && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="secondary"
+                          onClick={(e) => {
+                            const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                            handlePickInputForCondition(group.id, condition.id, {
+                              x: rect.left + rect.width / 2,
+                              y: rect.top + rect.height / 2,
+                            });
+                          }}
+                        >
+                          <Icon name="crosshair" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Link to filter input</TooltipContent>
+                    </Tooltip>
+                  )}
                 </div>
               )}
 
@@ -863,7 +874,7 @@ export default function CollectionFiltersSettings({
                         <Input
                           type="date"
                           value={condition.value2 || ''}
-                          onChange={(e) => handleValue2Change(group.id, condition.id, e.target.value)}
+                          onChange={(e) => patchCondition(group.id, condition.id, { value2: clampDateInputValue(e.target.value) })}
                         />
                       </div>
                       <Tooltip>

--- a/app/(builder)/ycode/components/ConditionalVisibilitySettings.tsx
+++ b/app/(builder)/ycode/components/ConditionalVisibilitySettings.tsx
@@ -819,7 +819,7 @@ export default function ConditionalVisibilitySettings({
                     </SelectTrigger>
                     <SelectContent>
                       <SelectGroup>
-                        <SelectItem value="_custom">Custom date...</SelectItem>
+                        <SelectItem value="_custom">Custom date</SelectItem>
                         {DATE_PRESET_OPTIONS
                           .filter((opt) => !opt.value.startsWith('$past_'))
                           .map((opt) => (

--- a/app/(builder)/ycode/components/ElementPickerOverlay.tsx
+++ b/app/(builder)/ycode/components/ElementPickerOverlay.tsx
@@ -99,6 +99,9 @@ export default function ElementPickerOverlay({ iframeElement, zoom }: ElementPic
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
+        // Stop other global Esc handlers (e.g. "select parent layer") from
+        // also reacting while the picker is being cancelled.
+        e.stopImmediatePropagation();
         stopElementPicker();
       }
     };
@@ -142,6 +145,7 @@ export default function ElementPickerOverlay({ iframeElement, zoom }: ElementPic
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
+        e.stopImmediatePropagation();
         stopElementPicker();
       }
     };

--- a/components/FilterableCollection.tsx
+++ b/components/FilterableCollection.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useLayoutEffect, useRef, useCallback, useState } from
 import { useFilterStore } from '@/stores/useFilterStore';
 import { LOAD_MORE_APPENDED_ATTR } from '@/components/LoadMoreCollection';
 import type { ConditionalVisibility, Layer } from '@/types';
-import { isDateFieldType, isDatePreset, resolveDateFilterValue } from '@/lib/collection-field-utils';
 
 interface FilterableCollectionProps {
   children: React.ReactNode;
@@ -292,18 +291,12 @@ export default function FilterableCollection({
           value = JSON.stringify([value]);
         }
 
-        let resolvedOperator: string = condition.operator;
-        if (isDateFieldType(condition.fieldType) && isDatePreset(value)) {
-          const resolved = resolveDateFilterValue(condition.operator, value, value2);
-          if (!resolved) continue;
-          resolvedOperator = resolved.operator;
-          value = resolved.value;
-          value2 = resolved.value2;
-        }
-
+        // Date presets (e.g. `$today`) are forwarded verbatim — the filter API
+        // resolves them against the project timezone, so "today" matches the
+        // site's configured timezone rather than the visitor's browser.
         activeInGroup.push({
           fieldId: condition.fieldId,
-          operator: resolvedOperator,
+          operator: condition.operator,
           value,
           value2,
           fieldType: condition.fieldType,

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1418,6 +1418,7 @@ const LayerItemImpl: React.FC<{
             pageCollectionCounts: {},
             currentItemId: item.id,
             pageCollectionItemId,
+            timezone,
           })
         );
       }
@@ -1445,7 +1446,7 @@ const LayerItemImpl: React.FC<{
     }
 
     return items;
-  }, [collectionId, allCollectionItems, sourceFieldId, sourceFieldType, sourceFieldSource, collectionLayerData, pageCollectionItemData, collectionLayerItemId, pageCollectionItemId, getAsset, collectionVariable?.filters, collectionVariable?.limit, collectionVariable?.offset, collectionVariable?.pagination, isEditMode]);
+  }, [collectionId, allCollectionItems, sourceFieldId, sourceFieldType, sourceFieldSource, collectionLayerData, pageCollectionItemData, collectionLayerItemId, pageCollectionItemId, getAsset, collectionVariable?.filters, collectionVariable?.limit, collectionVariable?.offset, collectionVariable?.pagination, isEditMode, timezone]);
 
   const optionsSourceSort = layer.settings?.optionsSource;
 
@@ -1814,6 +1815,7 @@ const LayerItemImpl: React.FC<{
       pageCollectionCounts,
       currentItemId: collectionLayerItemId,
       pageCollectionItemId,
+      timezone,
     });
     if (!isVisible) {
       return null;

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -354,57 +354,88 @@ const VISIBILITY_BOOT_SCRIPT = `
 (function () {
   if (typeof document === 'undefined') return;
 
-  function fmt(date) { return date.toISOString().slice(0, 10); }
+  function fmt(y, m0, d) { return new Date(Date.UTC(y, m0, d)).toISOString().slice(0, 10); }
 
-  // Mirror of resolveDatePreset: resolve a preset to YYYY-MM-DD bounds using
-  // the same local-component construction the server uses.
-  function resolvePreset(preset) {
-    var now = new Date();
-    var y = now.getFullYear(), m = now.getMonth(), d = now.getDate();
+  // Calendar Y/M/D (1-based month) of an instant as seen in a timezone.
+  function tzParts(date, tz) {
+    try {
+      var parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit'
+      }).formatToParts(date);
+      function get(t) { for (var i = 0; i < parts.length; i++) if (parts[i].type === t) return Number(parts[i].value); return 0; }
+      return { year: get('year'), month: get('month'), day: get('day') };
+    } catch (_) {
+      return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1, day: date.getUTCDate() };
+    }
+  }
+
+  // UTC epoch ms for a wall-clock time interpreted in the given timezone.
+  function zonedToUtc(y, m, d, h, mi, s, ms, tz) {
+    var guess = Date.UTC(y, m - 1, d, h, mi, s, ms);
+    try {
+      var parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: tz, hourCycle: 'h23', year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', second: '2-digit'
+      }).formatToParts(new Date(guess));
+      function get(t) { for (var i = 0; i < parts.length; i++) if (parts[i].type === t) return Number(parts[i].value); return 0; }
+      var wall = Date.UTC(get('year'), get('month') - 1, get('day'), get('hour'), get('minute'), get('second'));
+      return guess - (wall - guess);
+    } catch (_) { return guess; }
+  }
+
+  // Mirror of resolveDatePreset: resolve a preset to YYYY-MM-DD bounds relative
+  // to the current date in the project timezone.
+  function resolvePreset(preset, tz) {
+    var p = tzParts(new Date(), tz);
+    var y = p.year, m = p.month - 1, d = p.day;
     switch (preset) {
       case '$today':
-        return { start: fmt(new Date(y, m, d)), end: fmt(new Date(y, m, d)) };
+        return { start: fmt(y, m, d), end: fmt(y, m, d) };
       case '$this_week': {
-        var day = now.getDay();
-        var monday = new Date(y, m, d - ((day + 6) % 7));
-        var sunday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 6);
-        return { start: fmt(monday), end: fmt(sunday) };
+        var dow = new Date(Date.UTC(y, m, d)).getUTCDay();
+        var off = (dow + 6) % 7;
+        return { start: fmt(y, m, d - off), end: fmt(y, m, d - off + 6) };
       }
       case '$this_month':
-        return { start: fmt(new Date(y, m, 1)), end: fmt(new Date(y, m + 1, 0)) };
+        return { start: fmt(y, m, 1), end: fmt(y, m + 1, 0) };
       case '$this_year':
-        return { start: fmt(new Date(y, 0, 1)), end: fmt(new Date(y, 11, 31)) };
+        return { start: fmt(y, 0, 1), end: fmt(y, 11, 31) };
       case '$past_week':
-        return { start: fmt(new Date(y, m, d - 7)), end: fmt(new Date(y, m, d)) };
+        return { start: fmt(y, m, d - 7), end: fmt(y, m, d) };
       case '$past_month':
-        return { start: fmt(new Date(y, m - 1, d)), end: fmt(new Date(y, m, d)) };
+        return { start: fmt(y, m - 1, d), end: fmt(y, m, d) };
       case '$past_year':
-        return { start: fmt(new Date(y - 1, m, d)), end: fmt(new Date(y, m, d)) };
+        return { start: fmt(y - 1, m, d), end: fmt(y, m, d) };
       default:
         return null;
     }
   }
 
-  // Mirror of dateStringToDayBounds: YYYY-MM-DD spans a full UTC day; any other
-  // parseable value collapses to a single instant.
-  function dayBounds(value) {
+  // Mirror of dateStringToDayBounds: YYYY-MM-DD spans a full day in the project
+  // timezone (UTC for date_only fields); any other value collapses to an instant.
+  function dayBounds(value, tz, dateOnly) {
     if (!value) return null;
     if (/^\\d{4}-\\d{2}-\\d{2}$/.test(value)) {
-      var start = Date.parse(value + 'T00:00:00.000Z');
-      var end = Date.parse(value + 'T23:59:59.999Z');
-      if (isNaN(start) || isNaN(end)) return null;
-      return { start: start, end: end };
+      if (dateOnly) {
+        var s = Date.parse(value + 'T00:00:00.000Z');
+        var e = Date.parse(value + 'T23:59:59.999Z');
+        if (isNaN(s) || isNaN(e)) return null;
+        return { start: s, end: e };
+      }
+      var parts = value.split('-');
+      var y = Number(parts[0]), mo = Number(parts[1]), da = Number(parts[2]);
+      return { start: zonedToUtc(y, mo, da, 0, 0, 0, 0, tz), end: zonedToUtc(y, mo, da, 23, 59, 59, 999, tz) };
     }
     var ts = Date.parse(value);
     return isNaN(ts) ? null : { start: ts, end: ts };
   }
 
   // Mirror of resolveDateFilterValue.
-  function resolveCompareValue(operator, value) {
+  function resolveCompareValue(operator, value, tz) {
     if (typeof value !== 'string' || value.charAt(0) !== '$') {
       return { operator: operator, value: value, value2: undefined };
     }
-    var range = resolvePreset(value);
+    var range = resolvePreset(value, tz);
     if (!range) return { operator: operator, value: value, value2: undefined };
     switch (operator) {
       case 'is':
@@ -420,32 +451,33 @@ const VISIBILITY_BOOT_SCRIPT = `
   }
 
   // Mirror of compareDateFilter.
-  function compareDate(storedValue, operator, filterValue, filterValue2) {
+  function compareDate(storedValue, operator, filterValue, filterValue2, tz, dateOnly) {
     var valueTs = Date.parse(storedValue);
     if (isNaN(valueTs)) return false;
-    var bounds = dayBounds(filterValue);
+    var bounds = dayBounds(filterValue, tz, dateOnly);
     if (!bounds) return false;
     switch (operator) {
       case 'is': return valueTs >= bounds.start && valueTs <= bounds.end;
       case 'is_before': return valueTs < bounds.start;
       case 'is_after': return valueTs > bounds.end;
       case 'is_between':
-        var bounds2 = dayBounds(filterValue2);
+        var bounds2 = dayBounds(filterValue2, tz, dateOnly);
         if (!bounds2) return false;
         return valueTs >= bounds.start && valueTs <= bounds2.end;
       default: return false;
     }
   }
 
-  function evaluateDynamicCondition(condition) {
-    var resolved = resolveCompareValue(condition.operator, condition.value);
-    return compareDate(condition.fieldValue || '', resolved.operator, resolved.value, resolved.value2);
+  function evaluateDynamicCondition(condition, tz) {
+    var resolved = resolveCompareValue(condition.operator, condition.value, tz);
+    return compareDate(condition.fieldValue || '', resolved.operator, resolved.value, resolved.value2, tz, !!condition.dateOnly);
   }
 
   // Mirror of evaluateVisibility: conditions OR within a group, groups AND,
   // empty groups skipped. Non-date conditions carry a baked export-time
   // result; date-preset conditions re-evaluate against the current date.
   function evaluateRule(payload) {
+    var tz = (payload && payload.timezone) || 'UTC';
     var groups = (payload && payload.groups) || [];
     for (var i = 0; i < groups.length; i++) {
       var conditions = groups[i].conditions || [];
@@ -453,7 +485,7 @@ const VISIBILITY_BOOT_SCRIPT = `
       var groupResult = false;
       for (var j = 0; j < conditions.length; j++) {
         var c = conditions[j];
-        var ok = c.dynamic ? evaluateDynamicCondition(c) : !!c.result;
+        var ok = c.dynamic ? evaluateDynamicCondition(c, tz) : !!c.result;
         if (ok) { groupResult = true; break; }
       }
       if (!groupResult) return false;

--- a/lib/collection-field-utils.ts
+++ b/lib/collection-field-utils.ts
@@ -276,36 +276,97 @@ export function isDatePreset(value: string | undefined): boolean {
 }
 
 /**
- * Resolve a date preset string to a concrete YYYY-MM-DD date (or date pair for
- * range presets). Returns `null` for non-preset values.
+ * Calendar year/month/day (1-based month) of an instant as it appears in a
+ * timezone. Falls back to the UTC components if the timezone is invalid.
  */
-export function resolveDatePreset(preset: string): { start: string; end: string } | null {
-  const now = new Date();
-  const yyyy = now.getFullYear();
-  const mm = now.getMonth();
-  const dd = now.getDate();
+export function getDatePartsInTimezone(
+  date: Date,
+  timezone: string = 'UTC',
+): { year: number; month: number; day: number } {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(date);
+    const get = (t: string) => Number(parts.find(p => p.type === t)?.value);
+    return { year: get('year'), month: get('month'), day: get('day') };
+  } catch {
+    return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1, day: date.getUTCDate() };
+  }
+}
 
-  const fmt = (d: Date) => d.toISOString().slice(0, 10);
+/**
+ * UTC epoch milliseconds for a wall-clock time interpreted in the given
+ * timezone. Single-pass offset correction — accurate except within the rare
+ * ~1h DST overlap, which is acceptable for day-boundary filtering.
+ */
+export function zonedTimeToUtcMs(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  ms: number,
+  timezone: string = 'UTC',
+): number {
+  const utcGuess = Date.UTC(year, month - 1, day, hour, minute, second, ms);
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hourCycle: 'h23',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    }).formatToParts(new Date(utcGuess));
+    const get = (t: string) => Number(parts.find(p => p.type === t)?.value);
+    const wallAsUtc = Date.UTC(get('year'), get('month') - 1, get('day'), get('hour'), get('minute'), get('second'));
+    return utcGuess - (wallAsUtc - utcGuess);
+  } catch {
+    return utcGuess;
+  }
+}
+
+/**
+ * Resolve a date preset string to a concrete YYYY-MM-DD date (or date pair for
+ * range presets), relative to the current date in the project `timezone`.
+ * Returns `null` for non-preset values.
+ */
+export function resolveDatePreset(
+  preset: string,
+  timezone: string = 'UTC',
+): { start: string; end: string } | null {
+  const { year: yyyy, month, day: dd } = getDatePartsInTimezone(new Date(), timezone);
+  const mm = month - 1;
+
+  // Format calendar Y/M/D as YYYY-MM-DD using UTC purely as a calendar
+  // calculator (constructed and read in UTC, so no timezone shift).
+  const fmt = (y: number, m0: number, d: number) =>
+    new Date(Date.UTC(y, m0, d)).toISOString().slice(0, 10);
 
   switch (preset) {
     case '$today':
-      return { start: fmt(new Date(yyyy, mm, dd)), end: fmt(new Date(yyyy, mm, dd)) };
+      return { start: fmt(yyyy, mm, dd), end: fmt(yyyy, mm, dd) };
     case '$this_week': {
-      const day = now.getDay();
-      const monday = new Date(yyyy, mm, dd - ((day + 6) % 7));
-      const sunday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 6);
-      return { start: fmt(monday), end: fmt(sunday) };
+      const dow = new Date(Date.UTC(yyyy, mm, dd)).getUTCDay();
+      const mondayOffset = (dow + 6) % 7;
+      return { start: fmt(yyyy, mm, dd - mondayOffset), end: fmt(yyyy, mm, dd - mondayOffset + 6) };
     }
     case '$this_month':
-      return { start: fmt(new Date(yyyy, mm, 1)), end: fmt(new Date(yyyy, mm + 1, 0)) };
+      return { start: fmt(yyyy, mm, 1), end: fmt(yyyy, mm + 1, 0) };
     case '$this_year':
-      return { start: fmt(new Date(yyyy, 0, 1)), end: fmt(new Date(yyyy, 11, 31)) };
+      return { start: fmt(yyyy, 0, 1), end: fmt(yyyy, 11, 31) };
     case '$past_week':
-      return { start: fmt(new Date(yyyy, mm, dd - 7)), end: fmt(new Date(yyyy, mm, dd)) };
+      return { start: fmt(yyyy, mm, dd - 7), end: fmt(yyyy, mm, dd) };
     case '$past_month':
-      return { start: fmt(new Date(yyyy, mm - 1, dd)), end: fmt(new Date(yyyy, mm, dd)) };
+      return { start: fmt(yyyy, mm - 1, dd), end: fmt(yyyy, mm, dd) };
     case '$past_year':
-      return { start: fmt(new Date(yyyy - 1, mm, dd)), end: fmt(new Date(yyyy, mm, dd)) };
+      return { start: fmt(yyyy - 1, mm, dd), end: fmt(yyyy, mm, dd) };
     default:
       return null;
   }
@@ -320,10 +381,11 @@ export function resolveDateFilterValue(
   operator: string,
   value: string | undefined,
   value2: string | undefined,
+  timezone: string = 'UTC',
 ): { operator: string; value: string; value2?: string } | null {
   if (!value) return null;
   if (!isDatePreset(value)) return { operator, value, value2 };
-  const range = resolveDatePreset(value);
+  const range = resolveDatePreset(value, timezone);
   if (!range) return { operator, value, value2 };
 
   switch (operator) {
@@ -381,18 +443,29 @@ export function isDateOnlyString(value: string | undefined | null): boolean {
 
 /**
  * Convert a filter date string to start/end-of-day UTC timestamps.
- * For `YYYY-MM-DD` inputs the range spans the entire UTC day so that filters
- * match datetime values (which are stored as full ISO strings) regardless of
- * the time component. For other inputs, both bounds equal the parsed
- * timestamp. Returns `null` if the input cannot be parsed.
+ *
+ * For datetime (`date`) fields, a `YYYY-MM-DD` input spans the day in the
+ * project `timezone` (converted to the matching UTC instants) so filters align
+ * with what the user sees. For `date_only` fields (`dateOnly = true`) the day
+ * spans UTC, since those values are timezone-neutral calendar dates. Other
+ * inputs collapse to a single parsed instant. Returns `null` if unparseable.
  */
 export function dateStringToDayBounds(
   value: string | undefined | null,
+  timezone: string = 'UTC',
+  dateOnly: boolean = false,
 ): { start: number; end: number } | null {
   if (!value) return null;
   if (isDateOnlyString(value)) {
-    const start = Date.parse(`${value}T00:00:00.000Z`);
-    const end = Date.parse(`${value}T23:59:59.999Z`);
+    if (dateOnly) {
+      const start = Date.parse(`${value}T00:00:00.000Z`);
+      const end = Date.parse(`${value}T23:59:59.999Z`);
+      if (isNaN(start) || isNaN(end)) return null;
+      return { start, end };
+    }
+    const [y, m, d] = value.split('-').map(Number);
+    const start = zonedTimeToUtcMs(y, m, d, 0, 0, 0, 0, timezone);
+    const end = zonedTimeToUtcMs(y, m, d, 23, 59, 59, 999, timezone);
     if (isNaN(start) || isNaN(end)) return null;
     return { start, end };
   }
@@ -402,18 +475,21 @@ export function dateStringToDayBounds(
 
 /**
  * Compare a stored date/datetime value against a filter value using day-aware
- * semantics (so `is today` matches any timestamp on today's date).
- * Returns `false` if either value cannot be parsed.
+ * semantics (so `is today` matches any timestamp on today's date). Day bounds
+ * are resolved in the project `timezone` for datetime fields; `dateOnly` fields
+ * compare in UTC. Returns `false` if either value cannot be parsed.
  */
 export function compareDateFilter(
   storedValue: string,
   operator: 'is' | 'is_before' | 'is_after' | 'is_between',
   filterValue: string,
   filterValue2?: string,
+  timezone: string = 'UTC',
+  dateOnly: boolean = false,
 ): boolean {
   const valueTs = Date.parse(storedValue);
   if (isNaN(valueTs)) return false;
-  const bounds = dateStringToDayBounds(filterValue);
+  const bounds = dateStringToDayBounds(filterValue, timezone, dateOnly);
   if (!bounds) return false;
 
   switch (operator) {
@@ -424,7 +500,7 @@ export function compareDateFilter(
     case 'is_after':
       return valueTs > bounds.end;
     case 'is_between': {
-      const bounds2 = dateStringToDayBounds(filterValue2);
+      const bounds2 = dateStringToDayBounds(filterValue2, timezone, dateOnly);
       if (!bounds2) return false;
       return valueTs >= bounds.start && valueTs <= bounds2.end;
     }

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -1945,6 +1945,8 @@ export interface VisibilityContext {
   currentItemId?: string;
   /** ID of the dynamic page's collection item, when on a dynamic page. */
   pageCollectionItemId?: string | null;
+  /** Project timezone (IANA) used for day-aware date condition comparisons. */
+  timezone?: string;
 }
 
 /**
@@ -1958,6 +1960,7 @@ export function evaluateCondition(
   context: VisibilityContext
 ): boolean {
   const { collectionLayerData, pageCollectionData, pageCollectionCounts, currentItemId, pageCollectionItemId } = context;
+  const timezone = context.timezone || 'UTC';
 
   // Self conditions: compare the item being evaluated against a set of item
   // IDs (statically picked and/or the current dynamic page item). Used for
@@ -2014,9 +2017,10 @@ export function evaluateCondition(
     let compareValue2 = condition.value2;
     let effectiveOperator = condition.operator;
     const fieldType = condition.fieldType || 'text';
+    const isDateOnly = fieldType === 'date_only';
 
     if (isDateFieldType(fieldType) && isDatePreset(compareValue)) {
-      const resolved = resolveDateFilterValue(effectiveOperator, compareValue, compareValue2);
+      const resolved = resolveDateFilterValue(effectiveOperator, compareValue, compareValue2, timezone);
       if (resolved) {
         effectiveOperator = resolved.operator as typeof effectiveOperator;
         compareValue = resolved.value;
@@ -2040,7 +2044,7 @@ export function evaluateCondition(
           return parseFloat(value) === parseFloat(compareValue);
         }
         if (isDateFieldType(fieldType)) {
-          return compareDateFilter(value, 'is', compareValue);
+          return compareDateFilter(value, 'is', compareValue, undefined, timezone, isDateOnly);
         }
         return value === compareValue;
 
@@ -2052,7 +2056,7 @@ export function evaluateCondition(
           return parseFloat(value) !== parseFloat(compareValue);
         }
         if (isDateFieldType(fieldType)) {
-          return !compareDateFilter(value, 'is', compareValue);
+          return !compareDateFilter(value, 'is', compareValue, undefined, timezone, isDateOnly);
         }
         return value !== compareValue;
 
@@ -2081,15 +2085,16 @@ export function evaluateCondition(
       case 'gte':
         return parseFloat(value) >= parseFloat(compareValue);
 
-      // Date operators (day-aware: `YYYY-MM-DD` filter values span the full UTC day)
+      // Date operators (day-aware: `YYYY-MM-DD` filter values span the full day
+      // in the project timezone; `date_only` fields compare in UTC)
       case 'is_before':
-        return compareDateFilter(value, 'is_before', compareValue);
+        return compareDateFilter(value, 'is_before', compareValue, undefined, timezone, isDateOnly);
 
       case 'is_after':
-        return compareDateFilter(value, 'is_after', compareValue);
+        return compareDateFilter(value, 'is_after', compareValue, undefined, timezone, isDateOnly);
 
       case 'is_between':
-        return compareDateFilter(value, 'is_between', compareValue, compareValue2);
+        return compareDateFilter(value, 'is_between', compareValue, compareValue2, timezone, isDateOnly);
 
       case 'is_not_empty':
         return isPresent;

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -2361,6 +2361,7 @@ export async function resolveCollectionLayers(
                 pageCollectionCounts: {},
                 currentItemId: item.id,
                 pageCollectionItemId: pageCollectionItemId ?? parentCollectionItemId,
+                timezone,
               })
             );
           }
@@ -2825,7 +2826,7 @@ export async function resolveCollectionLayers(
   // Third pass: Filter layers by conditional visibility
   // We need to compute collection counts first, then filter
   // parentItemValues is the page collection data for dynamic pages
-  const filteredResult = filterByVisibility(resultWithPagination, undefined, parentItemValues, pageCollectionItemId ?? parentCollectionItemId);
+  const filteredResult = filterByVisibility(resultWithPagination, undefined, parentItemValues, pageCollectionItemId ?? parentCollectionItemId, timezone);
 
   return filteredResult;
 }
@@ -2922,6 +2923,7 @@ function filterByVisibility(
   collectionLayerData?: Record<string, string>,
   pageCollectionData?: Record<string, string> | null,
   pageCollectionItemId?: string | null,
+  timezone: string = 'UTC',
 ): Layer[] {
   const pageCollectionCounts = computeCollectionCounts(layers);
   const filterableCollectionIds = findFilterableCollectionIds(layers);
@@ -2942,6 +2944,7 @@ function filterByVisibility(
         pageCollectionCounts,
         currentItemId: effectiveCurrentItemId,
         pageCollectionItemId,
+        timezone,
       });
       const filterTarget = getFilterableCollectionTarget(conditionalVisibility, filterableCollectionIds);
       if (filterTarget) {
@@ -2989,6 +2992,7 @@ function filterByVisibility(
           pageCollectionCounts,
           currentItemId: effectiveCurrentItemId,
           pageCollectionItemId,
+          timezone,
         };
         const groups = conditionalVisibility.groups.map(group => ({
           conditions: (group.conditions || []).map((condition): DynamicVisibilityCondition => {
@@ -3004,6 +3008,7 @@ function filterByVisibility(
                 operator: condition.operator,
                 value: String(condition.value ?? ''),
                 fieldValue: String(v ?? ''),
+                dateOnly: condition.fieldType === 'date_only',
               };
             }
             return {
@@ -3018,7 +3023,7 @@ function filterByVisibility(
             ...(layer._dynamicStyles || {}),
             display: isVisible ? '' : 'none',
           },
-          _dynamicVisibilityRule: { groups },
+          _dynamicVisibilityRule: { timezone, groups },
           children: layer.children
             ? layer.children
               .map(child => filterLayer(child, effectiveCollectionLayerData, effectiveCurrentItemId))
@@ -3404,7 +3409,7 @@ export async function renderCollectionItemsToHtml(
       }
 
       // Apply conditional visibility based on this item's field values
-      resolvedLayers = filterByVisibility(resolvedLayers, item.values, undefined, pageLinkContext?.pageCollectionItemId);
+      resolvedLayers = filterByVisibility(resolvedLayers, item.values, undefined, pageLinkContext?.pageCollectionItemId, htmlTimezone);
 
       // Preferred path: rebuild a full clone of the collection layer just
       // like SSR does (link/action/attributes preserved). Renders one HTML

--- a/types/index.ts
+++ b/types/index.ts
@@ -1403,6 +1403,8 @@ export interface VisibilityCondition {
   // even before an input is linked. Absent on conditions created before this
   // existed — those fall back to linked-state/custom inference.
   dateInput?: boolean;
+  // Same as `dateInput`, but for the second bound (`is_between`).
+  dateInput2?: boolean;
 }
 
 export interface VisibilityConditionGroup {

--- a/types/index.ts
+++ b/types/index.ts
@@ -464,6 +464,8 @@ export interface Layer {
   // Non-date conditions are baked to a boolean at export time; only
   // date-preset conditions are re-evaluated client-side against the current date.
   _dynamicVisibilityRule?: {
+    /** Project timezone (IANA) for resolving date presets on the client. */
+    timezone?: string;
     groups: Array<{ conditions: DynamicVisibilityCondition[] }>;
   };
   // SSR-only property for filterable collection config (when collection has linked filter inputs)
@@ -1396,6 +1398,11 @@ export interface VisibilityCondition {
   // For linking filter value to an input layer inside a Filter
   inputLayerId?: string;
   inputLayerId2?: string; // For second bound (e.g. 'is_between')
+  // Date fields only: marks the value as sourced from a filter form input
+  // (vs. a preset or custom date). Persisted so the UI stays in input mode
+  // even before an input is linked. Absent on conditions created before this
+  // existed — those fall back to linked-state/custom inference.
+  dateInput?: boolean;
 }
 
 export interface VisibilityConditionGroup {
@@ -1413,7 +1420,7 @@ export interface ConditionalVisibility {
  * all other conditions carry their export-time result, baked in.
  */
 export type DynamicVisibilityCondition =
-  | { dynamic: true; operator: VisibilityOperator; value: string; fieldValue: string }
+  | { dynamic: true; operator: VisibilityOperator; value: string; fieldValue: string; dateOnly?: boolean }
   | { dynamic: false; result: boolean };
 
 // Localisation Types


### PR DESCRIPTION
## Summary

Collection date filters and conditional visibility now compare dates in the project's configured timezone instead of UTC, so items match the calendar day users actually see. Also makes the date filter UI consistent across both bounds of "is between".

## Changes

- Resolve date filter day-bounds and presets in the project timezone for datetime fields; keep `date_only` fields timezone-neutral (UTC)
- Apply timezone consistently across the filter API, SSR, static export, runtime client filtering, and the builder canvas (which previously still filtered in UTC)
- Fix the custom date input resetting while typing (immediate update + clamp)
- Add a "Filter form input" date option that reveals the link-to-input target icon only when selected
- Cancel input targeting on Escape without selecting the parent layer
- Give the "is between" second bound the same Custom date / Filter form input UI as the first, and hide dynamic presets for "is between"

## Test plan

- [ ] Set project timezone to a non-UTC zone (e.g. Australia/Perth)
- [ ] Item at `2026-06-01T17:00Z` matches `DT is 2026-06-02` (Perth day)
- [ ] Same filter shows the item in canvas, preview, and published
- [ ] Switch timezone to UTC → `is 2026-06-02` hides it, `is 2026-06-01` shows it
- [ ] `date_only` field results do NOT shift when the timezone changes
- [ ] Presets (`$today`, etc.) resolve in the project timezone
- [ ] Custom date input types smoothly without resetting
- [ ] "is between" shows select + input on both bounds, no presets