### PR TITLE
fix: keep icons visible and sized to their real proportions

### DIFF
--- a/app/(builder)/ycode/components/IconSettings.tsx
+++ b/app/(builder)/ycode/components/IconSettings.tsx
@@ -12,7 +12,8 @@ import { Label } from '@/components/ui/label';
 import SettingsPanel from './SettingsPanel';
 import type { Layer, IconSettingsValue } from '@/types';
 import { createAssetVariable, isAssetVariable, getAssetId, isStaticTextVariable, getStaticTextContent } from '@/lib/variable-utils';
-import { DEFAULT_ASSETS, isAssetOfType, ASSET_CATEGORIES } from '@/lib/asset-utils';
+import { DEFAULT_ASSETS, getSvgIntrinsicSize, isAssetOfType, ASSET_CATEGORIES } from '@/lib/asset-utils';
+import { useDesignSync } from '@/hooks/use-design-sync';
 import { Button } from '@/components/ui/button';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { useAssetsStore } from '@/stores/useAssetsStore';
@@ -61,6 +62,15 @@ export default function IconSettings(props: IconSettingsProps) {
   const standaloneOnChange = isStandaloneMode ? props.onChange : undefined;
   const [isOpen, setIsOpen] = useState(true);
 
+  // Pinned to desktop/neutral so adopting an icon's size updates the base
+  // dimensions (matching how the default icon element sets w-/h- at base).
+  const { updateDesignProperties } = useDesignSync({
+    layer,
+    onLayerUpdate: onLayerUpdate ?? (() => {}),
+    activeBreakpoint: 'desktop',
+    activeUIState: 'neutral',
+  });
+
   const openFileManager = useEditorStore((state) => state.openFileManager);
   const editingComponentId = useEditorStore((state) => state.editingComponentId);
   const getAsset = useAssetsStore((state) => state.getAsset);
@@ -98,7 +108,20 @@ export default function IconSettings(props: IconSettingsProps) {
         icon: { src: assetVariable },
       },
     });
