### PR TITLE
fix: prevent images from being cropped on the sides

### DIFF
--- a/app/a/[hash]/[...name]/route.ts
+++ b/app/a/[hash]/[...name]/route.ts
@@ -103,8 +103,14 @@ export async function GET(
       let pipeline = sharp(buffer);
 
       if (transform.width || transform.height) {
+        // `fit: 'inside'` scales the image down to fit within the requested
+        // bounds while preserving its aspect ratio — it never crops. This is
+        // the only correct behavior for a responsive-image proxy: cropping is a
+        // display concern handled by CSS `object-fit` on the rendered element.
+        // (Using `fit: 'cover'` here crops the sides whenever a height is
+        // present in the resize call, which silently breaks `object-cover`.)
         pipeline = pipeline.resize(transform.width, transform.height, {
-          fit: 'cover',
+          fit: 'inside',
           withoutEnlargement: true,
         });
       }

--- a/lib/asset-utils.ts
+++ b/lib/asset-utils.ts
@@ -557,7 +557,10 @@ export function generateImageSrcset(
       const sizeUrl = new URL(url);
       sizeUrl.searchParams.set('width', width.toString());
       sizeUrl.searchParams.set('quality', quality.toString());
-      sizeUrl.searchParams.set('resize', 'cover');
+      // `contain` preserves the source aspect ratio. `cover` would crop the
+      // image (e.g. the sides) on the transform CDN, silently breaking the
+      // element's own CSS `object-fit` — keep cropping a display-only concern.
+      sizeUrl.searchParams.set('resize', 'contain');
       return `${sizeUrl.toString()} ${width}w`;
     });
 


### PR DESCRIPTION
## Summary

The asset image proxy was server-side cropping every resized image, slicing off the sides. Because the cropped pixels are baked into the served file, the rendered element's CSS `object-fit` could no longer have any effect — so `object-cover` appeared broken and images showed up cut from the sides (visible on the live ycode.com marketing site).

## Changes

- Switch the asset proxy (`/a/[hash]/[...name]`) Sharp resize from `fit: 'cover'` to `fit: 'inside'`, so resizing always preserves the aspect ratio and never crops
- Mirror the same fix on the direct-Supabase srcset path (`resize=cover` -> `resize=contain`) for self-hosters serving Supabase transform URLs directly
- The avatar route keeps `fit: 'cover'` intentionally (avatars are meant to be cropped to a square)

## Why

Cropping belongs to the rendered element via CSS `object-fit`, not to the file the proxy returns. With `fit: 'cover'`, whenever a height reached the resize call the proxy returned a side-cropped file (e.g. a `3456x2060` source served as `1920x2060` for `?width=1920`), making the displayed box conform to the cropped ratio.

Verified with the project's Sharp:

```
both (1920,2060)  inside: 1920x1144   cover: 1920x2060   <- cover crops
width only        inside: 1920x1144   cover: 1920x1144
```

## Deploy note

`/a/:path*` is served with `Cache-Control: public, max-age=31536000, immutable` and the cache key is the URL (unchanged by this fix). After deploy, the CDN cache for `/a/*` must be purged so already-cropped variants are regenerated; users may also need a hard reload.

## Test plan

- [ ] Request a wide image variant (e.g. `/a/<hash>/<name>.webp?width=640`) and confirm the height scales proportionally instead of staying at the source height
- [ ] Verify an image with `w-full object-cover` (no fixed height) shows the full, uncropped image
- [ ] Verify an image inside a fixed-height/aspect container with `object-cover` still crops correctly via CSS (display-side cropping unaffected)
- [ ] Confirm avatars still crop to a 256x256 square
- [ ] Purge `/a/*` CDN cache and confirm the agencies hero is no longer cut on the sides

Made with [Cursor](https://cursor.com)