### PR TITLE
fix: make sliders work inside rich-text content on published pages

### DIFF
--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -179,22 +179,45 @@ function extractAnimationLayers(layers: Layer[]): Layer[] {
     }));
 }
 
-/** Recursively check if any layer in the tree is a slider */
-function hasSliderLayers(layers: Layer[]): boolean {
-  for (const layer of layers) {
-    if (layer.name === 'slider') return true;
-    if (layer.children && hasSliderLayers(layer.children)) return true;
+/** Scan a Tiptap JSON node for richTextComponent nodes and test their pre-resolved
+ * layers (populated by resolveTiptapComponentCollections) against the predicate. */
+function tiptapTreeHasLayer(node: any, predicate: (layer: Layer) => boolean): boolean {
+  if (!node || typeof node !== 'object') return false;
+  if (node.type === 'richTextComponent' && Array.isArray(node.attrs?._resolvedLayers)
+    && layerTreeHasLayer(node.attrs._resolvedLayers as Layer[], predicate)) {
+    return true;
+  }
+  if (Array.isArray(node.content)) {
+    for (const child of node.content) {
+      if (tiptapTreeHasLayer(child, predicate)) return true;
+    }
   }
   return false;
 }
 
-/** Recursively check if any layer in the tree is a lightbox */
-function hasLightboxLayers(layers: Layer[]): boolean {
+/** Recursively check if any layer matches the predicate, descending into both
+ * children and the pre-resolved layers of rich-text-embedded components. */
+function layerTreeHasLayer(layers: Layer[], predicate: (layer: Layer) => boolean): boolean {
   for (const layer of layers) {
-    if (layer.name === 'lightbox') return true;
-    if (layer.children && hasLightboxLayers(layer.children)) return true;
+    if (predicate(layer)) return true;
+    const textVar = layer.variables?.text as any;
+    if (textVar?.type === 'dynamic_rich_text' && textVar.data?.content
+      && tiptapTreeHasLayer(textVar.data.content, predicate)) {
+      return true;
+    }
+    if (layer.children && layerTreeHasLayer(layer.children, predicate)) return true;
   }
   return false;
+}
+
+/** Check if any layer in the tree (including rich-text-embedded components) is a slider */
+function hasSliderLayers(layers: Layer[]): boolean {
+  return layerTreeHasLayer(layers, layer => layer.name === 'slider');
+}
+
+/** Check if any layer in the tree (including rich-text-embedded components) is a lightbox */
+function hasLightboxLayers(layers: Layer[]): boolean {
+  return layerTreeHasLayer(layers, layer => layer.name === 'lightbox');
 }
 
 /**

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -573,9 +573,30 @@ export function collectInteractions(layers: Layer[]): ExportedInteraction[] {
   return collected
 }
 
+/** Scan a Tiptap JSON node for richTextComponent nodes and test their pre-resolved
+ * layers against the layer name (embedded rich-text components). */
+function tiptapTreeContains(node: any, name: string): boolean {
+  if (!node || typeof node !== 'object') return false
+  if (node.type === 'richTextComponent' && Array.isArray(node.attrs?._resolvedLayers)
+    && layerTreeContains(node.attrs._resolvedLayers as Layer[], name)) {
+    return true
+  }
+  if (Array.isArray(node.content)) {
+    for (const child of node.content) {
+      if (tiptapTreeContains(child, name)) return true
+    }
+  }
+  return false
+}
+
 export function layerTreeContains(layers: Layer[], name: string): boolean {
   for (const layer of layers) {
     if (layer.name === name) return true
+    const textVar = layer.variables?.text as any
+    if (textVar?.type === 'dynamic_rich_text' && textVar.data?.content
+      && tiptapTreeContains(textVar.data.content, name)) {
+      return true
+    }
     if (layer.children && layerTreeContains(layer.children, name)) return true
   }
   return false


### PR DESCRIPTION
## Summary

A slider placed inside a component that is embedded in a CMS rich-text field did not work on generated pages (preview, published, static export) — it worked in the editor but was inert everywhere else.

## Changes

- Make slider/lightbox detection in `PageRenderer` descend into rich-text-embedded components, so `SliderInitializer` (and `LightboxInitializer`) actually mount when the only slider/lightbox lives inside rich text.
- Apply the same fix to static-export `layerTreeContains` so exported sites include the Swiper assets in that case.

## Root cause

Detection only walked the page layer tree (`layer.children`). Sliders embedded in rich text live in `_resolvedLayers` on the Tiptap node, so they were never found and the client init script was never shipped. The editor worked because it initializes sliders per-layer via a separate canvas hook. This mirrors the existing link/slug resolution that already descends into `_resolvedLayers`.

## Test plan

- [ ] Bind a rich-text element to a CMS rich-text field whose content embeds a component containing a slider
- [ ] Open the preview page — slider should be interactive (swipe/arrows/autoplay)
- [ ] Publish the page and verify the slider works
- [ ] Static-export the site and confirm Swiper JS/CSS is included and the slider works
- [ ] Verify a page with no sliders still does not ship the slider init script