### PR TITLE
perf: drop builder-only style metadata from page payload

### DIFF
--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -138,10 +138,26 @@ function extractCollectionItemSlugs(layers: Layer[]): Record<string, string> {
 }
 
 /**
+ * The public renderer styles layers from their compiled `classes`; the structured
+ * `design` object is builder-only metadata used to regenerate those classes in the
+ * editor. The one exception is `design.backgrounds`, whose `bgImageVars` /
+ * `bgGradientVars` are applied as inline CSS custom properties at render time
+ * (see LayerRendererPublic). So for the client payload we keep only
+ * `design.backgrounds` and drop the rest — on a content-heavy page the full design
+ * tree can be ~30% of the serialized RSC Flight payload.
+ */
+function stripDesignForClient(design: Layer['design']): Layer['design'] | undefined {
+  const backgrounds = design?.backgrounds;
+  if (!backgrounds) return undefined;
+  return { backgrounds };
+}
+
+/**
  * Strip heavy SSR-only data from the layer tree before passing to client
  * components. After resolveCollectionLayers, all variables are pre-resolved
  * into the layers — _collectionItemValues and _layerDataMap are redundant
- * and can be enormous (e.g. 50 articles × full rich text bodies).
+ * and can be enormous (e.g. 50 articles × full rich text bodies). The
+ * builder-only `design` metadata is likewise dropped (see stripDesignForClient).
  *
  * The RSC Flight payload serializes everything passed to 'use client'
  * components, so stripping here avoids doubling the response size.
@@ -153,6 +169,13 @@ function stripSSROnlyData(layers: Layer[]): Layer[] {
     delete stripped._collectionItemValues;
     delete stripped._collectionItemSlug;
     delete stripped._layerDataMap;
+
+    const slimDesign = stripDesignForClient(stripped.design);
+    if (slimDesign) {
+      stripped.design = slimDesign;
+    } else {
+      delete stripped.design;
+    }
 
     if (stripped._filterConfig?.layerTemplate) {
       stripped._filterConfig = {

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -26,7 +26,7 @@ import { getClassesString, hasPasswordFormLayer } from '@/lib/layer-utils';
 import { buildLocalizedPageUrls, type LocalizedDynamicSlug } from '@/lib/page-utils';
 import { getTranslatableKey } from '@/lib/locale-runtime';
 import { getSlugTranslationsByLocale } from '@/lib/repositories/translationRepository';
-import type { Layer, Component, Page, CollectionItemWithValues, CollectionField, Locale, PageFolder, PasswordProtectionContext, Translation } from '@/types';
+import type { Layer, BackgroundsDesign, Component, Page, CollectionItemWithValues, CollectionField, Locale, PageFolder, PasswordProtectionContext, Translation } from '@/types';
 
 interface PageLinkRef { collection_item_id: string; page_id: string }
 
@@ -140,24 +140,57 @@ function extractCollectionItemSlugs(layers: Layer[]): Record<string, string> {
 /**
  * The public renderer styles layers from their compiled `classes`; the structured
  * `design` object is builder-only metadata used to regenerate those classes in the
- * editor. The one exception is `design.backgrounds`, whose `bgImageVars` /
- * `bgGradientVars` are applied as inline CSS custom properties at render time
- * (see LayerRendererPublic). So for the client payload we keep only
- * `design.backgrounds` and drop the rest — on a content-heavy page the full design
- * tree can be ~30% of the serialized RSC Flight payload.
+ * editor. The only part read at render time is `design.backgrounds.bgImageVars` /
+ * `bgGradientVars`, which are applied as inline CSS custom properties (see
+ * LayerRendererPublic and lib/page-fetcher). Everything else — including
+ * `backgroundColor` / `backgroundClip` (already baked into `classes`) — is dropped.
+ * On a content-heavy page the full design tree can be ~30% of the serialized RSC
+ * Flight payload.
  */
 function stripDesignForClient(design: Layer['design']): Layer['design'] | undefined {
   const backgrounds = design?.backgrounds;
   if (!backgrounds) return undefined;
-  return { backgrounds };
+  const slim: BackgroundsDesign = {};
+  if (backgrounds.bgImageVars) slim.bgImageVars = backgrounds.bgImageVars;
+  if (backgrounds.bgGradientVars) slim.bgGradientVars = backgrounds.bgGradientVars;
+  if (!slim.bgImageVars && !slim.bgGradientVars) return undefined;
+  return { backgrounds: slim };
+}
+
+/**
+ * Rich-text inline styles (`textStyles`) are applied at render time via their
+ * compiled `classes` (see getTextStyleClasses). The accompanying `design`,
+ * `styleOverrides`, `styleId`, and `label` are builder-only, so keep just `classes`.
+ *
+ * We must preserve an entry whenever its `classes` is a string — even an empty one.
+ * `getTextStyleClasses` does `textStyles?.[key]?.classes ?? DEFAULT_TEXT_STYLES[...]`,
+ * so an explicit `classes: ''` suppresses the default, whereas an absent entry falls
+ * back to it. Dropping empty-string entries would silently re-introduce default
+ * styling. Entries with no `classes` string already resolve to the default, so
+ * omitting them is equivalent to keeping them.
+ */
+function stripTextStylesForClient(textStyles: Layer['textStyles']): Layer['textStyles'] | undefined {
+  if (!textStyles) return undefined;
+  const slim: NonNullable<Layer['textStyles']> = {};
+  let kept = false;
+  for (const [key, style] of Object.entries(textStyles)) {
+    if (typeof style?.classes === 'string') {
+      slim[key] = { classes: style.classes };
+      kept = true;
+    }
+  }
+  return kept ? slim : undefined;
 }
 
 /**
  * Strip heavy SSR-only data from the layer tree before passing to client
  * components. After resolveCollectionLayers, all variables are pre-resolved
  * into the layers — _collectionItemValues and _layerDataMap are redundant
- * and can be enormous (e.g. 50 articles × full rich text bodies). The
- * builder-only `design` metadata is likewise dropped (see stripDesignForClient).
+ * and can be enormous (e.g. 50 articles × full rich text bodies). All builder-only
+ * style metadata (`design`, `styleIds`, `styleId`, `styleOverrides`,
+ * `styleOverridesByStyle`, and per-`textStyles` design) is likewise dropped — the
+ * published `classes` strings are already fully resolved, so the client never needs
+ * to re-resolve them (see stripDesignForClient / stripTextStylesForClient).
  *
  * The RSC Flight payload serializes everything passed to 'use client'
  * components, so stripping here avoids doubling the response size.
@@ -170,11 +203,25 @@ function stripSSROnlyData(layers: Layer[]): Layer[] {
     delete stripped._collectionItemSlug;
     delete stripped._layerDataMap;
 
+    // Builder-only style resolution inputs. The flat `classes` string is the
+    // already-resolved output, so the public renderer never reads these.
+    delete stripped.styleIds;
+    delete stripped.styleId;
+    delete stripped.styleOverrides;
+    delete stripped.styleOverridesByStyle;
+
     const slimDesign = stripDesignForClient(stripped.design);
     if (slimDesign) {
       stripped.design = slimDesign;
     } else {
       delete stripped.design;
+    }
+
+    const slimTextStyles = stripTextStylesForClient(stripped.textStyles);
+    if (slimTextStyles) {
+      stripped.textStyles = slimTextStyles;
+    } else {
+      delete stripped.textStyles;
     }
 
     if (stripped._filterConfig?.layerTemplate) {


### PR DESCRIPTION
## Summary

Published pages ship a large, redundant copy of builder-only style metadata
inside the RSC Flight payload. The public renderer styles layers entirely from
their compiled Tailwind `classes`; the structured `design` tree, the style
stack (`styleIds`/`styleId`/`styleOverrides`/`styleOverridesByStyle`), and the
`design` on rich-text `textStyles` only exist to regenerate those classes in
the editor. This strips all of it before the layer tree crosses the
`'use client'` boundary, keeping only what the renderer actually reads.

## What is kept vs dropped

Kept (read at render time):
- `design.backgrounds.bgImageVars` / `bgGradientVars` — applied as inline CSS
  custom properties (see `LayerRendererPublic` and `lib/page-fetcher`).
- `textStyles[*].classes` — applied to rich-text marks/blocks via
  `getTextStyleClasses`. Entries with an explicit empty `classes: ''` are
  preserved (an absent entry falls back to a default style; an empty string
  suppresses it — dropping empties would silently re-introduce default styling).
- `variables.design` — CMS-bound design color bindings (unaffected).

Dropped (builder-only; never read on the published render path):
- the rest of `design` (layout, typography, spacing, sizing, borders,
  positioning, effects, transforms, transitions) and the non-image parts of
  `design.backgrounds` (`backgroundColor`/`backgroundClip`/etc. — already baked
  into `classes`),
- `styleIds`, `styleId`, `styleOverrides`, `styleOverridesByStyle`,
- `design` / `styleOverrides` / `styleId` / `label` on each `textStyles` entry.

Applied inside the existing `stripSSROnlyData` traversal, so it covers the whole
tree including nested `children`, filter, and pagination templates.

## Impact (measured on a real published site)

The metadata is large but highly repetitive, so the win is primarily in the
**raw** payload — i.e. RSC parse/deserialization and hydration cost — rather
than compressed transfer.

Raw RSC payload (drives parse + hydration):

| page | before | after | delta |
|---|--:|--:|--:|
| homepage | 681 KB | 543 KB | -138 KB (-20%) |
| category (style-heavy) | 395 KB | 311 KB | -84 KB (-21%) |
| listing / CMS article | ~355 KB | ~325 KB | ~-8% |

Brotli transfer is reduced more modestly (~2-5%, ~1-2.5 KB/page) since the
repetitive metadata compresses well. The benefit is mainly lower client-side
parse/hydration and server serialization cost, most noticeable on low-end
mobile and very content-heavy pages.

## Why it's safe

- The public renderer reads `design` only via `design.backgrounds.bgImageVars`/
  `bgGradientVars`, and rich text only via `textStyles[*].classes`. Both are
  preserved.
- Neither `LayerRendererPublic` nor `lib/page-fetcher` reference
  `resolveLayerClasses`, `styleIds`, or `styleOverrides*` — the `classes`
  strings are already fully resolved at publish time.
- All other reads of these fields are editor-only (`LayerRenderer`,
  `use-design-sync`, layer-style panels, figma/import tooling) and never go
  through this strip, which runs only on the published render path.
- Verified: rendered markup is byte-identical before/after across the homepage
  and multiple content/CMS pages; `tsc`, ESLint, and the unit suite pass.

## Test plan

- [ ] Publish a page with background images/gradients and confirm they still render
- [ ] Confirm rich-text content (links, headings, lists, blockquotes) renders with the same styling
- [ ] Confirm a content-heavy/dynamic CMS page renders identically before/after
- [ ] Verify the raw page HTML shrinks (no `design`/`styleOverrides`/`textStyles` design in the inline `self.__next_f` payload)
- [ ] Sliders, forms, collection lists, and load-more still work (client hydration intact)