### PR TITLE
fix: show password protection edits in preview and published error pages

### DIFF
--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -59,7 +59,7 @@ import CollectionItemSelector from './CollectionItemSelector';
 import RichTextEditorSheet from './RichTextEditorSheet';
 
 // 6. Utils
-import { buildLocalizedSlugPath, buildLocalizedDynamicPageUrl } from '@/lib/page-utils';
+import { buildPreviewAuthRevision, buildLocalizedSlugPath, buildLocalizedDynamicPageUrl } from '@/lib/page-utils';
 import { getTranslationValue, applyCmsTranslations, extractLayerTranslatableItemsShallow } from '@/lib/localisation-utils';
 import { cn } from '@/lib/utils';
 import { getCollectionVariable, canDeleteLayer, findLayerById, findParentCollectionLayer, canLayerHaveLink, updateLayerProps, removeRichTextSublayer, isRichTextLayer, getLayerCmsFieldBinding } from '@/lib/layer-utils';
@@ -1966,8 +1966,13 @@ const CenterCanvas = React.memo(function CenterCanvas({
     return `/ycode/preview${path === '/' ? '' : path}`;
   }, [currentPage, folders, currentPageCollectionItemId, collectionItemsFromStore, collectionFieldsFromStore, selectedLocale, localeTranslations]);
 
-  // Reload preview iframe every time preview mode opens (covers all change sources:
-  // layer edits, component updates, CMS, layer styles, color variables, etc.)
+  // Reload preview when password settings change (URL path stays the same).
+  const previewAuthRevision = useMemo(
+    () => buildPreviewAuthRevision(currentPage, folders),
+    [currentPage, folders],
+  );
+
+  // Reload preview iframe when preview opens, URL changes, or auth settings change.
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
   useEffect(() => {
     if (!isPreviewMode || !previewUrl) return;
@@ -1980,7 +1985,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
       previewObserverRef.current?.disconnect();
       previewObserverRef.current = null;
     };
-  }, [isPreviewMode, previewUrl]);
+  }, [isPreviewMode, previewUrl, previewAuthRevision]);
 
   // Autofit when entering preview mode (not on every breakpoint change)
   const prevIsPreviewMode = useRef(false);

--- a/lib/page-auth.ts
+++ b/lib/page-auth.ts
@@ -181,24 +181,20 @@ export function getPasswordProtection(
 }
 
 /**
- * Fetch folders for password protection checks
- * 
- * @param isPublished - If true, fetch only published folders. If false, fetch all (for preview).
+ * Fetch folders for password protection checks.
+ *
+ * @param isPublished - If true, fetch published folders; if false, fetch draft folders (preview).
  * @returns Array of page folders
  */
 export async function fetchFoldersForAuth(isPublished: boolean): Promise<PageFolder[]> {
   const supabase = await getSupabaseAdmin();
   if (!supabase) return [];
 
-  let query = supabase
+  const { data } = await supabase
     .from('page_folders')
     .select('*')
+    .eq('is_published', isPublished)
     .is('deleted_at', null);
 
-  if (isPublished) {
-    query = query.eq('is_published', true);
-  }
-
-  const { data } = await query;
   return (data as PageFolder[]) || [];
 }

--- a/lib/page-auth.ts
+++ b/lib/page-auth.ts
@@ -13,24 +13,47 @@ import { getSupabaseAdmin } from '@/lib/supabase-server';
 /** Cookie name for page authentication - exported for use in API routes */
 export const PAGE_AUTH_COOKIE_NAME = 'ycode_page_auth';
 
