### PR TITLE
feat(static-export): emit global + page-level custom code

### DIFF
--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -621,6 +621,15 @@ export interface BuildHtmlInput {
   fontsCss?: string | null
   includeSwiper: boolean
   interactions: ExportedInteraction[]
+  /** Site-wide custom code from Settings → General (head + body slots). */
+  globalCustomCodeHead?: string | null
+  globalCustomCodeBody?: string | null
+  /**
+   * Page-level custom code from `page.settings.custom_code.{head,body}`,
+   * already placeholder-resolved by the resolver for dynamic pages.
+   */
+  pageCustomCodeHead?: string | null
+  pageCustomCodeBody?: string | null
 }
 
 export function buildDocument({
@@ -634,6 +643,10 @@ export function buildDocument({
   fontsCss,
   includeSwiper,
   interactions,
+  globalCustomCodeHead,
+  globalCustomCodeBody,
+  pageCustomCodeHead,
+  pageCustomCodeBody,
 }: BuildHtmlInput): string {
   const seo = extractSeo(page)
   const title = seo.title || page.name
@@ -665,6 +678,16 @@ export function buildDocument({
     head.push(`<link rel="stylesheet" href="${SWIPER_CSS_PATH}" />`)
   }
 
+  // Custom head code: global first (site-wide), then page-specific. Emitted
+  // verbatim — the same trust model the live site uses (operator-authored
+  // HTML/JS dropped straight into <head>).
+  if (globalCustomCodeHead && globalCustomCodeHead.trim()) {
+    head.push(globalCustomCodeHead)
+  }
+  if (pageCustomCodeHead && pageCustomCodeHead.trim()) {
+    head.push(pageCustomCodeHead)
+  }
+
   const indent = '  '
   const trailingScripts: string[] = []
   if (includeSwiper) {
@@ -683,6 +706,16 @@ export function buildDocument({
     trailingScripts.push(`<script>${VISIBILITY_BOOT_SCRIPT}</script>`)
   }
 
+  // Custom body code goes after the page body / scripts but before </body>,
+  // matching the live site's ordering (global first, then page-specific).
+  const customBodyChunks: string[] = []
+  if (globalCustomCodeBody && globalCustomCodeBody.trim()) {
+    customBodyChunks.push(globalCustomCodeBody)
+  }
+  if (pageCustomCodeBody && pageCustomCodeBody.trim()) {
+    customBodyChunks.push(pageCustomCodeBody)
+  }
+
   return [
     '<!DOCTYPE html>',
     `<html lang="${escapeHtml(lang)}">`,
@@ -692,6 +725,7 @@ export function buildDocument({
     bodyClasses ? `<body class="${escapeHtml(bodyClasses)}">` : '<body>',
     bodyHtml,
     ...trailingScripts,
+    ...customBodyChunks,
     '</body>',
     '</html>',
     '',

--- a/lib/apps/static-export/engine.ts
+++ b/lib/apps/static-export/engine.ts
@@ -139,7 +139,15 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
     }
 
     // ---- Folders + shared CSS + fonts + locales in parallel ---------------
-    const [folderResult, publishedCss, colorVariablesCss, fonts, localeResult] = await Promise.all([
+    const [
+      folderResult,
+      publishedCss,
+      colorVariablesCss,
+      fonts,
+      globalCustomCodeHead,
+      globalCustomCodeBody,
+      localeResult,
+    ] = await Promise.all([
       client
         .from('page_folders')
         .select('*')
@@ -148,6 +156,8 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
       getSettingByKey('published_css').catch(() => null),
       generateColorVariablesCss().catch(() => null),
       getPublishedFonts().catch(() => []),
+      getSettingByKey('custom_code_head').catch(() => null),
+      getSettingByKey('custom_code_body').catch(() => null),
       client
         .from('locales')
         .select('*')
@@ -206,6 +216,10 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
             fontsCss: fontsCss || null,
             includeSwiper: resolved.hasSlider,
             interactions: resolved.interactions,
+            globalCustomCodeHead: globalCustomCodeHead ?? null,
+            globalCustomCodeBody: globalCustomCodeBody ?? null,
+            pageCustomCodeHead: resolved.pageCustomCodeHead,
+            pageCustomCodeBody: resolved.pageCustomCodeBody,
           })
 
           // Collect Ycode's built-in placeholder URLs referenced from this

--- a/lib/apps/static-export/resolver.ts
+++ b/lib/apps/static-export/resolver.ts
@@ -17,6 +17,7 @@ import type { PageData } from '@/lib/page-fetcher'
 import { buildSlugPath, buildLocalizedSlugPath } from '@/lib/page-utils'
 import { getTranslatableKey } from '@/lib/locale-runtime'
 import { getValuesByFieldId } from '@/lib/repositories/collectionItemValueRepository'
+import { resolveCustomCodePlaceholders } from '@/lib/resolve-cms-variables'
 
 import type { Locale, Page, PageFolder, Translation } from '@/types'
 
@@ -39,6 +40,13 @@ export interface ResolvedPage {
   outputKey: string
   hasSlider: boolean
   interactions: ExportedInteraction[]
+  /**
+   * Page-level custom code from `page.settings.custom_code.{head,body}`.
+   * Already placeholder-resolved against the dynamic page's collection
+   * item when applicable. Null when the page has no per-page custom code.
+   */
+  pageCustomCodeHead: string | null
+  pageCustomCodeBody: string | null
 }
 
 interface PageCmsSettings {
@@ -168,6 +176,23 @@ function renderResolved(
     locale: data.locale ?? ctx.locale ?? null,
     translations: data.translations ?? ctx.translations,
   })
+
+  // Page-level custom code lives at `page.settings.custom_code.{head,body}`.
+  // For dynamic pages, the stored template may contain `{{FieldName}}`
+  // placeholders that need resolution against the current item — mirrors
+  // what PageRenderer.tsx does for the live site.
+  const customCode = (page.settings as { custom_code?: { head?: string; body?: string } } | undefined)?.custom_code
+  const rawHead = customCode?.head || ''
+  const rawBody = customCode?.body || ''
+  const shouldResolvePlaceholders =
+    page.is_dynamic && data.collectionItem && (data.collectionFields?.length ?? 0) > 0
+  const pageCustomCodeHead = shouldResolvePlaceholders
+    ? resolveCustomCodePlaceholders(rawHead, data.collectionItem!, data.collectionFields!)
+    : rawHead
+  const pageCustomCodeBody = shouldResolvePlaceholders
+    ? resolveCustomCodePlaceholders(rawBody, data.collectionItem!, data.collectionFields!)
+    : rawBody
+
   return {
     page,
     bodyHtml,
@@ -176,5 +201,7 @@ function renderResolved(
     outputKey,
     hasSlider: layerTreeContains(layers, 'slider'),
     interactions: collectInteractions(layers),
+    pageCustomCodeHead: pageCustomCodeHead || null,
+    pageCustomCodeBody: pageCustomCodeBody || null,
   }
 }


### PR DESCRIPTION
## Summary

The Static HTML Export silently dropped both **custom code** slots — the global one from Settings → General and the per-page one from Page Settings → Custom Code. The editor exposes them, live SSR injects them, but the static-export pipeline never read them. Analytics snippets, Google Search Console verification, custom fonts, structured-data JSON-LD, GA/GTM/Plausible/PostHog tags, third-party widget loaders — all stripped from every exported page.

This PR makes the static export emit them the same way live SSR does.

## What was missing

Live SSR pulls custom code from two places:

- `app/(site)/layout.tsx:44-46` (HEAD) and `components/PageRenderer.tsx:542-548, 729-738` (BODY) → reads `globalCustomCodeHead` / `globalCustomCodeBody` from `fetchGlobalPageSettings()` (which maps `settings.custom_code_head` / `settings.custom_code_body`).
- `components/PageRenderer.tsx:389-398` → reads `page.settings.custom_code.head` / `page.settings.custom_code.body` for the page-level slots, and runs `resolveCustomCodePlaceholders` against the dynamic page's collection item when `page.is_dynamic`.

Neither path existed anywhere in `lib/apps/static-export/`. `grep -rn 'custom_code\|globalCustomCode'` against the static-export module returned nothing before this PR.

## Fix

- **`engine.ts`** — fetch `custom_code_head` and `custom_code_body` from the `settings` table in the same parallel block as `published_css` / `color_variables_css` / fonts / locales. Thread them into every `buildDocument` call as `globalCustomCodeHead` / `globalCustomCodeBody`.

- **`resolver.ts`** — extract `page.settings.custom_code.{head,body}` per page. For dynamic CMS pages, run `resolveCustomCodePlaceholders` against `data.collectionItem` + `data.collectionFields` (which `fetchPageByPath` already provides). Attach to `ResolvedPage` as `pageCustomCodeHead` / `pageCustomCodeBody`.

- **`document.ts`** — extend `BuildHtmlInput` with four optional `string | null` fields. Append global head + page head to `<head>` (global first, matching live ordering). Append global body + page body right before `</body>`, *after* the existing trailing scripts (Swiper boot, interactions runtime, visibility runtime) so user analytics/init scripts come last and can safely reference what the export emitted. Emitted verbatim — same trust model as the live site (operator-authored HTML dropped straight into the document).

## Files

- `lib/apps/static-export/engine.ts` — +9 lines (two new fetches in the parallel block + threading into buildDocument).
- `lib/apps/static-export/resolver.ts` — +27 lines (read + placeholder-resolve per-page, extend ResolvedPage).
- `lib/apps/static-export/document.ts` — +34 lines (extend BuildHtmlInput, head + pre-`</body>` emission).

+76 / -1 total. Internal to the static-export module — no other consumers touched.

## Compatibility

- **Sites without any custom code**: byte-identical output. Both null → blocks skipped.
- **Live SSR / Vercel-hosted sites**: unchanged. This PR only touches the static-export pipeline.
- **Dynamic page placeholders**: same behavior as live — `{{FieldName}}` resolved per-item, left as-is if no item context (matches `resolveCustomCodePlaceholders`'s null-safe path).

## Test plan

- [x] Set global custom code in Settings → General (head: GA tag; body: chat widget). Export. Confirm every exported HTML carries both in the right places.
- [x] Set page-specific custom code on a single page (head: JSON-LD; body: page-specific init). Export. Confirm only that page's HTML has the additions; other pages stay clean.
- [x] On a dynamic CMS page, set per-page head code containing `{{Title}}`. Export. Confirm each item's HTML resolves to its own title; non-existent field names pass through as `{{...}}` (matches live behavior).
- [x] Site with zero custom code anywhere: confirm exported HTML is unchanged from the prior version.
- [x] `npm run type-check` passes.

## Verified end-to-end

Deployed to a self-hosted Ycode instance, real Grish music site with global GA + page-level structured-data snippets. Both surface correctly in every exported page; per-page snippets only on the pages they belong to; dynamic-page items each get their own resolved placeholders.