### PR TITLE
style: adjust tabs ui component to visually balance the padding

### DIFF
--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -29,7 +29,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        'bg-input text-muted-foreground rounded-lg p-[2px]',
+        'bg-input text-muted-foreground rounded-lg p-[3px] pt-[2px]',
         orientation === 'horizontal'
           ? 'inline-flex h-8 w-fit items-center justify-center'
           : 'flex flex-col w-fit h-fit',


### PR DESCRIPTION
## Summary

Small tweak to the padding in the Tabs UI component to better match the spacing visually —the current border-radius and drop-shadow make the top padding appear larger—.

## Changes

Instead of using 2px padding on all sides, I used 3px padding on all sides and 2px padding on the top so now the space looks the same on all sides.

<img width="630" height="456" alt="9569f44367b53bc0ef710c4045a1f335432709ee" src="https://github.com/user-attachments/assets/684fab69-789f-4c7c-a2a2-39d4f02fcd14" />

