### PR TITLE
fix: correct collection load more, nested fields, and empty state

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1814,25 +1814,23 @@ const LayerItemImpl: React.FC<{
     return null;
   }
 
-  // Evaluate conditional visibility (only in edit mode - SSR handles published pages)
+  // Evaluate conditional visibility on canvas (SSR handles published pages).
+  // Collection count-based conditions (`page_collection`: has_items / has_no_items
+  // / item_count) depend on runtime/published data, so on canvas we always render
+  // those blocks — e.g. empty states — to keep them selectable and styleable.
   const conditionalVisibility = layer.variables?.conditionalVisibility;
   if (isEditMode && conditionalVisibility && conditionalVisibility.groups?.length > 0) {
-    // Build page collection counts from the store
-    const pageCollectionCounts: Record<string, number> = {};
-    conditionalVisibility.groups.forEach(group => {
-      group.conditions?.forEach(condition => {
-        if (condition.source === 'page_collection' && condition.collectionLayerId) {
-          // Use the layerData from the store for collection counts
-          const storeData = useCollectionLayerStore.getState().layerData[condition.collectionLayerId];
-          pageCollectionCounts[condition.collectionLayerId] = storeData?.length ?? 0;
-        }
-      });
-    });
+    const canvasVisibility = {
+      groups: conditionalVisibility.groups.map(group => ({
+        ...group,
+        conditions: group.conditions?.filter(c => c.source !== 'page_collection') ?? [],
+      })),
+    };
 
-    const isVisible = evaluateVisibility(conditionalVisibility, {
+    const isVisible = evaluateVisibility(canvasVisibility, {
       collectionLayerData,
       pageCollectionData: pageCollectionItemData,
-      pageCollectionCounts,
+      pageCollectionCounts: {},
       currentItemId: collectionLayerItemId,
       pageCollectionItemId,
       timezone,

--- a/components/LoadMoreCollection.tsx
+++ b/components/LoadMoreCollection.tsx
@@ -99,10 +99,21 @@ export default function LoadMoreCollection({
       if (html && parent) {
         const temp = document.createElement('div');
         temp.innerHTML = html;
+        // When the pagination controls live inside the same parent as the items
+        // (e.g. as the last grid cell), insert new items before the controls so
+        // the "load more" button stays at the end. Falls back to appending when
+        // the controls are an outside sibling (the common case).
+        const paginationControls = parent.querySelector(
+          `:scope > [data-pagination-for="${collectionLayerId}"]`
+        );
         while (temp.firstChild) {
           const child = temp.firstChild;
           if (child instanceof Element) child.setAttribute(LOAD_MORE_APPENDED_ATTR, '');
-          parent.appendChild(child);
+          if (paginationControls) {
+            parent.insertBefore(child, paginationControls);
+          } else {
+            parent.appendChild(child);
+          }
         }
         if (newItemIds.length > 0) {
           const detail: ItemsInjectedDetail = {

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -3474,6 +3474,14 @@ async function injectCollectionDataForHtml(
   rawItemValues?: Record<string, string>,
   timezone: string = 'UTC'
 ): Promise<Layer> {
+  // Nested collection layers are resolved separately by resolveCollectionLayers,
+  // which clones them per referenced item and injects each item's own values.
+  // Injecting here with the parent item's values would resolve their inner
+  // variables against the wrong context and clobber them (emptying nested fields).
+  if (layer.variables?.collection?.id) {
+    return layer;
+  }
+
   // Reference fields are resolved once per item by the caller
   // (renderCollectionItemsToHtml). Re-resolving on every recursive
   // child would cause redundant Supabase queries.

--- a/lib/resolve-components.ts
+++ b/lib/resolve-components.ts
@@ -182,6 +182,26 @@ function remapVariableCollectionLayerIds(vars: LayerVariables, idMap: Map<string
     if (designChanged) { result.design = newDesign; changed = true; }
   }
 
+  // Conditional visibility conditions targeting a collection by layer ID
+  // (e.g. empty-state "has no items" rules inside a component instance)
+  if (vars.conditionalVisibility?.groups?.length) {
+    const groups = vars.conditionalVisibility.groups;
+    const newGroups = groups.map((group) => {
+      if (!Array.isArray(group?.conditions)) return group;
+      const newConditions = group.conditions.map((cond) => {
+        const mapped = cond?.collectionLayerId ? idMap.get(cond.collectionLayerId) : undefined;
+        return mapped && mapped !== cond.collectionLayerId ? { ...cond, collectionLayerId: mapped } : cond;
+      });
+      return newConditions.some((c, i) => c !== group.conditions[i])
+        ? { ...group, conditions: newConditions }
+        : group;
+    });
+    if (newGroups.some((g, i) => g !== groups[i])) {
+      result.conditionalVisibility = { ...vars.conditionalVisibility, groups: newGroups };
+      changed = true;
+    }
+  }
+
   return changed ? result : vars;
 }
 


### PR DESCRIPTION
## Summary

Fixes several collection rendering issues on generated/preview pages and the editor canvas: load-more items appeared after the pagination button, nested reference fields rendered blank in loaded items, and collection empty states inside component instances never resolved correctly (and weren't styleable on canvas).

## Changes

- Insert loaded items before the pagination controls when they live inside the same parent (e.g. as the last grid cell), so the "load more" button stays at the end. Falls back to appending when the controls are an outside sibling.
- Skip nested collection layers in `injectCollectionDataForHtml`. They are resolved separately by `resolveCollectionLayers` (cloned per referenced item with each item's own values); injecting them with the parent item's values clobbered their inner variables, leaving nested reference fields blank.
- Remap `conditionalVisibility.collectionLayerId` references when expanding component instances so collection-targeting rules (e.g. empty states) resolve to the instance-scoped collection ID instead of the component-definition ID.
- Always render collection count-based visibility blocks (`page_collection`: has_items / has_no_items / item_count) on canvas so empty states stay selectable and styleable; preview/published still evaluate the real condition.

## Test plan

- [ ] On a collection with load-more pagination, click "Load more" — new items append above the button, which stays at the end
- [ ] Verify a collection whose template includes a nested collection (multi-reference field) — loaded items show the nested reference values, matching the initial SSR items
- [ ] Confirm a collection whose pagination controls sit outside the items still appends correctly (no regression)
- [ ] In a component with a collection + empty state, confirm the empty state is hidden in preview when results exist
- [ ] Confirm the empty state is always visible/selectable on the editor canvas for styling