### PR TITLE
feat: add active-page current state for navigation links

### DIFF
--- a/app/(builder)/ycode/components/UIStateSelector.tsx
+++ b/app/(builder)/ycode/components/UIStateSelector.tsx
@@ -2,6 +2,7 @@
 
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useEditorStore } from '@/stores/useEditorStore';
+import { layerHasLink } from '@/lib/link-utils';
 import type { UIState, Layer } from '@/types';
 
 interface UIStateSelectorProps {
@@ -21,8 +22,10 @@ export default function UIStateSelector({ selectedLayer }: UIStateSelectorProps)
 
   const isCurrentApplicable = () => {
     if (!selectedLayer) return false;
+    // Any element with a link can become the "active page" element, plus the
+    // built-in navigation/slider-bullet types that get aria-current at runtime.
     const applicableTypes = ['link', 'a', 'navigation', 'slideBullet'];
-    return applicableTypes.includes(selectedLayer.name || '');
+    return applicableTypes.includes(selectedLayer.name || '') || layerHasLink(selectedLayer);
   };
 
   return (

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -46,7 +46,7 @@ import FilterableCollection from '@/components/FilterableCollection';
 import LocaleSelector from '@/components/layers/LocaleSelector';
 import { usePagesStore } from '@/stores/usePagesStore';
 import { useSettingsStore } from '@/stores/useSettingsStore';
-import { generateLinkHref, resolveLinkAttrs, isLinkAtCollectionBoundary, type LinkResolutionContext } from '@/lib/link-utils';
+import { generateLinkHref, resolveLinkAttrs, isLinkAtCollectionBoundary, isLinkToCurrentPage, type LinkResolutionContext } from '@/lib/link-utils';
 import { collectEditorHiddenLayerIds, type HiddenLayerInfo } from '@/lib/animation-utils';
 import AnimationInitializer from '@/components/AnimationInitializer';
 import { transformLayerIdsForInstance, resolveVariableLinks } from '@/lib/resolve-components';
@@ -467,6 +467,12 @@ const LayerItemImpl: React.FC<{
   // Subscribe to selection state from the store for reactive updates without
   // forcing the entire LayerRenderer tree to re-render when selection changes
   const isSelected = useEditorStore((state) => state.selectedLayerId === layer.id);
+  // Preview the `current:` style state in the canvas: only the selected layer
+  // re-renders when the "Current" UI state is active (the selector returns a
+  // stable `false` for every other layer, so it doesn't trigger re-renders).
+  const isCurrentStatePreview = useEditorStore(
+    (state) => state.selectedLayerId === layer.id && state.activeUIState === 'current'
+  );
   const isEditing = editingLayerId === layer.id;
   const isDragging = activeLayerId === layer.id;
   const textEditable = isTextEditable(layer);
@@ -1865,6 +1871,30 @@ const LayerItemImpl: React.FC<{
     pageCollectionSortedItemIds,
   };
 
+  // Editor-only: a link that targets the page currently being edited is marked
+  // with `aria-current` so its `current:` styles render in the canvas, mirroring
+  // the published "active page" behaviour. Uses the same resolution context as
+  // the published renderer so page, url and CMS (field) links all match.
+  const isCurrentPageLinkInEditor = isEditMode
+    && isLinkToCurrentPage(layer.variables?.link, {
+      pages,
+      folders,
+      collectionItemSlugs,
+      collectionItemId: collectionLayerItemId,
+      pageCollectionItemId,
+      collectionItemData: collectionLayerData,
+      pageCollectionItemData: pageCollectionItemData || undefined,
+      isPreview,
+      locale: currentLocale,
+      translations,
+      getAsset,
+      anchorMap,
+      resolvedAssets,
+      layerDataMap: effectiveLayerDataMap,
+      pageCollectionSortedItemIds,
+      pageId,
+    });
+
   // Render element-specific content
   const renderContent = () => {
     // Component instances in EDIT MODE: render component's layers directly
@@ -2032,6 +2062,12 @@ const LayerItemImpl: React.FC<{
       ...(enableDragDrop && !isEditing && !isLockedByOther ? { ...normalizedAttributes, ...listeners } : normalizedAttributes),
       ...(!isEditMode && { suppressHydrationWarning: true }),
     };
+
+    // Editor: mark current-page links (and preview the selected layer's
+    // `current:` state) so the "active page" styles are visible in the canvas.
+    if (isEditMode && (isCurrentPageLinkInEditor || isCurrentStatePreview)) {
+      elementProps['aria-current'] = 'page';
+    }
 
     // Apply link attributes for elements rendered as <a> (buttons with links or <a> layers)
     if (htmlTag === 'a' && layer.variables?.link) {

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -21,7 +21,7 @@ import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/l
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
 import { getDynamicTextContent, getImageUrlFromVariable, getVideoUrlFromVariable, getIframeUrlFromVariable, isFieldVariable, isAssetVariable, isStaticTextVariable, isDynamicTextVariable, getStaticTextContent, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
 import { getTranslatedAssetId, getTranslatedText } from '@/lib/locale-runtime';
-import { isValidLinkSettings, generateLinkHref, resolveLinkAttrs, isLinkAtCollectionBoundary, type LinkResolutionContext } from '@/lib/link-utils';
+import { isValidLinkSettings, generateLinkHref, resolveLinkAttrs, isLinkAtCollectionBoundary, isLinkToCurrentPage, type LinkResolutionContext } from '@/lib/link-utils';
 import { DEFAULT_ASSETS, buildImageSizes, generateImageSrcset, getOptimizedImageUrl, parseImageDimension } from '@/lib/asset-utils';
 import { resolveInlineVariablesFromData } from '@/lib/inline-variables';
 import { renderRichText, hasBlockElementsWithInlineVariables, getTextStyleClasses, flattenTiptapParagraphs, type RichTextLinkContext, type RenderComponentBlockFn } from '@/lib/text-format-utils';
@@ -747,6 +747,7 @@ const LayerItem: React.FC<{
   const layerLinkContext: LinkResolutionContext = {
     pages,
     folders,
+    pageId,
     collectionItemSlugs,
     collectionItemId: collectionLayerItemId,
     pageCollectionItemId,
@@ -885,6 +886,9 @@ const LayerItem: React.FC<{
         const linkAttrs = resolveLinkAttrs(layer.variables.link, layerLinkContext);
         if (linkAttrs) {
           Object.assign(elementProps, linkAttrs);
+          if (isLinkToCurrentPage(layer.variables.link, layerLinkContext, linkAttrs.href)) {
+            elementProps['aria-current'] = 'page';
+          }
         } else if (isLinkAtCollectionBoundary(layer.variables.link, layerLinkContext)) {
           elementProps['aria-disabled'] = 'true';
           elementProps['data-link-disabled'] = 'true';
@@ -1786,6 +1790,7 @@ const LayerItem: React.FC<{
       content = (
         <a
           {...linkAttrs}
+          {...(isLinkToCurrentPage(linkSettings, layerLinkContext, linkAttrs.href) ? { 'aria-current': 'page' } : {})}
           className="contents"
         >
           {content}

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -704,6 +704,7 @@ export default async function PageRenderer({
         <LayerRendererPublic
           layers={childLayers}
           isPublished={page.is_published}
+          pageId={page.id}
           pageCollectionItemId={collectionItem?.id}
           pageCollectionItemData={collectionItem?.values || undefined}
           pageCollectionSortedItemIds={pageCollectionSortedItemIds}

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -37,6 +37,8 @@ export interface PageRenderContext {
   components: PageData['components']
   locale: PageData['locale'] | null
   translations: PageData['translations'] | undefined
+  /** ID of the page being rendered — drives `aria-current` on active-page links. */
+  pageId?: string
 }
 
 /**
@@ -77,7 +79,7 @@ export function renderPageBody(
         ctx.components,
         undefined, // ancestorComponentIds
         false, // isSlideChild
-        { isStaticExport: true }, // pageLinkContext — opt out of iframe htmlEmbed wrapping
+        { isStaticExport: true, currentPageId: ctx.pageId }, // pageLinkContext — opt out of iframe htmlEmbed wrapping
       ),
     )
     .filter(Boolean)

--- a/lib/apps/static-export/resolver.ts
+++ b/lib/apps/static-export/resolver.ts
@@ -167,6 +167,7 @@ function renderResolved(
     components: data.components,
     locale: data.locale ?? ctx.locale ?? null,
     translations: data.translations ?? ctx.translations,
+    pageId: page.id,
   })
   return {
     page,

--- a/lib/link-utils.ts
+++ b/lib/link-utils.ts
@@ -251,6 +251,12 @@ export interface LinkResolutionContext {
   collectionItemSlugs?: Record<string, string>;
   collectionItemId?: string;
   pageCollectionItemId?: string;
+  /**
+   * ID of the page currently being rendered. Used to detect links that point
+   * to the current page so they can be marked with `aria-current` (drives the
+   * `current:` style state, i.e. the "active page" indicator in navigation).
+   */
+  pageId?: string;
   collectionItemData?: Record<string, string>;
   pageCollectionItemData?: Record<string, string>;
   isPreview?: boolean;
@@ -666,6 +672,124 @@ export function looksLikePhone(value: unknown): boolean {
   const trimmed = value.trim();
   const digitCount = (trimmed.match(/\d/g) || []).length;
   return /^[\d\s\-()+.]*$/.test(trimmed) && digitCount >= 7;
+}
+
+/**
+ * Resolve a page link's `collection_item_id` (keyword, ref, or literal id) to a
+ * concrete collection item id, using the same rules as `generateLinkHref`.
+ * Returns null for navigation keywords (next/previous) that never represent the
+ * "current" item.
+ */
+function resolveLinkTargetItemId(
+  collectionItemId: string | null | undefined,
+  context: LinkResolutionContext
+): string | undefined {
+  if (!collectionItemId) return undefined;
+
+  if (isCollectionItemKeyword(collectionItemId)) {
+    switch (collectionItemId) {
+      case COLLECTION_ITEM_KEYWORDS.CURRENT_PAGE:
+        return context.pageCollectionItemId;
+      case COLLECTION_ITEM_KEYWORDS.CURRENT_COLLECTION:
+        return context.collectionItemId;
+      default:
+        // next-item / previous-item are never the current page.
+        return undefined;
+    }
+  }
+
+  if (collectionItemId.startsWith(REF_PAGE_PREFIX) || collectionItemId.startsWith(REF_COLLECTION_PREFIX)) {
+    return resolveRefCollectionItemId(collectionItemId, context.pageCollectionItemData, context.collectionItemData);
+  }
+
+  return collectionItemId;
+}
+
+/**
+ * Normalise an href to a comparable path: drops origin, query, hash, the
+ * `/ycode/preview` prefix, and any trailing slash so two URLs that point at the
+ * same page compare equal regardless of formatting.
+ */
+function normalizeLinkPath(href: string): string | null {
+  let path = href.trim();
+  if (!path) return null;
+
+  // Non-navigational schemes (mailto:, tel:, etc.) are never a page match.
+  if (/^(mailto:|tel:|javascript:)/i.test(path)) return null;
+
+  // Absolute URL → keep only the pathname (origin/query/hash dropped).
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(path)) {
+    try {
+      path = new URL(path).pathname;
+    } catch {
+      return null;
+    }
+  }
+
+  path = path.split('#')[0].split('?')[0];
+  path = path.replace(/^\/ycode\/preview/, '');
+  if (path.length > 1) path = path.replace(/\/+$/, '');
+  if (path === '') path = '/';
+  return path;
+}
+
+/** Build the normalised path of the page currently being rendered. */
+function getCurrentPagePath(context: LinkResolutionContext): string | null {
+  if (!context.pageId) return null;
+  const selfLink = createPageLinkSettings(context.pageId, context.pageCollectionItemId ?? null);
+  const href = generateLinkHref(selfLink, context);
+  return href ? normalizeLinkPath(href) : null;
+}
+
+/**
+ * Detects whether a link points to the page currently being rendered. Used to
+ * mark navigation links with `aria-current="page"`, which activates the
+ * `current:` style state (the legacy "Active" page indicator).
+ *
+ * - `page` links match by target page id (and, for dynamic collection pages, the
+ *   resolved collection item id — covering lists where each item links to its
+ *   own detail page).
+ * - `url` / `field` (CMS) links match by comparing their resolved path to the
+ *   current page's path.
+ *
+ * `resolvedHref` can be supplied by callers that already resolved the link to
+ * avoid resolving it twice.
+ */
+export function isLinkToCurrentPage(
+  linkSettings: LinkSettings | undefined | null,
+  context: LinkResolutionContext,
+  resolvedHref?: string | null
+): boolean {
+  if (!linkSettings || !context.pageId) return false;
+
+  // Page links: compare by page identity (id + collection item) — works without
+  // resolved slugs, so it behaves identically in the editor and on the server.
+  if (linkSettings.type === 'page') {
+    const targetPageId = linkSettings.page?.id;
+    if (!targetPageId || targetPageId !== context.pageId) return false;
+
+    const page = context.pages?.find(p => p.id === targetPageId);
+    const linkItemId = linkSettings.page?.collection_item_id;
+
+    // Plain page link (no specific collection item) targeting the current page id
+    // is "current". Covers static pages and generic links to dynamic pages, and
+    // stays correct even when `pages`/`pageCollectionItemId` are unavailable.
+    if (!page?.is_dynamic || !linkItemId) return true;
+
+    // Item-specific dynamic link: require the resolved item to be the current one.
+    if (!context.pageCollectionItemId) return false;
+    const targetItemId = resolveLinkTargetItemId(linkItemId, context);
+    return !!targetItemId && targetItemId === context.pageCollectionItemId;
+  }
+
+  // Other link types (url, field, …): compare resolved paths.
+  const href = resolvedHref ?? generateLinkHref(linkSettings, context);
+  if (!href) return false;
+  const linkPath = normalizeLinkPath(href);
+  if (!linkPath) return false;
+
+  const currentPath = getCurrentPagePath(context);
+  return !!currentPath && linkPath === currentPath;
 }
 
 export interface ResolvedLinkAttrs {

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -25,7 +25,7 @@ export interface PaginationContext {
   defaultPage?: number;
 }
 
-import { resolveFieldLinkValue, resolveRefCollectionItemId, generateLinkHref, isLinkAtCollectionBoundary, parseCollectionLinkValue, extractCrossCollectionItemIds } from '@/lib/link-utils';
+import { resolveFieldLinkValue, resolveRefCollectionItemId, generateLinkHref, isLinkAtCollectionBoundary, isLinkToCurrentPage, parseCollectionLinkValue, extractCrossCollectionItemIds } from '@/lib/link-utils';
 import type { LinkResolutionContext } from '@/lib/link-utils';
 import { getLinkSettingsFromMark } from '@/lib/tiptap-extensions/rich-text-link';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
@@ -4103,6 +4103,12 @@ export interface PageLinkContext {
   pageCollectionSortedItemIds?: string[];
   isPreview?: boolean;
   /**
+   * ID of the page being rendered. Links that target this page receive
+   * `aria-current="page"`, which activates their `current:` styles — the
+   * "active page" indicator used in navigation menus.
+   */
+  currentPageId?: string;
+  /**
    * Set by the static export to opt out of the iframe-wrapped htmlEmbed
    * SSR fallback. The live site relies on React hydration to replace the
    * SSR iframe with an inline `HtmlEmbedRenderer`; the static export has
@@ -4158,6 +4164,29 @@ export function layerToHtml(
 
   // Build layer data map with stored collection layer data
   const effectiveLayerDataMap = layer._layerDataMap || layerDataMap;
+
+  // A link targeting the page currently being rendered is marked with
+  // `aria-current="page"` so its `current:` styles apply (active-page state).
+  // Uses the same resolution context as `generateLinkHref` so page, url and CMS
+  // (field) links are all matched correctly.
+  const isCurrentPageLink = !!pageLinkContext?.currentPageId
+    && isLinkToCurrentPage(layer.variables?.link, {
+      pages,
+      folders,
+      collectionItemSlugs,
+      collectionItemId: effectiveCollectionItemId,
+      pageCollectionItemId: pageLinkContext.pageCollectionItemId,
+      collectionItemData: effectiveCollectionItemData,
+      pageCollectionItemData,
+      isPreview: pageLinkContext.isPreview,
+      locale,
+      translations,
+      getAsset: makeAssetMapResolver(assetMap),
+      anchorMap,
+      layerDataMap: effectiveLayerDataMap,
+      pageCollectionSortedItemIds: pageLinkContext.pageCollectionSortedItemIds,
+      pageId: pageLinkContext.currentPageId,
+    });
 
   // Get the HTML tag
   let tag = getLayerHtmlTag(layer);
@@ -4584,6 +4613,9 @@ export function layerToHtml(
 
       if (hrefValue) {
         attrs.push(`href="${escapeHtml(hrefValue)}"`);
+        if (isCurrentPageLink) {
+          attrs.push('aria-current="page"');
+        }
       } else if (isLinkAtCollectionBoundary(linkSettings, {
         pageCollectionItemId: pageLinkContext?.pageCollectionItemId,
         pageCollectionSortedItemIds: pageLinkContext?.pageCollectionSortedItemIds,
@@ -4824,6 +4856,9 @@ export function layerToHtml(
         const linkAttrs: string[] = [];
         if (linkHref) {
           linkAttrs.push(`href="${escapeHtml(linkHref)}"`);
+          if (isCurrentPageLink) {
+            linkAttrs.push('aria-current="page"');
+          }
         } else {
           linkAttrs.push('aria-disabled="true"', 'data-link-disabled="true"');
         }
@@ -4929,6 +4964,10 @@ export function layerToHtml(
     // Wrap content in <a> tag if we have a valid href
     if (linkHref) {
       const linkAttrs: string[] = [`href="${escapeHtml(linkHref)}"`];
+
+      if (isCurrentPageLink) {
+        linkAttrs.push('aria-current="page"');
+      }
 
       if (linkSettings.target) {
         linkAttrs.push(`target="${escapeHtml(linkSettings.target)}"`);

--- a/lib/server/cssGenerator.ts
+++ b/lib/server/cssGenerator.ts
@@ -84,7 +84,13 @@ async function getCompiler() {
   if (compilerCache) return compilerCache;
 
   const twPath = join(process.cwd(), 'node_modules/tailwindcss/index.css');
-  const input = await readFile(twPath, 'utf-8');
+  const baseInput = await readFile(twPath, 'utf-8');
+
+  // Register the same custom variants the client/browser generator uses so
+  // state-specific utilities compile server-side too. `current` (&[aria-current])
+  // powers the active-page navigation styling; the `disabled` override extends
+  // the built-in variant to also match `[aria-disabled]`.
+  const input = `${baseInput}\n@custom-variant current (&[aria-current]);\n@custom-variant disabled (&:is(:disabled, [aria-disabled]));\n`;
 
   compilerCache = await compile(input, {
     base: process.cwd(),


### PR DESCRIPTION
## Summary

Reintroduces the legacy "Active" page state from Ycode Legacy. Navigation links that point to the page currently being viewed now get `aria-current="page"`, which activates their `current:` Tailwind styles — so you can visually highlight the active page in a nav menu. This works in the editor canvas, on the published site, and in static exports.

## Changes

- Add `isLinkToCurrentPage` matcher in `lib/link-utils.ts` that detects links pointing to the current page across all link types:
  - **Page links** match by target page id; dynamic detail pages also match by resolved collection item id (covers CMS lists where each item links to its own page)
  - **URL / CMS field links** match by comparing their normalized resolved path to the current page's path
- Thread the current `pageId` through every render path: `PageRenderer` → `LayerRendererPublic`, the editor `LayerRenderer`, and the static export (`page-fetcher`, static-export `document`/`resolver`)
- Apply `aria-current="page"` wherever link attributes are emitted (public renderer, editor canvas, link wrappers, and all three `layerToHtml` spots)
- Register the `current` (`&[aria-current]`) and `disabled` custom variants in the **server** CSS generator so these utilities compile server-side, matching the browser generator
- Enable the **Current** UI state in `UIStateSelector` for any element that has a link (not just the hardcoded `link`/`a`/`navigation`/`slideBullet` types)

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes on all touched files
- [x] Rendered regular pages mark only their own link: verified `/`, `/about`, `/webui`, `/icons`, `/artwork`, `/print`, `/illustration`, `/event-design` each apply `aria-current` to exactly their own path — no cross-page false positives
- [ ] CMS/dynamic detail page: active item link highlights correctly
- [ ] Editor canvas: selecting a link and switching to the **Current** state previews its styling
- [ ] Editor canvas: the link to the page being edited shows its `current:` styles automatically
- [ ] Publish a page and confirm `current:` utilities are present in the generated CSS

Made with [Cursor](https://cursor.com)