### PR TITLE
fix: show quotes in dynamic rich text on published pages

### DIFF
--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -1517,8 +1517,9 @@ function resolveRichTextVariables(
     const isBlockNode = (n: any) =>
       n?.type === 'paragraph' || n?.type === 'heading' ||
       n?.type === 'bulletList' || n?.type === 'orderedList' ||
-      n?.type === 'richTextComponent' || n?.type === 'richTextImage' ||
-      n?.type === 'table' || n?.type === 'richTextHtmlEmbed' || n?.type === 'horizontalRule';
+      n?.type === 'blockquote' || n?.type === 'richTextComponent' ||
+      n?.type === 'richTextImage' || n?.type === 'table' ||
+      n?.type === 'richTextHtmlEmbed' || n?.type === 'horizontalRule';
     const hasBlockChildren = result.content.some(isBlockNode);
     if (hasBlockChildren) {
       const lifted: any[] = [];


### PR DESCRIPTION
## Summary

Blockquotes inside a dynamic rich text field were not appearing (or appearing unstyled) on generated/preview pages, even though they rendered correctly on the canvas.

## Changes

- Add `blockquote` to the block-node detection in `resolveRichTextVariables` (`lib/page-fetcher.ts`). When a `rich_text` field expands inline within a wrapping paragraph, blockquotes are now lifted out as proper block-level nodes instead of being wrapped back into a paragraph and dropped at render time.

## Test plan

- [ ] Open a published/preview page with a dynamic rich text field that contains one or more quotes
- [ ] Verify each quote renders as a `<blockquote>` with its configured styles (border, padding, margin, font size)
- [ ] Confirm the rendering matches the canvas
- [ ] Verify surrounding paragraphs, headings, and lists are unaffected