### PR TITLE
fix: prevent editor canvas from clipping tall collection content

### DIFF
--- a/lib/canvas-utils.ts
+++ b/lib/canvas-utils.ts
@@ -266,7 +266,7 @@ export function getCanvasIframeHtml(mountId: string = 'canvas-mount'): string {
     /* Dynamically populated: overrides vh/svh/dvh/lvh with fixed px values */
   </style>
 </head>
-<body class="h-full">
+<body class="min-h-full">
   <div id="${mountId}" class="contents"></div>
 </body>
 </html>`;


### PR DESCRIPTION
## Summary

Tall content (e.g. a collection grid with many items) could appear cut off in the editor canvas, with later sections overlapping it — while the same page rendered correctly on preview/published. This fixes the canvas to grow with its content like the live site does.

## Changes

- Change the canvas iframe template body from `h-full` to `min-h-full` in `getCanvasIframeHtml`

## Why

The canvas iframe body used `h-full` (`height: 100%`), locking it to the iframe height. Once the body layer's `flex flex-col` classes are applied, a direct flex child with `overflow-hidden` gets an automatic minimum size of 0 (CSS flex spec) and shrinks to fit instead of growing — clipping its content, with the following sibling (e.g. the footer) sitting on top of it. The height-measurement loop then reads every child as fitting within the current height, so the iframe never grows and the clip becomes permanent. The published `<body>` only ever uses `min-h-*` (grows with content), which is why preview was unaffected. Using `min-h-full` aligns the canvas body with production semantics.

## Test plan

- [ ] Open a page with a large collection grid inside an `overflow-hidden` section in the editor — items render in full and the footer sits below them
- [ ] Confirm the canvas matches preview/published for the same page
- [ ] Verify a `h-screen` hero still fills the viewport on the canvas
- [ ] Verify short pages and empty canvas still fill the available height
- [ ] Verify component-editing mode canvas is unaffected