### PR TITLE
feat: add hreflang tags to localized page heads

### DIFF
--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -8,14 +8,22 @@ import 'server-only';
 
 import { cache } from 'react';
 import type { Metadata } from 'next';
-import type { Asset, Page } from '@/types';
+import type { Asset, Locale, Page, PageFolder, Translation } from '@/types';
 import type { CollectionItemWithValues } from '@/types';
 import { resolveInlineVariables, resolveImageUrl } from '@/lib/resolve-cms-variables';
 import { getSettingsByKeys } from '@/lib/repositories/settingsRepository';
 import { getAssetById } from '@/lib/repositories/assetRepository';
+import { getAllLocales } from '@/lib/repositories/localeRepository';
+import { getAllPublishedPageFolders } from '@/lib/repositories/pageFolderRepository';
+import { getTranslationsByLocale } from '@/lib/repositories/translationRepository';
 import { buildSvgDataUrl, getAssetProxyUrl } from '@/lib/asset-utils';
 import { generateColorVariablesCss } from '@/lib/repositories/colorVariableRepository';
+import { buildPageHreflangAlternates } from '@/lib/hreflang-utils';
+import { getTranslatableKey } from '@/lib/locale-runtime';
 import { getSiteBaseUrl } from '@/lib/url-utils';
+
+/** Languages map shape Next.js expects under `metadata.alternates.languages`. */
+type MetadataLanguages = NonNullable<NonNullable<Metadata['alternates']>['languages']>;
 
 /**
  * Global page render settings fetched once per page render
@@ -159,6 +167,91 @@ export async function fetchGlobalPageSettings(isPreview = false): Promise<Global
 export const fetchGlobalSeoSettings = fetchGlobalPageSettingsCached;
 
 /**
+ * Localization data needed to build per-page hreflang alternates.
+ * Translations are keyed by locale ID, then by translatable key.
+ */
+interface HreflangDataset {
+  locales: Locale[];
+  folders: PageFolder[];
+  translationsByLocale: Map<string, Record<string, Translation>>;
+}
+
+/**
+ * Load published locales, folders and per-locale translations needed to build
+ * hreflang alternates. Wrapped in React cache so it runs once per request even
+ * when multiple metadata helpers ask for it. Returns a single locale only when
+ * the site isn't multilingual, in which case callers skip hreflang.
+ */
+const fetchHreflangDataset = cache(async (): Promise<HreflangDataset> => {
+  const [locales, folders] = await Promise.all([
+    getAllLocales(true),
+    getAllPublishedPageFolders(),
+  ]);
+
+  const translationsByLocale = new Map<string, Record<string, Translation>>();
+
+  if (locales.length > 1) {
+    for (const locale of locales) {
+      if (locale.is_default) continue;
+      const translations = await getTranslationsByLocale(locale.id, true);
+      const map: Record<string, Translation> = {};
+      for (const t of translations) {
+        map[getTranslatableKey(t)] = t;
+      }
+      translationsByLocale.set(locale.id, map);
+    }
+  }
+
+  return { locales, folders, translationsByLocale };
+});
+
+/**
+ * Build the `metadata.alternates.languages` map for a page on a multilingual
+ * site. Returns null when hreflang shouldn't be emitted (single locale, no
+ * absolute base URL, or no resolvable alternates).
+ */
+async function buildHreflangLanguages(
+  page: Page,
+  baseUrl: string,
+  collectionItem?: CollectionItemWithValues
+): Promise<MetadataLanguages | null> {
+  const { locales, folders, translationsByLocale } = await fetchHreflangDataset();
+
+  if (locales.length <= 1) {
+    return null;
+  }
+
+  // Dynamic pages need the collection item's slug to resolve per-locale URLs.
+  const slugFieldId = page.settings?.cms?.slug_field_id;
+  const dynamicSlug = page.is_dynamic && collectionItem && slugFieldId
+    ? {
+      itemId: collectionItem.id,
+      fieldId: slugFieldId,
+      defaultValue: collectionItem.values?.[slugFieldId] || '',
+    }
+    : null;
+
+  const alternates = buildPageHreflangAlternates({
+    page,
+    folders,
+    baseUrl,
+    locales,
+    translationsByLocale,
+    dynamicSlug,
+  });
+
+  if (alternates.length === 0) {
+    return null;
+  }
+
+  const languages: MetadataLanguages = {};
+  for (const alt of alternates) {
+    languages[alt.hreflang as keyof MetadataLanguages] = alt.href;
+  }
+  return languages;
+}
+
+/**
  * Generate Next.js metadata from a page object
  * Handles SEO settings, Open Graph, Twitter Card, and noindex rules
  * Resolves field variables for dynamic pages
@@ -227,8 +320,27 @@ export async function generatePageMetadata(
         : `${canonicalBase}${pagePath.startsWith('/') ? pagePath : '/' + pagePath}`;
 
       metadata.alternates = {
+        ...metadata.alternates,
         canonical: canonicalUrl,
       };
+    }
+
+    // Add hreflang alternates for multilingual sites. Skipped for error pages
+    // and noindex pages (excluded from the language cluster, mirroring the
+    // sitemap), and requires an absolute base URL to emit valid links.
+    if (siteBaseUrl && !isErrorPage && !seo?.noindex) {
+      try {
+        const languages = await buildHreflangLanguages(page, siteBaseUrl, collectionItem);
+        if (languages) {
+          metadata.alternates = {
+            ...metadata.alternates,
+            languages,
+          };
+        }
+      } catch (error) {
+        // Non-fatal: a page should still render without hreflang links.
+        console.error('Failed to generate hreflang alternates:', error);
+      }
     }
   }
 

--- a/lib/hreflang-utils.ts
+++ b/lib/hreflang-utils.ts
@@ -1,0 +1,126 @@
+/**
+ * Hreflang Utility Functions
+ *
+ * Builds language alternate links for a page (and optional dynamic collection
+ * item). Shared by the sitemap generator and the per-page <head> metadata so
+ * both surfaces emit identical hreflang clusters.
+ */
+
+import type { Locale, Page, PageFolder, Translation } from '@/types';
+import { buildSlugPath, buildLocalizedSlugPath } from './page-utils';
+import { getTranslatableKey } from './locale-runtime';
+
+export interface HreflangAlternate {
+  hreflang: string;
+  href: string;
+}
+
+/**
+ * Slug context for a dynamic (CMS-driven) page. Required to resolve the
+ * translated item slug per locale.
+ */
+export interface DynamicSlugContext {
+  /** Collection item ID (translation source_id). */
+  itemId: string;
+  /** Slug field ID (translation content_key). */
+  fieldId: string;
+  /** Default-locale slug value used as the fallback. */
+  defaultValue: string;
+}
+
+/** Build the default-locale absolute URL for a dynamic item. */
+function buildDynamicDefaultUrl(
+  page: Page,
+  folders: PageFolder[],
+  baseUrl: string,
+  slugValue: string
+): string {
+  const folderPath = buildSlugPath(page, folders, 'page', '').replace(/\/$/, '');
+  const itemPath = folderPath ? `${folderPath}/${slugValue}` : `/${slugValue}`;
+  return `${baseUrl}${itemPath}`;
+}
+
+/** Build a localized absolute URL for a dynamic item in a non-default locale. */
+function buildDynamicLocalizedUrl(
+  page: Page,
+  folders: PageFolder[],
+  baseUrl: string,
+  locale: Locale,
+  translations: Record<string, Translation> | undefined,
+  dynamicSlug: DynamicSlugContext
+): string {
+  const localizedFolderPath = buildLocalizedSlugPath(
+    page,
+    folders,
+    'page',
+    locale,
+    translations,
+    ''
+  ).replace(/\/$/, '');
+
+  const translatedSlugKey = getTranslatableKey({
+    source_type: 'cms',
+    source_id: dynamicSlug.itemId,
+    content_key: dynamicSlug.fieldId,
+  });
+  const translatedSlug = translations?.[translatedSlugKey]?.content_value || dynamicSlug.defaultValue;
+
+  const localizedItemPath = localizedFolderPath
+    ? `${localizedFolderPath}/${translatedSlug}`
+    : `/${locale.code}/${translatedSlug}`;
+
+  return `${baseUrl}${localizedItemPath}`;
+}
+
+/**
+ * Build the full set of hreflang alternates for a single page (or dynamic
+ * collection item). Returns one entry per locale plus an `x-default` pointing
+ * at the default-locale URL. Returns an empty array for single-locale sites.
+ *
+ * @example
+ * buildPageHreflangAlternates({ page, folders, baseUrl, locales, translationsByLocale })
+ * // [{ hreflang: 'en', href: 'https://x.com/about' },
+ * //  { hreflang: 'fr', href: 'https://x.com/fr/a-propos' },
+ * //  { hreflang: 'x-default', href: 'https://x.com/about' }]
+ */
+export function buildPageHreflangAlternates(params: {
+  page: Page;
+  folders: PageFolder[];
+  baseUrl: string;
+  locales: Locale[];
+  translationsByLocale: Map<string, Record<string, Translation>>;
+  dynamicSlug?: DynamicSlugContext | null;
+}): HreflangAlternate[] {
+  const { page, folders, baseUrl, locales, translationsByLocale, dynamicSlug } = params;
+
+  // hreflang only makes sense when there's more than one language.
+  if (locales.length <= 1) {
+    return [];
+  }
+
+  const defaultLocale = locales.find(l => l.is_default);
+  const nonDefaultLocales = locales.filter(l => !l.is_default);
+
+  const defaultUrl = dynamicSlug
+    ? buildDynamicDefaultUrl(page, folders, baseUrl, dynamicSlug.defaultValue)
+    : `${baseUrl}${buildSlugPath(page, folders, 'page')}`;
+
+  const alternates: HreflangAlternate[] = [];
+
+  if (defaultLocale) {
+    alternates.push({ hreflang: defaultLocale.code, href: defaultUrl });
+  }
+
+  for (const locale of nonDefaultLocales) {
+    const translations = translationsByLocale.get(locale.id);
+    const href = dynamicSlug
+      ? buildDynamicLocalizedUrl(page, folders, baseUrl, locale, translations, dynamicSlug)
+      : `${baseUrl}${buildLocalizedSlugPath(page, folders, 'page', locale, translations)}`;
+    alternates.push({ hreflang: locale.code, href });
+  }
+
+  // x-default lets search engines pick when no language matches the user.
+  alternates.push({ hreflang: 'x-default', href: defaultUrl });
+
+  return alternates;
+}

