### PR TITLE
feat: expand MCP CMS and dynamic content support

### DIFF
--- a/lib/layer-style-utils.ts
+++ b/lib/layer-style-utils.ts
@@ -31,6 +31,44 @@ export function applyStyleToLayer(layer: Layer, style: LayerStyle): Layer {
 }
 
 /**
+ * Set a layer's full ordered style stack (combo classes), low -> high priority,
+ * and re-flatten the resolved classes/design from the referenced styles.
+ *
+ * Later styles win on conflicting properties, mirroring Webflow combo classes.
+ * Per-chip overrides are pruned to the styles that remain in the stack, and the
+ * legacy single-blob `styleOverrides` is dropped so the stack drives the render.
+ * An empty stack detaches all styles while preserving the current rendered look.
+ */
+export function setLayerStyleStack(
+  layer: Layer,
+  styleIds: string[],
+  stylesById: Map<string, LayerStyle>,
+): Layer {
+  if (styleIds.length === 0) {
+    return detachStyleFromLayer(layer);
+  }
+
+  const prevMap = layer.styleOverridesByStyle ?? {};
+  const map: NonNullable<Layer['styleOverridesByStyle']> = {};
+  for (const id of styleIds) {
+    if (prevMap[id]) map[id] = prevMap[id];
+  }
+
+  const next: Layer = {
+    ...layer,
+    styleIds,
+    styleId: styleIds[0],
+    styleOverridesByStyle: Object.keys(map).length > 0 ? map : undefined,
+    styleOverrides: undefined,
+  };
+
+  const classes = resolveLayerClasses(next, stylesById);
+  next.classes = classes;
+  next.design = buildDesign(classes);
+  return next;
+}
+
+/**
  * Detach style from a layer
  * Copies the current effective styling (style + overrides) to the layer's own classes/design
  * Then removes the style link and overrides

--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -187,8 +187,19 @@ update_layer_design({
 })
 \`\`\`
 
-Available states: \`neutral\` (default), \`hover\`, \`focus\`, \`active\`, \`disabled\`
+Available states: \`neutral\` (default), \`hover\`, \`focus\`, \`active\`, \`disabled\`, \`current\`
 Combine with breakpoints: \`desktop\`, \`tablet\`, \`mobile\`
+
+The \`current\` state styles a navigation link when it points to the page currently
+being viewed (rendered via \`aria-current\`). Use it to highlight the active nav link,
+the current pagination item, or the active slider bullet:
+\`\`\`
+update_layer_design({
+  layer_id: "<nav link>",
+  ui_state: "current",
+  design: { typography: { isActive: true, color: "#171717", fontWeight: "600" } }
+})
+\`\`\`
 
 Works in \`batch_operations\` too — add \`ui_state\` to any \`update_design\` operation.
 
@@ -497,6 +508,151 @@ reorder_collection_fields({ collection_id: "...", field_ids: ["...", "...", "...
 set_collection_item_order({ collection_id: "...", item_id: "...", manual_order: 0 })
 \`\`\`
 
+### Collection Lists on a Page (binding + filtering)
+
+A \`collection\` element (add_layer template "collection") is a Collection List: it repeats its
+children once per item in a bound collection. Build the row UI once inside it, then bind and filter:
+
+**1. Bind the list to a collection** (also sets sorting, limit, pagination):
+\`\`\`
+bind_collection_layer({
+  page_id, layer_id: "<collection layer>",
+  collection_id: "<posts collection>",
+  sort_by: "<date field id>", sort_order: "desc",   // or "manual" / "random" / "none"
+  limit: 6,
+  pagination: { enabled: true, mode: "load_more", items_per_page: 9 }
+})
+\`\`\`
+
+**2. Filter which items render** with \`set_collection_filters\`. Groups are joined by AND;
+conditions within a group are joined by OR. This replaces all filters (empty groups clears them):
+\`\`\`
+// Only published posts in a chosen category
+set_collection_filters({ page_id, layer_id, groups: [
+  { conditions: [{ source: "field", field_id: "<published bool>", operator: "is", value: "true" }] },
+  { conditions: [{ source: "field", field_id: "<category ref>", operator: "is_one_of", item_ids: ["<cat id>"] }] }
+]})
+\`\`\`
+
+Condition sources:
+- \`field\` — filter by a collection field. operator depends on field type (text: is/contains; number: is/lt/gt;
+  boolean: is + value "true"/"false"; date: is/is_before/is_after/is_between with value/value2; reference: is_one_of
+  with item_ids; multi_reference: contains_all_of/has_items).
+- \`item_id\` — filter by the item's own identity (is_one_of / is_not_one_of with item_ids and/or includes_current_page_item).
+
+**Current page (dynamic pages) — the "Current Category/Tag" pattern.** On a dynamic page, bind a filter
+to the current page's item:
+\`\`\`
+// Related posts: same category as the post being viewed (category is a reference field)
+set_collection_filters({ page_id, layer_id, groups: [
+  { conditions: [{ source: "field", field_id: "<category ref>", operator: "is_one_of", value_mode: "current_page" }] }
+]})
+
+// Show only the current page's own item
+set_collection_filters({ page_id, layer_id, groups: [
+  { conditions: [{ source: "item_id", operator: "is_one_of", includes_current_page_item: true }] }
+]})
+\`\`\`
+For a scalar field bound to the current page, also pass \`current_page_field_id\` (a field on the page's
+collection whose value is compared).
+
+**3. Bind child elements to fields** with \`bind_layer_field\` so each item shows live data. Build the row
+markup once inside the Collection List, then wire each element to a field:
+\`\`\`
+// Inside a Collection List bound to "Posts":
+bind_layer_field({ page_id, layer_id: "<title text>",  field_id: "<title field>" })   // text → Title
+bind_layer_field({ page_id, layer_id: "<cover image>", field_id: "<image field>" })   // image src → Cover
+bind_layer_field({ page_id, layer_id: "<cover image>", field_id: "<title field>", target: "alt" })
+bind_layer_field({ page_id, layer_id: "<byline>", field_id: "<author field>", prefix: "By " }) // "By {author}"
+\`\`\`
+- Binds by layer type: text/heading/richText → text; image → src (or target "alt"); video/audio → src
+  (video also "poster"); any layer with target "background" → background image.
+- \`source: "collection"\` (default) resolves the field from the nearest ancestor Collection List.
+  \`source: "page"\` resolves from the dynamic page's own collection item (use on dynamic CMS pages).
+- **Link a card to the item's page:** use \`update_layer_link\` with link_type "page", page_id_target = the
+  dynamic page, and NO collection_item_id — it resolves to the current item at runtime.
+
+**Multi-field text in one node** — when a single field isn't enough (e.g. a full name or a price string),
+use \`set_dynamic_text\` with ordered segments of literal text and field references:
+\`\`\`
+set_dynamic_text({ page_id, layer_id: "<name text>", segments: [
+  { type: "field", field_id: "<first name>" },
+  { type: "text", text: " " },
+  { type: "field", field_id: "<last name>" }
+]})
+// "$" + price + " / mo"
+set_dynamic_text({ page_id, layer_id: "<price text>", segments: [
+  { type: "text", text: "$" },
+  { type: "field", field_id: "<price>" },
+  { type: "text", text: " / mo" }
+]})
+\`\`\`
+
+### Nested Collection Lists
+
+A Collection List can be sourced from a reference field of a parent item instead of a whole collection —
+e.g. a post's related "Tags", or the products in the current page's "Category". Pass \`source_field_id\`
++ \`source_field_type\` to \`bind_collection_layer\`:
+\`\`\`
+// Inner list rendering the Tags (multi_reference) of each post in an outer Posts list:
+bind_collection_layer({
+  page_id, layer_id: "<inner collection layer>",
+  collection_id: "<tags collection>",            // the reference field's target collection
+  source_field_id: "<post.tags field id>",
+  source_field_type: "multi_reference",
+  source_field_source: "collection"              // field lives on the ancestor list's item
+})
+
+// On a dynamic Category page, list that category's products via a reference field on the page item:
+bind_collection_layer({
+  page_id, layer_id: "<products layer>",
+  collection_id: "<products collection>",
+  source_field_id: "<category.products field id>",
+  source_field_type: "multi_reference",
+  source_field_source: "page"
+})
+\`\`\`
+Pass \`source_field_id: null\` to clear nesting and revert to a direct collection.
+
+### Visitor-facing Filtering & Sorting (filter inputs)
+
+Build a \`filter\` element with inputs (text/select/checkbox) inside it, then link those inputs so visitors
+drive the list at runtime:
+- **Filter by an input:** add \`input_layer_id\` to a \`field\` condition in \`set_collection_filters\`
+  (and \`input_layer_id2\` for the second bound of \`is_between\`). The input's value replaces the static value.
+- **Sort by inputs:** pass \`sort_by_input_layer_id\` / \`sort_order_input_layer_id\` to \`bind_collection_layer\`.
+\`\`\`
+set_collection_filters({ page_id, layer_id, groups: [
+  { conditions: [{ source: "field", field_id: "<title>", operator: "contains", input_layer_id: "<search input>" }] }
+]})
+bind_collection_layer({ page_id, layer_id, collection_id, sort_by_input_layer_id: "<sort select>" })
+\`\`\`
+
+### Conditional Visibility (show/hide any layer)
+
+Any layer can be shown/hidden based on conditions via \`set_layer_visibility\`. It uses the SAME condition
+model as \`set_collection_filters\` (groups joined by AND, conditions by OR), plus a \`page_collection\` source.
+This REPLACES all conditions; an empty groups array clears them (always visible).
+\`\`\`
+// Hide a "Sale" badge unless the item's on_sale boolean is true (inside a Collection List or dynamic page)
+set_layer_visibility({ page_id, layer_id: "<sale badge>", groups: [
+  { conditions: [{ source: "field", field_id: "<on_sale bool>", operator: "is", value: "true" }] }
+]})
+
+// Show an "empty state" only when a Collection List on the page has no items
+set_layer_visibility({ page_id, layer_id: "<empty state>", groups: [
+  { conditions: [{ source: "page_collection", collection_layer_id: "<results list>", operator: "has_no_items" }] }
+]})
+
+// Show a "Featured" ribbon only on the current dynamic page's own item
+set_layer_visibility({ page_id, layer_id: "<ribbon>", groups: [
+  { conditions: [{ source: "item_id", operator: "is_one_of", includes_current_page_item: true }] }
+]})
+\`\`\`
+- \`field\` conditions resolve fields from the nearest ancestor Collection List and/or the dynamic page's collection.
+- \`page_collection\` tests another list's item count: \`has_items\` / \`has_no_items\`, or \`item_count\` with
+  \`compare_operator\` ("eq"/"lt"/"lte"/"gt"/"gte") + \`compare_value\`.
+
 ### Color Variables (Design Tokens)
 
 Color variables are site-wide CSS custom properties for consistent theming:
@@ -786,6 +942,20 @@ When building multiple similar elements (cards, buttons), create styles first:
 1. \`create_style\` to define the design once
 2. \`apply_style\` to apply it to each element
 3. Updating the style later updates all elements using it
+
+**Combo classes (stacking multiple styles):** A layer can reference an ordered stack
+of styles, not just one — like Webflow combo classes. Styles are listed low -> high
+priority and later styles win on conflicting properties. Use \`set_layer_styles\` to set
+the whole stack at once:
+\`\`\`
+// Base "Button" style + "Primary" modifier on top (Primary wins on conflicts)
+set_layer_styles({ page_id, layer_id, style_ids: ["<button>", "<button-primary>"] })
+
+// Detach all styles but keep the current look as local classes
+set_layer_styles({ page_id, layer_id, style_ids: [] })
+\`\`\`
+Use \`apply_style\` for the simple single-style case; use \`set_layer_styles\` whenever a
+layer needs more than one style or you need to control their order.
 
 ### Asset Management
 

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -13,6 +13,7 @@ import { registerLayerTools } from '@/lib/mcp/tools/layers';
 import { registerBatchTools } from '@/lib/mcp/tools/batch';
 import { registerLayoutTools } from '@/lib/mcp/tools/layouts';
 import { registerCollectionTools } from '@/lib/mcp/tools/collections';
+import { registerCollectionLayerTools } from '@/lib/mcp/tools/collection-layers';
 import { registerStyleTools } from '@/lib/mcp/tools/styles';
 import { registerAssetTools } from '@/lib/mcp/tools/assets';
 import { registerAssetFolderTools } from '@/lib/mcp/tools/asset-folders';
@@ -39,6 +40,7 @@ export function createMcpServer(): McpServer {
   registerBatchTools(server);
   registerLayoutTools(server);
   registerCollectionTools(server);
+  registerCollectionLayerTools(server);
   registerStyleTools(server);
   registerAssetTools(server);
   registerAssetFolderTools(server);

--- a/lib/mcp/tools/batch.ts
+++ b/lib/mcp/tools/batch.ts
@@ -35,8 +35,8 @@ const updateDesignOp = z.object({
   layer_id: z.string().describe('Layer ID or ref_id from a prior add_layer'),
   design: designSchema,
   breakpoint: z.enum(['desktop', 'tablet', 'mobile']).default('desktop').optional(),
-  ui_state: z.enum(['neutral', 'hover', 'focus', 'active', 'disabled']).default('neutral').optional()
-    .describe('UI state: "hover" for hover styles, "focus" for focus, etc.'),
+  ui_state: z.enum(['neutral', 'hover', 'focus', 'active', 'disabled', 'current']).default('neutral').optional()
+    .describe('UI state: "hover" for hover styles, "focus" for focus, "current" for the active/current navigation link, etc.'),
 });
 
 const updateTextOp = z.object({

--- a/lib/mcp/tools/collection-layers.ts
+++ b/lib/mcp/tools/collection-layers.ts
@@ -1,0 +1,614 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type {
+  Layer,
+  CollectionVariable,
+  CollectionField,
+} from '@/types';
+import { getCollectionById } from '@/lib/repositories/collectionRepository';
+import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
+import { getPageById } from '@/lib/repositories/pageRepository';
+import { getCachedDraft, saveCachedLayers } from '@/lib/mcp/page-layers';
+import { findLayerById, updateLayerById } from '@/lib/mcp/utils';
+import { findParentCollectionLayer } from '@/lib/layer-utils';
+import {
+  fieldConditionSchema,
+  itemIdConditionSchema,
+  pageCollectionConditionSchema,
+  buildConditionGroups,
+} from './visibility-conditions';
+
+/** A field variable's data payload — binds a layer's content to a CMS field. */
+function buildFieldData(
+  field: CollectionField,
+  source: 'collection' | 'page',
+  collectionLayerId: string | undefined,
+  format: string | undefined,
+) {
+  return {
+    field_id: field.id,
+    field_type: field.type,
+    relationships: [] as string[],
+    source,
+    ...(collectionLayerId ? { collection_layer_id: collectionLayerId } : {}),
+    ...(format ? { format } : {}),
+  };
+}
+
+/** Wrap a field variable in the `<ycode-inline-variable>` tag used in dynamic-text strings. */
+function inlineVariableTag(fieldData: ReturnType<typeof buildFieldData>): string {
+  return `<ycode-inline-variable>${JSON.stringify({ type: 'field', data: fieldData })}</ycode-inline-variable>`;
+}
+
+/** A single Tiptap inline node representing a bound field. */
+function dynamicVariableNode(fieldData: ReturnType<typeof buildFieldData>, label: string) {
+  return { type: 'dynamicVariable', attrs: { variable: { type: 'field', data: fieldData }, label } };
+}
+
+/** Wrap inline nodes in a single-paragraph Tiptap doc. */
+function paragraphDoc(content: Record<string, unknown>[]) {
+  return { type: 'doc', content: [{ type: 'paragraph', content }] };
+}
+
+/** Build a Tiptap rich-text doc that renders optional prefix/suffix around a bound field. */
+function buildBoundTextDoc(
+  fieldData: ReturnType<typeof buildFieldData>,
+  label: string,
+  prefix?: string,
+  suffix?: string,
+) {
+  const content: Record<string, unknown>[] = [];
+  if (prefix) content.push({ type: 'text', text: prefix });
+  content.push(dynamicVariableNode(fieldData, label));
+  if (suffix) content.push({ type: 'text', text: suffix });
+  return paragraphDoc(content);
+}
+
+/**
+ * Resolve the collection a binding should pull from: the nearest ancestor
+ * Collection List (source "collection") or the dynamic page's own collection
+ * (source "page"). Returns the collection id plus, for the collection source,
+ * the ancestor list layer id stamped onto the FieldVariable.
+ */
+async function resolveBindingContext(
+  layers: Layer[],
+  layerId: string,
+  pageId: string,
+  source: 'collection' | 'page',
+): Promise<{ collectionId: string; collectionLayerId?: string } | { error: string }> {
+  if (source === 'collection') {
+    const parent = findParentCollectionLayer(layers, layerId);
+    if (!parent) {
+      return { error: 'Layer is not inside a Collection List. Place it inside a bound "collection" element, or use source "page".' };
+    }
+    const collectionId = parent.variables?.collection?.id;
+    if (!collectionId) {
+      return { error: 'The ancestor Collection List is not bound yet. Call bind_collection_layer first.' };
+    }
+    return { collectionId, collectionLayerId: parent.id };
+  }
+
+  const page = await getPageById(pageId);
+  const collectionId = page?.settings?.cms?.collection_id;
+  if (!collectionId) {
+    return { error: 'This page is not a dynamic CMS page. Bind it to a collection (update_page_settings.cms) or use source "collection".' };
+  }
+  return { collectionId };
+}
+
+/**
+ * Find a collection-list layer (a layer carrying a `collection` variable). Such
+ * layers render as `div` but repeat their children for each item in the bound
+ * collection — they're created via add_layer template "collection".
+ */
+function findCollectionLayer(layers: Layer[], layerId: string):
+  | { layer: Layer; collection: CollectionVariable }
+  | { error: string } {
+  const layer = findLayerById(layers, layerId);
+  if (!layer) return { error: `Layer "${layerId}" not found.` };
+  const collection = layer.variables?.collection;
+  if (!collection) {
+    return { error: `Layer "${layerId}" is not a Collection List. Add one with add_layer template "collection", then bind it.` };
+  }
+  return { layer, collection };
+}
+
+export function registerCollectionLayerTools(server: McpServer) {
+  server.tool(
+    'bind_collection_layer',
+    `Bind a Collection List element (add_layer template "collection") to a CMS collection so it
+repeats its children for each item. Also sets sorting, an optional item limit, and pagination.
+
+Changing the bound collection clears any existing filters on the layer, since they reference the
+previous collection's fields. After binding, use set_collection_filters to filter the items.
+
+NESTED COLLECTIONS: To source a list from a reference field of a parent item instead of a whole
+collection, pass source_field_id + source_field_type:
+- "reference" / "multi_reference": collection_id must be the field's target collection; set
+  source_field_source "collection" (field on the ancestor list's item) or "page" (field on the
+  dynamic page's item).
+- "inverse_reference": collection_id is the child collection, source_field_id is the child field
+  that points back to the parent.
+
+SORT INPUTS: link sort_by_input_layer_id / sort_order_input_layer_id to filter input layers so
+visitors control sorting at runtime.`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The Collection List layer ID'),
+      collection_id: z.string().describe('The CMS collection to display (for nested reference/multi_reference, the field\'s target collection).'),
+      sort_by: z.string().optional()
+        .describe('"manual" (collection order), "random", "none", or a field ID to sort by. Omit to leave unchanged.'),
+      sort_order: z.enum(['asc', 'desc']).optional().describe('Sort direction when sort_by is a field ID.'),
+      limit: z.number().int().positive().optional().describe('Maximum number of items to show (ignored when pagination is enabled).'),
+      pagination: z.object({
+        enabled: z.boolean().describe('Turn pagination on or off.'),
+        mode: z.enum(['pages', 'load_more']).optional().describe('"pages" for numbered pages, "load_more" for a load-more button. Defaults to "pages".'),
+        items_per_page: z.number().int().positive().optional().describe('Items per page. Defaults to 10.'),
+      }).optional().describe('Pagination settings.'),
+      source_field_id: z.string().nullable().optional()
+        .describe('Nested collections: the reference field to source items from. Pass null to clear nesting (revert to a direct collection).'),
+      source_field_type: z.enum(['reference', 'multi_reference', 'multi_asset', 'inverse_reference']).optional()
+        .describe('Type of the source field. Required when source_field_id is set.'),
+      source_field_source: z.enum(['page', 'collection']).nullable().optional()
+        .describe('Where the source field lives: "collection" (ancestor list item) or "page" (dynamic page item). Omit for inverse_reference.'),
+      sort_by_input_layer_id: z.string().nullable().optional().describe('Link sort_by to a filter input layer (null clears).'),
+      sort_order_input_layer_id: z.string().nullable().optional().describe('Link sort_order to a filter input layer (null clears).'),
+    },
+    async ({ page_id, layer_id, collection_id, sort_by, sort_order, limit, pagination, source_field_id, source_field_type, source_field_source, sort_by_input_layer_id, sort_order_input_layer_id }) => {
+      const pageLayers = await getCachedDraft(page_id);
+      if (!pageLayers) {
+        return { content: [{ type: 'text' as const, text: `Error: Page "${page_id}" has no layers.` }], isError: true };
+      }
+
+      const layers = pageLayers.layers as Layer[];
+      const found = findCollectionLayer(layers, layer_id);
+      if ('error' in found) {
+        return { content: [{ type: 'text' as const, text: `Error: ${found.error}` }], isError: true };
+      }
+
+      const collection = await getCollectionById(collection_id);
+      if (!collection) {
+        return { content: [{ type: 'text' as const, text: `Error: Collection "${collection_id}" not found.` }], isError: true };
+      }
+
+      if (source_field_id && !source_field_type) {
+        return { content: [{ type: 'text' as const, text: 'Error: source_field_type is required when source_field_id is set.' }], isError: true };
+      }
+
+      const existing = found.collection;
+      const collectionChanged = !!existing.id && existing.id !== collection_id;
+
+      const nextVariable: CollectionVariable = {
+        ...existing,
+        id: collection_id,
+        ...(sort_by !== undefined ? { sort_by } : {}),
+        ...(sort_order !== undefined ? { sort_order } : {}),
+        ...(limit !== undefined ? { limit } : {}),
+        ...(pagination !== undefined ? {
+          pagination: {
+            enabled: pagination.enabled,
+            mode: pagination.mode ?? 'pages',
+            items_per_page: pagination.items_per_page ?? 10,
+          },
+        } : {}),
+      };
+
+      // Nested-collection sourcing. null clears nesting; a field id sets it.
+      if (source_field_id === null) {
+        delete nextVariable.source_field_id;
+        delete nextVariable.source_field_type;
+        delete nextVariable.source_field_source;
+      } else if (source_field_id !== undefined) {
+        nextVariable.source_field_id = source_field_id;
+        nextVariable.source_field_type = source_field_type;
+        nextVariable.source_field_source = source_field_source ?? undefined;
+      }
+
+      // Sort input linking. null clears the link.
+      if (sort_by_input_layer_id === null) delete nextVariable.sort_by_inputLayerId;
+      else if (sort_by_input_layer_id !== undefined) nextVariable.sort_by_inputLayerId = sort_by_input_layer_id;
+      if (sort_order_input_layer_id === null) delete nextVariable.sort_order_inputLayerId;
+      else if (sort_order_input_layer_id !== undefined) nextVariable.sort_order_inputLayerId = sort_order_input_layer_id;
+
+      // Filters reference the previous collection's fields — drop them when the
+      // bound collection changes so we never persist conditions that can't resolve.
+      if (collectionChanged) {
+        delete nextVariable.filters;
+      }
+
+      const updated = updateLayerById(layers, layer_id, (l) => ({
+        ...l,
+        variables: { ...l.variables, collection: nextVariable },
+      }));
+      await saveCachedLayers(page_id, updated);
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            message: `Bound layer to collection "${collection.name}"`,
+            layer_id,
+            collection_id,
+            filters_cleared: collectionChanged || undefined,
+          }),
+        }],
+      };
+    },
+  );
+
+  server.tool(
+    'set_collection_filters',
+    `Set the filters on a Collection List element so it only renders matching items (filtering at the
+data level, before render). REPLACES all existing filters. Pass an empty groups array to clear them.
+
+STRUCTURE: groups are joined by AND; conditions within a group are joined by OR.
+
+CONDITION SOURCES:
+- "field": filter by a collection field value. Provide field_id and operator. Operators depend on
+  the field type (e.g. text: is/is_not/contains; number: is/lt/gt; reference: is_one_of; multi_reference:
+  contains_all_of/has_items; boolean: is with value "true"/"false"; date: is/is_before/is_after/is_between).
+  - For reference / multi_reference operators, pass item_ids (collection item IDs).
+  - For a two-bound date operator (is_between), pass value and value2.
+- "item_id": filter by the item's own identity (like reference semantics). operator is_one_of / is_not_one_of
+  with item_ids and/or includes_current_page_item.
+
+CURRENT PAGE (dynamic pages only) — the "Current Category/Tag" pattern:
+- Set value_mode "current_page" on a "field" condition to bind the compare value to the current dynamic
+  page item. For a reference / multi_reference field, it compares against the page item's ID (no value needed).
+  For a scalar field, also pass current_page_field_id (a field on the page's collection whose value is compared).
+- Or use an "item_id" condition with includes_current_page_item: true to show only the current page's item.
+
+FILTER INPUTS (visitor-facing filtering): set input_layer_id on a "field" condition to bind its value to a
+filter input layer (an input/select/etc. inside a Filter element). The visitor's input then drives the filter
+at runtime instead of a static value (use input_layer_id2 for the second bound of is_between).`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The Collection List layer ID'),
+      groups: z.array(z.object({
+        conditions: z.array(z.discriminatedUnion('source', [
+          fieldConditionSchema,
+          itemIdConditionSchema,
+        ])).min(1).describe('Conditions joined by OR.'),
+      })).describe('Filter groups joined by AND. Empty array clears all filters.'),
+    },
+    async ({ page_id, layer_id, groups }) => {
+      const pageLayers = await getCachedDraft(page_id);
+      if (!pageLayers) {
+        return { content: [{ type: 'text' as const, text: `Error: Page "${page_id}" has no layers.` }], isError: true };
+      }
+
+      const layers = pageLayers.layers as Layer[];
+      const found = findCollectionLayer(layers, layer_id);
+      if ('error' in found) {
+        return { content: [{ type: 'text' as const, text: `Error: ${found.error}` }], isError: true };
+      }
+
+      const collectionId = found.collection.id;
+      if (!collectionId) {
+        return { content: [{ type: 'text' as const, text: 'Error: Layer is not bound to a collection. Call bind_collection_layer first.' }], isError: true };
+      }
+
+      const fields = await getFieldsByCollectionId(collectionId);
+      const fieldsById = new Map<string, CollectionField>(fields.map((f) => [f.id, f]));
+
+      const result = buildConditionGroups(groups, { fieldsById, layers });
+      if ('error' in result) {
+        return { content: [{ type: 'text' as const, text: `Error: ${result.error}` }], isError: true };
+      }
+      const builtGroups = result.groups;
+
+      const nextVariable: CollectionVariable = { ...found.collection };
+      if (builtGroups.length > 0) {
+        nextVariable.filters = { groups: builtGroups };
+      } else {
+        delete nextVariable.filters;
+      }
+
+      const updated = updateLayerById(layers, layer_id, (l) => ({
+        ...l,
+        variables: { ...l.variables, collection: nextVariable },
+      }));
+      await saveCachedLayers(page_id, updated);
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            message: builtGroups.length > 0
+              ? `Set ${builtGroups.length} filter group(s) on the collection layer`
+              : 'Cleared all filters on the collection layer',
+            layer_id,
+            groups: builtGroups.length,
+          }),
+        }],
+      };
+    },
+  );
+
+  server.tool(
+    'bind_layer_field',
+    `Bind a layer's content to a CMS collection field so it shows live data per item. Use this on
+elements INSIDE a Collection List (source "collection") or anywhere on a dynamic CMS page
+(source "page") to wire up titles, images, prices, etc.
+
+WHAT GETS BOUND (by layer type):
+- text / heading / richText → the text content (optionally wrapped with prefix/suffix, e.g. "By " + Author)
+- image → the image src (or target "alt" for alt text)
+- video / audio → the media src (video also supports target "poster")
+- any layer with target "background" → the background image
+
+The field must exist in the relevant collection: for source "collection" that's the collection bound to
+the nearest ancestor Collection List; for source "page" it's the dynamic page's collection.
+
+TIP: To link a card to the item's own dynamic page, use update_layer_link with link_type "page",
+page_id_target = the dynamic page, and NO collection_item_id (it resolves to the current item).`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer whose content to bind'),
+      field_id: z.string().describe('The collection field ID to bind to'),
+      source: z.enum(['collection', 'page']).default('collection')
+        .describe('"collection" = nearest ancestor Collection List (default). "page" = the dynamic page\'s collection item.'),
+      target: z.enum(['auto', 'src', 'alt', 'poster', 'background']).default('auto')
+        .describe('What to bind. "auto" picks by layer type (text→text, image/video/audio→src). Use "alt", "poster", or "background" for those specific targets.'),
+      format: z.string().optional().describe('Optional value format (e.g. a date format) applied when rendering the field.'),
+      prefix: z.string().optional().describe('Text layers only: literal text rendered before the field value.'),
+      suffix: z.string().optional().describe('Text layers only: literal text rendered after the field value.'),
+    },
+    async ({ page_id, layer_id, field_id, source, target, format, prefix, suffix }) => {
+      const pageLayers = await getCachedDraft(page_id);
+      if (!pageLayers) {
+        return { content: [{ type: 'text' as const, text: `Error: Page "${page_id}" has no layers.` }], isError: true };
+      }
+
+      const layers = pageLayers.layers as Layer[];
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+
+      // Resolve which collection the field must belong to, plus the FieldVariable source metadata.
+      const ctx = await resolveBindingContext(layers, layer_id, page_id, source);
+      if ('error' in ctx) {
+        return { content: [{ type: 'text' as const, text: `Error: ${ctx.error}` }], isError: true };
+      }
+      const { collectionId, collectionLayerId } = ctx;
+
+      const fields = await getFieldsByCollectionId(collectionId);
+      const field = fields.find((f) => f.id === field_id);
+      if (!field) {
+        return { content: [{ type: 'text' as const, text: `Error: Field "${field_id}" not found in the ${source === 'page' ? 'page' : 'list'} collection.` }], isError: true };
+      }
+
+      const fieldData = buildFieldData(field, source, collectionLayerId, format);
+      const isText = layer.name === 'text' || layer.name === 'richText';
+
+      let nextVariables: Layer['variables'];
+      let summary: string;
+
+      if (target === 'background') {
+        nextVariables = { ...layer.variables, backgroundImage: { src: { type: 'field', data: fieldData } } };
+        summary = `background image → "${field.name}"`;
+      } else if (isText && (target === 'auto' || target === 'src')) {
+        nextVariables = {
+          ...layer.variables,
+          text: { type: 'dynamic_rich_text', data: { content: buildBoundTextDoc(fieldData, field.name, prefix, suffix) } },
+        };
+        summary = `text → "${field.name}"`;
+      } else if (layer.name === 'image') {
+        const existing = layer.variables?.image;
+        if (target === 'alt') {
+          nextVariables = {
+            ...layer.variables,
+            image: {
+              src: existing?.src ?? { type: 'asset', data: { asset_id: null } },
+              alt: { type: 'dynamic_text', data: { content: `${prefix ?? ''}${inlineVariableTag(fieldData)}${suffix ?? ''}` } },
+            },
+          };
+          summary = `image alt → "${field.name}"`;
+        } else {
+          nextVariables = {
+            ...layer.variables,
+            image: {
+              src: { type: 'field', data: fieldData },
+              alt: existing?.alt ?? { type: 'dynamic_text', data: { content: '' } },
+            },
+          };
+          summary = `image src → "${field.name}"`;
+        }
+      } else if (layer.name === 'video') {
+        const existing = layer.variables?.video;
+        if (target === 'poster') {
+          nextVariables = { ...layer.variables, video: { ...existing, poster: { type: 'field', data: fieldData } } };
+          summary = `video poster → "${field.name}"`;
+        } else {
+          nextVariables = { ...layer.variables, video: { ...existing, src: { type: 'field', data: fieldData } } };
+          summary = `video src → "${field.name}"`;
+        }
+      } else if (layer.name === 'audio') {
+        nextVariables = { ...layer.variables, audio: { ...layer.variables?.audio, src: { type: 'field', data: fieldData } } };
+        summary = `audio src → "${field.name}"`;
+      } else {
+        return {
+          content: [{ type: 'text' as const, text: `Error: Layer "${layer.customName || layer.name}" (${layer.name}) cannot bind a "${target}" field. Use a text, image, video, or audio layer, or target "background".` }],
+          isError: true,
+        };
+      }
+
+      const updated = updateLayerById(layers, layer_id, (l) => ({ ...l, variables: nextVariables }));
+      await saveCachedLayers(page_id, updated);
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({ message: `Bound ${summary}`, layer_id, field_id, source }),
+        }],
+      };
+    },
+  );
+
+  server.tool(
+    'set_dynamic_text',
+    `Set a text layer's content to a mix of literal text and one or more CMS fields in a single text node
+(e.g. "{first_name} {last_name}" or "$" + price + " / mo"). Use this when one field (bind_layer_field)
+isn't enough.
+
+Provide ordered segments: { type: "text", text } literals interleaved with { type: "field", field_id }
+references. Works on text / heading / richText layers, inside a Collection List (source "collection")
+or on a dynamic CMS page (source "page").`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The text / heading / richText layer'),
+      source: z.enum(['collection', 'page']).default('collection')
+        .describe('"collection" = nearest ancestor Collection List (default). "page" = the dynamic page\'s collection item.'),
+      segments: z.array(z.discriminatedUnion('type', [
+        z.object({ type: z.literal('text'), text: z.string().describe('Literal text.') }),
+        z.object({
+          type: z.literal('field'),
+          field_id: z.string().describe('Collection field ID to insert.'),
+          format: z.string().optional().describe('Optional value format (e.g. a date format).'),
+        }),
+      ])).min(1).describe('Ordered segments interleaving literal text and field references.'),
+    },
+    async ({ page_id, layer_id, source, segments }) => {
+      const pageLayers = await getCachedDraft(page_id);
+      if (!pageLayers) {
+        return { content: [{ type: 'text' as const, text: `Error: Page "${page_id}" has no layers.` }], isError: true };
+      }
+      const layers = pageLayers.layers as Layer[];
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+      if (layer.name !== 'text' && layer.name !== 'richText') {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer.customName || layer.name}" (${layer.name}) is not a text layer.` }], isError: true };
+      }
+
+      const ctx = await resolveBindingContext(layers, layer_id, page_id, source);
+      if ('error' in ctx) {
+        return { content: [{ type: 'text' as const, text: `Error: ${ctx.error}` }], isError: true };
+      }
+      const { collectionId, collectionLayerId } = ctx;
+
+      const fields = await getFieldsByCollectionId(collectionId);
+      const fieldsById = new Map<string, CollectionField>(fields.map((f) => [f.id, f]));
+
+      const content: Record<string, unknown>[] = [];
+      let fieldCount = 0;
+      for (const seg of segments) {
+        if (seg.type === 'text') {
+          if (seg.text) content.push({ type: 'text', text: seg.text });
+          continue;
+        }
+        const field = fieldsById.get(seg.field_id);
+        if (!field) {
+          return { content: [{ type: 'text' as const, text: `Error: Field "${seg.field_id}" not found in the ${source === 'page' ? 'page' : 'list'} collection.` }], isError: true };
+        }
+        content.push(dynamicVariableNode(buildFieldData(field, source, collectionLayerId, seg.format), field.name));
+        fieldCount += 1;
+      }
+
+      if (fieldCount === 0) {
+        return { content: [{ type: 'text' as const, text: 'Error: Provide at least one "field" segment (use plain static text for non-dynamic content).' }], isError: true };
+      }
+
+      const nextVariables: Layer['variables'] = {
+        ...layer.variables,
+        text: { type: 'dynamic_rich_text', data: { content: paragraphDoc(content) } },
+      };
+      const updated = updateLayerById(layers, layer_id, (l) => ({ ...l, variables: nextVariables }));
+      await saveCachedLayers(page_id, updated);
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({ message: `Set dynamic text with ${fieldCount} field(s)`, layer_id, source }),
+        }],
+      };
+    },
+  );
+
+  server.tool(
+    'set_layer_visibility',
+    `Set conditional visibility on ANY layer: it only renders when the conditions match. REPLACES all
+existing visibility conditions; pass an empty groups array to clear them (always visible).
+
+STRUCTURE: groups are joined by AND; conditions within a group are joined by OR.
+
+CONDITION SOURCES:
+- "field": test a collection field value. Fields resolve from the nearest ancestor Collection List
+  and/or, on a dynamic CMS page, the page's collection. Operators depend on the field type (same as
+  set_collection_filters). For reference/multi_reference operators pass item_ids; for is_between pass
+  value + value2. value_mode "current_page" binds the compare value to the current dynamic page item.
+- "item_id": test the enclosing item's own identity (is_one_of / is_not_one_of, with item_ids and/or
+  includes_current_page_item).
+- "page_collection": test how many items another Collection List on the page has — has_items /
+  has_no_items, or item_count with compare_operator + compare_value. Pass that list's collection_layer_id.`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer to show/hide conditionally'),
+      groups: z.array(z.object({
+        conditions: z.array(z.discriminatedUnion('source', [
+          fieldConditionSchema,
+          itemIdConditionSchema,
+          pageCollectionConditionSchema,
+        ])).min(1).describe('Conditions joined by OR.'),
+      })).describe('Condition groups joined by AND. Empty array clears all conditions (always visible).'),
+    },
+    async ({ page_id, layer_id, groups }) => {
+      const pageLayers = await getCachedDraft(page_id);
+      if (!pageLayers) {
+        return { content: [{ type: 'text' as const, text: `Error: Page "${page_id}" has no layers.` }], isError: true };
+      }
+      const layers = pageLayers.layers as Layer[];
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+
+      // Gather candidate fields from every collection context the layer can see:
+      // the nearest ancestor Collection List, the layer's own collection (if any),
+      // and the dynamic page's collection. collection_field conditions resolve by
+      // field id at render time, so a merged lookup is sufficient for validation.
+      const collectionIds = new Set<string>();
+      const ancestor = findParentCollectionLayer(layers, layer_id);
+      if (ancestor?.variables?.collection?.id) collectionIds.add(ancestor.variables.collection.id);
+      if (layer.variables?.collection?.id) collectionIds.add(layer.variables.collection.id);
+      const page = await getPageById(page_id);
+      if (page?.settings?.cms?.collection_id) collectionIds.add(page.settings.cms.collection_id);
+
+      const fieldArrays = await Promise.all([...collectionIds].map((cid) => getFieldsByCollectionId(cid)));
+      const fieldsById = new Map<string, CollectionField>();
+      for (const fields of fieldArrays) {
+        for (const f of fields) fieldsById.set(f.id, f);
+      }
+
+      const result = buildConditionGroups(groups, { fieldsById, layers });
+      if ('error' in result) {
+        return { content: [{ type: 'text' as const, text: `Error: ${result.error}` }], isError: true };
+      }
+      const builtGroups = result.groups;
+
+      const updated = updateLayerById(layers, layer_id, (l) => ({
+        ...l,
+        variables: {
+          ...l.variables,
+          conditionalVisibility: builtGroups.length > 0 ? { groups: builtGroups } : undefined,
+        },
+      }));
+      await saveCachedLayers(page_id, updated);
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            message: builtGroups.length > 0
+              ? `Set ${builtGroups.length} visibility condition group(s)`
+              : 'Cleared conditional visibility (always visible)',
+            layer_id,
+            groups: builtGroups.length,
+          }),
+        }],
+      };
+    },
+  );
+}

