### PR TITLE
fix: publish all changes in large CMS collections and style-synced pages

### DIFF
--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -19,7 +19,7 @@ import { getAllDraftPages, hardDeleteSoftDeletedPages, backfillMissingPageHashes
 import { publishComponents, getUnpublishedComponents, hardDeleteSoftDeletedComponents } from '@/lib/repositories/componentRepository';
 import { publishLayerStyles, getUnpublishedLayerStyles, hardDeleteSoftDeletedLayerStyles } from '@/lib/repositories/layerStyleRepository';
 import { getAllCollections } from '@/lib/repositories/collectionRepository';
-import { getItemsByCollectionId } from '@/lib/repositories/collectionItemRepository';
+import { getAllItemsByCollectionId } from '@/lib/repositories/collectionItemRepository';
 import { publishAssets, getUnpublishedAssets, hardDeleteSoftDeletedAssets } from '@/lib/repositories/assetRepository';
 import { publishAssetFolders, getUnpublishedAssetFolders, hardDeleteSoftDeletedAssetFolders } from '@/lib/repositories/assetFolderRepository';
 import { publishFonts } from '@/lib/repositories/fontRepository';
@@ -223,7 +223,7 @@ export async function POST(request: NextRequest) {
 
         if (collectionIds && collectionIds.length > 0) {
           for (const collectionId of collectionIds) {
-            const { items } = await getItemsByCollectionId(collectionId, false);
+            const items = await getAllItemsByCollectionId(collectionId, false);
             collectionPublishes.push({
               collectionId,
               itemIds: items.map((item: any) => item.id),
@@ -250,6 +250,9 @@ export async function POST(request: NextRequest) {
               collectionId: collectionPublish.collectionId,
               itemIds: collectionPublish.itemIds,
             });
+            if (!publishResult.success) {
+              console.error(`[Publish] collection ${collectionPublish.collectionId} FAILED (${collectionPublish.itemIds.length} items):`, publishResult.errors);
+            }
             const p = publishResult.published;
             const changed = (p?.itemsCount || 0)
               + (p?.valuesCount || 0)
@@ -284,11 +287,14 @@ export async function POST(request: NextRequest) {
         const allCollections = await getAllCollections({ is_published: false });
 
         for (const collection of allCollections) {
-          const { items } = await getItemsByCollectionId(collection.id, false);
+          const items = await getAllItemsByCollectionId(collection.id, false);
           const publishResult = await publishCollectionWithItems({
             collectionId: collection.id,
             itemIds: items.map((item: any) => item.id),
           });
+          if (!publishResult.success) {
+            console.error(`[Publish] collection ${collection.id} (${collection.name}) FAILED (${items.length} items):`, publishResult.errors);
+          }
           const p = publishResult.published;
           const changedItems = p?.itemsCount || 0;
           const changedValues = p?.valuesCount || 0;

--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -614,7 +614,12 @@ export async function POST(request: NextRequest) {
       // components/styles. The builder only regenerates CSS for pages open
       // in memory — pages not loaded keep stale generated_css/content_hash.
       // This ensures batchPublishPageLayers detects the real hash change.
-      if (!globalChanged && cssAffectedPageIds.length > 0) {
+      //
+      // Runs regardless of globalChanged: this is a data-publish step (it
+      // pushes style-sync-rewritten draft layers to the published version),
+      // not a cache operation. Skipping it when a global resource changed
+      // would leave those pages' published layers stale.
+      if (cssAffectedPageIds.length > 0) {
         try {
           const { generateCSSForPages } = await import('@/lib/server/cssGenerator');
           await generateCSSForPages(cssAffectedPageIds);

--- a/lib/repositories/collectionItemRepository.ts
+++ b/lib/repositories/collectionItemRepository.ts
@@ -1,6 +1,6 @@
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { getKnexClient } from '@/lib/knex-client';
-import { SUPABASE_QUERY_LIMIT } from '@/lib/supabase-constants';
+import { SUPABASE_QUERY_LIMIT, SUPABASE_WRITE_BATCH_SIZE } from '@/lib/supabase-constants';
 import type { CollectionField, CollectionItem, CollectionItemWithValues } from '@/types';
 import { randomUUID } from 'crypto';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
@@ -439,29 +439,39 @@ export async function getItemById(id: string, isPublished: boolean = false): Pro
  * @param isPublished - Get draft (false) or published (true) items
  * @returns Array of items found
  */
-export async function getItemsByIds(ids: string[], isPublished: boolean = false): Promise<CollectionItem[]> {
+export async function getItemsByIds(ids: string[], isPublished: boolean = false, tenantId?: string): Promise<CollectionItem[]> {
   if (ids.length === 0) {
     return [];
   }
 
-  const client = await getSupabaseAdmin();
+  const client = await getSupabaseAdmin(tenantId);
 
   if (!client) {
     throw new Error('Supabase client not configured');
   }
 
-  const { data, error } = await client
-    .from('collection_items')
-    .select('*')
-    .in('id', ids)
-    .eq('is_published', isPublished)
-    .is('deleted_at', null);
+  const allItems: CollectionItem[] = [];
 
-  if (error) {
-    throw new Error(`Failed to fetch collection items: ${error.message}`);
+  for (let i = 0; i < ids.length; i += SUPABASE_WRITE_BATCH_SIZE) {
+    const batchIds = ids.slice(i, i + SUPABASE_WRITE_BATCH_SIZE);
+
+    const { data, error } = await client
+      .from('collection_items')
+      .select('*')
+      .in('id', batchIds)
+      .eq('is_published', isPublished)
+      .is('deleted_at', null);
+
+    if (error) {
+      throw new Error(`Failed to fetch collection items: ${error.message}`);
+    }
+
+    if (data) {
+      allItems.push(...data);
+    }
   }
 
-  return data || [];
+  return allItems;
 }
 
 /**
@@ -1310,27 +1320,46 @@ export async function getTotalPublishableItemsCount(): Promise<number> {
 
   const collectionIds = collections.map(c => c.id);
 
-  const [draftResult, publishedResult] = await Promise.all([
-    client
-      .from('collection_items')
-      .select('id, manual_order')
-      .in('collection_id', collectionIds)
-      .eq('is_published', false)
-      .eq('is_publishable', true)
-      .is('deleted_at', null),
-    client
-      .from('collection_items')
-      .select('id, manual_order')
-      .in('collection_id', collectionIds)
-      .eq('is_published', true),
+  // Paginate both queries to avoid PostgREST's default 1000-row limit
+  const fetchAllItems = async (isPublished: boolean): Promise<Array<{ id: string; manual_order: number }>> => {
+    const rows: Array<{ id: string; manual_order: number }> = [];
+    let offset = 0;
+
+    while (true) {
+      let query = client
+        .from('collection_items')
+        .select('id, manual_order')
+        .in('collection_id', collectionIds)
+        .eq('is_published', isPublished)
+        .order('id', { ascending: true })
+        .range(offset, offset + SUPABASE_QUERY_LIMIT - 1);
+
+      if (!isPublished) {
+        query = query.eq('is_publishable', true).is('deleted_at', null);
+      }
+
+      const { data, error } = await query;
+      if (error) {
+        throw new Error(`Failed to fetch ${isPublished ? 'published' : 'draft'} items: ${error.message}`);
+      }
+
+      const batch = data || [];
+      rows.push(...batch);
+
+      if (batch.length < SUPABASE_QUERY_LIMIT) break;
+      offset += SUPABASE_QUERY_LIMIT;
+    }
+
+    return rows;
+  };
+
+  const [draftItems, publishedItems] = await Promise.all([
+    fetchAllItems(false),
+    fetchAllItems(true),
   ]);
 
-  if (draftResult.error) {
-    throw new Error(`Failed to fetch draft items: ${draftResult.error.message}`);
-  }
-
   const publishedMap = new Map<string, number>();
-  for (const pub of publishedResult.data || []) {
+  for (const pub of publishedItems) {
     publishedMap.set(pub.id, pub.manual_order);
   }
 
@@ -1338,7 +1367,7 @@ export async function getTotalPublishableItemsCount(): Promise<number> {
   let count = 0;
   const matchingOrderItemIds: string[] = [];
 
-  for (const draft of draftResult.data || []) {
+  for (const draft of draftItems) {
     const pubOrder = publishedMap.get(draft.id);
     if (pubOrder === undefined || draft.manual_order !== pubOrder) {
       count++;

--- a/lib/services/collectionService.ts
+++ b/lib/services/collectionService.ts
@@ -13,6 +13,7 @@
 
 import { withTransaction } from '../database/transaction';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { SUPABASE_WRITE_BATCH_SIZE } from '@/lib/supabase-constants';
 import { getCollectionById, hardDeleteCollection } from '@/lib/repositories/collectionRepository';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { getItemsByCollectionId, getAllItemsByCollectionId, getItemById, getItemsByIds } from '@/lib/repositories/collectionItemRepository';
@@ -636,15 +637,19 @@ async function publishItemValuesBatch(itemIds: string[]): Promise<number> {
     return 0;
   }
 
-  // Batch upsert changed values only
-  const { error } = await client
-    .from('collection_item_values')
-    .upsert(valuesToUpsert, {
-      onConflict: 'id,is_published',
-    });
+  // Upsert in chunks within PostgREST payload limits
+  for (let j = 0; j < valuesToUpsert.length; j += SUPABASE_WRITE_BATCH_SIZE) {
+    const chunk = valuesToUpsert.slice(j, j + SUPABASE_WRITE_BATCH_SIZE);
+    const { error } = await client
+      .from('collection_item_values')
+      .upsert(chunk, {
+        onConflict: 'id,is_published',
+      });
 
-  if (error) {
-    throw new Error(`Failed to publish item values: ${error.message}`);
+    if (error) {
+      console.error(`[PUBLISH:VALUES] Value upsert failed:`, error.message);
+      throw new Error(`Failed to publish item values: ${error.message}`);
+    }
   }
 
   return valuesToUpsert.length;


### PR DESCRIPTION
## Summary

Large CMS collections and certain pages kept showing as "changed" no matter how many times you published. Two separate root causes, both surfacing as content that never finishes publishing.

## Changes

- Publish every item in large collections (>1000): the publish path now fetches all items via the paginated helper instead of the default 1000-row cap, and chunks the item-id lookup so a long `IN` filter no longer fails with "Bad Request" and silently aborts the publish.
- Chunk the item-value upsert and slug lookups in the publish path to stay within PostgREST limits.
- Paginate the publish-preview item count so it stops reporting a phantom "items changed" miscount.
- Log per-collection publish failures instead of swallowing them.
- Republish style-synced page layers even when a global resource changes: the layer-style sync rewrites affected page drafts after pages are published, and the catch-up republish was being skipped whenever a global resource (e.g. the first-ever color hash) changed — leaving those pages stuck as "not published".

## Test plan

- [ ] Publish a project with a collection of >1000 items — all items publish and the collection stops showing as changed
- [ ] Re-open the publish dialog — the changed-items count reads 0 (no phantom count)
- [ ] Publish a project where a global resource changed (e.g. first publish setting colors) and components/styles affect pages — affected pages publish and none remain "not published"
- [ ] Confirm a failing collection publish now logs an error instead of silently succeeding