### PR TITLE
fix: keep sample collection custom fields editable

### DIFF
--- a/app/(builder)/ycode/components/CMS.tsx
+++ b/app/(builder)/ycode/components/CMS.tsx
@@ -2267,7 +2267,7 @@ const CMS = React.memo(function CMS() {
 
       {/* Items Content */}
       <div className="flex-1 overflow-auto flex flex-col min-w-0">
-        {loadingSampleCollectionId === selectedCollectionId ? (
+        {loadingSampleCollectionId === selectedCollectionId || selectedCollectionId?.startsWith('temp-') ? (
           <div className="flex flex-col items-center justify-center gap-4 p-8 flex-1">
             <Spinner />
             <span className="text-sm text-muted-foreground">Creating collection...</span>

--- a/lib/services/sampleCollectionService.ts
+++ b/lib/services/sampleCollectionService.ts
@@ -71,22 +71,30 @@ export async function createSampleCollection(
     is_published: false,
   });
 
-  // 2. Create all fields with sequential ordering: start built-ins, custom, end built-ins
+  // 2. Create all fields with sequential ordering: start built-ins, custom, end built-ins.
+  // Built-in fields persist their `key` (which locks them from editing/deletion), while
+  // custom fields persist `key: null` so they remain editable like user-created fields.
+  // The sample key is retained separately (`lookupKey`) only to map sample item values.
   const customFieldsReordered = sample.customFields.map((f, i) => ({
     ...f,
     order: BUILT_IN_FIELDS_START.length + i,
+    lookupKey: f.key,
+    persistKey: null as string | null,
   }));
+  const startFields = BUILT_IN_FIELDS_START.map(f => ({ ...f, lookupKey: f.key, persistKey: f.key }));
   const endFieldsReordered = BUILT_IN_FIELDS_END.map((f, i) => ({
     ...f,
     order: BUILT_IN_FIELDS_START.length + sample.customFields.length + i,
+    lookupKey: f.key,
+    persistKey: f.key,
   }));
-  const allFieldDefs = [...BUILT_IN_FIELDS_START, ...customFieldsReordered, ...endFieldsReordered];
+  const allFieldDefs = [...startFields, ...customFieldsReordered, ...endFieldsReordered];
 
   const fields = await Promise.all(
     allFieldDefs.map(field =>
       createField({
         name: field.name,
-        key: field.key,
+        key: field.persistKey,
         type: field.type,
         fillable: field.fillable,
         hidden: field.hidden,
@@ -98,13 +106,13 @@ export async function createSampleCollection(
     )
   );
 
-  // 3. Build field key-to-id lookup
+  // 3. Build field key-to-id lookup using the sample key (fields share the order of allFieldDefs)
   const fieldKeyToId: Record<string, string> = {};
-  for (const field of fields) {
-    if (field.key) {
-      fieldKeyToId[field.key] = field.id;
+  allFieldDefs.forEach((def, i) => {
+    if (def.lookupKey) {
+      fieldKeyToId[def.lookupKey] = fields[i].id;
     }
-  }
+  });
 
   // 4. Create assets for image fields in parallel
   const { assetIdMap, assets } = await createImageAssets(sample.items, fieldKeyToId);


### PR DESCRIPTION
## Summary

When creating a collection from a sample template, all of its fields became locked (could not be edited, duplicated, or deleted) — only the default built-in fields should be locked. This fixes field editability and also prevents a brief flash of the "No Fields Defined" empty state during creation.

## Changes

- Persist sample custom fields with `key: null` so they behave like user-created fields and stay editable; only built-in fields keep a `key` (which the CMS uses to lock them)
- Retain the sample field key internally (`lookupKey`) to correctly map sample item values to created fields
- Keep the "Creating collection..." spinner visible across the optimistic-to-real collection swap to avoid flashing the empty state

## Test plan

- [ ] Create a sample collection and confirm custom fields (e.g. Image, Description, Content) can be edited, duplicated, and deleted
- [ ] Confirm built-in fields (ID, Status, Name, Slug, Created/Updated Date) remain locked
- [ ] Confirm sample item values are populated correctly for all custom fields
- [ ] Confirm the empty "No Fields Defined" state no longer flashes while the sample collection is being created