### PR TITLE
fix: preview Bad Request on large collections and head hydration warning

### DIFF
--- a/lib/parse-head-html.ts
+++ b/lib/parse-head-html.ts
@@ -75,15 +75,19 @@ export function renderRootLayoutHeadCode(html: string, prefix = 'global-head'): 
     const pairedTag = match[3]?.toLowerCase();
     const pairedAttrStr = match[4] || '';
 
+    // Third-party scripts (AdSense, GTM, etc.) mutate their own head tags at
+    // runtime (e.g. adding `data-checked-head`), so the live DOM diverges from
+    // the SSR markup. suppressHydrationWarning silences these expected diffs.
     if (voidTag) {
       const attrs = toReactAttrs(parseAttributes(voidAttrStr.trim()));
-      elements.push(React.createElement(voidTag, { key: `${prefix}-${idx++}`, ...attrs }));
+      elements.push(React.createElement(voidTag, { key: `${prefix}-${idx++}`, suppressHydrationWarning: true, ...attrs }));
     } else if (pairedTag === 'script') {
       const attrs = parseAttributes(pairedAttrStr.trim());
       const inner = extractInnerHtml(match[0], 'script');
       const reactAttrs = toReactAttrs(attrs);
       const props: Record<string, unknown> = {
         key: `${prefix}-${idx++}`,
+        suppressHydrationWarning: true,
         ...reactAttrs,
       };
       if (inner) {
@@ -96,19 +100,21 @@ export function renderRootLayoutHeadCode(html: string, prefix = 'global-head'): 
       elements.push(
         React.createElement('style', {
           key: `${prefix}-${idx++}`,
+          suppressHydrationWarning: true,
           ...attrs,
           dangerouslySetInnerHTML: { __html: inner },
         }),
       );
     } else if (pairedTag === 'title') {
       const inner = extractInnerHtml(match[0], 'title');
-      elements.push(React.createElement('title', { key: `${prefix}-${idx++}` }, inner));
+      elements.push(React.createElement('title', { key: `${prefix}-${idx++}`, suppressHydrationWarning: true }, inner));
     } else if (pairedTag) {
       const attrs = toReactAttrs(parseAttributes(pairedAttrStr.trim()));
       const inner = extractInnerHtml(match[0], pairedTag);
       elements.push(
         React.createElement(pairedTag, {
           key: `${prefix}-${idx++}`,
+          suppressHydrationWarning: true,
           ...attrs,
           dangerouslySetInnerHTML: { __html: inner },
         }),

--- a/lib/repositories/assetRepository.ts
+++ b/lib/repositories/assetRepository.ts
@@ -1,7 +1,8 @@
 import { getSupabaseAdmin } from '@/lib/supabase-server';
-import { SUPABASE_QUERY_LIMIT, SUPABASE_WRITE_BATCH_SIZE } from '@/lib/supabase-constants';
+import { SUPABASE_IN_FILTER_CHUNK_SIZE, SUPABASE_QUERY_LIMIT, SUPABASE_WRITE_BATCH_SIZE } from '@/lib/supabase-constants';
 import { STORAGE_BUCKET, STORAGE_FOLDERS } from '@/lib/asset-constants';
 import { cleanupOrphanedStorageFiles } from '@/lib/storage-utils';
+import { chunk } from '@/lib/utils';
 import { generateAssetContentHash } from '../hash-utils';
 import type { Asset } from '../../types';
 
@@ -236,8 +237,8 @@ export async function getAssetForProxy(id: string): Promise<Pick<Asset, 'id' | '
  * Returns a map of asset ID to asset for quick lookup
  * @param isPublished If true, get published versions; if false, get draft versions (default: false)
  */
-export async function getAssetsByIds(ids: string[], isPublished: boolean = false): Promise<Record<string, Asset>> {
-  const client = await getSupabaseAdmin();
+export async function getAssetsByIds(ids: string[], isPublished: boolean = false, tenantId?: string): Promise<Record<string, Asset>> {
+  const client = await getSupabaseAdmin(tenantId);
 
   if (!client) {
     throw new Error('Supabase not configured');
@@ -247,28 +248,38 @@ export async function getAssetsByIds(ids: string[], isPublished: boolean = false
     return {};
   }
 
-  let query = client
-    .from('assets')
-    .select('*')
-    .eq('is_published', isPublished)
-    .in('id', ids);
+  // Chunk the ID list: a single large `.in()` overflows the request URL length
+  // limit and returns 400 Bad Request. Fetch chunks in parallel and merge.
+  const results = await Promise.all(
+    chunk(ids, SUPABASE_IN_FILTER_CHUNK_SIZE).map(async (idsChunk) => {
+      let query = client
+        .from('assets')
+        .select('*')
+        .eq('is_published', isPublished)
+        .in('id', idsChunk);
 
-  // Only filter deleted_at for drafts
-  if (!isPublished) {
-    query = query.is('deleted_at', null);
-  }
+      // Only filter deleted_at for drafts
+      if (!isPublished) {
+        query = query.is('deleted_at', null);
+      }
 
-  const { data, error } = await query;
+      const { data, error } = await query;
 
-  if (error) {
-    throw new Error(`Failed to fetch assets: ${error.message}`);
-  }
+      if (error) {
+        throw new Error(`Failed to fetch assets: ${error.message}`);
+      }
 
-  // Convert array to map for O(1) lookup
+      return data ?? [];
+    }),
+  );
+
+  // Convert to map for O(1) lookup
   const assetMap: Record<string, Asset> = {};
-  data?.forEach(asset => {
-    assetMap[asset.id] = asset;
-  });
+  for (const assets of results) {
+    for (const asset of assets) {
+      assetMap[asset.id] = asset;
+    }
+  }
 
   return assetMap;
 }

--- a/lib/repositories/collectionItemRepository.ts
+++ b/lib/repositories/collectionItemRepository.ts
@@ -1,6 +1,6 @@
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { getKnexClient } from '@/lib/knex-client';
-import { SUPABASE_QUERY_LIMIT } from '@/lib/supabase-constants';
+import { SUPABASE_IN_FILTER_CHUNK_SIZE, SUPABASE_QUERY_LIMIT } from '@/lib/supabase-constants';
 import type { CollectionField, CollectionItem, CollectionItemWithValues } from '@/types';
 import { randomUUID } from 'crypto';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
@@ -8,6 +8,7 @@ import { getValuesByFieldId, getValuesByItemIds, getValuesByItemId } from '@/lib
 import { generateCollectionItemContentHash } from '@/lib/hash-utils';
 import { castValue } from '../collection-utils';
 import { findStatusFieldId, buildStatusValue } from '@/lib/collection-field-utils';
+import { chunk } from '@/lib/utils';
 
 /**
  * Collection Item Repository
@@ -261,17 +262,28 @@ export async function fetchPublishedHashMap(
 
   let publishedRows: Array<{ id: string; content_hash: string | null }> | null = null;
   try {
-    const { data, error } = await client
-      .from('collection_items')
-      .select('id, content_hash')
-      .in('id', itemIds)
-      .eq('is_published', true)
-      .is('deleted_at', null);
+    // Chunk the ID list: a single large `.in()` overflows the request URL length
+    // limit and returns 400 Bad Request. Fetch chunks in parallel and merge.
+    const chunkResults = await Promise.all(
+      chunk(itemIds, SUPABASE_IN_FILTER_CHUNK_SIZE).map(async (idsChunk) => {
+        const { data, error } = await client
+          .from('collection_items')
+          .select('id, content_hash')
+          .in('id', idsChunk)
+          .eq('is_published', true)
+          .is('deleted_at', null);
 
-    if (error) {
-      console.error('Failed to fetch published items for status:', error.message);
-    } else {
-      publishedRows = data;
+        if (error) {
+          console.error('Failed to fetch published items for status:', error.message);
+          return null;
+        }
+        return data;
+      }),
+    );
+
+    // If every chunk failed, keep publishedRows null; otherwise merge successful chunks
+    if (chunkResults.some((rows) => rows !== null)) {
+      publishedRows = chunkResults.flatMap((rows) => rows ?? []);
     }
   } catch (err) {
     // Transient network errors should not break the items endpoint

--- a/lib/supabase-constants.ts
+++ b/lib/supabase-constants.ts
@@ -19,6 +19,13 @@ export const SUPABASE_QUERY_LIMIT = 1000;
 export const SUPABASE_WRITE_BATCH_SIZE = 100;
 
 /**
+ * Max number of IDs per `.in()` filter on a SELECT.
+ * Large lists overflow the request URL length limit and return 400 Bad Request,
+ * so callers must chunk and merge results.
+ */
+export const SUPABASE_IN_FILTER_CHUNK_SIZE = 100;
+
+/**
  * Page through a Supabase SELECT past the 1000-row default cap.
  * `buildPage(from, to)` must return a fresh query each call (Supabase
  * builders aren't reusable). Stops on error or short page.

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -263,6 +263,22 @@ export function isValidUUID(str: string): boolean {
 }
 
 /**
+ * Split an array into chunks of a given size.
+ * Useful for batching `.in()` queries to stay under request URL length limits.
+ * @param items - The array to split
+ * @param size - Max items per chunk (must be > 0)
+ * @returns Array of chunks preserving order
+ */
+export function chunk<T>(items: T[], size: number): T[][] {
+  if (size <= 0) return [items];
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
  * Generate a unique ID with optional prefix
  * @param prefix - Optional 3 letter prefix to prepend (e.g., 'lyr' for 'layer')
  * @returns Unique ID string (e.g., "lyr-mip1xm2qt9vvh")


### PR DESCRIPTION
## Summary

Fixes two issues that surfaced on preview for pages with large collections and custom head code. Large collection list pages failed to render assets, and pages with third-party head scripts logged hydration mismatch warnings.

## Changes

- Chunk `getAssetsByIds` and `fetchPublishedHashMap` into batches so large `.in('id', [...])` lists no longer overflow the request URL and return 400 Bad Request
- Add a shared `chunk()` utility to `lib/utils.ts` and a `SUPABASE_IN_FILTER_CHUNK_SIZE` constant
- Add a `tenantId?` passthrough to `getAssetsByIds` for multi-tenant parity
- Mark injected custom head elements with `suppressHydrationWarning` so third-party scripts (AdSense, GTM, GA, etc.) that mutate their own tags don't trip hydration mismatch warnings

## Test plan

- [ ] Open preview of a page rendering a collection list with 1000+ items — images resolve, no "Failed to fetch assets" error
- [ ] Load a collection items endpoint for a large collection — no "Failed to fetch published items for status: Bad Request"
- [ ] Preview a page whose global head code includes AdSense/GTM — no hydration mismatch warning in the console
- [ ] Verify small collections and pages without custom head code still render correctly