### PR TITLE
feat: pan the canvas with Space-drag or middle mouse

### DIFF
--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/components/ui/empty';
 
 // 4. Hooks
+import { useCanvasPan } from '@/hooks/use-canvas-pan';
 import { useEditorUrl } from '@/hooks/use-editor-url';
 import { useEditComponent } from '@/hooks/use-edit-component';
 import { useZoom } from '@/hooks/use-zoom';
@@ -167,6 +168,9 @@ function ViewportZoomControls({
           avoidCollisions={false}
           collisionPadding={0}
           className="max-h-75! w-38"
+          // Don't return focus to the trigger on close, otherwise pressing Space
+          // (the pan shortcut) re-activates the focused button and reopens this menu.
+          onCloseAutoFocus={(e) => e.preventDefault()}
         >
           <DropdownMenuItem onClick={onZoomIn}>
             Zoom in
@@ -824,6 +828,14 @@ const CenterCanvas = React.memo(function CenterCanvas({
     shortcutsEnabled: !isPreviewMode,
   });
 
+  // Pan the canvas by dragging while holding Space or with the middle mouse button
+  const { isPanGestureActive } = useCanvasPan({
+    scrollContainerRef,
+    iframeElement: canvasIframeElement,
+    enabled: !isPreviewMode,
+    isTextEditing,
+  });
+
   // Independent zoom for the preview (second useZoom instance, active only in preview mode)
   const previewContentWidth = parseInt(viewportSizes[viewportMode].width);
   const {
@@ -1349,12 +1361,17 @@ const CenterCanvas = React.memo(function CenterCanvas({
 
   // Handle any click inside the canvas (closes ElementLibrary panel and other popovers)
   const handleCanvasClick = useCallback(() => {
+    // Ignore clicks that are part of a pan gesture (Space-drag / middle-mouse)
+    if (isPanGestureActive()) return;
     window.dispatchEvent(new CustomEvent('closeElementLibrary'));
     window.dispatchEvent(new CustomEvent('canvasClick'));
-  }, []);
+  }, [isPanGestureActive]);
 
   // Canvas callback handlers
   const handleCanvasLayerClick = useCallback((layerId: string, event?: React.MouseEvent) => {
+    // Don't select layers while panning the canvas (Space-drag / middle-mouse)
+    if (isPanGestureActive()) return;
+
     // Skip selection changes during drag operations
     const { isDraggingLayerOnCanvas, isDraggingToCanvas, elementPicker: picker } = useEditorStore.getState();
     if (isDraggingLayerOnCanvas || isDraggingToCanvas) {
@@ -1440,7 +1457,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
         listItemIndex: resolvedListItemIndex,
       });
     }
-  }, [isPreviewMode, setActiveSidebarTab, selectLayerWithSublayer, editingComponentId, activeComponentVariantId, componentDrafts, currentDraft]);
+  }, [isPanGestureActive, isPreviewMode, setActiveSidebarTab, selectLayerWithSublayer, editingComponentId, activeComponentVariantId, componentDrafts, currentDraft]);
 
   const handleCanvasLayerUpdate = useCallback((layerId: string, updates: Partial<Layer>) => {
     // Block all source-layer mutations from the canvas while in a non-default
@@ -1715,8 +1732,13 @@ const CenterCanvas = React.memo(function CenterCanvas({
 
   // Handle layer hover from Canvas (for SelectionOverlay)
   const handleCanvasLayerHover = useCallback((layerId: string | null) => {
+    // Don't draw hover outlines while panning the canvas (Space-drag / middle-mouse)
+    if (isPanGestureActive()) {
+      setHoveredLayerId(null);
+      return;
+    }
     setHoveredLayerId(layerId);
-  }, [setHoveredLayerId]);
+  }, [isPanGestureActive, setHoveredLayerId]);
 
   // Open the master component when a component instance is double-clicked.
   // Mirrors the "Edit component" sidebar button.

--- a/hooks/use-canvas-pan.ts
+++ b/hooks/use-canvas-pan.ts
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+interface UseCanvasPanOptions {
+  /** The scrollable canvas container whose scroll offset gets adjusted while panning */
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  /** The canvas iframe — the drag often starts and stays inside it */
+  iframeElement: HTMLIFrameElement | null;
+  /** Disable panning (e.g. in preview mode) */
+  enabled?: boolean;
+  /** When true, the spacebar is reserved for typing and won't arm panning */
+  isTextEditing?: boolean;
+}
+
+interface UseCanvasPanResult {
+  /** True while a pan is armed (Space held) or in progress — gate canvas selection with this */
+  isPanGestureActive: () => boolean;
+}
+
+/**
+ * Enables panning the canvas by dragging while holding Space (industry standard
+ * "hand tool"), or with the middle mouse button. Lets users navigate a large
+ * canvas at high zoom levels.
+ *
+ * Space only arms panning while the pointer is over the canvas, so it keeps
+ * behaving normally for selects, inputs and buttons in the settings panels.
+ */
+export function useCanvasPan({
+  scrollContainerRef,
+  iframeElement,
+  enabled = true,
+  isTextEditing = false,
+}: UseCanvasPanOptions): UseCanvasPanResult {
+  const stateRef = useRef({
+    isPanning: false,
+    spaceHeld: false,
+    overCanvas: false,
+    suppressNextClick: false,
+    lastX: 0,
+    lastY: 0,
+  });
+  const isTextEditingRef = useRef(isTextEditing);
+  useEffect(() => {
+    isTextEditingRef.current = isTextEditing;
+  }, [isTextEditing]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const scrollEl = scrollContainerRef.current;
+    if (!scrollEl) return;
+
+    const state = stateRef.current;
+
+    let iframeDoc: Document | null = null;
+    try {
+      iframeDoc = iframeElement?.contentDocument ?? null;
+    } catch {
+      // Cross-origin iframe — ignore
+    }
+
+    const setCursor = (mode: 'grab' | 'grabbing' | '') => {
+      scrollEl.style.cursor = mode;
+      if (iframeElement) iframeElement.style.cursor = mode;
+      try {
+        if (iframeDoc?.body) iframeDoc.body.style.cursor = mode;
+      } catch {
+        // Ignore
+      }
+    };
+
+    const shouldStartPan = (e: MouseEvent) =>
+      e.button === 1 || (e.button === 0 && state.spaceHeld);
+
+    const handleMove = (e: MouseEvent) => {
+      if (!state.isPanning) return;
+      e.preventDefault();
+      // screenX/Y are global physical coordinates — consistent across the parent
+      // document and the (CSS-zoomed) iframe, unlike clientX/movementX.
+      const dx = e.screenX - state.lastX;
+      const dy = e.screenY - state.lastY;
+      state.lastX = e.screenX;
+      state.lastY = e.screenY;
+
+      // Horizontal overflow lives on the outer container.
+      scrollEl.scrollLeft -= dx;
+
+      // Vertical overflow usually scrolls inside the iframe (it's sized to the
+      // visible area, scrolling its own taller content). Fall back to the outer
+      // container when the iframe can't scroll (e.g. component editing).
+      let scroller: Element | null = null;
+      try {
+        scroller = iframeDoc?.scrollingElement ?? iframeDoc?.documentElement ?? null;
+      } catch {
+        scroller = null;
+      }
+      if (scroller && scroller.scrollHeight > scroller.clientHeight) {
+        scroller.scrollTop -= dy;
+      } else {
+        scrollEl.scrollTop -= dy;
+      }
+    };
+
+    const endPan = () => {
+      if (!state.isPanning) return;
+      state.isPanning = false;
+      setCursor(state.spaceHeld ? 'grab' : '');
+      window.removeEventListener('mousemove', handleMove, true);
+      window.removeEventListener('mouseup', endPan, true);
+      try {
+        iframeDoc?.removeEventListener('mousemove', handleMove, true);
+        iframeDoc?.removeEventListener('mouseup', endPan, true);
+      } catch {
+        // Ignore
+      }
+      // Clear after the post-mouseup click has had a chance to be suppressed.
+      setTimeout(() => { state.suppressNextClick = false; }, 0);
+    };
+
+    // A pan gesture is a mousedown+mouseup, which also fires a click that would
+    // otherwise select a layer. Swallow that click in the capture phase.
+    const handleClick = (e: MouseEvent) => {
+      if (!state.spaceHeld && !state.suppressNextClick) return;
+      e.preventDefault();
+      e.stopPropagation();
+    };
+
+    const startPan = (e: MouseEvent) => {
+      if (state.isPanning || !shouldStartPan(e)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      state.isPanning = true;
+      state.suppressNextClick = true;
+      state.lastX = e.screenX;
+      state.lastY = e.screenY;
+      setCursor('grabbing');
+
+      // Listen on both contexts: a drag that starts inside the iframe keeps
+      // delivering move/up events to the iframe document (and vice versa), so
+      // each surface needs the listeners to pan live during the drag.
+      window.addEventListener('mousemove', handleMove, true);
+      window.addEventListener('mouseup', endPan, true);
+      try {
+        iframeDoc?.addEventListener('mousemove', handleMove, true);
+        iframeDoc?.addEventListener('mouseup', endPan, true);
+      } catch {
+        // Ignore
+      }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.code !== 'Space' || e.repeat || state.spaceHeld) return;
+      // Only hijack Space when the pointer is over the canvas, so it keeps
+      // working normally for inputs/selects/buttons in the settings panels.
+      if (isTextEditingRef.current || !state.overCanvas) return;
+      state.spaceHeld = true;
+      e.preventDefault(); // stop the page from scrolling on space
+      if (!state.isPanning) setCursor('grab');
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.code !== 'Space') return;
+      state.spaceHeld = false;
+      if (!state.isPanning) setCursor('');
+    };
+
+    // Track whether the pointer is over the canvas (incl. the iframe, which sits
+    // inside the scroll container). The iframe is a separate browsing context,
+    // so its own mousemove keeps the flag set while hovering page content.
+    const markOver = () => { state.overCanvas = true; };
+    const markOut = () => { state.overCanvas = false; };
+
+    scrollEl.addEventListener('mousedown', startPan, true);
+    scrollEl.addEventListener('click', handleClick, true);
+    scrollEl.addEventListener('mouseenter', markOver);
+    scrollEl.addEventListener('mousemove', markOver);
+    scrollEl.addEventListener('mouseleave', markOut);
+    window.addEventListener('keydown', handleKeyDown, true);
+    window.addEventListener('keyup', handleKeyUp, true);
+    try {
+      iframeDoc?.addEventListener('mousedown', startPan, true);
+      iframeDoc?.addEventListener('click', handleClick, true);
+      iframeDoc?.addEventListener('mousemove', markOver);
+      iframeDoc?.addEventListener('keydown', handleKeyDown, true);
+      iframeDoc?.addEventListener('keyup', handleKeyUp, true);
+    } catch {
+      // Ignore
+    }
+
+    return () => {
+      scrollEl.removeEventListener('mousedown', startPan, true);
+      scrollEl.removeEventListener('click', handleClick, true);
+      scrollEl.removeEventListener('mouseenter', markOver);
+      scrollEl.removeEventListener('mousemove', markOver);
+      scrollEl.removeEventListener('mouseleave', markOut);
+      window.removeEventListener('keydown', handleKeyDown, true);
+      window.removeEventListener('keyup', handleKeyUp, true);
+      try {
+        iframeDoc?.removeEventListener('mousedown', startPan, true);
+        iframeDoc?.removeEventListener('click', handleClick, true);
+        iframeDoc?.removeEventListener('mousemove', markOver);
+        iframeDoc?.removeEventListener('keydown', handleKeyDown, true);
+        iframeDoc?.removeEventListener('keyup', handleKeyUp, true);
+      } catch {
+        // Ignore
+      }
+      endPan();
+      state.spaceHeld = false;
+      state.overCanvas = false;
+      setCursor('');
+    };
+  }, [enabled, scrollContainerRef, iframeElement]);
+
+  const isPanGestureActive = useCallback(() => {
+    const s = stateRef.current;
+    return s.spaceHeld || s.isPanning || s.suppressNextClick;
+  }, []);
+
+  return { isPanGestureActive };
+}

--- a/hooks/use-canvas-sibling-reorder.ts
+++ b/hooks/use-canvas-sibling-reorder.ts
@@ -523,11 +523,12 @@ export function useCanvasSiblingReorder({
     iframeDoc.addEventListener('mousedown', handleIframeMouseDown);
     // Listen to mousemove and mouseup on BOTH documents
     // (iframe events don't bubble to parent document)
-    // Use passive: true for mousemove to improve scroll performance
-    iframeDoc.addEventListener('mousemove', handleDocumentMouseMove, { passive: true });
+    // Not passive: handleDocumentMouseMove calls preventDefault() to cancel the
+    // native text selection when a drag-to-reorder starts.
+    iframeDoc.addEventListener('mousemove', handleDocumentMouseMove);
     iframeDoc.addEventListener('mouseup', handleDocumentMouseUp);
     iframeDoc.addEventListener('selectstart', handleSelectStart);
-    document.addEventListener('mousemove', handleDocumentMouseMove, { passive: true });
+    document.addEventListener('mousemove', handleDocumentMouseMove);
     document.addEventListener('mouseup', handleDocumentMouseUp);
 
     return () => {


### PR DESCRIPTION
## Summary

Adds the ability to pan the editor canvas by dragging, so users can navigate a large page at 100% zoom when it doesn't fit on screen. Uses the industry-standard bindings: hold **Space + drag** ("hand tool", like Figma/Webflow) or **middle-mouse drag**.

## Changes

- Add `useCanvasPan` hook that pans the outer container horizontally and the iframe's own scroller vertically, live during the drag
- Arm Space-pan only while the pointer is over the canvas, so Space keeps behaving normally for inputs/selects/buttons in the settings panels
- Skip panning during inline text editing
- Suppress layer selection (click) and hover outlines while a pan gesture is active
- Prevent the zoom dropdown from reopening on Space by dropping its close-auto-focus
- Fix passive `mousemove` listeners in `use-canvas-sibling-reorder` that blocked `preventDefault()` (resolves the "Unable to preventDefault inside passive event listener" warning)

## Test plan

- [ ] Zoom to 100% on a large page; hold Space and drag to pan horizontally and vertically
- [ ] Pan with the middle mouse button
- [ ] Confirm Space still types/activates controls when the cursor is over the settings panels
- [ ] Confirm Space + click (or middle-mouse) does not select layers and shows no hover outlines while dragging
- [ ] Open the zoom dropdown, use it, then press Space — it should pan, not reopen
- [ ] Drag-to-reorder a layer on the canvas and confirm no console warning appears