### PR TITLE
perf: scope translation loading to rendered content

### DIFF
--- a/app/(site)/sitemap.xml/route.ts
+++ b/app/(site)/sitemap.xml/route.ts
@@ -10,7 +10,7 @@ import { credentials } from '@/lib/credentials';
 import { getAllPages } from '@/lib/repositories/pageRepository';
 import { getAllPublishedPageFolders } from '@/lib/repositories/pageFolderRepository';
 import { getAllLocales } from '@/lib/repositories/localeRepository';
-import { getTranslationsByLocale } from '@/lib/repositories/translationRepository';
+import { getSlugTranslationsByLocale } from '@/lib/repositories/translationRepository';
 import { getSettingsByKeys } from '@/lib/repositories/settingsRepository';
 import { getItemsByCollectionId } from '@/lib/repositories/collectionItemRepository';
 import { getValuesByItemIds } from '@/lib/repositories/collectionItemValueRepository';
@@ -75,7 +75,7 @@ export async function GET() {
     if (locales.length > 1) {
       for (const locale of locales) {
         if (!locale.is_default) {
-          const translations = await getTranslationsByLocale(locale.id, true); // Get published translations
+          const translations = await getSlugTranslationsByLocale(locale.id, true); // Slug rows only — sitemap builds URLs
           const translationsMap: Record<string, Translation> = {};
           for (const t of translations) {
             // Create key: source_type:source_id:content_key

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -25,7 +25,7 @@ import { REF_PAGE_PREFIX, REF_COLLECTION_PREFIX, isCollectionItemKeyword, parseC
 import { getClassesString, hasPasswordFormLayer } from '@/lib/layer-utils';
 import { buildLocalizedPageUrls, type LocalizedDynamicSlug } from '@/lib/page-utils';
 import { getTranslatableKey } from '@/lib/locale-runtime';
-import { getTranslationsByLocale } from '@/lib/repositories/translationRepository';
+import { getSlugTranslationsByLocale } from '@/lib/repositories/translationRepository';
 import type { Layer, Component, Page, CollectionItemWithValues, CollectionField, Locale, PageFolder, PasswordProtectionContext, Translation } from '@/types';
 
 interface PageLinkRef { collection_item_id: string; page_id: string }
@@ -449,7 +449,9 @@ export default async function PageRenderer({
               translationsByLocale[l.id] = translations as Record<string, Translation>;
               return;
             }
-            const rows = await getTranslationsByLocale(l.id, usePublishedData);
+            // Only slug rows are needed to build localized URLs for the locale
+            // switcher — avoid loading the full CMS-content catalogue per locale.
+            const rows = await getSlugTranslationsByLocale(l.id, usePublishedData);
             const map: Record<string, Translation> = {};
             for (const t of rows) {
               map[getTranslatableKey(t)] = t;

--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -15,7 +15,7 @@ import { getSettingsByKeys } from '@/lib/repositories/settingsRepository';
 import { getAssetById } from '@/lib/repositories/assetRepository';
 import { getAllLocales } from '@/lib/repositories/localeRepository';
 import { getAllPublishedPageFolders } from '@/lib/repositories/pageFolderRepository';
-import { getTranslationsByLocale } from '@/lib/repositories/translationRepository';
+import { getSlugTranslationsByLocale } from '@/lib/repositories/translationRepository';
 import { buildSvgDataUrl, getAssetProxyUrl } from '@/lib/asset-utils';
 import { generateColorVariablesCss } from '@/lib/repositories/colorVariableRepository';
 import { buildPageHreflangAlternates } from '@/lib/hreflang-utils';
@@ -193,7 +193,8 @@ const fetchHreflangDataset = cache(async (): Promise<HreflangDataset> => {
   if (locales.length > 1) {
     for (const locale of locales) {
       if (locale.is_default) continue;
-      const translations = await getTranslationsByLocale(locale.id, true);
+      // hreflang alternates only need slug rows to build localized URLs.
+      const translations = await getSlugTranslationsByLocale(locale.id, true);
       const map: Record<string, Translation> = {};
       for (const t of translations) {
         map[getTranslatableKey(t)] = t;

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -7,6 +7,8 @@ import { getItemWithValues, getItemsWithValues, getItemsWithValuesByIds, getItem
 import { getValuesByItemIds } from '@/lib/repositories/collectionItemValueRepository';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { enrichItemsWithCountValues } from '@/lib/repositories/collectionCountRepository';
+import { getLocaleScaffoldTranslations, getCmsTranslationsForItems } from '@/lib/repositories/translationRepository';
+import { getTranslatableKey } from '@/lib/locale-runtime';
 import type { Page, PageFolder, PageLayers, Component, ComponentVariable, CollectionItemWithValues, CollectionField, Layer, CollectionPaginationMeta, Translation, Locale } from '@/types';
 import { getCollectionVariable, resolveFieldValue, evaluateVisibility, evaluateCondition, getLayerHtmlTag, filterDisabledSliderLayers } from '@/lib/layer-utils';
 import { isFieldVariable, isAssetVariable, createDynamicTextVariable, createDynamicRichTextVariable, createAssetVariable, getDynamicTextContent, getVariableStringValue, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
@@ -214,43 +216,96 @@ export async function loadTranslationsForLocale(
       return { locale: null, translations: {} };
     }
 
-    // Fetch all translations for this locale. Supabase caps PostgREST
-    // responses at 1000 rows by default — projects with more translations
-    // were silently truncated, causing entire layers to render in the
-    // source language on SSR while the editor (which fetches via its own
-    // paginated API) showed them correctly. Page through explicit ranges.
-    const PAGE_SIZE = 1000;
-    const translations: Translation[] = [];
-    for (let from = 0; ; from += PAGE_SIZE) {
-      const { data: page, error } = await supabase
-        .from('translations')
-        .select('*')
-        .eq('locale_id', locale.id)
-        .eq('is_published', isPublished)
-        .is('deleted_at', null)
-        .range(from, from + PAGE_SIZE - 1);
+    // Load the per-locale "scaffold" only: page/folder/component translations
+    // plus CMS *slug* rows. This covers routing, SEO, page/component rendering
+    // and URL generation. The bulk CMS *content* translations (text/rich text)
+    // — which dominate large catalogues and previously made every render fetch
+    // the entire locale catalogue — are loaded on demand per rendered item via
+    // `ensureCmsTranslations`.
+    const scaffold = await getLocaleScaffoldTranslations(locale.id, isPublished, tenantId);
 
-      if (error) {
-        console.error('Failed to fetch translations page:', error);
-        break;
-      }
-
-      if (!page || page.length === 0) break;
-      translations.push(...(page as Translation[]));
-      if (page.length < PAGE_SIZE) break;
-    }
-
-    // Build translations map keyed by translatable key
     const translationsMap: Record<string, Translation> = {};
-    for (const translation of translations) {
-      const key = `${translation.source_type}:${translation.source_id}:${translation.content_key}`;
-      translationsMap[key] = translation;
+    for (const translation of scaffold) {
+      translationsMap[getTranslatableKey(translation)] = translation;
     }
+
+    registerTranslationContext(translationsMap, locale.id, isPublished, tenantId);
 
     return { locale, translations: translationsMap };
   } catch (error) {
     console.error('Failed to load translations for locale:', localeCode, error);
     return { locale: null, translations: {} };
+  }
+}
+
+// ── Scoped CMS translation augmentation ───────────────────────────────────
+//
+// `loadTranslationsForLocale` returns a scaffold map (no CMS *content*). Each
+// server render path then augments that same map object in place with the CMS
+// translations for exactly the collection items it materialises, so
+// `applyCmsTranslations` finds them. The map identity is preserved as it is
+// threaded through the render pipeline, so all holders observe the additions.
+//
+// Tracking the locale/publish/tenant + already-loaded item ids on a WeakMap
+// keyed by the map object keeps render call sites free of extra plumbing.
+
+interface TranslationLoadContext {
+  localeId: string;
+  isPublished: boolean;
+  tenantId?: string;
+  loadedItemIds: Set<string>;
+}
+
+const translationLoadContexts = new WeakMap<object, TranslationLoadContext>();
+
+/** Associate a freshly-built scaffold map with its locale loading context. */
+function registerTranslationContext(
+  translations: Record<string, Translation>,
+  localeId: string,
+  isPublished: boolean,
+  tenantId?: string,
+): void {
+  translationLoadContexts.set(translations, {
+    localeId,
+    isPublished,
+    tenantId,
+    loadedItemIds: new Set(),
+  });
+}
+
+/**
+ * Ensure CMS *content* translations for the given collection item IDs are
+ * present in `translations`, fetching any that haven't been loaded yet and
+ * merging them into the same map object.
+ *
+ * No-ops when the map has no registered context (e.g. default locale, or maps
+ * built outside `loadTranslationsForLocale`) — in those cases the caller
+ * either needs no translations or already holds the full set.
+ */
+export async function ensureCmsTranslations(
+  translations: Record<string, Translation> | null | undefined,
+  itemIds: Array<string | null | undefined>,
+): Promise<void> {
+  if (!translations) return;
+  const ctx = translationLoadContexts.get(translations);
+  if (!ctx) return;
+
+  const missing: string[] = [];
+  for (const id of itemIds) {
+    if (id && !ctx.loadedItemIds.has(id)) {
+      ctx.loadedItemIds.add(id);
+      missing.push(id);
+    }
+  }
+  if (missing.length === 0) return;
+
+  try {
+    const rows = await getCmsTranslationsForItems(ctx.localeId, ctx.isPublished, missing, ctx.tenantId);
+    for (const row of rows) {
+      translations[getTranslatableKey(row)] = row;
+    }
+  } catch (error) {
+    console.error('Failed to load scoped CMS translations:', error);
   }
 }
 
@@ -522,6 +577,7 @@ async function fetchPageByPathInternal(
                 new Set(),
                 translations
               );
+              await ensureCmsTranslations(translations, [collectionItem.id]);
               enhancedItemValues = applyCmsTranslations(collectionItem.id, enhancedItemValues, collectionFields, translations, { includeIncomplete: !isPublished });
               enhancedItemValues = formatDateFieldsInItemValues(enhancedItemValues, collectionFields, timezone);
 
@@ -570,6 +626,7 @@ async function fetchPageByPathInternal(
             );
 
             // Apply CMS translations to the item values
+            await ensureCmsTranslations(translations, [collectionItem.id]);
             enhancedItemValues = applyCmsTranslations(collectionItem.id, enhancedItemValues, collectionFields, translations, { includeIncomplete: !isPublished });
 
             const rawItemValues = { ...enhancedItemValues };
@@ -995,6 +1052,7 @@ async function resolveReferenceFields(
 
       // Translate the referenced item's values so localized pages render
       // referenced CMS content in the active locale (not the source language)
+      await ensureCmsTranslations(translations, [refItem.id]);
       const refValues = applyCmsTranslations(refItem.id, refItem.values, refFields, translations, { includeIncomplete: !isPublished });
 
       // Build the path prefix for this level
@@ -1106,6 +1164,7 @@ async function batchResolveReferenceFields(
   // Translate each referenced item's values once (reused across all rows that
   // reference it) so localized pages render referenced CMS content in the
   // active locale instead of the source language.
+  await ensureCmsTranslations(translations, Array.from(allRefItemIds));
   const translatedRefValuesById = new Map<string, Record<string, string>>();
   const getTranslatedRefValues = (refItem: CollectionItemWithValues, refFields: CollectionField[]): Record<string, string> => {
     let cached = translatedRefValuesById.get(refItem.id);
@@ -2484,6 +2543,7 @@ export async function resolveCollectionLayers(
           const slugField = collectionFields.find(f => f.key === 'slug');
 
           // Pre-process all items: translations + date formatting (pure computation)
+          await ensureCmsTranslations(translations, sortedItems.map(item => item.id));
           const preprocessed = sortedItems.map(item => {
             let translatedValues = applyCmsTranslations(item.id, item.values, collectionFields, translations, { includeIncomplete: !isPublished });
             const rawTranslatedValues = { ...translatedValues };
@@ -2691,6 +2751,7 @@ export async function resolveCollectionLayers(
           },
         };
 
+        await ensureCmsTranslations(translations, sourceItems.map(item => item.id));
         const generatedOptions: Layer[] = sourceItems.map(item => {
           const translatedValues = applyCmsTranslations(item.id, item.values, sourceFields, translations, { includeIncomplete: !isPublished });
           const label = displayField ? (translatedValues[displayField.id] || 'Untitled') : 'Untitled';
@@ -2825,6 +2886,7 @@ export async function resolveCollectionLayers(
           const sourceCollectionId = layer.settings.optionsSource.collectionId;
           const items = cache.itemsByCollection.get(sourceCollectionId) || [];
           const fields = cache.fieldsByCollection.get(sourceCollectionId) || [];
+          await ensureCmsTranslations(translations, items.map(item => item.id));
           return buildInputGroupFragment(inputType, items, fields);
         } catch (error) {
           console.error(`Failed to resolve collection-sourced ${inputType} options for layer ${layer.id}:`, error);
@@ -3360,6 +3422,11 @@ export async function renderCollectionItemsToHtml(
     ensureMapTokens(),
   ]);
   const htmlTimezone = (timezoneRaw as string | null) || 'UTC';
+
+  // Augment the scoped translation map with CMS content for the items being
+  // rendered so `applyCmsTranslations` (here and in nested resolution) finds
+  // them — the map arrives as a per-locale scaffold without bulk CMS content.
+  await ensureCmsTranslations(translations, items.map(item => item.id));
 
   // Enrich slugs with cross-collection link field references
   const enrichedSlugs = { ...collectionItemSlugs };

--- a/lib/repositories/translationRepository.ts
+++ b/lib/repositories/translationRepository.ts
@@ -88,6 +88,170 @@ export async function getTranslationsByLocale(
 }
 
 /**
+ * Content keys that influence URL generation (page/folder/CMS slugs). Kept in
+ * the per-locale "scaffold" so routing, hreflang and locale-switcher URLs work
+ * without loading the full (CMS-content-heavy) translation catalogue.
+ */
+const SLUG_CONTENT_KEYS = ['slug', 'field:key:slug'];
+
+/** Source types whose translations are small and always needed per render. */
+const NON_CMS_SOURCE_TYPES = ['page', 'folder', 'component'];
+
+/** Supabase caps `.in()` lists; chunk large id arrays to stay under it. */
+const IN_CHUNK_SIZE = 300;
+
+function chunkIds(ids: string[], size: number): string[][] {
+  const out: string[][] = [];
+  for (let i = 0; i < ids.length; i += size) out.push(ids.slice(i, i + size));
+  return out;
+}
+
+/**
+ * Load the per-locale translation "scaffold": every non-CMS translation
+ * (page / folder / component) plus only the CMS *slug* rows.
+ *
+ * This is everything needed for routing, page/component rendering, SEO and
+ * URL generation — but excludes the bulk CMS *content* translations (text /
+ * rich text), which dominate large catalogues and are loaded on demand per
+ * rendered item via {@link getCmsTranslationsForItems}.
+ */
+export async function getLocaleScaffoldTranslations(
+  localeId: string,
+  isPublished: boolean,
+  tenantId?: string,
+): Promise<Translation[]> {
+  const client = await getSupabaseAdmin(tenantId);
+
+  if (!client) {
+    throw new Error('Supabase not configured');
+  }
+
+  const PAGE_SIZE = 1000;
+  const results: Translation[] = [];
+
+  const pageThrough = async (
+    build: (from: number, to: number) => PromiseLike<{ data: Translation[] | null; error: { message: string } | null }>,
+  ) => {
+    for (let from = 0; ; from += PAGE_SIZE) {
+      const { data, error } = await build(from, from + PAGE_SIZE - 1);
+      if (error) throw new Error(`Failed to fetch translations: ${error.message}`);
+      if (!data || data.length === 0) break;
+      results.push(...(data as Translation[]));
+      if (data.length < PAGE_SIZE) break;
+    }
+  };
+
+  // Non-CMS rows (page / folder / component).
+  await pageThrough((from, to) =>
+    client
+      .from('translations')
+      .select('*')
+      .eq('locale_id', localeId)
+      .eq('is_published', isPublished)
+      .is('deleted_at', null)
+      .in('source_type', NON_CMS_SOURCE_TYPES)
+      .order('created_at', { ascending: true })
+      .range(from, to) as unknown as PromiseLike<{ data: Translation[] | null; error: { message: string } | null }>,
+  );
+
+  // CMS slug rows (needed to match/build localized dynamic-page URLs).
+  await pageThrough((from, to) =>
+    client
+      .from('translations')
+      .select('*')
+      .eq('locale_id', localeId)
+      .eq('is_published', isPublished)
+      .is('deleted_at', null)
+      .eq('source_type', 'cms')
+      .in('content_key', SLUG_CONTENT_KEYS)
+      .order('created_at', { ascending: true })
+      .range(from, to) as unknown as PromiseLike<{ data: Translation[] | null; error: { message: string } | null }>,
+  );
+
+  return results;
+}
+
+/**
+ * Load CMS *content* translations for a specific set of collection items in a
+ * locale. Used to augment the scaffold on demand for exactly the items a given
+ * render path materialises, instead of loading the whole locale catalogue.
+ */
+export async function getCmsTranslationsForItems(
+  localeId: string,
+  isPublished: boolean,
+  itemIds: string[],
+  tenantId?: string,
+): Promise<Translation[]> {
+  if (itemIds.length === 0) return [];
+
+  const client = await getSupabaseAdmin(tenantId);
+  if (!client) {
+    throw new Error('Supabase not configured');
+  }
+
+  const results: Translation[] = [];
+
+  for (const chunk of chunkIds(itemIds, IN_CHUNK_SIZE)) {
+    const { data, error } = await client
+      .from('translations')
+      .select('*')
+      .eq('locale_id', localeId)
+      .eq('is_published', isPublished)
+      .is('deleted_at', null)
+      .eq('source_type', 'cms')
+      .in('source_id', chunk);
+
+    if (error) {
+      throw new Error(`Failed to fetch CMS translations: ${error.message}`);
+    }
+    if (data) results.push(...(data as Translation[]));
+  }
+
+  return results;
+}
+
+/**
+ * Load only slug translations (page / folder / CMS) for a locale. Used by URL
+ * builders (hreflang, sitemap, locale switcher) that never read CMS content —
+ * avoids pulling the full catalogue just to construct localized URLs.
+ */
+export async function getSlugTranslationsByLocale(
+  localeId: string,
+  isPublished: boolean,
+  tenantId?: string,
+): Promise<Translation[]> {
+  const client = await getSupabaseAdmin(tenantId);
+
+  if (!client) {
+    throw new Error('Supabase not configured');
+  }
+
+  const PAGE_SIZE = 1000;
+  const results: Translation[] = [];
+
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await client
+      .from('translations')
+      .select('*')
+      .eq('locale_id', localeId)
+      .eq('is_published', isPublished)
+      .is('deleted_at', null)
+      .in('content_key', SLUG_CONTENT_KEYS)
+      .order('created_at', { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+
+    if (error) {
+      throw new Error(`Failed to fetch slug translations: ${error.message}`);
+    }
+    if (!data || data.length === 0) break;
+    results.push(...(data as Translation[]));
+    if (data.length < PAGE_SIZE) break;
+  }
+
+  return results;
+}
+
+/**
  * Get translations by source (draft by default)
  */
 export async function getTranslationsBySource(


### PR DESCRIPTION
## Summary

Server renders previously loaded a locale's **entire** translation catalogue on every request. On large multilingual sites this is overwhelmingly CMS content translations (often >95% of rows), even though a page only needs translations for the items it actually renders. This loaded tens of thousands of rows per render (via many sequential paginated round-trips), and the same full load repeated per non-default locale in the locale switcher, sitemap, hreflang metadata, and load-more.

This change loads a small per-locale **scaffold** and augments it on demand with CMS content for only the items each render path materialises.

## Changes

- Add scoped translation repository helpers: `getLocaleScaffoldTranslations` (page/folder/component rows + CMS *slug* rows), `getCmsTranslationsForItems` (CMS content for specific item IDs), and `getSlugTranslationsByLocale` (slug rows only)
- `loadTranslationsForLocale` now returns the scaffold and registers a per-map loading context
- Add `ensureCmsTranslations`, which augments the scaffold map in place with CMS content for given item IDs, before every server-side `applyCmsTranslations` site (dynamic-page item, single + batch reference resolvers, collection lists, select/checkbox/radio option sources, and collection HTML rendering used by load-more/filter)
- Switch URL-only consumers (locale switcher, sitemap, hreflang metadata) to the slug-only loader so they no longer pull the full catalogue per locale

## Why it's safe

On the public site, all CMS content translation happens server-side (initial SSR and load-more's `renderCollectionItemsToHtml`). The client `translations` map is used only for URL/slug generation — the client-side CMS translation path in `LayerRenderer` is gated on edit mode, which still loads the full map via its own API and is unchanged. Output is identical because the scaffold keeps everything non-CMS plus all slug rows, and CMS content is loaded precisely for the items each page renders.

## Test plan

- [ ] Multilingual dynamic page (e.g. blog post): translated text, images, and slug render correctly in a non-default locale
- [ ] Collection list / grid on a non-default locale: each item's text and referenced fields are translated
- [ ] Collection-sourced select / checkbox / radio options render translated labels
- [ ] Load-more and filter on a localized collection return translated items
- [ ] Locale switcher links resolve to correct localized URLs (translated folder/page/CMS slugs)
- [ ] Sitemap and hreflang alternates contain correct localized URLs
- [ ] Default-locale pages and single-locale sites render unchanged
- [ ] Builder canvas localized preview still renders translated content

Made with [Cursor](https://cursor.com)