### PR TITLE
feat: allow duplicating dynamic pages

### DIFF
--- a/app/(builder)/ycode/components/PageContextMenu.tsx
+++ b/app/(builder)/ycode/components/PageContextMenu.tsx
@@ -41,7 +41,6 @@ function PageContextMenuInner({
   statusAvailability,
 }: Omit<PageContextMenuProps, 'children'>) {
   const isItemHomepage = nodeType === 'page' && isHomepage(item as Page);
-  const isItemDynamic = nodeType === 'page' && (item as Page).is_dynamic;
   const isTempItem = item.id.startsWith('temp-page-') || item.id.startsWith('temp-folder-');
 
   return (
@@ -105,7 +104,7 @@ function PageContextMenuInner({
       {(onDuplicate || onDelete) && <ContextMenuSeparator />}
 
       {onDuplicate && (
-        <ContextMenuItem onClick={onDuplicate} disabled={isItemDynamic}>
+        <ContextMenuItem onClick={onDuplicate}>
           <span>Duplicate</span>
         </ContextMenuItem>
       )}

--- a/app/(builder)/ycode/components/PagesTree.tsx
+++ b/app/(builder)/ycode/components/PagesTree.tsx
@@ -298,7 +298,6 @@ const PageRow = React.memo(function PageRow({
                 }}
                 disabled={
                   !onDuplicate ||
-                  (node.type === 'page' && (node.data as Page).is_dynamic) ||
                   (node.type === 'page' && (node.data as Page).error_page !== null)
                 }
               >

--- a/lib/repositories/pageRepository.ts
+++ b/lib/repositories/pageRepository.ts
@@ -801,46 +801,47 @@ export async function duplicatePage(pageId: string): Promise<Page> {
     throw new Error('Page not found');
   }
 
-  // Dynamic pages cannot be duplicated
-  if (originalPage.is_dynamic) {
-    throw new Error('Dynamic pages cannot be duplicated');
-  }
-
   const newName = `${originalPage.name} (Copy)`;
 
-  // Generate base slug from the new name
-  const baseSlug = newName
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
+  // Dynamic pages keep their original slug pattern (e.g. '*'); the conflicting
+  // slug warning between dynamic pages in the same folder is handled in the UI.
+  let newSlug = originalPage.slug;
 
-  // Get all existing slugs in the same folder to find a unique one
-  let query = client
-    .from('pages')
-    .select('slug')
-    .eq('is_published', false)
-    .is('error_page', null)
-    .is('deleted_at', null);
+  if (!originalPage.is_dynamic) {
+    // Generate base slug from the new name
+    const baseSlug = newName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
 
-  // Handle null parent folder properly
-  if (originalPage.page_folder_id === null) {
-    query = query.is('page_folder_id', null);
-  } else {
-    query = query.eq('page_folder_id', originalPage.page_folder_id);
-  }
+    // Get all existing slugs in the same folder to find a unique one
+    let query = client
+      .from('pages')
+      .select('slug')
+      .eq('is_published', false)
+      .is('error_page', null)
+      .is('deleted_at', null);
 
-  const { data: existingPages } = await query;
+    // Handle null parent folder properly
+    if (originalPage.page_folder_id === null) {
+      query = query.is('page_folder_id', null);
+    } else {
+      query = query.eq('page_folder_id', originalPage.page_folder_id);
+    }
 
-  const existingSlugs = (existingPages || []).map(p => p.slug.toLowerCase());
+    const { data: existingPages } = await query;
 
-  // Find unique slug
-  let newSlug = baseSlug;
-  if (existingSlugs.includes(baseSlug)) {
-    let counter = 2;
-    newSlug = `${baseSlug}-${counter}`;
-    while (existingSlugs.includes(newSlug)) {
-      counter++;
+    const existingSlugs = (existingPages || []).map(p => p.slug.toLowerCase());
+
+    // Find unique slug
+    newSlug = baseSlug;
+    if (existingSlugs.includes(baseSlug)) {
+      let counter = 2;
       newSlug = `${baseSlug}-${counter}`;
+      while (existingSlugs.includes(newSlug)) {
+        counter++;
+        newSlug = `${baseSlug}-${counter}`;
+      }
     }
   }
 

--- a/stores/usePagesStore.ts
+++ b/stores/usePagesStore.ts
@@ -1942,21 +1942,22 @@ export const usePagesStore = create<PagesStore>((set, get) => ({
       return { success: false, error: 'Page not found' };
     }
 
-    // Dynamic pages cannot be duplicated
-    if (originalPage.is_dynamic) {
-      return { success: false, error: 'Dynamic pages cannot be duplicated' };
-    }
-
     // Generate temporary ID for optimistic update
     const tempId = `temp-page-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const tempPublishKey = `temp-${Date.now()}`;
     const newOrder = originalPage.order + 1;
 
+    // Dynamic pages keep their original slug pattern; other pages get a temporary
+    // unique slug until the server returns the real duplicated page.
+    const tempSlug = originalPage.is_dynamic
+      ? originalPage.slug
+      : `${originalPage.slug}-copy-${Date.now()}`;
+
     // Create temporary duplicated page
     const tempPage: Page = {
       id: tempId,
       name: `${originalPage.name} (Copy)`,
-      slug: `${originalPage.slug}-copy-${Date.now()}`,
+      slug: tempSlug,
       is_published: false,
       is_publishable: originalPage.is_publishable ?? true,
       page_folder_id: originalPage.page_folder_id,


### PR DESCRIPTION
## Summary

Dynamic (CMS) pages can now be duplicated, just like static pages. The duplicate keeps the original `*` slug and its collection binding, so it sits in the same folder as the source and surfaces the existing conflicting-slug warning between dynamic pages.

## Changes

- Remove the dynamic-page guard in `duplicatePage` repository function; dynamic pages now keep their original `*` slug instead of generating a name-based slug, while non-dynamic pages keep the unique-slug behavior
- Remove the client-side block in the pages store and keep the original slug for the optimistic dynamic-page copy
- Re-enable the Duplicate action for dynamic pages in both the context menu and the pages tree dropdown

## Notes

- The slug uniqueness index already excludes dynamic pages (`is_dynamic = false`), so duplicating into the same folder does not violate any constraint
- The conflicting-slug warning between two dynamic pages in a folder is already handled in the UI

## Test plan

- [ ] Right-click a dynamic page and confirm Duplicate is enabled
- [ ] Duplicate a dynamic page and verify the copy appears in the same folder with the collection binding intact
- [ ] Confirm the conflicting-slug warning is shown for the two dynamic pages
- [ ] Verify duplicating a static page still generates a unique slug
- [ ] Verify error pages remain non-duplicable