### PR TITLE
feat: filter collections by current page item

### DIFF
--- a/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
+++ b/app/(builder)/ycode/api/collections/[id]/items/filter/route.ts
@@ -29,6 +29,11 @@ interface FilterCondition {
   // For source === 'self': also include the current dynamic page item's ID
   // in the comparison set at runtime.
   includesCurrentPageItem?: boolean;
+  // 'current_page' binds the compare value to the current dynamic page item:
+  // reference fields inject the page item's ID; scalar fields use the value of
+  // `currentPageFieldId` on the page item.
+  valueMode?: 'static' | 'current_page';
+  currentPageFieldId?: string;
 }
 
 // PostgREST encodes .in() values into a URL query param.
@@ -442,6 +447,38 @@ function getSelfFilterMatches(
   return new Set(candidateIds.filter(id => compareSet.has(id)));
 }
 
+/**
+ * Resolve a `valueMode: 'current_page'` filter into a concrete static filter by
+ * binding its compare value to the current dynamic page item:
+ *   - reference fields inject the page item's ID into the compared ID set
+ *   - scalar fields read the page item's `currentPageFieldId` value
+ * Mirrors the SSR resolution in `evaluateCondition`.
+ */
+async function resolveCurrentPageFilter(
+  filter: FilterCondition,
+  isPublished: boolean,
+  pageCollectionItemId?: string,
+): Promise<FilterCondition> {
+  const isReferenceField = filter.fieldType === 'reference'
+    || filter.fieldType === 'multi_reference'
+    || ['is_one_of', 'is_not_one_of', 'contains_all_of', 'contains_exactly'].includes(filter.operator);
+  if (isReferenceField) {
+    const ids = parseItemIdList(filter.value);
+    if (pageCollectionItemId && !ids.includes(pageCollectionItemId)) {
+      ids.push(pageCollectionItemId);
+    }
+    // 'contains exactly' against a single injected page-item id can never match a real
+    // multi-reference set — the "Current X" intent is "contains the current item".
+    const operator = filter.operator === 'contains_exactly' ? 'contains_all_of' : filter.operator;
+    return { ...filter, operator, value: JSON.stringify(ids) };
+  }
+  if (filter.currentPageFieldId && pageCollectionItemId) {
+    const valueMap = await getFieldValuesForItems(filter.currentPageFieldId, isPublished, [pageCollectionItemId]);
+    return { ...filter, value: valueMap.get(pageCollectionItemId) ?? '' };
+  }
+  return { ...filter, value: '' };
+}
+
 async function getFilteredItemIds(
   collectionId: string,
   isPublished: boolean,
@@ -470,6 +507,9 @@ async function getFilteredItemIds(
         const matchingForFilter = getSelfFilterMatches(filter, [...currentIds], pageCollectionItemId);
         currentIds = new Set([...currentIds].filter(id => matchingForFilter.has(id)));
         continue;
+      }
+      if (filter.valueMode === 'current_page') {
+        filter = await resolveCurrentPageFilter(filter, isPublished, pageCollectionItemId);
       }
       if (isDateFieldType(filter.fieldType) && isDatePreset(filter.value)) {
         const resolved = resolveDateFilterValue(filter.operator, filter.value, filter.value2, timezone);

--- a/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
+++ b/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
@@ -31,6 +31,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   DropdownMenuCheckboxItem,
 } from '@/components/ui/dropdown-menu';
@@ -82,6 +83,18 @@ const SCALAR_FIELD_GROUP: Partial<Record<CollectionFieldType, string>> = {
 
 const getScalarFieldGroup = (type?: CollectionFieldType): string | undefined =>
   type ? SCALAR_FIELD_GROUP[type] : undefined;
+
+/**
+ * Best-effort singularization of a collection name for "Current X" labels
+ * (e.g. "Tags" -> "Tag", "Categories" -> "Category"). Handles the common
+ * English plural endings; leaves anything it doesn't recognize untouched.
+ */
+const singularizeCollectionName = (name: string): string => {
+  if (/ies$/i.test(name)) return name.replace(/ies$/i, 'y');
+  if (/(sses|shes|ches|xes|zes)$/i.test(name)) return name.replace(/es$/i, '');
+  if (/s$/i.test(name) && !/ss$/i.test(name)) return name.replace(/s$/i, '');
+  return name;
+};
 
 /**
  * Reference Items Selector Component
@@ -211,7 +224,10 @@ function ReferenceItemsSelector({
             onCheckedChange={(checked) => currentPageBinding.onChange(checked === true)}
             onSelect={(e) => e.preventDefault()}
           >
-            {currentPageBinding.label}
+            <span className="flex items-center gap-1.5">
+              <Icon name="zap" className="size-2.5 opacity-60" />
+              {currentPageBinding.label}
+            </span>
           </DropdownMenuCheckboxItem>
         )}
         {currentPageItem && (
@@ -222,6 +238,9 @@ function ReferenceItemsSelector({
           >
             Current page item
           </DropdownMenuCheckboxItem>
+        )}
+        {(currentPageBinding || currentPageItem) && items.length > 0 && (
+          <DropdownMenuSeparator />
         )}
         {loading ? (
           <div className="flex items-center justify-center py-4">
@@ -287,6 +306,11 @@ export default function CollectionFiltersSettings({
   const pageCollectionName = useMemo(
     () => collections.find((c) => c.id === pageCollectionId)?.name || 'page',
     [collections, pageCollectionId]
+  );
+  // Singular form for "Current X" labels (e.g. "Tags" page -> "Current Tag").
+  const pageCollectionNameSingular = useMemo(
+    () => singularizeCollectionName(pageCollectionName),
+    [pageCollectionName]
   );
   const pageCollectionFields = useMemo(
     () => (pageCollectionId ? allFields[pageCollectionId] || [] : []),
@@ -819,7 +843,7 @@ export default function CollectionFiltersSettings({
                       value={condition.value || '[]'}
                       onChange={(value) => handleValueChange(group.id, condition.id, value)}
                       currentPageBinding={canBindReferenceToCurrentPage ? {
-                        label: `Current ${pageCollectionName}`,
+                        label: `Current ${pageCollectionNameSingular}`,
                         checked: isCurrentPageMode,
                         onChange: (checked) => patchCondition(group.id, condition.id, {
                           valueMode: checked ? 'current_page' : 'static',
@@ -881,7 +905,7 @@ export default function CollectionFiltersSettings({
                       onValueChange={(v) => patchCondition(group.id, condition.id, { currentPageFieldId: v })}
                     >
                       <SelectTrigger>
-                        <SelectValue placeholder={`Current ${pageCollectionName} field...`} />
+                        <SelectValue placeholder={`Current ${pageCollectionNameSingular} field...`} />
                       </SelectTrigger>
                       <SelectContent>
                         <SelectGroup>
@@ -1011,7 +1035,7 @@ export default function CollectionFiltersSettings({
                           <Icon name="database" />
                         </Button>
                       </TooltipTrigger>
-                      <TooltipContent>Use current {pageCollectionName} field</TooltipContent>
+                      <TooltipContent>Use current {pageCollectionNameSingular} field</TooltipContent>
                     </Tooltip>
                   )}
                 </div>

--- a/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
+++ b/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
@@ -64,6 +64,25 @@ interface CollectionFiltersSettingsProps {
   collectionId: string;
 }
 
+// Groups scalar field types that are mutually comparable, so a "current page
+// field" binding only offers fields whose value format matches the condition's
+// field (e.g. a text field can bind to another text-like field, not a date).
+const SCALAR_FIELD_GROUP: Partial<Record<CollectionFieldType, string>> = {
+  number: 'number',
+  count: 'number',
+  date: 'date',
+  date_only: 'date',
+  boolean: 'boolean',
+  color: 'text',
+  text: 'text',
+  rich_text: 'text',
+  email: 'text',
+  phone: 'text',
+};
+
+const getScalarFieldGroup = (type?: CollectionFieldType): string | undefined =>
+  type ? SCALAR_FIELD_GROUP[type] : undefined;
+
 /**
  * Reference Items Selector Component
  * Multi-select dropdown for selecting collection items for is_one_of/is_not_one_of operators
@@ -73,12 +92,22 @@ function ReferenceItemsSelector({
   value,
   onChange,
   currentPageItem,
+  currentPageBinding,
 }: {
   collectionId: string;
   value: string; // JSON array of item IDs
   onChange: (value: string) => void;
   /** When provided, renders a "Current page item" entry above the items list. */
   currentPageItem?: {
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+  };
+  /**
+   * When provided, renders a "Current {collection}" entry that binds the value
+   * to the current dynamic page item (the "Current Category/Tag" pattern).
+   */
+  currentPageBinding?: {
+    label: string;
     checked: boolean;
     onChange: (checked: boolean) => void;
   };
@@ -143,10 +172,12 @@ function ReferenceItemsSelector({
 
   // Get display text for closed state
   const getDisplayText = () => {
-    const totalCount = selectedIds.length + (currentPageItem?.checked ? 1 : 0);
+    const bindingCount = currentPageBinding?.checked ? 1 : 0;
+    const totalCount = selectedIds.length + (currentPageItem?.checked ? 1 : 0) + bindingCount;
     if (totalCount === 0) return 'Select items...';
 
     const labels: string[] = [];
+    if (currentPageBinding?.checked) labels.push(currentPageBinding.label);
     if (currentPageItem?.checked) labels.push('Current page item');
     for (const id of selectedIds) {
       const item = items.find(i => i.id === id);
@@ -174,6 +205,15 @@ function ReferenceItemsSelector({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-(--radix-dropdown-menu-trigger-width) min-w-50 max-h-60 overflow-y-auto" align="start">
+        {currentPageBinding && (
+          <DropdownMenuCheckboxItem
+            checked={currentPageBinding.checked}
+            onCheckedChange={(checked) => currentPageBinding.onChange(checked === true)}
+            onSelect={(e) => e.preventDefault()}
+          >
+            {currentPageBinding.label}
+          </DropdownMenuCheckboxItem>
+        )}
         {currentPageItem && (
           <DropdownMenuCheckboxItem
             checked={currentPageItem.checked}
@@ -219,13 +259,15 @@ export default function CollectionFiltersSettings({
   const [isOpen, setIsOpen] = useState(true);
 
   // Get fields from the collections store
-  const { fields: allFields, loadFields } = useCollectionsStore();
+  const { collections, fields: allFields, loadFields } = useCollectionsStore();
   const fields = allFields[collectionId] || [];
 
   // Element picker and layer access for filter input linking
   const startElementPicker = useEditorStore((state) => state.startElementPicker);
   const stopElementPicker = useEditorStore((state) => state.stopElementPicker);
   const currentPageId = useEditorStore((state) => state.currentPageId);
+  const editingComponentId = useEditorStore((state) => state.editingComponentId);
+  const pages = usePagesStore((state) => state.pages);
   const draftsByPageId = usePagesStore((state) => state.draftsByPageId);
   const allLayers = useMemo(() => {
     if (!currentPageId) return [];
@@ -233,12 +275,37 @@ export default function CollectionFiltersSettings({
     return draft ? draft.layers : [];
   }, [currentPageId, draftsByPageId]);
 
+  // Dynamic page context: when editing a dynamic CMS page (not a component), the
+  // page is bound to a collection whose current item provides "Current
+  // {collection}" filter values (the "Current Category/Tag" pattern).
+  const currentPage = useMemo(
+    () => pages.find((page) => page.id === currentPageId) || null,
+    [pages, currentPageId]
+  );
+  const isDynamicPage = !editingComponentId && !!currentPage?.is_dynamic;
+  const pageCollectionId = isDynamicPage ? currentPage?.settings?.cms?.collection_id : undefined;
+  const pageCollectionName = useMemo(
+    () => collections.find((c) => c.id === pageCollectionId)?.name || 'page',
+    [collections, pageCollectionId]
+  );
+  const pageCollectionFields = useMemo(
+    () => (pageCollectionId ? allFields[pageCollectionId] || [] : []),
+    [pageCollectionId, allFields]
+  );
+
   // Load fields if not already loaded
   useEffect(() => {
     if (collectionId && fields.length === 0) {
       loadFields(collectionId);
     }
   }, [collectionId, fields.length, loadFields]);
+
+  // Load the dynamic page collection's fields (for current-page field binding)
+  useEffect(() => {
+    if (pageCollectionId && (allFields[pageCollectionId]?.length ?? 0) === 0) {
+      loadFields(pageCollectionId);
+    }
+  }, [pageCollectionId, allFields, loadFields]);
 
   // Get current collection variable
   const collectionVariable = layer ? getCollectionVariable(layer) : null;
@@ -427,11 +494,16 @@ export default function CollectionFiltersSettings({
     const value = operatorRequiresValue(operator)
       ? (needsSecondValue && isDatePreset(existing?.value) ? '' : existing?.value)
       : undefined;
+    // Current-page binding is only supported for single-bound operators; drop it
+    // when switching to a two-bound operator (e.g. date `is between`).
+    const dropCurrentPage = needsSecondValue && existing?.valueMode === 'current_page';
     patchCondition(groupId, conditionId, {
       operator,
       value,
       value2: needsSecondValue ? existing?.value2 : undefined,
       inputLayerId2: needsSecondValue ? existing?.inputLayerId2 : undefined,
+      valueMode: dropCurrentPage ? 'static' : existing?.valueMode,
+      currentPageFieldId: dropCurrentPage ? undefined : existing?.currentPageFieldId,
     });
   };
 
@@ -467,7 +539,12 @@ export default function CollectionFiltersSettings({
     startElementPicker(
       (layerId: string) => {
         const resolvedId = resolveFilterInputId(layerId, allLayers);
-        patchCondition(groupId, conditionId, { inputLayerId: resolvedId, value: undefined });
+        patchCondition(groupId, conditionId, {
+          inputLayerId: resolvedId,
+          value: undefined,
+          valueMode: 'static',
+          currentPageFieldId: undefined,
+        });
         stopElementPicker();
       },
       (layerId: string) => isInputInsideFilter(layerId, allLayers),
@@ -612,10 +689,27 @@ export default function CollectionFiltersSettings({
       return renderSelfCondition(condition, group, index);
     }
     const fieldType = condition.fieldType || getFieldType(condition.fieldId || '');
-    const operators = getOperatorsForFieldType(fieldType);
     const icon = getFieldIcon(fieldType);
     const displayName = getFieldName(condition.fieldId || '');
     const referenceCollectionId = getReferenceCollectionId(condition);
+    const isCurrentPageMode = condition.valueMode === 'current_page';
+    // 'contains exactly' compares against a single current-page id, which can never
+    // match a real multi-reference set, so hide it while bound to the current item.
+    const operators = isCurrentPageMode
+      ? getOperatorsForFieldType(fieldType).filter((op) => op.value !== 'contains_exactly')
+      : getOperatorsForFieldType(fieldType);
+    // A reference field can bind to "Current {collection}" only when its target
+    // collection matches the dynamic page's collection (so the page item is a
+    // valid member of the compared set).
+    const canBindReferenceToCurrentPage = isDynamicPage
+      && !!pageCollectionId
+      && referenceCollectionId === pageCollectionId;
+    // Scalar fields can bind to a value-compatible field on the current page item.
+    const compatiblePageFields = isDynamicPage
+      ? pageCollectionFields.filter(
+        (f) => !!getScalarFieldGroup(f.type) && getScalarFieldGroup(f.type) === getScalarFieldGroup(fieldType)
+      )
+      : [];
     // Date fields use a dropdown for value mode; the "Filter form input" option
     // is the only place that reveals the link-to-input target icon. Falls back
     // to a linked input for conditions saved before `dateInput` existed.
@@ -724,6 +818,18 @@ export default function CollectionFiltersSettings({
                       collectionId={referenceCollectionId}
                       value={condition.value || '[]'}
                       onChange={(value) => handleValueChange(group.id, condition.id, value)}
+                      currentPageBinding={canBindReferenceToCurrentPage ? {
+                        label: `Current ${pageCollectionName}`,
+                        checked: isCurrentPageMode,
+                        onChange: (checked) => patchCondition(group.id, condition.id, {
+                          valueMode: checked ? 'current_page' : 'static',
+                          // 'contains exactly' against a single current-page id can never
+                          // match — the intent is "contains the current item".
+                          ...(checked && condition.operator === 'contains_exactly'
+                            ? { operator: 'contains_all_of' as VisibilityOperator }
+                            : {}),
+                        }),
+                      } : undefined}
                     />
                   </div>
                   <Tooltip>
@@ -766,6 +872,42 @@ export default function CollectionFiltersSettings({
                       <TooltipContent>Unlink filter input</TooltipContent>
                     </Tooltip>
                   </div>
+                </div>
+              ) : isCurrentPageMode ? (
+                <div className="flex items-center gap-1">
+                  <div className="flex-1">
+                    <Select
+                      value={condition.currentPageFieldId || ''}
+                      onValueChange={(v) => patchCondition(group.id, condition.id, { currentPageFieldId: v })}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder={`Current ${pageCollectionName} field...`} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {compatiblePageFields.map((f) => (
+                            <SelectItem key={f.id} value={f.id}>
+                              <span className="flex items-center gap-2">
+                                <Icon name={getFieldIcon(f.type)} className="size-3 opacity-60" />
+                                {f.name}
+                              </span>
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="secondary"
+                        onClick={() => patchCondition(group.id, condition.id, { valueMode: 'static', currentPageFieldId: undefined })}
+                      >
+                        <Icon name="x" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Use static value</TooltipContent>
+                  </Tooltip>
                 </div>
               ) : (
                 <div className="flex items-center gap-1">
@@ -854,6 +996,22 @@ export default function CollectionFiltersSettings({
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent>Link to filter input</TooltipContent>
+                    </Tooltip>
+                  )}
+                  {!isDateFieldType(fieldType) && !operatorRequiresSecondValue(condition.operator) && compatiblePageFields.length > 0 && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="secondary"
+                          onClick={() => patchCondition(group.id, condition.id, {
+                            valueMode: 'current_page',
+                            currentPageFieldId: compatiblePageFields[0]?.id,
+                          })}
+                        >
+                          <Icon name="database" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Use current {pageCollectionName} field</TooltipContent>
                     </Tooltip>
                   )}
                 </div>

--- a/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
+++ b/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
@@ -224,10 +224,12 @@ function ReferenceItemsSelector({
             onCheckedChange={(checked) => currentPageBinding.onChange(checked === true)}
             onSelect={(e) => e.preventDefault()}
           >
-            <span className="flex items-center gap-1.5">
-              <Icon name="zap" className="size-2.5 opacity-60" />
-              {currentPageBinding.label}
-            </span>
+            {!currentPageBinding.checked && (
+              <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+                <Icon name="zap" className="size-2.5 opacity-60" />
+              </span>
+            )}
+            {currentPageBinding.label}
           </DropdownMenuCheckboxItem>
         )}
         {currentPageItem && (

--- a/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
+++ b/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
@@ -226,7 +226,7 @@ function ReferenceItemsSelector({
           >
             {!currentPageBinding.checked && (
               <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-                <Icon name="zap" className="size-2.5 opacity-60" />
+                <Icon name="database" className="size-2.5 opacity-60" />
               </span>
             )}
             {currentPageBinding.label}

--- a/components/FilterableCollection.tsx
+++ b/components/FilterableCollection.tsx
@@ -199,6 +199,8 @@ export default function FilterableCollection({
       fieldType?: string;
       source?: 'collection_field' | 'self';
       includesCurrentPageItem?: boolean;
+      valueMode?: 'static' | 'current_page';
+      currentPageFieldId?: string;
     };
     const operatorsWithoutValue = new Set([
       'is_present',
@@ -232,6 +234,21 @@ export default function FilterableCollection({
         }
 
         if (!condition.fieldId) continue;
+
+        // Current-page conditions are forwarded verbatim; the server resolves the
+        // compare value from the current dynamic page item (its own ID for
+        // reference fields, or `currentPageFieldId`'s value for scalar fields).
+        if (condition.valueMode === 'current_page') {
+          activeInGroup.push({
+            fieldId: condition.fieldId,
+            operator: condition.operator,
+            value: condition.value || '',
+            fieldType: condition.fieldType,
+            valueMode: 'current_page',
+            currentPageFieldId: condition.currentPageFieldId,
+          });
+          continue;
+        }
 
         let value = condition.inputLayerId ? '' : (condition.value || '');
         let value2 = condition.inputLayerId2 ? '' : condition.value2;
@@ -581,6 +598,8 @@ export default function FilterableCollection({
       fieldType?: string;
       source?: 'collection_field' | 'self';
       includesCurrentPageItem?: boolean;
+      valueMode?: 'static' | 'current_page';
+      currentPageFieldId?: string;
     }>>,
     offset: number,
     append: boolean,

--- a/lib/current-page-filter.test.ts
+++ b/lib/current-page-filter.test.ts
@@ -1,0 +1,179 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { ConditionalVisibility, VisibilityCondition } from '@/types';
+import { evaluateCondition, evaluateVisibility, type VisibilityContext } from '@/lib/layer-utils';
+
+const TAG_A = 'tag-aaaa';
+const TAG_B = 'tag-bbbb';
+
+function refCondition(overrides: Partial<VisibilityCondition> = {}): VisibilityCondition {
+  return {
+    id: 'c1',
+    source: 'collection_field',
+    fieldId: 'posts-tags-field',
+    fieldType: 'multi_reference',
+    referenceCollectionId: 'tags-collection',
+    operator: 'is_one_of',
+    value: '[]',
+    valueMode: 'current_page',
+    ...overrides,
+  };
+}
+
+function ctx(overrides: Partial<VisibilityContext> = {}): VisibilityContext {
+  return {
+    collectionLayerData: {},
+    pageCollectionData: null,
+    pageCollectionItemId: TAG_A,
+    ...overrides,
+  };
+}
+
+test('current_page reference: matches a post that references the current tag (multi_reference JSON array)', () => {
+  const cond = refCondition();
+  const context = ctx({
+    collectionLayerData: { 'posts-tags-field': JSON.stringify([TAG_A, TAG_B]) },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, context), true);
+});
+
+test('current_page reference: excludes a post that does NOT reference the current tag', () => {
+  const cond = refCondition();
+  const context = ctx({
+    collectionLayerData: { 'posts-tags-field': JSON.stringify([TAG_B]) },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, context), false);
+});
+
+test('current_page reference: single reference stored as bare UUID matches', () => {
+  const cond = refCondition({ fieldType: 'reference' });
+  const context = ctx({
+    collectionLayerData: { 'posts-tags-field': TAG_A },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, context), true);
+});
+
+test('current_page reference: works even if fieldType is missing (operator-based detection)', () => {
+  const cond = refCondition({ fieldType: undefined });
+  const context = ctx({
+    collectionLayerData: { 'posts-tags-field': JSON.stringify([TAG_A]) },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, context), true);
+});
+
+test('current_page reference: no current page item -> condition is skipped (returns true)', () => {
+  const cond = refCondition();
+  const context = ctx({
+    collectionLayerData: { 'posts-tags-field': JSON.stringify([TAG_B]) },
+    pageCollectionItemId: undefined,
+  });
+  assert.equal(evaluateCondition(cond, context), true);
+});
+
+test('current_page reference: is_not_one_of excludes the current tag', () => {
+  const cond = refCondition({ operator: 'is_not_one_of' });
+  const matches = ctx({
+    collectionLayerData: { 'posts-tags-field': JSON.stringify([TAG_A]) },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, matches), false);
+  const noMatch = ctx({
+    collectionLayerData: { 'posts-tags-field': JSON.stringify([TAG_B]) },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, noMatch), true);
+});
+
+test('current_page reference: contains_exactly is treated as "contains current item" (multi-tag post matches)', () => {
+  // A real post usually has multiple tags. With contains_exactly + a single injected
+  // current-page id this would otherwise require the post to have ONLY that tag.
+  const cond = refCondition({ operator: 'contains_exactly', value: '[]' });
+  const multiTagPost = ctx({
+    collectionLayerData: { 'posts-tags-field': JSON.stringify([TAG_A, TAG_B]) },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, multiTagPost), true);
+  const otherTagPost = ctx({
+    collectionLayerData: { 'posts-tags-field': JSON.stringify([TAG_B]) },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, otherTagPost), false);
+});
+
+test('static contains_exactly is unchanged (still requires exact set match)', () => {
+  const cond = refCondition({ operator: 'contains_exactly', valueMode: 'static', value: JSON.stringify([TAG_A]) });
+  const exact = ctx({ collectionLayerData: { 'posts-tags-field': JSON.stringify([TAG_A]) } });
+  assert.equal(evaluateCondition(cond, exact), true);
+  const superset = ctx({ collectionLayerData: { 'posts-tags-field': JSON.stringify([TAG_A, TAG_B]) } });
+  assert.equal(evaluateCondition(cond, superset), false);
+});
+
+test('current_page reference: matches when the field value is an ARRAY (SSR cache form)', () => {
+  // The SSR collection cache hands multi-reference values as parsed arrays, not
+  // JSON strings. `String([...])` used to comma-join them into an unparseable
+  // string, dropping every match. Cover the array form explicitly.
+  const cond = refCondition({ operator: 'is_one_of', value: '[]' });
+  const arrayMatch = ctx({
+    collectionLayerData: { 'posts-tags-field': [TAG_A, TAG_B] as unknown as string },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, arrayMatch), true);
+  const arrayNoMatch = ctx({
+    collectionLayerData: { 'posts-tags-field': [TAG_B] as unknown as string },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, arrayNoMatch), false);
+});
+
+test('current_page reference: contains_all_of works with ARRAY field value', () => {
+  const cond = refCondition({ operator: 'contains_all_of', value: '[]' });
+  const multiTag = ctx({
+    collectionLayerData: { 'posts-tags-field': [TAG_A, TAG_B] as unknown as string },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, multiTag), true);
+});
+
+test('current_page scalar: matches when page field value equals item field value', () => {
+  const cond: VisibilityCondition = {
+    id: 'c1',
+    source: 'collection_field',
+    fieldId: 'posts-category-name',
+    fieldType: 'text',
+    operator: 'is',
+    valueMode: 'current_page',
+    currentPageFieldId: 'tags-name-field',
+  };
+  const match = ctx({
+    collectionLayerData: { 'posts-category-name': 'Design' },
+    pageCollectionData: { 'tags-name-field': 'Design' },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, match), true);
+  const noMatch = ctx({
+    collectionLayerData: { 'posts-category-name': 'Marketing' },
+    pageCollectionData: { 'tags-name-field': 'Design' },
+    pageCollectionItemId: TAG_A,
+  });
+  assert.equal(evaluateCondition(cond, noMatch), false);
+});
+
+test('evaluateVisibility end-to-end: single group with a current_page reference condition', () => {
+  const filters: ConditionalVisibility = {
+    groups: [{ id: 'g1', conditions: [refCondition()] }],
+  };
+  const keep = evaluateVisibility(filters, ctx({
+    collectionLayerData: { 'posts-tags-field': JSON.stringify([TAG_A]) },
+    pageCollectionItemId: TAG_A,
+  }));
+  assert.equal(keep, true);
+  const drop = evaluateVisibility(filters, ctx({
+    collectionLayerData: { 'posts-tags-field': JSON.stringify([TAG_B]) },
+    pageCollectionItemId: TAG_A,
+  }));
+  assert.equal(drop, false);
+});

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -2010,14 +2010,58 @@ export function evaluateCondition(
     const fieldId = condition.fieldId;
     if (!fieldId) return true;
 
-    // Use source-aware resolution (collection layer data first, then page data)
+    // Use source-aware resolution (collection layer data first, then page data).
+    // Multi-reference / multi-asset values can arrive already parsed as arrays
+    // (e.g. from the SSR collection cache). `String([...])` would comma-join them
+    // into an unparseable string, so serialize arrays back to JSON — the form
+    // every downstream parser (parseMultiReferenceValue, JSON.parse, `[`-prefix
+    // checks) expects.
     const rawValue = resolveFieldFromSources(fieldId, undefined, collectionLayerData, pageCollectionData);
-    const value = String(rawValue ?? '');
-    let compareValue = String(condition.value ?? '');
-    let compareValue2 = condition.value2;
-    let effectiveOperator = condition.operator;
+    const value = Array.isArray(rawValue) ? JSON.stringify(rawValue) : String(rawValue ?? '');
     const fieldType = condition.fieldType || 'text';
     const isDateOnly = fieldType === 'date_only';
+
+    // Resolve the compare value. In 'current_page' mode it is bound to the
+    // current dynamic page item instead of the static `condition.value`:
+    //   - reference fields inject the page item's own ID into the compared ID
+    //     set (alongside any statically picked IDs), so reference operators parse
+    //     it normally — this is the "Current Category/Tag" pattern
+    //   - scalar fields compare against the page item's `currentPageFieldId` value
+    // Reference detection also keys off the operator so it stays correct even if
+    // `fieldType` was not persisted on the condition.
+    let compareValue = String(condition.value ?? '');
+    if (condition.valueMode === 'current_page') {
+      const isReferenceField = fieldType === 'reference'
+        || fieldType === 'multi_reference'
+        || ['is_one_of', 'is_not_one_of', 'contains_all_of', 'contains_exactly'].includes(condition.operator);
+
+      // When the page item context is unavailable (e.g. the editor preview before
+      // a CMS item is selected), skip the condition instead of filtering everything
+      // out — mirrors the `self` source returning true when there is no current item.
+      if (isReferenceField && !pageCollectionItemId) return true;
+      if (!isReferenceField && !pageCollectionData) return true;
+
+      if (isReferenceField) {
+        const ids = parseItemIdList(condition.value);
+        if (pageCollectionItemId && !ids.includes(pageCollectionItemId)) {
+          ids.push(pageCollectionItemId);
+        }
+        compareValue = JSON.stringify(ids);
+      } else if (condition.currentPageFieldId) {
+        compareValue = String(pageCollectionData?.[condition.currentPageFieldId] ?? '');
+      }
+    }
+    let compareValue2 = condition.value2;
+    let effectiveOperator = condition.operator;
+
+    // In 'current_page' mode the compare set is a single injected page-item id, so
+    // 'contains exactly' (exact set equality) can essentially never match a real
+    // multi-reference field — it would only keep items whose entire reference set is
+    // just the current item. The intent of the "Current X" pattern is "contains the
+    // current item", so treat it as 'contains_all_of'.
+    if (condition.valueMode === 'current_page' && effectiveOperator === 'contains_exactly') {
+      effectiveOperator = 'contains_all_of';
+    }
 
     if (isDateFieldType(fieldType) && isDatePreset(compareValue)) {
       const resolved = resolveDateFilterValue(effectiveOperator, compareValue, compareValue2, timezone);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "type-check": "tsc --noEmit",
-    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts",
+    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts",
     "migrate:make": "NODE_NO_WARNINGS=1 knex migrate:make --knexfile knexfile.ts -x ts",
     "migrate:latest": "NODE_NO_WARNINGS=1 knex migrate:latest --knexfile knexfile.ts",
     "migrate:rollback": "NODE_NO_WARNINGS=1 knex migrate:rollback --knexfile knexfile.ts",

--- a/types/index.ts
+++ b/types/index.ts
@@ -1428,6 +1428,16 @@ export interface VisibilityCondition {
   // For self source: when true, the current dynamic page item ID is injected
   // into the comparison set alongside any statically picked IDs in `value`.
   includesCurrentPageItem?: boolean;
+  // How the compare value is sourced. Defaults to 'static' (uses `value`).
+  // 'current_page' binds the compare value to the current dynamic page item:
+  //   - reference/multi_reference fields compare against the page item's own ID
+  //     (the "Current Category/Tag" pattern)
+  //   - scalar fields compare against the value of `currentPageFieldId` on the
+  //     current page item
+  valueMode?: 'static' | 'current_page';
+  // For scalar fields with valueMode 'current_page': the field on the current
+  // dynamic page item whose value is used as the compare value.
+  currentPageFieldId?: string;
   // For linking filter value to an input layer inside a Filter
   inputLayerId?: string;
   inputLayerId2?: string; // For second bound (e.g. 'is_between')


### PR DESCRIPTION
## Summary

Brings back the "Current Tag/Category" CMS filter from legacy Ycode: a collection list on a dynamic page can now filter its items against the current page's CMS item — e.g. a Tags page showing only the posts that reference the current tag. Works for both reference fields (the "current item" pattern) and scalar fields (matching a field on the current page item).

## Changes

- Add `valueMode` + `currentPageFieldId` to `VisibilityCondition`
- Resolve current-page-bound filters in `evaluateCondition`, the SSR `page-fetcher`, and the runtime filter API so editor, published, and input-linked paths all behave consistently
- Add the "Current X" binding UI in the filter picker — separated with a divider, marked with a lightning icon, and labelled with the singular collection name (Tags → Current Tag)
- Hide/coerce the meaningless "contains exactly" operator while bound to the current item (treated as "contains the current item")
- Fix array-form multi-reference values: the SSR collection cache hands these as parsed arrays, and `String([...])` comma-joined them into an unparseable string so nothing matched — now serialized back to JSON
- Add regression tests for current-page reference/scalar filtering, including the array-value case

## Test plan

- [ ] On a dynamic page (e.g. Tags), add a collection list and a filter on a reference field that points to the page's collection; enable "Current Tag" and confirm only matching items show
- [ ] Verify items differ correctly between two CMS items (e.g. two tags with different post sets)
- [ ] Scalar binding: filter a text/number field against a compatible field on the current page item
- [ ] Confirm the editor preview reflects the selected CMS item in the top picker
- [ ] Re-publish and verify the live page shows the filtered items
- [ ] Confirm static (non-current-page) reference filters still work as before

Made with [Cursor](https://cursor.com)