### PR TITLE
fix: render slider images and active dot on published pages

### DIFF
--- a/lib/client/cssGenerator.ts
+++ b/lib/client/cssGenerator.ts
@@ -9,6 +9,7 @@
 
 import type { Component, Layer } from '@/types';
 import { DEFAULT_TEXT_STYLES } from '@/lib/text-format-utils';
+import { TAILWIND_CUSTOM_VARIANTS } from '@/lib/tailwind-custom-variants';
 
 /**
  * Extract all classes from layers recursively
@@ -132,8 +133,7 @@ export async function generateCSS(layers: Layer[]): Promise<string> {
   <meta charset="UTF-8">
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <style type="text/tailwindcss">
-    @custom-variant current (&[aria-current]);
-    @custom-variant disabled (&:is(:disabled, [aria-disabled]));
+    ${TAILWIND_CUSTOM_VARIANTS}
   </style>
 </head>
 <body>

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -2236,17 +2236,34 @@ export async function resolveCollectionLayers(
                   )
                 );
 
+                // Inject the cloned layer's OWN field variables (e.g. a slide's
+                // backgroundImage bound to the virtual __asset_url field). The
+                // React renderer resolves these at render time from
+                // _collectionItemValues, but static HTML export expects them
+                // pre-resolved — so resolve them here against this asset's values.
+                // Strip children first to avoid re-injecting the already-resolved
+                // per-asset children, then reattach them.
+                const layerWithOwnData = await injectCollectionData(
+                  {
+                    ...layer,
+                    variables: { ...layer.variables, collection: undefined },
+                    children: [],
+                  },
+                  virtualValues,
+                  undefined,
+                  isPublished,
+                  updatedLayerDataMap,
+                  undefined,
+                  timezone
+                );
+
                 // Build the cloned layer with original IDs first
                 const clonedLayer: Layer = {
-                  ...layer,
+                  ...layerWithOwnData,
                   attributes: {
                     ...layer.attributes,
                     'data-collection-item-id': assetId,
                   } as Record<string, any>,
-                  variables: {
-                    ...layer.variables,
-                    collection: undefined,
-                  },
                   children: injectedChildren,
                   _collectionItemValues: virtualValues,
                   _collectionItemId: assetId,

--- a/lib/server/cssGenerator.ts
+++ b/lib/server/cssGenerator.ts
@@ -15,6 +15,7 @@ import { join, dirname } from 'node:path';
 import { compile } from 'tailwindcss';
 import type { Layer, Component } from '@/types';
 import { DEFAULT_TEXT_STYLES } from '@/lib/text-format-utils';
+import { TAILWIND_CUSTOM_VARIANTS } from '@/lib/tailwind-custom-variants';
 import { getAllDraftLayers, getDraftLayers } from '@/lib/repositories/pageLayersRepository';
 import { getAllComponents } from '@/lib/repositories/componentRepository';
 import { setSetting } from '@/lib/repositories/settingsRepository';
@@ -84,7 +85,11 @@ async function getCompiler() {
   if (compilerCache) return compilerCache;
 
   const twPath = join(process.cwd(), 'node_modules/tailwindcss/index.css');
-  const input = await readFile(twPath, 'utf-8');
+  const baseInput = await readFile(twPath, 'utf-8');
+  // Register custom variants (current:, disabled:) so user classes like
+  // `current:opacity-100` on slider bullets compile — mirrors the client
+  // generator and app/globals.css.
+  const input = `${baseInput}\n${TAILWIND_CUSTOM_VARIANTS}\n`;
 
   compilerCache = await compile(input, {
     base: process.cwd(),

--- a/lib/tailwind-custom-variants.ts
+++ b/lib/tailwind-custom-variants.ts
@@ -1,0 +1,10 @@
+/**
+ * Tailwind custom variants used by generated user content.
+ *
+ * These must be registered with every Tailwind compiler that processes
+ * user-authored classes (client + server CSS generators) so variants like
+ * `current:` (active slider bullet) and `disabled:` (nav buttons) emit rules.
+ * Keep in sync with the `@custom-variant` declarations in `app/globals.css`.
+ */
+export const TAILWIND_CUSTOM_VARIANTS = `@custom-variant current (&[aria-current]);
+@custom-variant disabled (&:is(:disabled, [aria-disabled]));`;


### PR DESCRIPTION
## Summary

Fixes two issues where multi-asset sliders rendered correctly in preview but broke on published pages: missing slide background images and the active pagination dot not highlighting.

## Changes

- Resolve a multi-asset slide's own field variables (e.g. `backgroundImage` bound to the virtual `__asset_url` field) during SSR. Previously only the slide's children were injected, so static HTML export left the slide background unresolved while the React renderer still worked in preview.
- Register the `current:` and `disabled:` Tailwind custom variants in the server-side CSS generator so per-page `generated_css` (served on published pages) emits rules like `current:opacity-100` for the active slider bullet.
- Add `lib/tailwind-custom-variants.ts` as a single source for these variant declarations and reuse it in the client generator.

## Test plan

- [ ] On a dynamic page, add a slider whose slides come from a multi-asset (page) field
- [ ] Publish and confirm slide background images appear on the published page
- [ ] Confirm the active pagination bullet highlights (e.g. `current:opacity-100`) on the published page
- [ ] Verify preview still renders both correctly
- [ ] Re-publish an existing slider page and confirm regenerated CSS includes the `current:` rule