### PR TITLE
fix: translate form options and redirect slugs for CMS items

### DIFF
--- a/app/(builder)/ycode/components/FormSettings.tsx
+++ b/app/(builder)/ycode/components/FormSettings.tsx
@@ -178,7 +178,7 @@ export default function FormSettings({ layer, onLayerUpdate }: FormSettingsProps
       isOpen={isOpen}
       onToggle={() => setIsOpen(!isOpen)}
     >
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2.5">
         {/* Success Action Toggle */}
         <div className="grid grid-cols-3">
           <Label variant="muted">Success</Label>

--- a/app/(builder)/ycode/components/LinkSettings.tsx
+++ b/app/(builder)/ycode/components/LinkSettings.tsx
@@ -18,6 +18,7 @@ import SettingsPanel from './SettingsPanel';
 import RichTextEditor from './RichTextEditor';
 import { filterFieldGroupsByType, flattenFieldGroups, LINK_FIELD_TYPES, buildReferenceItemOptions } from '@/lib/collection-field-utils';
 import { generateLinkHref } from '@/lib/link-utils';
+import { cn } from '@/lib/utils';
 import LinkCollectionItemPicker from './LinkCollectionItemPicker';
 import { FieldSelectDropdown, type FieldGroup, type FieldSourceType } from './CollectionFieldSelector';
 import ComponentVariableLabel, { VARIABLE_TYPE_ICONS } from './ComponentVariableLabel';
@@ -973,7 +974,7 @@ export default function LinkSettings(props: LinkSettingsProps) {
   // Standalone mode: render without SettingsPanel wrapper
   if (isStandaloneMode) {
     return (
-      <div className="flex flex-col">
+      <div className={cn('flex flex-col', !useStackedLayout && 'gap-2.5')}>
         {linkTypeContent}
         {typeSpecificContent}
         {anchorContent}

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -86,6 +86,12 @@ function collectLayerPageLinks(layers: Layer[]): PageLinkRef[] {
         }
       }
     }
+    // Form redirect_url: extract page refs so the target item slug is pre-fetched
+    const redirectUrl = layer.settings?.form?.redirect_url;
+    if (redirectUrl?.type === 'page') {
+      const { collection_item_id, id: page_id } = redirectUrl.page ?? {};
+      if (collection_item_id && page_id) results.push({ collection_item_id, page_id });
+    }
     const textVar = layer.variables?.text as any;
     if (textVar?.type === 'dynamic_rich_text' && textVar.data?.content) {
       results.push(...collectTiptapPageLinks(textVar.data.content));

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -2692,7 +2692,8 @@ export async function resolveCollectionLayers(
         };
 
         const generatedOptions: Layer[] = sourceItems.map(item => {
-          const label = displayField ? (item.values[displayField.id] || 'Untitled') : 'Untitled';
+          const translatedValues = applyCmsTranslations(item.id, item.values, sourceFields, translations, { includeIncomplete: !isPublished });
+          const label = displayField ? (translatedValues[displayField.id] || 'Untitled') : 'Untitled';
           return {
             id: `${layer.id}-opt-${item.id}`,
             name: 'option',
@@ -2762,7 +2763,8 @@ export async function resolveCollectionLayers(
       const { type: _t, name: _n, value: _v, checked: _c, ...inheritedInputAttrs } = templateInput?.attributes || {};
 
       const generatedChildren: Layer[] = items.map(item => {
-        const label = displayField ? (item.values[displayField.id] || 'Untitled') : 'Untitled';
+        const translatedValues = applyCmsTranslations(item.id, item.values, fields as CollectionField[], translations, { includeIncomplete: !isPublished });
+        const label = displayField ? (translatedValues[displayField.id] || 'Untitled') : 'Untitled';
         const isDefault = inputType === 'checkbox'
           ? (opts.defaultItemIds || []).includes(item.id)
           : opts.defaultItemId === item.id;


### PR DESCRIPTION
## Summary

Fixes two localization gaps in forms: generated option labels now respect CMS translations, and form redirects to dynamic pages resolve to the correct (translated) item slug instead of a literal `/{slug}`.

## Changes

- Apply CMS translations to `optionsSource`-generated select, checkbox, and radio option labels so they localize in non-default locales (Closes #343)
- Scan `form.redirect_url` page links in `collectLayerPageLinks` so the target collection item slug is pre-fetched, letting the redirect resolve to the real (and translated) URL (Closes #344)
- Even out the spacing between the redirect/page/CMS item rows in the form redirect settings

## Test plan

- [ ] On a non-default locale, render a select/checkbox/radio bound to a CMS collection — option labels show translated values
- [ ] Submit a form whose redirect targets a dynamic page + specific item — redirects to the item slug (e.g. `/merci`), not `/{slug}`
- [ ] On a translated page, the form redirect resolves to the localized slug (e.g. `/fr/fichier-fr/a-fr`)
- [ ] Form redirect settings rows are evenly spaced in the builder