+// Last-resort per-process secret. Resets on every process/deploy and differs
+// between serverless instances, so cookies signed with it won't verify across
+// requests. Only used when no stable secret is available.
 const fallbackSecret = randomUUID();
 let hasWarnedMissingSecret = false;
 
 /**
- * Get the signing secret from environment.
- * Falls back to a per-process random value if PAGE_AUTH_SECRET is not set,
- * which means auth cookies won't persist across server restarts.
+ * Get the HMAC signing secret for auth cookies.
+ *
+ * Order of preference:
+ *  1. PAGE_AUTH_SECRET — explicit, recommended.
+ *  2. A value derived from an always-present Supabase secret. This keeps the
+ *     signature stable across serverless instances and deploys WITHOUT extra
+ *     configuration. It's run through HMAC (never used raw) so the cookie
+ *     signature can't leak the underlying key.
+ *  3. A per-process random secret — last resort. Cookies won't verify across
+ *     serverless instances or restarts, so password unlock appears to fail.
+ *
+ * Before (2) existed, an unset PAGE_AUTH_SECRET meant the /verify endpoint and
+ * the redirected page render could run on different instances with different
+ * random secrets — the correct password was accepted but the session cookie
+ * was rejected, leaving the visitor stuck on the 401 page.
  */
 function getSigningSecret(): string {
-  const secret = process.env.PAGE_AUTH_SECRET;
-  if (!secret) {
-    if (!hasWarnedMissingSecret && process.env.NODE_ENV === 'production') {
-      console.warn('[page-auth] PAGE_AUTH_SECRET is not set. Page password protection is using a temporary secret that resets on each deploy. Set PAGE_AUTH_SECRET in your environment variables (generate with: openssl rand -hex 32).');
-      hasWarnedMissingSecret = true;
-    }
-    return fallbackSecret;
+  const explicit = process.env.PAGE_AUTH_SECRET;
+  if (explicit) return explicit;
+
+  const supabaseSecret =
+    process.env.SUPABASE_SECRET_KEY
+    || process.env.SUPABASE_SERVICE_ROLE_KEY
+    || process.env.SUPABASE_DB_PASSWORD;
+
+  if (supabaseSecret) {
+    return createHmac('sha256', supabaseSecret).update('ycode-page-auth-v1').digest('hex');
   }
-  return secret;
+
+  if (!hasWarnedMissingSecret && process.env.NODE_ENV === 'production') {
+    console.warn('[page-auth] PAGE_AUTH_SECRET is not set and no Supabase secret is available. Page password protection is using a temporary secret that resets on each deploy and will not verify across serverless instances. Set PAGE_AUTH_SECRET (generate with: openssl rand -hex 32).');
+    hasWarnedMissingSecret = true;
+  }
+  return fallbackSecret;
 }
 
 /**

--- a/lib/page-utils.ts
+++ b/lib/page-utils.ts
@@ -9,6 +9,38 @@ import { getTiptapTextContent } from '@/lib/text-format-utils';
 import { buildPasswordFormSubtree } from '@/lib/password-form-template';
 
 /**
+ * Build a revision key from a page's effective password protection (its own
+ * settings plus any ancestor folder settings). Used by the builder to reload
+ * the preview iframe when password settings change but the URL stays the same.
+ */
+export function buildPreviewAuthRevision(
+  page: Page | null | undefined,
+  folders: PageFolder[],
+): string {
+  if (!page) return '';
+
+  const parts: string[] = [
+    page.updated_at,
+    String(page.settings?.auth?.enabled ?? false),
+    page.settings?.auth?.password ?? '',
+  ];
+
+  let folderId = page.page_folder_id;
+  while (folderId) {
+    const folder = folders.find((f) => f.id === folderId);
+    if (!folder) break;
+    parts.push(
+      folder.updated_at,
+      String(folder.settings?.auth?.enabled ?? false),
+      folder.settings?.auth?.password ?? '',
+    );
+    folderId = folder.page_folder_id;
+  }
+
+  return parts.join('|');
+}
+
+/**
  * Reserved slugs that cannot be used at the root level (null parent folder)
  * These conflict with the app's routing structure
  */

--- a/lib/services/cacheService.ts
+++ b/lib/services/cacheService.ts
@@ -413,6 +413,32 @@ export interface SelectiveInvalidationResult {
 }
 
 /**
+ * Returns true if any of the given page IDs is a published error page
+ * (404/401, etc.). Error pages carry an `error_page` code instead of a slug.
+ */
+async function hasErrorPage(pageIds: string[]): Promise<boolean> {
+  if (pageIds.length === 0) return false;
+
+  const client = await getSupabaseAdmin();
+  if (!client) return false;
+
+  for (const ids of chunk(pageIds, SUPABASE_IN_LIMIT)) {
+    const { data } = await client
+      .from('pages')
+      .select('id')
+      .in('id', ids)
+      .eq('is_published', true)
+      .not('error_page', 'is', null)
+      .is('deleted_at', null)
+      .limit(1);
+
+    if (data && data.length > 0) return true;
+  }
+
+  return false;
+}
+
+/**
  * Perform selective cache invalidation based on what actually changed.
  *
  * Receives the exact page IDs that were modified during publish (content_hash
@@ -437,6 +463,17 @@ export async function selectiveInvalidation(
 
   if (allAffectedIds.length === 0) {
     return { strategy: 'selective', invalidatedRoutes: [], reason: 'no pages changed' };
+  }
+
+  // Error pages (401/404) have empty slugs, so they resolve to no route and
+  // can't be selectively invalidated. They're also embedded into other routes
+  // (the 401 page renders inside every password-protected page; the 404 page
+  // renders on unmatched URLs) and served via the `all-pages`-tagged
+  // `error-<code>` data cache. A selective route purge would never refresh
+  // them, so escalate to a full invalidation when an error page changed.
+  if (await hasErrorPage(allAffectedIds)) {
+    await clearAllCache();
+    return { strategy: 'full', invalidatedRoutes: [], reason: 'error page changed' };
   }
 
   const routePaths = await getRoutePathsForPages(allAffectedIds);


### PR DESCRIPTION
## Summary

Several password-protection issues found while testing the feature end to end: edits weren't visible in Preview, edits to the 401/404 error pages weren't reflected on the published site, and entering the correct password on the published site left the visitor stuck on the 401 page.

## Changes

- Restrict preview auth checks to **draft** folders. `fetchFoldersForAuth(false)` previously loaded both draft and published folders, so the folder lookup could resolve a stale published row instead of the draft the user just edited.
- Reload the preview iframe when a page's (or ancestor folder's) password settings change while the URL stays the same, via a new `buildPreviewAuthRevision` helper in `page-utils` (client-safe, no server-only deps).
- Escalate to a **full** cache invalidation when a changed page is an error page. Error pages have empty slugs (no route to purge selectively) and their content is served through the `all-pages`-tagged `error-<code>` data cache and the routes that embed them (401 inside every password-protected page, 404 on unmatched URLs), so selective invalidation never refreshed them.
- Derive a **stable** page-auth cookie signing secret from an always-present Supabase secret when `PAGE_AUTH_SECRET` is unset. Previously the fallback was a per-process random UUID, so on serverless the `/verify` request and the redirected page render ran on different instances with different secrets — the correct password was accepted but the session cookie was rejected, leaving the visitor on the 401 page.

## Test plan

- [ ] Enable/change folder-level password protection, save, open Preview without publishing — the 401 gate and new password should appear
- [ ] Repeat for page-level password protection
- [ ] With Preview already open, change password settings and save — the iframe should refresh automatically
- [ ] Edit the published 401 page, publish, visit a password-protected URL — updated 401 content should show
- [ ] Edit the 404 page, publish, hit an unknown URL — updated 404 content should show
- [ ] On the published site, enter the correct password — should unlock and load the protected page (no longer stuck on 401), including across serverless instances
- [ ] Confirm a normal page edit still logs `selective invalidation`, while an error-page publish logs `full invalidation: error page changed`