### PR TITLE
fix: translate referenced CMS values and embedded components

### DIFF
--- a/app/(builder)/ycode/components/Canvas.tsx
+++ b/app/(builder)/ycode/components/Canvas.tsx
@@ -30,7 +30,7 @@ import { useColorVariablesStore } from '@/stores/useColorVariablesStore';
 import { usePagesStore } from '@/stores/usePagesStore';
 import { useSettingsStore } from '@/stores/useSettingsStore';
 
-import { injectTranslatedText, translateComponentOverrides } from '@/lib/localisation-utils';
+import { applyCmsTranslations, injectTranslatedText, translateComponentOverrides } from '@/lib/localisation-utils';
 
 import type { Layer, Component, CollectionItemWithValues, CollectionField, Breakpoint, Asset, ComponentVariable, Locale, Translation } from '@/types';
 import type { UseLiveLayerUpdatesReturn } from '@/hooks/use-live-layer-updates';
@@ -381,13 +381,21 @@ const Canvas = React.memo(function Canvas({
   const enrichedPageCollectionItemDataRaw = useMemo(() => {
     const values = pageCollectionItem?.values;
     if (!values || !pageCollectionFields?.length) return values || null;
+    // Translate referenced item values so relationship paths render in the
+    // active locale on canvas (matches server-side page fetcher).
+    const translateRefValues = (currentLocale && !currentLocale.is_default && translations)
+      ? (refItemId: string, refValues: Record<string, string>, refFields: CollectionField[]) =>
+        applyCmsTranslations(refItemId, refValues, refFields, translations, { includeIncomplete: true })
+      : undefined;
     return resolveReferenceFieldsSync(
       values,
       pageCollectionFields,
       collectionItems,
-      collectionFields
+      collectionFields,
+      new Set(),
+      translateRefValues
     );
-  }, [pageCollectionItem?.values, pageCollectionFields, collectionItems, collectionFields]);
+  }, [pageCollectionItem?.values, pageCollectionFields, collectionItems, collectionFields, currentLocale, translations]);
 
   const enrichedPageCollectionItemDataRef = useRef(enrichedPageCollectionItemDataRaw);
   const enrichedPageCollectionItemDataKeyRef = useRef('');

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -7,7 +7,7 @@ import LayerLockIndicator from '@/components/collaboration/LayerLockIndicator';
 import EditingIndicator from '@/components/collaboration/EditingIndicator';
 import { useCollaborationPresenceStore, getResourceLockKey, RESOURCE_TYPES } from '@/stores/useCollaborationPresenceStore';
 import { useAuthStore } from '@/stores/useAuthStore';
-import type { Layer, Locale, ComponentVariable, FormSettings, LinkSettings, Breakpoint, CollectionItemWithValues, Component } from '@/types';
+import type { Layer, Locale, ComponentVariable, FormSettings, LinkSettings, Breakpoint, CollectionItemWithValues, CollectionField, Component } from '@/types';
 import type { UseLiveLayerUpdatesReturn } from '@/hooks/use-live-layer-updates';
 import type { UseLiveComponentUpdatesReturn } from '@/hooks/use-live-component-updates';
 import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEditable, isTextContentLayer, isRichTextLayer, getCollectionVariable, evaluateVisibility, findAncestorByName, filterDisabledSliderLayers, getLayerCmsFieldBinding, findLayerById } from '@/lib/layer-utils';
