### PR TITLE
fix: autoplay videos inline on mobile

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -2954,6 +2954,17 @@ const LayerItemImpl: React.FC<{
       const shouldAutoPlay = mediaProps.autoplay === true;
       delete mediaProps.autoplay;
 
+      // React doesn't reliably reflect `muted` to the DOM during SSR/hydration,
+      // so apply it via ref. Mobile browsers reject autoplay unless the element
+      // is actually muted at play() time.
+      const shouldMute = mediaProps.muted === true;
+
+      // Mobile (iOS/Android) only autoplays videos rendered inline. Without
+      // playsInline it forces fullscreen and blocks autoplay.
+      if (htmlTag === 'video') {
+        mediaProps.playsInline = true;
+      }
+
       if (mediaSrc) {
         mediaProps.src = mediaSrc;
       }
@@ -2963,14 +2974,14 @@ const LayerItemImpl: React.FC<{
       }
 
       // Handle special attributes that need to be set on the DOM element
-      // (autoplay and volume must be set via JavaScript on the DOM element)
+      // (autoplay, muted, and volume must be set via JavaScript on the DOM element)
       if (htmlTag === 'audio' || htmlTag === 'video') {
         const originalRef = mediaProps.ref;
         const volumeValue = normalizedAttributes?.volume
           ? parseInt(normalizedAttributes.volume) / 100
           : undefined;
 
-        if (shouldAutoPlay || volumeValue !== undefined) {
+        if (shouldAutoPlay || shouldMute || volumeValue !== undefined) {
           mediaProps.ref = (element: HTMLAudioElement | HTMLVideoElement | null) => {
             if (originalRef) {
               if (typeof originalRef === 'function') {
@@ -2981,6 +2992,11 @@ const LayerItemImpl: React.FC<{
             }
 
             if (element) {
+              // Mute before play() so mobile browsers allow autoplay.
+              if (shouldMute) {
+                element.muted = true;
+                element.setAttribute('muted', '');
+              }
               if (shouldAutoPlay) {
                 element.autoplay = true;
                 element.setAttribute('autoplay', '');

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -1583,6 +1583,17 @@ const LayerItem: React.FC<{
       const shouldAutoPlay = mediaProps.autoplay === true;
       delete mediaProps.autoplay;
 
+      // React doesn't reliably reflect `muted` to the DOM during SSR/hydration,
+      // so apply it via ref. Mobile browsers reject autoplay unless the element
+      // is actually muted at play() time.
+      const shouldMute = mediaProps.muted === true;
+
+      // Mobile (iOS/Android) only autoplays videos rendered inline. Without
+      // playsInline it forces fullscreen and blocks autoplay.
+      if (htmlTag === 'video') {
+        mediaProps.playsInline = true;
+      }
+
       if (mediaSrc) {
         mediaProps.src = mediaSrc;
       }
@@ -1592,14 +1603,14 @@ const LayerItem: React.FC<{
       }
 
       // Handle special attributes that need to be set on the DOM element
-      // (autoplay and volume must be set via JavaScript on the DOM element)
+      // (autoplay, muted, and volume must be set via JavaScript on the DOM element)
       if (htmlTag === 'audio' || htmlTag === 'video') {
         const originalRef = mediaProps.ref;
         const volumeValue = normalizedAttributes?.volume
           ? parseInt(normalizedAttributes.volume) / 100
           : undefined;
 
-        if (shouldAutoPlay || volumeValue !== undefined) {
+        if (shouldAutoPlay || shouldMute || volumeValue !== undefined) {
           mediaProps.ref = (element: HTMLAudioElement | HTMLVideoElement | null) => {
             if (originalRef) {
               if (typeof originalRef === 'function') {
@@ -1610,6 +1621,11 @@ const LayerItem: React.FC<{
             }
 
             if (element) {
+              // Mute before play() so mobile browsers allow autoplay.
+              if (shouldMute) {
+                element.muted = true;
+                element.setAttribute('muted', '');
+              }
               if (shouldAutoPlay) {
                 element.autoplay = true;
                 element.setAttribute('autoplay', '');

--- a/lib/html-layer-converter.ts
+++ b/lib/html-layer-converter.ts
@@ -800,6 +800,8 @@ function layerToHtmlString(layer: Layer, indent: number): string {
     if (layer.attributes?.loop) attrs.push('loop');
     if (layer.attributes?.muted) attrs.push('muted');
     if (layer.attributes?.autoplay) attrs.push('autoplay');
+    // Mobile (iOS/Android) requires playsinline for inline autoplay (no forced fullscreen).
+    if (layer.name === 'video') attrs.push('playsinline');
   }
 
   const attrStr = attrs.length > 0 ? ` ${attrs.join(' ')}` : '';


### PR DESCRIPTION
## Summary

Videos with autoplay did not play on mobile browsers (iOS Safari, Android Chrome). Mobile only autoplays a video when it is rendered inline and is genuinely muted at `play()` time. The element was missing `playsinline`, and React does not reliably emit the `muted` attribute in SSR markup, so the video stayed unmuted and autoplay was blocked.

## Changes

- Set `playsInline` on video elements so mobile plays inline instead of forcing fullscreen
- Force the `muted` property via ref before calling `play()`, working around React's unreliable SSR `muted` output
- Apply the same handling in the public renderer, the builder/preview renderer, and the static HTML export

## Test plan

- [ ] Open a page with an autoplaying video on iOS Safari — video plays inline
- [ ] Open the same page on Android Chrome — video plays inline
- [ ] Confirm the video does not force fullscreen on mobile
- [ ] Confirm autoplay still works on desktop Chrome and Safari
- [ ] Confirm videos with sound (not muted) still respect autoplay rules