### PR TITLE
fix: correct font loading and rendering on published sites

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -49,8 +49,11 @@ export default async function SiteLayout({
     }
   }
 
+  // Published sites render text with the browser-default (`auto`) font
+  // smoothing — matching legacy output. Forcing `antialiased` here would render
+  // glyphs thinner/lighter than the original site.
   return (
-    <RootLayoutShell headElements={headElements}>
+    <RootLayoutShell headElements={headElements} bodyClassName="font-sans">
       {children}
     </RootLayoutShell>
   );

--- a/lib/font-utils.ts
+++ b/lib/font-utils.ts
@@ -134,13 +134,11 @@ export function buildGoogleFontUrl(font: Font): string {
 
   const sortedWeights = [...new Set(weights)].sort();
 
-  // Heuristic: contiguous weight range likely means variable font without axes data
-  const weightRange = getContiguousWeightRange(sortedWeights);
-  if (weightRange) {
-    return buildVariableFontUrl(family, weightRange, hasItalic, font.axes);
-  }
-
-  // Static font: list individual weights
+  // No variable `axes` data → treat as static and list discrete weights.
+  // Discrete `wght@` syntax works for both static and variable families, while
+  // the range syntax (`wght@200..800`) is rejected by Google Fonts for static
+  // families (e.g. Spectral) — the stylesheet then fails and text silently
+  // falls back to a system serif (Times).
   if (hasItalic) {
     const tuples: string[] = [];
     for (const w of sortedWeights) tuples.push(`0,${w}`);
@@ -205,34 +203,6 @@ function extractWeightsFromVariants(variants: string[]): string[] {
     }
   }
   return Array.from(weights);
-}
-
-/**
- * Check if sorted weights form a contiguous range in steps of 100
- * (e.g. 100,200,...,900). Returns the range bounds or null for non-contiguous sets.
- * Variable fonts on Google Fonts expose a full contiguous range, while static
- * fonts typically list only a few discrete weights.
- */
-function getContiguousWeightRange(
-  sortedWeights: string[]
-): { min: number; max: number } | null {
-  const nums = sortedWeights
-    .map(Number)
-    .filter(n => !isNaN(n) && n >= 100 && n <= 900);
-
-  if (nums.length < 3) return null;
-
-  const min = nums[0];
-  const max = nums[nums.length - 1];
-  const expectedCount = (max - min) / 100 + 1;
-
-  if (nums.length !== expectedCount) return null;
-
-  for (let i = 1; i < nums.length; i++) {
-    if (nums[i] - nums[i - 1] !== 100) return null;
-  }
-
-  return { min, max };
 }
 
 /**

--- a/lib/repositories/collectionItemValueRepository.ts
+++ b/lib/repositories/collectionItemValueRepository.ts
@@ -2,6 +2,7 @@ import { getSupabaseAdmin, getTenantIdFromHeaders } from '@/lib/supabase-server'
 import { SUPABASE_QUERY_LIMIT } from '@/lib/supabase-constants';
 import { getKnexClient } from '@/lib/knex-client';
 import type { CollectionItemValue, CollectionFieldType } from '@/types';
+import { isValidUUID } from '@/lib/utils';
 import { castValue, valueToString } from '../collection-utils';
 import { generateCollectionItemContentHash } from '../hash-utils';
 import { randomUUID } from 'crypto';
@@ -130,7 +131,13 @@ export async function getValuesByItemIds(
     throw new Error('Supabase client not configured');
   }
 
-  if (item_ids.length === 0) {
+  // Guard against non-UUID ids (e.g. dangling legacy bindings from imported
+  // content). Passing them to a uuid column throws and would otherwise take
+  // down the whole page render.
+  const safeItemIds = item_ids.filter(isValidUUID);
+  const safeFieldIds = fieldIds?.filter(isValidUUID);
+
+  if (safeItemIds.length === 0 || (safeFieldIds && safeFieldIds.length === 0)) {
     return {};
   }
 
@@ -143,19 +150,19 @@ export async function getValuesByItemIds(
     const knex = await getKnexClient();
     let query = knex('collection_item_values')
       .select('item_id', 'field_id', 'value')
-      .whereIn('item_id', item_ids)
+      .whereIn('item_id', safeItemIds)
       .andWhere('is_published', is_published)
       .whereNull('deleted_at');
-    if (fieldIds) {
-      query = query.whereIn('field_id', fieldIds);
+    if (safeFieldIds) {
+      query = query.whereIn('field_id', safeFieldIds);
     }
     allRows = await query;
   } catch {
     // Fallback: Supabase chunked reads
     const CHUNK_SIZE = 50;
     const chunks: string[][] = [];
-    for (let i = 0; i < item_ids.length; i += CHUNK_SIZE) {
-      chunks.push(item_ids.slice(i, i + CHUNK_SIZE));
+    for (let i = 0; i < safeItemIds.length; i += CHUNK_SIZE) {
+      chunks.push(safeItemIds.slice(i, i + CHUNK_SIZE));
     }
 
     const chunkResults = await Promise.all(
@@ -166,8 +173,8 @@ export async function getValuesByItemIds(
           .in('item_id', chunk)
           .eq('is_published', is_published)
           .is('deleted_at', null);
-        if (fieldIds) {
-          q = q.in('field_id', fieldIds);
+        if (safeFieldIds) {
+          q = q.in('field_id', safeFieldIds);
         }
         const { data, error } = await q.limit(5000);
 


### PR DESCRIPTION
## Summary

Published sites had several font/rendering issues that made imported content look different from the original and could even crash a page. This fixes static Google font loading, text smoothing, and a crash on dangling collection bindings.

## Changes

- Load Google fonts without variable `axes` using discrete weights. The variable range syntax (`wght@200..800`) is rejected by Google Fonts for static families like Spectral, so the stylesheet failed to load and text silently fell back to a system serif (Times).
- Stop forcing `antialiased` on published pages — text now renders with the browser-default smoothing, matching the original output instead of appearing thinner.
- Guard collection value lookups against non-UUID ids so dangling imported bindings can't throw on the uuid column and take down the whole page render.

## Test plan

- [ ] Publish a site using a static font with all weights (e.g. Spectral) and confirm it renders in the real font, not a system serif
- [ ] Confirm a variable font (e.g. Inter) still loads correctly via range syntax
- [ ] Compare heading text weight/smoothing against the expected design
- [ ] Render a page containing a rich-text field bound to a non-UUID/legacy field id and confirm it loads instead of erroring