### PR TITLE
fix: dedupe anchor ids in link settings dropdowns

### DIFF
--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -4313,17 +4313,22 @@ export function updateLayerProps(
 
 /**
  * Find all layers with a custom anchor ID (settings.id takes priority over attributes.id).
+ * Deduplicates by anchor ID since an `#id` link resolves to the first match, so a
+ * repeated ID (e.g. duplicated component instances) would otherwise produce duplicate
+ * dropdown options and React key collisions.
  * Used by link settings to populate anchor selection dropdowns.
  */
 export function findLayersWithAnchorId(layers: Layer[]): Array<{ layer: Layer; id: string }> {
   const result: Array<{ layer: Layer; id: string }> = [];
+  const seen = new Set<string>();
   const stack: Layer[] = [...layers];
 
   while (stack.length > 0) {
     const layer = stack.pop()!;
 
     const layerId = layer.settings?.id || layer.attributes?.id;
-    if (layerId) {
+    if (layerId && !seen.has(layerId)) {
+      seen.add(layerId);
       result.push({ layer, id: layerId });
     }
 


### PR DESCRIPTION
## Summary

Selecting a link layer could log a React "two children with the same key" warning. The anchor selection dropdown lists every element with a custom HTML id and keyed each option by that id, so two layers sharing an id (e.g. duplicated component instances) produced duplicate keys.

## Changes

- Deduplicate by anchor id in `findLayersWithAnchorId`, fixing all anchor dropdowns (link settings, rich text link settings, collection link field input). An `#id` link resolves to the first match, so each anchor only needs to appear once — this also removes confusing duplicate options.

## Test plan

- [ ] Open a page where two elements share the same custom HTML id
- [ ] Select a link/button layer and open the Anchor dropdown — no duplicate-key warning in the console
- [ ] Confirm the shared id appears only once in the dropdown and linking to it still works