--- a/lib/mcp/tools/components.ts
+++ b/lib/mcp/tools/components.ts
@@ -374,8 +374,8 @@ Pass variant_id to target a specific named variant; omit it to update the primar
           layer_id: z.string().describe('Layer ID or ref_id'),
           design: designSchema,
           breakpoint: z.enum(['desktop', 'tablet', 'mobile']).default('desktop').optional(),
-          ui_state: z.enum(['neutral', 'hover', 'focus', 'active', 'disabled']).default('neutral').optional()
-            .describe('UI state: "hover" for hover styles, "focus" for focus, etc.'),
+          ui_state: z.enum(['neutral', 'hover', 'focus', 'active', 'disabled', 'current']).default('neutral').optional()
+            .describe('UI state: "hover" for hover styles, "focus" for focus, "current" for the active/current navigation link, etc.'),
         }),
         z.object({
           type: z.literal('update_text'),

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -106,9 +106,11 @@ and regenerates Tailwind CSS classes.
 
 IMPORTANT: Set isActive: true on any design category you want to apply.
 
-HOVER/FOCUS STATES: Set ui_state to apply styles only on hover, focus, or active.
+HOVER/FOCUS STATES: Set ui_state to apply styles only on hover, focus, active, disabled, or current.
 Example: { backgrounds: { isActive: true, backgroundColor: "#3b82f6" }, ui_state: "hover" }
 produces the class "hover:bg-[#3b82f6]".
+The "current" state styles a navigation link when it points to the page currently
+being viewed (aria-current) — use it for active nav-link and pagination styling.
 
 GRADIENTS: Use bgGradientVars in backgrounds to set CSS gradients.
 Example: { backgrounds: { isActive: true, bgGradientVars: { "--bg-img": "linear-gradient(135deg, #667eea 0%, #764ba2 100%)" } } }
@@ -118,8 +120,8 @@ For gradient text: also set backgroundClip: "text" and color to "transparent".`,
       layer_id: z.string().describe('The layer ID to update'),
       breakpoint: z.enum(['desktop', 'tablet', 'mobile']).default('desktop')
         .describe('Responsive breakpoint. Desktop is default.'),
-      ui_state: z.enum(['neutral', 'hover', 'focus', 'active', 'disabled']).default('neutral')
-        .describe('UI state to style. Use "hover" for hover effects, "focus" for focus styles, etc.'),
+      ui_state: z.enum(['neutral', 'hover', 'focus', 'active', 'disabled', 'current']).default('neutral')
+        .describe('UI state to style. Use "hover" for hover effects, "focus" for focus styles, "current" for the active/current navigation link, etc.'),
       design: designSchema,
     },
     async ({ page_id, layer_id, breakpoint, ui_state, design }) => {

--- a/lib/mcp/tools/pages.ts
+++ b/lib/mcp/tools/pages.ts
@@ -47,13 +47,16 @@ export function registerPageTools(server: McpServer) {
 
   server.tool(
     'create_page',
-    'Create a new page. Returns the created page with its ID. The page is created as a draft — use the publish tool to make it live.',
+    `Create a new page. Returns the created page with its ID. The page is unpublished — use the publish tool to make it live.
+
+DRAFT STATUS: Set is_publishable to false to keep this page as a draft that is skipped when the site is published (it will not go live until you flip it back to publishable). Defaults to publishable.`,
     {
       name: z.string().describe('Page title (e.g. "About Us", "Contact")'),
       slug: z.string().optional().describe('URL slug. Auto-generated from name if omitted.'),
       page_folder_id: z.string().nullable().optional().describe('Parent folder ID, or null for root'),
       is_index: z.boolean().optional().describe('Set to true to make this the homepage'),
       is_dynamic: z.boolean().optional().describe('Set to true for CMS dynamic pages'),
+      is_publishable: z.boolean().optional().describe('Set to false to keep the page as a draft that is excluded from publishing. Defaults to true.'),
     },
     async (args) => {
       const isIndex = args.is_index || false;
@@ -67,6 +70,7 @@ export function registerPageTools(server: McpServer) {
         name: args.name,
         slug,
         is_published: false,
+        ...(args.is_publishable !== undefined ? { is_publishable: args.is_publishable } : {}),
         page_folder_id: folderId,
         order: maxOrder + 1,
         depth: 0,
@@ -97,7 +101,8 @@ export function registerPageTools(server: McpServer) {
     `Update a page's metadata: name, slug, folder, homepage flag, dynamic flag, and error-page assignment.
 
 ERROR PAGES: Set error_page to 401, 404, or 500 to designate this as the auth-required / not-found / server-error page for the site. Pass null to clear.
-DYNAMIC PAGES: Set is_dynamic true to turn this into a CMS-driven page (then use update_page_settings.cms to bind it to a collection).`,
+DYNAMIC PAGES: Set is_dynamic true to turn this into a CMS-driven page (then use update_page_settings.cms to bind it to a collection).
+DRAFT STATUS: Set is_publishable to false to keep the page as a draft that is skipped when the site is published; set true to allow it to go live on the next publish.`,
     {
       page_id: z.string().describe('The page ID to update'),
       name: z.string().optional().describe('New page title'),
@@ -105,6 +110,7 @@ DYNAMIC PAGES: Set is_dynamic true to turn this into a CMS-driven page (then use
       page_folder_id: z.string().nullable().optional().describe('Move to folder ID, or null for root'),
       is_index: z.boolean().optional().describe('Mark as the homepage (only one page can be the index)'),
       is_dynamic: z.boolean().optional().describe('Turn into a CMS dynamic page'),
+      is_publishable: z.boolean().optional().describe('Set false to keep the page as a draft excluded from publishing; true to allow it to go live on publish.'),
       error_page: z.union([z.literal(401), z.literal(404), z.literal(500)]).nullable().optional()
         .describe('Designate as 401 / 404 / 500 error page. Pass null to clear.'),
     },

--- a/lib/mcp/tools/styles.ts
+++ b/lib/mcp/tools/styles.ts
@@ -4,7 +4,7 @@ import type { DesignProperties, Layer } from '@/types';
 import { getAllStyles, createStyle, updateStyle, deleteStyle } from '@/lib/repositories/layerStyleRepository';
 import { getCachedDraft, saveCachedLayers } from '@/lib/mcp/page-layers';
 import { findLayerById, updateLayerById, designToClassString } from '@/lib/mcp/utils';
-import { applyStyleToLayer } from '@/lib/layer-style-utils';
+import { applyStyleToLayer, setLayerStyleStack } from '@/lib/layer-style-utils';
 import { designSchema } from './shared-schemas';
 
 export function registerStyleTools(server: McpServer) {
@@ -39,7 +39,7 @@ export function registerStyleTools(server: McpServer) {
 
   server.tool(
     'apply_style',
-    'Apply a reusable layer style to a layer.',
+    'Apply a single reusable layer style to a layer, replacing any existing style stack. To stack multiple styles (combo classes) or control their priority order, use set_layer_styles instead.',
     {
       page_id: z.string().describe('The page ID'),
       layer_id: z.string().describe('The layer ID to apply the style to'),
@@ -67,6 +67,59 @@ export function registerStyleTools(server: McpServer) {
       await saveCachedLayers(page_id, updated);
 
       return { content: [{ type: 'text' as const, text: `Applied style "${style_id}" to "${layer.customName || layer.name}"` }] };
+    },
+  );
+
+  server.tool(
+    'set_layer_styles',
+    `Set the ordered stack of reusable styles applied to a layer (combo classes).
+
+Styles are listed low -> high priority — later styles win on conflicting properties,
+exactly like Webflow combo classes. This REPLACES the layer's current style stack and
+re-flattens the resulting classes. Use this (instead of apply_style) whenever a layer
+needs more than one style.
+
+- Apply a single style:        style_ids: ["<card>"]
+- Stack base + modifier:       style_ids: ["<button>", "<button-primary>"]
+- Reorder priority:            reorder the array (last wins)
+- Detach all styles (keep the current look as local classes): style_ids: []`,
+    {
+      page_id: z.string().describe('The page ID'),
+      layer_id: z.string().describe('The layer ID'),
+      style_ids: z.array(z.string())
+        .describe('Ordered style IDs, low -> high priority (last wins on conflicts). Pass an empty array to detach all styles while keeping the current look.'),
+    },
+    async ({ page_id, layer_id, style_ids }) => {
+      const pageLayers = await getCachedDraft(page_id);
+      if (!pageLayers) {
+        return { content: [{ type: 'text' as const, text: `Error: Page "${page_id}" has no layers.` }], isError: true };
+      }
+
+      const layers = pageLayers.layers as Layer[];
+      const layer = findLayerById(layers, layer_id);
+      if (!layer) {
+        return { content: [{ type: 'text' as const, text: `Error: Layer "${layer_id}" not found.` }], isError: true };
+      }
+
+      const stylesById = new Map((await getAllStyles()).map((s) => [s.id, s]));
+      const missing = style_ids.filter((id) => !stylesById.has(id));
+      if (missing.length > 0) {
+        return { content: [{ type: 'text' as const, text: `Error: Style(s) not found: ${missing.join(', ')}` }], isError: true };
+      }
+
+      const updated = updateLayerById(layers, layer_id, (l) => setLayerStyleStack(l, style_ids, stylesById));
+      await saveCachedLayers(page_id, updated);
+
+      const target = findLayerById(updated, layer_id);
+      const label = style_ids.length === 0
+        ? `Detached all styles from "${layer.customName || layer.name}"`
+        : `Applied style stack [${style_ids.join(', ')}] to "${layer.customName || layer.name}"`;
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({ message: label, layer_id, style_ids, classes: target?.classes }),
+        }],
+      };
     },
   );
 

--- a/lib/mcp/tools/visibility-conditions.ts
+++ b/lib/mcp/tools/visibility-conditions.ts
@@ -1,0 +1,179 @@
+/**
+ * Shared schema + builder for the AND-of-ORs condition model used by both
+ * collection filters (`variables.collection.filters`) and conditional
+ * visibility (`variables.conditionalVisibility`). Both persist the same
+ * `VisibilityConditionGroup[]` shape, so the MCP exposes one condition
+ * vocabulary and one builder, keeping the two tools from drifting apart.
+ */
+
+import { z } from 'zod';
+import type {
+  CollectionField,
+  Layer,
+  VisibilityCondition,
+  VisibilityConditionGroup,
+  VisibilityOperator,
+} from '@/types';
+import { findLayerById } from '@/lib/mcp/utils';
+import { getOperatorsForFieldType, operatorRequiresValue } from '@/lib/collection-field-utils';
+
+// Operators whose value is a JSON array of collection item IDs.
+const ITEM_SELECTION_OPERATORS = new Set<VisibilityOperator>([
+  'is_one_of', 'is_not_one_of', 'contains_all_of', 'contains_exactly',
+]);
+
+// Field types whose "current page" binding compares against the current dynamic
+// page item's identity rather than a scalar field value.
+const REFERENCE_FIELD_TYPES = new Set(['reference', 'multi_reference']);
+
+/** Filter/visibility condition on a collection field. */
+export const fieldConditionSchema = z.object({
+  source: z.literal('field'),
+  field_id: z.string().describe('Collection field ID to test'),
+  operator: z.string().describe('Operator valid for the field type (e.g. "is", "contains", "is_one_of", "has_items", "is_between")'),
+  value: z.string().optional().describe('Compare value for scalar fields (booleans use "true"/"false"; dates use YYYY-MM-DD or a preset).'),
+  value2: z.string().optional().describe('Second bound for the "is_between" date operator.'),
+  item_ids: z.array(z.string()).optional().describe('Collection item IDs for reference / multi_reference operators.'),
+  value_mode: z.enum(['static', 'current_page']).optional().describe('"current_page" binds the compare value to the current dynamic page item. Defaults to "static".'),
+  current_page_field_id: z.string().optional().describe('For value_mode "current_page" on a scalar field: the field on the page\'s collection whose value is compared.'),
+  input_layer_id: z.string().optional().describe('Link the value to a filter input layer (inside a Filter element) so visitors control it at runtime. Overrides the static value.'),
+  input_layer_id2: z.string().optional().describe('Link the second bound (is_between) to a filter input layer.'),
+});
+
+/** Filter/visibility condition on the item's own identity (self). */
+export const itemIdConditionSchema = z.object({
+  source: z.literal('item_id'),
+  operator: z.enum(['is_one_of', 'is_not_one_of']).default('is_one_of').describe('Whether the item must be (or must not be) in the set.'),
+  item_ids: z.array(z.string()).optional().describe('Collection item IDs to match against.'),
+  includes_current_page_item: z.boolean().optional().describe('Include the current dynamic page item in the match set.'),
+});
+
+/** Visibility-only condition on the item count of another Collection List on the page. */
+export const pageCollectionConditionSchema = z.object({
+  source: z.literal('page_collection'),
+  collection_layer_id: z.string().describe('A Collection List layer on the page whose item count is tested.'),
+  operator: z.enum(['item_count', 'has_items', 'has_no_items']).default('has_items'),
+  compare_operator: z.enum(['eq', 'lt', 'lte', 'gt', 'gte']).optional().describe('For operator "item_count": how to compare the count.'),
+  compare_value: z.number().int().optional().describe('For operator "item_count": the number to compare against.'),
+});
+
+export type FieldConditionInput = z.infer<typeof fieldConditionSchema>;
+export type ItemIdConditionInput = z.infer<typeof itemIdConditionSchema>;
+export type PageCollectionConditionInput = z.infer<typeof pageCollectionConditionSchema>;
+export type RawCondition = FieldConditionInput | ItemIdConditionInput | PageCollectionConditionInput;
+
+interface BuildContext {
+  fieldsById: Map<string, CollectionField>;
+  layers: Layer[];
+  id: string;
+}
+
+function buildCondition(input: RawCondition, ctx: BuildContext): { condition: VisibilityCondition } | { error: string } {
+  const { id } = ctx;
+
+  if (input.source === 'item_id') {
+    return {
+      condition: {
+        id,
+        source: 'self',
+        operator: input.operator,
+        value: JSON.stringify(input.item_ids ?? []),
+        includesCurrentPageItem: input.includes_current_page_item ?? false,
+      },
+    };
+  }
+
+  if (input.source === 'page_collection') {
+    const target = findLayerById(ctx.layers, input.collection_layer_id);
+    if (!target || !target.variables?.collection) {
+      return { error: `Layer "${input.collection_layer_id}" is not a Collection List.` };
+    }
+    const condition: VisibilityCondition = {
+      id,
+      source: 'page_collection',
+      collectionLayerId: input.collection_layer_id,
+      collectionLayerName: target.customName || target.name,
+      operator: input.operator,
+    };
+    if (input.operator === 'item_count') {
+      condition.compareOperator = input.compare_operator ?? 'eq';
+      condition.compareValue = input.compare_value ?? 0;
+    }
+    return { condition };
+  }
+
+  const field = ctx.fieldsById.get(input.field_id);
+  if (!field) {
+    return { error: `Field "${input.field_id}" not found in the collection.` };
+  }
+
+  const allowed = getOperatorsForFieldType(field.type).map((o) => o.value);
+  if (!allowed.includes(input.operator as VisibilityOperator)) {
+    return { error: `Operator "${input.operator}" is not valid for field "${field.name}" (${field.type}). Allowed: ${allowed.join(', ')}.` };
+  }
+
+  const operator = input.operator as VisibilityOperator;
+  const isReferenceField = REFERENCE_FIELD_TYPES.has(field.type);
+  const condition: VisibilityCondition = {
+    id,
+    source: 'collection_field',
+    fieldId: field.id,
+    fieldType: field.type,
+    operator,
+    ...(field.reference_collection_id ? { referenceCollectionId: field.reference_collection_id } : {}),
+  };
+
+  if (input.input_layer_id) condition.inputLayerId = input.input_layer_id;
+  if (input.input_layer_id2) condition.inputLayerId2 = input.input_layer_id2;
+
+  if (input.value_mode === 'current_page') {
+    condition.valueMode = 'current_page';
+    if (isReferenceField) {
+      condition.value = JSON.stringify(input.item_ids ?? []);
+    } else {
+      if (!input.current_page_field_id) {
+        return { error: `current_page_field_id is required for value_mode "current_page" on scalar field "${field.name}".` };
+      }
+      condition.currentPageFieldId = input.current_page_field_id;
+    }
+  } else if (input.input_layer_id) {
+    // Value is supplied by the linked filter input at runtime — no static value.
+  } else if (ITEM_SELECTION_OPERATORS.has(operator)) {
+    condition.value = JSON.stringify(input.item_ids ?? []);
+  } else if (operatorRequiresValue(operator)) {
+    condition.value = input.value ?? '';
+    if (operator === 'is_between') {
+      condition.value2 = input.value2 ?? '';
+    }
+  }
+
+  return { condition };
+}
+
+/**
+ * Build the persisted `VisibilityConditionGroup[]` from the MCP-facing groups.
+ * Returns an error string for unknown fields/operators or invalid references.
+ */
+export function buildConditionGroups(
+  groups: { conditions: RawCondition[] }[],
+  ctx: { fieldsById: Map<string, CollectionField>; layers: Layer[] },
+): { groups: VisibilityConditionGroup[] } | { error: string } {
+  const ts = Date.now();
+  const built: VisibilityConditionGroup[] = [];
+
+  for (let gi = 0; gi < groups.length; gi += 1) {
+    const conditions: VisibilityCondition[] = [];
+    for (let ci = 0; ci < groups[gi].conditions.length; ci += 1) {
+      const result = buildCondition(groups[gi].conditions[ci], {
+        fieldsById: ctx.fieldsById,
+        layers: ctx.layers,
+        id: `vc-${ts}-${gi}-${ci}`,
+      });
+      if ('error' in result) return { error: result.error };
+      conditions.push(result.condition);
+    }
+    built.push({ id: `vc-g-${ts}-${gi}`, conditions });
+  }
+
+  return { groups: built };
+}


### PR DESCRIPTION
## Summary

Brings the MCP server up to parity with recently shipped builder features, focused on CMS and dynamic content. Adds collection-list binding/filtering, conditional visibility, dynamic content binding, combo classes, page draft status, and the active/current UI state.

## Changes

- Add `bind_collection_layer` to bind a Collection List to a collection with sorting, limit, pagination, and nested-collection sourcing (reference / multi_reference / multi_asset / inverse_reference)
- Add `set_collection_filters` (AND-of-ORs conditions) including current-page filtering and visitor-facing filter inputs (`input_layer_id`)
- Add `set_layer_visibility` for conditional show/hide on any layer (field, item identity, and page-collection count sources)
- Add `bind_layer_field` to bind text, image src/alt, video src/poster, audio src, and background image to CMS fields
- Add `set_dynamic_text` to compose one text node from multiple fields and literals
- Add `set_layer_styles` to stack/reorder multiple reusable styles (combo classes)
- Expose page draft status (`is_publishable`) in `create_page` / `update_page`
- Add the `current` UI state to design tools (`update_layer_design`, batch, components) for active nav-link styling
- Extract a shared condition builder (`visibility-conditions.ts`) reused by filters and visibility
- Document all new tools and patterns in the MCP instructions

## Test plan

- [ ] Bind a Collection List to a collection and confirm items repeat with sorting/pagination
- [ ] Filter a list (field + current-page + filter input) and verify items render correctly
- [ ] Bind a nested list from a reference field on the parent/page item
- [ ] Bind text/image/video/background fields and a multi-field text node; confirm live data in editor and SSR
- [ ] Set conditional visibility (field, item_id, page_collection) and verify show/hide
- [ ] Stack two styles via `set_layer_styles` and confirm later style wins on conflicts
- [ ] Create a page with `is_publishable: false` and confirm it is skipped on publish
- [ ] Apply the `current` UI state and confirm active nav-link styling

Made with [Cursor](https://cursor.com)