-  }, [isStandaloneMode, standaloneOnChange, layer, onLayerUpdate]);
+
+    // Adopt the selected icon's intrinsic size so it reflects the new icon's
+    // real dimensions rather than inheriting the previous icon's box (e.g. the
+    // default 24×24 element size). Sends design + classes in a separate update
+    // that doesn't touch the variables set above.
+    const selectedAsset = getAsset(assetId);
+    const intrinsicSize = getSvgIntrinsicSize(selectedAsset?.content);
+    if (intrinsicSize) {
+      updateDesignProperties([
+        { category: 'sizing', property: 'width', value: `${intrinsicSize.width}px` },
+        { category: 'sizing', property: 'height', value: `${intrinsicSize.height}px` },
+      ]);
+    }
+  }, [isStandaloneMode, standaloneOnChange, layer, onLayerUpdate, getAsset, updateDesignProperties]);
 
   const handleBrowseAsset = useCallback(() => {
     const currentAssetId = (() => {

--- a/app/site.css
+++ b/app/site.css
@@ -42,6 +42,20 @@
   }
 }
 
+/* Icon SVG styling — exclude `.hidden` so Tailwind's `display: none` always
+   wins for hidden icons. Mirrors the editor rules in `globals.css`/`canvas.css`
+   so icons whose inline <svg> carries only a viewBox (no width/height) still
+   fill their sized container instead of collapsing to 0×0. */
+[data-icon]:not(.hidden) {
+  display: inline-block;
+}
+
+[data-icon] svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 /* Force inline SVG fill/stroke attributes (even on nested nodes) to inherit
    the icon layer's text color — matches the legacy `<i>` wrapper behavior so
    migrated icons with hard-coded colors still tint with `text-*` utilities.

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -22,7 +22,7 @@ import { DEFAULT_ASSETS, ASSET_CATEGORIES, isAssetOfType } from '@/lib/asset-uti
 import { parseMultiAssetFieldValue, buildAssetVirtualValues } from '@/lib/multi-asset-utils';
 import { parseMultiReferenceValue, resolveReferenceFieldsSync } from '@/lib/collection-utils';
 import { MULTI_ASSET_COLLECTION_ID } from '@/lib/collection-field-utils';
-import { buildImageSizes, generateImageSrcset, getOptimizedImageUrl, parseImageDimension } from '@/lib/asset-utils';
+import { buildImageSizes, generateImageSrcset, getOptimizedImageUrl, getSvgAspectRatioStyle, parseImageDimension } from '@/lib/asset-utils';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { toast } from 'sonner';
 import { resolveInlineVariablesFromData } from '@/lib/inline-variables';
@@ -2682,10 +2682,17 @@ const LayerItemImpl: React.FC<{
         iconHtml = DEFAULT_ASSETS.ICON;
       }
 
+      // Derive aspect-ratio from the SVG viewBox so an icon with only one of
+      // width/height set resolves the missing axis to its true proportions
+      // instead of collapsing. Inert when both dimensions are explicitly set.
+      const iconAspectRatio = getSvgAspectRatioStyle(iconHtml);
+      const iconElementStyle = (typeof elementProps.style === 'object' && elementProps.style) || undefined;
+
       return (
         <Tag
           {...elementProps}
           data-icon="true"
+          style={iconAspectRatio ? { aspectRatio: iconAspectRatio, ...iconElementStyle } : iconElementStyle}
           dangerouslySetInnerHTML={{ __html: iconHtml }}
         />
       );

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -22,7 +22,7 @@ import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
 import { getDynamicTextContent, getImageUrlFromVariable, getVideoUrlFromVariable, getIframeUrlFromVariable, isFieldVariable, isAssetVariable, isStaticTextVariable, isDynamicTextVariable, getStaticTextContent, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
 import { getTranslatedAssetId, getTranslatedText } from '@/lib/locale-runtime';
 import { isValidLinkSettings, generateLinkHref, resolveLinkAttrs, isLinkAtCollectionBoundary, type LinkResolutionContext } from '@/lib/link-utils';
-import { DEFAULT_ASSETS, buildImageSizes, generateImageSrcset, getOptimizedImageUrl, parseImageDimension } from '@/lib/asset-utils';
+import { DEFAULT_ASSETS, buildImageSizes, generateImageSrcset, getOptimizedImageUrl, getSvgAspectRatioStyle, parseImageDimension } from '@/lib/asset-utils';
 import { resolveInlineVariablesFromData } from '@/lib/inline-variables';
 import { renderRichText, hasBlockElementsWithInlineVariables, getTextStyleClasses, flattenTiptapParagraphs, type RichTextLinkContext, type RenderComponentBlockFn } from '@/lib/text-format-utils';
 import { combineBgValues, mergeStaticBgVars } from '@/lib/tailwind-class-mapper';
@@ -1339,10 +1339,17 @@ const LayerItem: React.FC<{
         iconHtml = DEFAULT_ASSETS.ICON;
       }
 
+      // Derive aspect-ratio from the SVG viewBox so an icon with only one of
+      // width/height set resolves the missing axis to its true proportions
+      // instead of collapsing. Inert when both dimensions are explicitly set.
+      const iconAspectRatio = getSvgAspectRatioStyle(iconHtml);
+      const iconElementStyle = (typeof elementProps.style === 'object' && elementProps.style) || undefined;
+
       return (
         <Tag
           {...elementProps}
           data-icon="true"
+          style={iconAspectRatio ? { aspectRatio: iconAspectRatio, ...iconElementStyle } : iconElementStyle}
           dangerouslySetInnerHTML={{ __html: iconHtml }}
         />
       );

--- a/lib/asset-utils.ts
+++ b/lib/asset-utils.ts
@@ -27,6 +27,92 @@ export function buildSvgDataUrl(
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 
+/**
+ * Derive a CSS `aspect-ratio` value (e.g. `"24 / 24"`) from an inline icon SVG.
+ *
+ * Icon layers render the SVG at `width: 100%; height: 100%` of their
+ * `[data-icon]` container. When the container has only one dimension set
+ * (common after HTML import or manual edits) the other axis is `auto`, and an
+ * inline-block box that shrink-wraps a 100%-sized child collapses to 0 —
+ * making the icon invisible. Applying this aspect-ratio to the container lets
+ * the missing axis resolve from the icon's true proportions while staying
+ * inert when both width and height are explicitly set.
+ *
+ * Prefers the `viewBox`, falling back to numeric `width`/`height` attributes.
+ * Returns null when no usable ratio can be determined.
+ */
+export function getSvgAspectRatioStyle(svgContent: string | null | undefined): string | null {
+  if (!svgContent) return null;
+
+  const viewBoxMatch = svgContent.match(
+    /viewBox\s*=\s*["']\s*[\d.+-]+\s+[\d.+-]+\s+([\d.+-]+)\s+([\d.+-]+)\s*["']/i
+  );
+  if (viewBoxMatch) {
+    const width = parseFloat(viewBoxMatch[1]);
+    const height = parseFloat(viewBoxMatch[2]);
+    if (Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
+      return `${width} / ${height}`;
+    }
+  }
+
+  const svgTagMatch = svgContent.match(/<svg\b([^>]*)>/i);
+  if (svgTagMatch) {
+    const attrs = svgTagMatch[1];
+    const widthAttr = attrs.match(/\bwidth\s*=\s*["']?\s*([\d.]+)/i);
+    const heightAttr = attrs.match(/\bheight\s*=\s*["']?\s*([\d.]+)/i);
+    if (widthAttr && heightAttr) {
+      const width = parseFloat(widthAttr[1]);
+      const height = parseFloat(heightAttr[1]);
+      if (Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
+        return `${width} / ${height}`;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Derive an inline icon SVG's intrinsic pixel size so a layer can adopt the
+ * icon's real dimensions (instead of inheriting whatever box the previous icon
+ * had). Prefers numeric `width`/`height` attributes, falling back to the
+ * `viewBox` extents. Returns null when no usable pixel size can be determined
+ * (e.g. percentage/`em` dimensions or a missing viewBox).
+ */
+export function getSvgIntrinsicSize(
+  svgContent: string | null | undefined
+): { width: number; height: number } | null {
+  if (!svgContent) return null;
+
+  const svgTagMatch = svgContent.match(/<svg\b([^>]*)>/i);
+  if (svgTagMatch) {
+    const attrs = svgTagMatch[1];
+    // Only accept bare numbers or explicit px — skip %, em, rem, etc.
+    const widthAttr = attrs.match(/\bwidth\s*=\s*["']?\s*([\d.]+)\s*(px)?["'\s>]/i);
+    const heightAttr = attrs.match(/\bheight\s*=\s*["']?\s*([\d.]+)\s*(px)?["'\s>]/i);
+    if (widthAttr && heightAttr) {
+      const width = Math.round(parseFloat(widthAttr[1]));
+      const height = Math.round(parseFloat(heightAttr[1]));
+      if (Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
+        return { width, height };
+      }
+    }
+  }
+
+  const viewBoxMatch = svgContent.match(
+    /viewBox\s*=\s*["']\s*[\d.+-]+\s+[\d.+-]+\s+([\d.+-]+)\s+([\d.+-]+)\s*["']/i
+  );
+  if (viewBoxMatch) {
+    const width = Math.round(parseFloat(viewBoxMatch[1]));
+    const height = Math.round(parseFloat(viewBoxMatch[2]));
+    if (Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
+      return { width, height };
+    }
+  }
+
+  return null;
+}
+
 import type { AssetCategory, AssetCategoryFilter, Layer, Component, ComponentVariable } from '@/types';
 import {
   ASSET_CATEGORIES,

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -10,7 +10,7 @@ import { enrichItemsWithCountValues } from '@/lib/repositories/collectionCountRe
 import type { Page, PageFolder, PageLayers, Component, ComponentVariable, CollectionItemWithValues, CollectionField, Layer, CollectionPaginationMeta, Translation, Locale } from '@/types';
 import { getCollectionVariable, resolveFieldValue, evaluateVisibility, evaluateCondition, getLayerHtmlTag, filterDisabledSliderLayers } from '@/lib/layer-utils';
 import { isFieldVariable, isAssetVariable, createDynamicTextVariable, createDynamicRichTextVariable, createAssetVariable, getDynamicTextContent, getVariableStringValue, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
-import { buildImageSizes, generateImageSrcset, getOptimizedImageUrl, getAssetProxyUrl, DEFAULT_ASSETS, collectLayerAssetIds, buildSvgDataUrl, parseImageDimension } from '@/lib/asset-utils';
+import { buildImageSizes, generateImageSrcset, getOptimizedImageUrl, getAssetProxyUrl, DEFAULT_ASSETS, collectLayerAssetIds, buildSvgDataUrl, parseImageDimension, getSvgAspectRatioStyle } from '@/lib/asset-utils';
 import { resolveComponents, applyComponentOverrides } from '@/lib/resolve-components';
 import { getComponentVariantLayers } from '@/lib/component-variant-utils';
 import { isTiptapDoc, hasBlockElementsWithResolver } from '@/lib/tiptap-utils';
@@ -4319,6 +4319,19 @@ export function layerToHtml(
   if (cmsGradient) {
     const existingImg = inlineStyles['--bg-img']?.split(', ').find(v => v.startsWith('url(')) || bgImageVars?.['--bg-img'];
     inlineStyles['--bg-img'] = combineBgValues(existingImg, cmsGradient);
+  }
+
+  // Icons render their SVG at 100% of the container, so an icon with only one
+  // of width/height set collapses on the other (auto) axis. Derive an
+  // aspect-ratio from the icon's viewBox so the missing axis resolves to the
+  // icon's true proportions. It stays inert when both dimensions are set.
+  if (layer.name === 'icon' && !inlineStyles['aspect-ratio'] && !inlineStyles['aspectRatio']) {
+    const iconSrcForAspect = layer.variables?.icon?.src;
+    const iconContentForAspect = iconSrcForAspect ? (getVariableStringValue(iconSrcForAspect) || '') : '';
+    const iconAspectRatio = getSvgAspectRatioStyle(iconContentForAspect || DEFAULT_ASSETS.ICON);
+    if (iconAspectRatio) {
+      inlineStyles['aspect-ratio'] = iconAspectRatio;
+    }
   }
 
   if (Object.keys(inlineStyles).length > 0) {


### PR DESCRIPTION
## Summary

Fixes three related icon problems: icons that collapse and become invisible on published pages, icons that disappear when only one of width/height is set, and replaced icons that keep the previous icon's size instead of their own.

## Changes

- **Published pages were missing icon CSS.** Added the `[data-icon]` display + SVG sizing rules to the published site bundle (`app/site.css`) so inline icon SVGs scale to their container exactly as they do in the editor.
- **Single-dimension icons collapsed to 0.** An icon with only a width or only a height set collapsed on the other axis, because the `inline-block` container shrink-wraps a `100%`-sized SVG. We now derive an `aspect-ratio` from the SVG's `viewBox` and apply it to the container across all render paths (`page-fetcher`, `LayerRenderer`, `LayerRendererPublic`). It auto-resolves the missing axis to the icon's true proportions and stays inert when both dimensions are set.
- **Replacing an icon kept the old box.** Adding the default Icon element starts at 24×24; swapping in another SVG previously retained that box. Selecting an icon now adopts the new SVG's intrinsic size (from `width`/`height` attributes, falling back to the `viewBox`).
- Added shared helpers `getSvgAspectRatioStyle` and `getSvgIntrinsicSize` in `lib/asset-utils.ts`.

## Test plan

- [ ] Publish a page with an icon and confirm it's visible (previously invisible/0×0)
- [ ] Set only a height (or only a width) on an icon — the other axis should auto-size to the icon's real proportions in both the editor and the published site
- [ ] Verify normal icons with both width and height set are unchanged (aspect-ratio inert)
- [ ] Add the default Icon element (24×24), replace it with a differently-sized SVG, and confirm it adopts the new icon's real dimensions
- [ ] Replace with a non-square SVG (e.g. a wide logo) and confirm width/height match its viewBox

Made with [Cursor](https://cursor.com)