--- a/lib/sitemap-utils.ts
+++ b/lib/sitemap-utils.ts
@@ -13,8 +13,9 @@ import type {
   SitemapChangeFrequency,
   CollectionItem,
 } from '@/types';
-import { buildSlugPath, buildLocalizedSlugPath } from './page-utils';
-import { getTranslatableKey } from './localisation-utils';
+import { buildSlugPath } from './page-utils';
+import { buildPageHreflangAlternates } from './hreflang-utils';
+import type { HreflangAlternate } from './hreflang-utils';
 
 export interface SitemapUrl {
   loc: string;
@@ -23,10 +24,7 @@ export interface SitemapUrl {
   alternates?: SitemapAlternate[];
 }
 
-export interface SitemapAlternate {
-  hreflang: string;
-  href: string;
-}
+export type SitemapAlternate = HreflangAlternate;
 
 /**
  * Build sitemap URLs for a static page (non-dynamic)
@@ -49,9 +47,6 @@ function buildStaticPageUrls(
     return [];
   }
 
-  const defaultLocale = locales.find(l => l.is_default);
-  const nonDefaultLocales = locales.filter(l => !l.is_default);
-
   // Build the default (base) URL
   const defaultPath = buildSlugPath(page, folders, 'page');
   const defaultUrl = `${baseUrl}${defaultPath}`;
@@ -63,39 +58,14 @@ function buildStaticPageUrls(
   };
 
   // Always add localized alternates when multiple locales exist
-  if (locales.length > 1) {
-    const alternates: SitemapAlternate[] = [];
-
-    // Add default locale alternate
-    if (defaultLocale) {
-      alternates.push({
-        hreflang: defaultLocale.code,
-        href: defaultUrl,
-      });
-    }
-
-    // Add non-default locale alternates
-    for (const locale of nonDefaultLocales) {
-      const translations = translationsByLocale.get(locale.id);
-      const localizedPath = buildLocalizedSlugPath(
-        page,
-        folders,
-        'page',
-        locale,
-        translations
-      );
-      alternates.push({
-        hreflang: locale.code,
-        href: `${baseUrl}${localizedPath}`,
-      });
-    }
-
-    // Add x-default for language negotiation
-    alternates.push({
-      hreflang: 'x-default',
-      href: defaultUrl,
-    });
-
+  const alternates = buildPageHreflangAlternates({
+    page,
+    folders,
+    baseUrl,
+    locales,
+    translationsByLocale,
+  });
+  if (alternates.length > 0) {
     sitemapUrl.alternates = alternates;
   }
 
@@ -127,8 +97,6 @@ function buildDynamicPageUrls(
   }
 
   const urls: SitemapUrl[] = [];
-  const defaultLocale = locales.find(l => l.is_default);
-  const nonDefaultLocales = locales.filter(l => !l.is_default);
 
   // Build folder path prefix (without the {slug} placeholder)
   const folderPath = buildSlugPath(page, folders, 'page', '').replace(/\/$/, '');
@@ -150,54 +118,15 @@ function buildDynamicPageUrls(
     };
 
     // Always add localized alternates when multiple locales exist
-    if (locales.length > 1) {
-      const alternates: SitemapAlternate[] = [];
-
-      // Add default locale alternate
-      if (defaultLocale) {
-        alternates.push({
-          hreflang: defaultLocale.code,
-          href: itemUrl,
-        });
-      }
-
-      // Add non-default locale alternates
-      for (const locale of nonDefaultLocales) {
-        const translations = translationsByLocale.get(locale.id);
-        // Build localized folder path
-        const localizedFolderPath = buildLocalizedSlugPath(
-          page,
-          folders,
-          'page',
-          locale,
-          translations,
-          ''
-        ).replace(/\/$/, '');
-
-        // Get translated slug for the CMS item if available
-        const translatedSlugKey = getTranslatableKey({
-          source_type: 'cms',
-          source_id: item.id,
-          content_key: slugFieldId,
-        });
-        const translatedSlug = translations?.[translatedSlugKey]?.content_value || slugValue;
-
-        const localizedItemPath = localizedFolderPath
-          ? `${localizedFolderPath}/${translatedSlug}`
-          : `/${locale.code}/${translatedSlug}`;
-
-        alternates.push({
-          hreflang: locale.code,
-          href: `${baseUrl}${localizedItemPath}`,
-        });
-      }
-
-      // Add x-default
-      alternates.push({
-        hreflang: 'x-default',
-        href: itemUrl,
-      });
-
+    const alternates = buildPageHreflangAlternates({
+      page,
+      folders,
+      baseUrl,
+      locales,
+      translationsByLocale,
+      dynamicSlug: { itemId: item.id, fieldId: slugFieldId, defaultValue: slugValue },
+    });
+    if (alternates.length > 0) {
       sitemapUrl.alternates = alternates;
     }
 


### PR DESCRIPTION
## Summary

Multilingual sites only exposed `hreflang` through the sitemap, so localized pages had no language alternates in the HTML `<head>`. Search engines were clustering them as "duplicate without canonical" and skipping indexing. This adds per-locale `hreflang` link tags (plus `x-default`) to every page head, reusing a single builder shared with the sitemap so the two surfaces can't drift.

## Changes

- Add `lib/hreflang-utils.ts` with `buildPageHreflangAlternates()` — builds the full alternate cluster (one entry per locale + `x-default`) for static pages and dynamic CMS items
- Refactor `lib/sitemap-utils.ts` to delegate to the shared builder (behavior-preserving; sitemap XML output is unchanged)
- Emit `metadata.alternates.languages` from `generatePageMetadata`, resolving translated slugs for dynamic pages and merging with the existing canonical tag
- Skip hreflang for preview, error, and `noindex` pages, and only emit when an absolute base URL is resolvable

## Test plan

- [ ] On a site with 2+ published locales, view source of `/`, `/fr`, and a dynamic CMS page and confirm `<link rel="alternate" hreflang="...">` tags appear with correct URLs
- [ ] Confirm `x-default` points at the default-locale URL
- [ ] Confirm dynamic CMS pages use the translated item slug per locale
- [ ] Confirm single-locale sites emit no hreflang tags
- [ ] Confirm `noindex`, error, and preview pages emit no hreflang tags
- [ ] Confirm `sitemap.xml` output is unchanged

Made with [Cursor](https://cursor.com)