@@ -567,8 +567,17 @@ const LayerItemImpl: React.FC<{
   // Clicks on the embedded component's internal layers should select the text layer
   const renderComponentBlock: RenderComponentBlockFn = useCallback(
     (comp, resolvedLayers, _overrides, key, innerAncestorIds) => {
+      // In edit mode, embedded rich-text component layers are resolved live and
+      // are not pre-translated (SSR pre-translates them in page-fetcher). Apply
+      // component-scope translations here so the canvas shows localized content.
+      const localizedLayers = (isEditMode && currentLocale && !currentLocale.is_default && translations)
+        ? injectTranslatedText(resolvedLayers, pageId || comp.id, translations, {
+          includeIncomplete: true,
+          defaultMasterComponentId: comp.id,
+        })
+        : resolvedLayers;
       const uniqueLayers = transformLayerIdsForInstance(
-        resolvedLayers,
+        localizedLayers,
         `${layer.id}-rtc-${key}`
       );
       return (
@@ -599,7 +608,7 @@ const LayerItemImpl: React.FC<{
       </React.Fragment>
       );
     },
-    [layer.id, sharedRendererProps, isEditMode]
+    [layer.id, sharedRendererProps, isEditMode, currentLocale, translations, pageId]
   );
 
   let htmlTag = getLayerHtmlTag(layer);
@@ -1057,6 +1066,22 @@ const LayerItemImpl: React.FC<{
       const variableDef = componentVariables.find(v => v.id === linkedVariableId);
       const overrideCategory = variableDef?.type === 'rich_text' ? 'rich_text' : 'text';
       const overrideValue = parentComponentOverrides?.[overrideCategory]?.[linkedVariableId];
+
+      // When localizing, a component-scope translation for this layer was
+      // injected into its own text variable (id preserved). Prefer it over the
+      // untranslated variable default — but an instance override still wins.
+      if (overrideValue === undefined && (layer as any)._textTranslated && textVariable) {
+        if (textVariable.type === 'dynamic_rich_text') {
+          const variable = isSimpleTextLayer
+            ? { ...textVariable, data: { ...textVariable.data, content: flattenTiptapParagraphs(textVariable.data.content) } }
+            : textVariable;
+          return renderRichText(variable as any, collectionLayerData, pageCollectionItemData || undefined, layer.textStyles, useSpanForParagraphs, isEditMode, linkContext, timezone, effectiveLayerDataMap, allComponents, renderComponentBlock, effectiveAncestorIds, isSimpleTextLayer);
+        }
+        if (textVariable.type === 'dynamic_text') {
+          return (textVariable as any).data.content;
+        }
+      }
+
       const valueToRender = overrideValue ?? variableDef?.default_value;
 
       if (valueToRender !== undefined) {
@@ -3154,9 +3179,17 @@ const LayerItemImpl: React.FC<{
             // what the server-side page fetcher does on /preview and published
             // routes via applyCmsTranslations.
             const baseItemValues = item.values || {};
-            const translatedItemValues = (currentLocale && !currentLocale.is_default && translations)
+            const shouldTranslateCms = !!(currentLocale && !currentLocale.is_default && translations);
+            const translatedItemValues = shouldTranslateCms
               ? applyCmsTranslations(item.id, baseItemValues, collectionFields, translations, isEditMode ? { includeIncomplete: true } : undefined)
               : baseItemValues;
+
+            // Translate referenced item values too so relationship paths render
+            // in the active locale on canvas (matches server-side page fetcher).
+            const translateRefValues = shouldTranslateCms
+              ? (refItemId: string, refValues: Record<string, string>, refFields: CollectionField[]) =>
+                applyCmsTranslations(refItemId, refValues, refFields, translations, isEditMode ? { includeIncomplete: true } : undefined)
+              : undefined;
 
             // Resolve reference fields to add relationship paths (e.g., "refFieldId.targetFieldId")
             const enhancedItemValues = collectionFields.length > 0
@@ -3164,7 +3197,9 @@ const LayerItemImpl: React.FC<{
                 translatedItemValues,
                 collectionFields,
                 itemsForReferenceResolution,
-                fieldsByCollectionId
+                fieldsByCollectionId,
+                new Set(),
+                translateRefValues
               )
               : translatedItemValues;
 

--- a/lib/collection-utils.ts
+++ b/lib/collection-utils.ts
@@ -281,7 +281,8 @@ export function resolveReferenceFieldsSync(
   fields: import('@/types').CollectionField[],
   allItems: Record<string, import('@/types').CollectionItemWithValues[]>,
   allFields: Record<string, import('@/types').CollectionField[]>,
-  visited: Set<string> = new Set()
+  visited: Set<string> = new Set(),
+  translateValues?: (itemId: string, values: Record<string, string>, fields: import('@/types').CollectionField[]) => Record<string, string>
 ): Record<string, string> {
   const enhancedValues = { ...itemValues };
 
@@ -307,9 +308,15 @@ export function resolveReferenceFieldsSync(
     // Get fields for the referenced collection
     const refFields = allFields[field.reference_collection_id] || [];
 
+    // Translate the referenced item's values so the canvas renders referenced
+    // CMS content in the active locale (matches the server-side page fetcher)
+    const refValues = translateValues
+      ? translateValues(refItem.id, refItem.values, refFields)
+      : refItem.values;
+
     // Add referenced item's values with field.id as prefix
     for (const refField of refFields) {
-      const refValue = refItem.values[refField.id];
+      const refValue = refValues[refField.id];
       if (refValue !== undefined) {
         enhancedValues[`${field.id}.${refField.id}`] = refValue;
       }
@@ -317,11 +324,12 @@ export function resolveReferenceFieldsSync(
 
     // Recursively resolve nested reference fields
     const nestedValues = resolveReferenceFieldsSync(
-      refItem.values,
+      refValues,
       refFields,
       allItems,
       allFields,
-      visited
+      visited,
+      translateValues
     );
 
     // Merge nested values with proper path prefix

--- a/lib/localisation-utils.ts
+++ b/lib/localisation-utils.ts
@@ -897,16 +897,15 @@ export function injectTranslatedText(
     // point at an ancestor div/section without `variables.text`) would
     // otherwise materialise text content on layers that should have none,
     // breaking layout with random strings.
-    // Skip the component-scope layer translation when:
-    // (a) this layer's text was set by an instance override — the override
-    //     value has already been translated at page scope via
-    //     `translateComponentOverrides`, and re-translating here would
-    //     clobber it with the component default; or
-    // (b) the layer has an active component-variable binding
-    //     (`variables.text.id`) — the renderer resolves the value via the
-    //     parent instance's overrides or the variable's default value, so
-    //     overwriting `variables.text` here would strip the binding id and
-    //     break that lookup chain.
+    // Skip the plain component-scope layer translation when this layer's text
+    // was set by an instance override — the override value has already been
+    // translated at page scope via `translateComponentOverrides`, and
+    // re-translating here would clobber it with the component default.
+    //
+    // Layers with an active component-variable binding (`variables.text.id`)
+    // are handled by the dedicated branch below, which preserves the binding
+    // id while injecting the translated content (replacing the whole variable
+    // would strip the id and break the binding lookup chain).
     const hasComponentVariableBinding = !!(layer.variables?.text as any)?.id;
     if (
       textValue
@@ -937,6 +936,33 @@ export function injectTranslatedText(
         // Plain-text value for a simple text source.
         (variableUpdates as any).text = createDynamicTextVariable(textValue);
       }
+    } else if (
+      textValue
+      && hasComponentVariableBinding
+      && !(layer as any)._textFromOverride
+    ) {
+      // Layer text is bound to a component variable (`variables.text.id`).
+      // Inject the translated content while preserving the binding `id` so the
+      // editor still sees the variable link and the renderer can use the
+      // localized value. Replacing the whole variable (as above) would strip
+      // the `id` and break the binding lookup chain.
+      const existingText = layer.variables!.text as any;
+      if (existingText.type === 'dynamic_rich_text') {
+        const translated = looksLikeTiptapJson(textValue)
+          ? createDynamicRichTextVariable(textValue)
+          : createDynamicRichTextVariableFromPlainText(textValue);
+        (variableUpdates as any).text = { ...translated, id: existingText.id };
+      } else {
+        (variableUpdates as any).text = {
+          ...existingText,
+          data: { ...existingText.data, content: textValue },
+        };
+      }
+      // Flag so the renderer prefers this injected (translated) content over the
+      // bound component variable's default when localizing on canvas. Without
+      // this, the binding-resolution branch would render the untranslated
+      // default value instead.
+      (updates as any)._textTranslated = true;
     }
 
     // 2. Inject asset translations for media layers

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -517,7 +517,10 @@ async function fetchPageByPathInternal(
               let enhancedItemValues = await resolveReferenceFields(
                 collectionItem.values,
                 collectionFields,
-                isPublished
+                isPublished,
+                '',
+                new Set(),
+                translations
               );
               enhancedItemValues = applyCmsTranslations(collectionItem.id, enhancedItemValues, collectionFields, translations, { includeIncomplete: !isPublished });
               enhancedItemValues = formatDateFieldsInItemValues(enhancedItemValues, collectionFields, timezone);
@@ -560,7 +563,10 @@ async function fetchPageByPathInternal(
             let enhancedItemValues = await resolveReferenceFields(
               collectionItem.values,
               collectionFields,
-              isPublished
+              isPublished,
+              '',
+              new Set(),
+              translations
             );
 
             // Apply CMS translations to the item values
@@ -954,6 +960,7 @@ async function fetchComponents(supabase: any, isPublished: boolean = false): Pro
  * @param itemValues - Current item values (field_id -> value)
  * @param fields - Collection fields to check for references
  * @param isPublished - Whether to fetch published data
+ * @param translations - CMS translations applied to resolved referenced values
  * @returns Enhanced item values with resolved reference data
  */
 async function resolveReferenceFields(
@@ -961,7 +968,8 @@ async function resolveReferenceFields(
   fields: CollectionField[],
   isPublished: boolean,
   pathPrefix: string = '',
-  visited: Set<string> = new Set()
+  visited: Set<string> = new Set(),
+  translations?: Record<string, Translation> | null
 ): Promise<Record<string, string>> {
   const enhancedValues = { ...itemValues };
 
@@ -985,6 +993,10 @@ async function resolveReferenceFields(
 
       const refFields = await getFieldsByCollectionId(field.reference_collection_id, isPublished, { excludeComputed: true });
 
+      // Translate the referenced item's values so localized pages render
+      // referenced CMS content in the active locale (not the source language)
+      const refValues = applyCmsTranslations(refItem.id, refItem.values, refFields, translations, { includeIncomplete: !isPublished });
+
       // Build the path prefix for this level
       const currentPath = pathPrefix ? `${pathPrefix}.${field.id}` : field.id;
 
@@ -992,7 +1004,7 @@ async function resolveReferenceFields(
       // e.g., if field is "Author" with id "abc123", and referenced item has "name" field with id "xyz789"
       // the value becomes accessible as "abc123.xyz789" in the values map
       for (const refField of refFields) {
-        const refValue = refItem.values[refField.id];
+        const refValue = refValues[refField.id];
         if (refValue !== undefined) {
           // Store as: parentFieldId.refFieldId for relationship path resolution
           enhancedValues[`${currentPath}.${refField.id}`] = refValue;
@@ -1001,11 +1013,12 @@ async function resolveReferenceFields(
 
       // Recursively resolve nested reference fields
       const nestedValues = await resolveReferenceFields(
-        refItem.values,
+        refValues,
         refFields,
         isPublished,
         currentPath,
-        visited
+        visited,
+        translations
       );
 
       // Merge nested values (they'll have the full path)
@@ -1034,6 +1047,7 @@ async function batchResolveReferenceFields(
   isPublished: boolean,
   dataCache?: CollectionDataCache,
   boundFieldPaths?: Set<string>,
+  translations?: Record<string, Translation> | null,
 ): Promise<Record<string, string>[]> {
   let referenceFields = fields.filter(
     f => f.type === 'reference' && f.reference_collection_id
@@ -1089,6 +1103,19 @@ async function batchResolveReferenceFields(
     refFieldsMap = new Map<string, CollectionField[]>(fieldEntries);
   }
 
+  // Translate each referenced item's values once (reused across all rows that
+  // reference it) so localized pages render referenced CMS content in the
+  // active locale instead of the source language.
+  const translatedRefValuesById = new Map<string, Record<string, string>>();
+  const getTranslatedRefValues = (refItem: CollectionItemWithValues, refFields: CollectionField[]): Record<string, string> => {
+    let cached = translatedRefValuesById.get(refItem.id);
+    if (!cached) {
+      cached = applyCmsTranslations(refItem.id, refItem.values, refFields, translations, { includeIncomplete: !isPublished });
+      translatedRefValuesById.set(refItem.id, cached);
+    }
+    return cached;
+  };
+
   return itemsValues.map(values => {
     const enhanced = { ...values };
 
@@ -1102,11 +1129,13 @@ async function batchResolveReferenceFields(
       const refFields = refFieldsMap.get(field.reference_collection_id);
       if (!refFields) continue;
 
+      const refValues = getTranslatedRefValues(refItem, refFields);
+
       for (const rf of refFields) {
         const dotKey = `${field.id}.${rf.id}`;
         if (boundFieldPaths && !boundFieldPaths.has(dotKey)) continue;
-        if (refItem.values[rf.id] !== undefined) {
-          enhanced[dotKey] = refItem.values[rf.id];
+        if (refValues[rf.id] !== undefined) {
+          enhanced[dotKey] = refValues[rf.id];
         }
       }
     }
@@ -1596,9 +1625,20 @@ async function resolveTiptapComponentCollections(
 
         // Recursively resolve rich text components inside the resolved layers
         // (handles Component A → rich text → Component B → collection)
-        const fullyResolved = await resolveRichTextCollections(
+        let fullyResolved = await resolveRichTextCollections(
           withCollections, components, isPublished, translations, childAncestors,
         );
+
+        // Translate the embedded component's layers. Component-scope
+        // translations are keyed `component:<comp.id>:layer:...`, so the
+        // resolved component id must be passed as the master component id —
+        // otherwise the lookup falls back to page scope and never matches.
+        if (translations) {
+          fullyResolved = injectTranslatedText(fullyResolved, '', translations, {
+            includeIncomplete: !isPublished,
+            defaultMasterComponentId: comp.id,
+          });
+        }
 
         node = {
           ...node,
@@ -2441,6 +2481,7 @@ export async function resolveCollectionLayers(
             isPublished,
             cache,
             layerBoundPaths,
+            translations,
           );
           const clonedLayers: Layer[] = await Promise.all(
             preprocessed.map(async ({ item, rawTranslatedValues }, index) => {
@@ -3317,6 +3358,9 @@ export async function renderCollectionItemsToHtml(
     preprocessed.map(p => p.formattedValues),
     collectionFields,
     isPublished,
+    undefined,
+    undefined,
+    translations,
   );
 
   // Render each item using the template

--- a/lib/text-format-utils.ts
+++ b/lib/text-format-utils.ts
@@ -1177,7 +1177,10 @@ export function renderRichText(
   return doc.content.map((block: any, idx: number) => {
     const element = renderBlock(block, idx, collectionItemData, pageCollectionItemData, textStyles, useSpanForParagraphs, isEditMode, linkContext, timezone, layerDataMap, components, renderComponentBlock, ancestorComponentIds);
     const isVisibleBlock = block.type !== 'paragraph' || block.content?.length;
-    if (element && isVisibleBlock && isEditMode) {
+    // Embedded component blocks render as a React.Fragment, which only accepts
+    // `key`/`children` — cloning to inject `data-block-index` would throw.
+    const isFragment = React.isValidElement(element) && (element as React.ReactElement).type === React.Fragment;
+    if (element && isVisibleBlock && isEditMode && !isFragment) {
       return React.cloneElement(element as React.ReactElement<any>, {
         'data-block-index': visibleBlockIdx++,
       });


### PR DESCRIPTION
## Summary

Fixes three related localization bugs where CMS content rendered in the source language instead of the active locale, plus a console error surfaced by the embedded-component work. Covers both generated (SSR/preview) pages and the editor canvas.

Closes #323
Closes #324
Closes #325

## Changes

- **Referenced CMS values (#323)**: apply CMS translations to referenced item values during reference-field resolution — server side (`resolveReferenceFields` / `batchResolveReferenceFields`) and on the canvas (`resolveReferenceFieldsSync` via a translate callback). Referenced fields like an author's name/job title now localize in lists, dynamic pages, and the editor.
- **Components in CMS rich_text (#324)**: translate component layers embedded in rich_text bodies by passing the resolved component id as the master component id to `injectTranslatedText` (SSR path), and apply the same component-scope translation in the canvas `renderComponentBlock` path.
- **Component-variable-bound text (#325)**: inject translations for layers bound to a component variable (`variables.text.id`) while preserving the binding id, and make the renderer prefer that translated value over the variable default when localizing (instance overrides still win).
- **Fragment prop fix**: skip `data-block-index` cloning for embedded-component blocks that render as a `React.Fragment` (only accepts `key`/`children`).

## Test plan

- [ ] Dynamic page with a reference field (e.g. author name/job title): referenced values localize on published pages, preview, and canvas
- [ ] Collection list binding referenced fields: each item's referenced values localize (incl. Load More)
- [ ] Component embedded in a CMS rich_text field: embedded component layers localize on published pages and canvas
- [ ] Component embedded in a static rich_text layer: same localization behavior
- [ ] Text layer bound to a component variable with a component-scope translation: renders translated while keeping the variable link in the editor
- [ ] Instance override on a bound layer still takes precedence over the component-scope translation
- [ ] No console error about `data-block-index` on `React.Fragment` when editing rich text with embedded components