### PR TITLE
fix: stop unpublished pages returning indexable 200s

### DIFF
--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -288,6 +288,7 @@ export async function POST(request: NextRequest) {
             const staleSlugsCombined = [
               ...(p?.deletedItemSlugs || []),
               ...(p?.renamedItemOldSlugs || []),
+              ...(p?.unpublishedItemSlugs || []),
             ];
             if (staleSlugsCombined.length > 0) {
               const existing = deletedCollectionItemSlugs.get(collectionPublish.collectionId) || [];
@@ -356,6 +357,7 @@ export async function POST(request: NextRequest) {
           const staleSlugsCombined = [
             ...(p?.deletedItemSlugs || []),
             ...(p?.renamedItemOldSlugs || []),
+            ...(p?.unpublishedItemSlugs || []),
           ];
           if (staleSlugsCombined.length > 0) {
             const existing = deletedCollectionItemSlugs.get(collection.id) || [];

--- a/app/(site)/[...slug]/page.tsx
+++ b/app/(site)/[...slug]/page.tsx
@@ -290,28 +290,10 @@ export default async function Page({ params }: PageProps) {
     fetchCachedGlobalSettings(),
   ]);
 
-  // If page not found, try to show custom 404 error page
+  // Page not found: hand off to the 404 boundary so the response carries a real
+  // HTTP 404 status (the custom 404 page is rendered there). Returning content
+  // here would emit a 200 "soft 404", which search engines penalize.
   if (!data) {
-    const errorPageData = await fetchCachedErrorPage(404);
-
-    if (errorPageData) {
-      const { page: errorPage, pageLayers: errorPageLayers, components: errorComponents } = errorPageData;
-
-      return (
-        <PageRenderer
-          page={errorPage}
-          layers={errorPageLayers.layers || []}
-          components={errorComponents}
-          generatedCss={globalSettings.publishedCss || undefined}
-          colorVariablesCss={globalSettings.colorVariablesCss || undefined}
-          globalCustomCodeHead={globalSettings.globalCustomCodeHead}
-          globalCustomCodeBody={globalSettings.globalCustomCodeBody}
-          ycodeBadge={globalSettings.ycodeBadge}
-        />
-      );
-    }
-
-    // No custom 404 page, use default Next.js 404
     notFound();
   }
 
@@ -415,6 +397,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   if (!data) {
     return {
       title: 'Page Not Found',
+      robots: { index: false, follow: false },
     };
   }
 

--- a/app/(site)/_dynamic/[...slug]/page.tsx
+++ b/app/(site)/_dynamic/[...slug]/page.tsx
@@ -61,23 +61,10 @@ export default async function DynamicSlugPage({ params, searchParams }: DynamicS
     fetchGlobalPageSettings(),
   ]);
 
+  // Page not found: hand off to the 404 boundary for a real HTTP 404 status
+  // (the custom 404 page is rendered there). Rendering content here would emit
+  // a 200 "soft 404", which search engines penalize.
   if (!data) {
-    const errorPageData = await fetchErrorPage(404, true);
-    if (errorPageData) {
-      const { page, pageLayers, components } = errorPageData;
-
-      return (
-        <PageRenderer
-          page={page}
-          layers={pageLayers.layers || []}
-          components={components}
-          generatedCss={globalSettings.publishedCss || undefined}
-          colorVariablesCss={globalSettings.colorVariablesCss || undefined}
-          ycodeBadge={globalSettings.ycodeBadge}
-        />
-      );
-    }
-
     notFound();
   }
 

--- a/app/(site)/not-found.tsx
+++ b/app/(site)/not-found.tsx
@@ -1,12 +1,52 @@
 import Link from 'next/link';
+import { unstable_cache } from 'next/cache';
+import { fetchErrorPage, slimPageData } from '@/lib/page-fetcher';
+import { fetchGlobalPageSettings } from '@/lib/generate-page-metadata';
 import { getSettingByKey } from '@/lib/repositories/settingsRepository';
+import { tenantStore } from '@/lib/supabase-server';
+import PageRenderer from '@/components/PageRenderer';
 import YcodeBadge from '@/components/YcodeBadge';
 
+/** Cached lookup of the user's custom 404 page, invalidated on publish. */
+function fetchCachedCustom404(tenantId?: string) {
+  return unstable_cache(
+    async () => {
+      const data = await fetchErrorPage(404, true, tenantId);
+      return data ? slimPageData(data) : null;
+    },
+    ['error-404'],
+    { tags: ['all-pages'], revalidate: false }
+  )();
+}
+
 /**
- * Default 404 page fallback
- * Shown when no custom 404 error page exists in the database
+ * 404 boundary for public pages. Renders the user's custom 404 page when one
+ * exists, otherwise a default fallback. Next.js serves this with a real HTTP
+ * 404 status, which avoids soft-404 SEO penalties from search engines.
  */
 export default async function NotFound() {
+  const tenantId = tenantStore.getStore();
+
+  const errorPageData = await fetchCachedCustom404(tenantId).catch(() => null);
+
+  if (errorPageData) {
+    const globalSettings = await fetchGlobalPageSettings().catch(() => null);
+    const { page, pageLayers, components } = errorPageData;
+
+    return (
+      <PageRenderer
+        page={page}
+        layers={pageLayers.layers || []}
+        components={components}
+        generatedCss={globalSettings?.publishedCss || undefined}
+        colorVariablesCss={globalSettings?.colorVariablesCss || undefined}
+        globalCustomCodeHead={globalSettings?.globalCustomCodeHead}
+        globalCustomCodeBody={globalSettings?.globalCustomCodeBody}
+        ycodeBadge={globalSettings?.ycodeBadge ?? true}
+      />
+    );
+  }
+
   let showBadge = true;
   try {
     const setting = await getSettingByKey('ycode_badge');

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -353,15 +353,17 @@ async function getCollectionItemBySlug(
             // Extract item ID from translation key
             const itemId = translation.source_id;
 
-            // Verify this item belongs to the correct collection
-            const { data: item, error: itemError } = await supabase
+            // Verify this item belongs to the correct collection. On the public
+            // path also require is_publishable so unpublished items can't resolve.
+            let itemQuery = supabase
               .from('collection_items')
               .select('*')
               .eq('id', itemId)
               .eq('collection_id', collectionId)
               .eq('is_published', isPublished)
-              .is('deleted_at', null)
-              .single();
+              .is('deleted_at', null);
+            if (isPublished) itemQuery = itemQuery.eq('is_publishable', true);
+            const { data: item, error: itemError } = await itemQuery.single();
 
             if (!itemError && item) {
               // Found the item via translation - return it with all values
@@ -387,15 +389,17 @@ async function getCollectionItemBySlug(
       return null;
     }
 
-    // Verify the item belongs to the correct collection
-    const { data: item, error: itemError } = await supabase
+    // Verify the item belongs to the correct collection. On the public path
+    // also require is_publishable so unpublished items can't resolve.
+    let itemQuery = supabase
       .from('collection_items')
       .select('*')
       .eq('id', valueData.item_id)
       .eq('collection_id', collectionId)
       .eq('is_published', isPublished)
-      .is('deleted_at', null)
-      .single();
+      .is('deleted_at', null);
+    if (isPublished) itemQuery = itemQuery.eq('is_publishable', true);
+    const { data: item, error: itemError } = await itemQuery.single();
 
     if (itemError || !item) {
       return null;

--- a/lib/services/cacheService.ts
+++ b/lib/services/cacheService.ts
@@ -289,7 +289,9 @@ async function resolveDynamicPageRoutes(
           currentFolderId = folder.page_folder_id;
         }
         slugParts.push(...folderSegments);
-        slugParts.push(itemSlug);
+        // Use the item's translated slug for this locale (the actual localized
+        // URL); fall back to the default slug when no translation exists.
+        slugParts.push(lt[`cms:${sv.item_id}:field:key:slug`] || itemSlug);
 
         const localePath = slugParts.map(normalizeSlugSegment).filter(Boolean).join('/');
         if (localePath) routes.push(localePath);
@@ -321,13 +323,53 @@ export async function getRoutePathsForDeletedCollectionItems(
     { data: dynamicPages },
     { data: folders },
     { data: locales },
+    { data: translations },
   ] = await Promise.all([
     client.from('pages').select('*').eq('is_published', true).eq('is_dynamic', true).is('deleted_at', null),
     client.from('page_folders').select('*').eq('is_published', true).is('deleted_at', null),
     client.from('locales').select('*').is('deleted_at', null),
+    client.from('translations')
+      .select('locale_id, source_type, source_id, content_key, content_value')
+      .eq('is_published', true).is('deleted_at', null)
+      .in('content_key', ['slug', 'field:key:slug']),
   ]);
 
   if (!dynamicPages || !folders) return [];
+
+  // Build translations lookup: locale_id → "type:source:key" → value
+  const translationsMap: Record<string, Record<string, string>> = {};
+  for (const t of translations || []) {
+    if (!translationsMap[t.locale_id]) translationsMap[t.locale_id] = {};
+    translationsMap[t.locale_id][`${t.source_type}:${t.source_id}:${t.content_key}`] = t.content_value;
+  }
+
+  // Translated slugs are keyed by item id, but callers only pass default slug
+  // values. Map each old slug back to its item id (draft rows survive unpublish,
+  // so they still resolve) to look up per-locale translated slugs.
+  const slugToItemIdByCollection = new Map<string, Map<string, string>>();
+  for (const [collectionId, slugs] of deletedSlugs) {
+    if (!slugs || slugs.length === 0) continue;
+    const { data: slugField } = await client
+      .from('collection_fields')
+      .select('id')
+      .eq('collection_id', collectionId)
+      .eq('key', 'slug')
+      .is('deleted_at', null)
+      .limit(1)
+      .single();
+    if (!slugField) continue;
+    const { data: values } = await client
+      .from('collection_item_values')
+      .select('item_id, value')
+      .eq('field_id', slugField.id)
+      .is('deleted_at', null)
+      .in('value', slugs);
+    const map = new Map<string, string>();
+    for (const v of values || []) {
+      if (typeof v.value === 'string') map.set(v.value, v.item_id);
+    }
+    slugToItemIdByCollection.set(collectionId, map);
+  }
 
   for (const page of dynamicPages as Page[]) {
     const collectionId = (page.settings as any)?.cms?.collection_id;
@@ -336,27 +378,32 @@ export async function getRoutePathsForDeletedCollectionItems(
     const slugs = deletedSlugs.get(collectionId);
     if (!slugs || slugs.length === 0) continue;
 
+    const slugToItemId = slugToItemIdByCollection.get(collectionId) || new Map<string, string>();
     const basePath = buildSlugPath(page, folders as PageFolder[], 'page', '').slice(1).replace(/\/$/, '');
 
     for (const itemSlug of slugs) {
       const fullPath = basePath ? `${basePath}/${itemSlug}` : itemSlug;
       routes.push(fullPath);
 
-      // Locale-prefixed paths
+      const itemId = slugToItemId.get(itemSlug);
+
+      // Locale-prefixed paths with translated folder + item slugs
       if (locales) {
         for (const locale of locales) {
           if (locale.is_default) continue;
+          const lt = translationsMap[locale.id] || {};
           const slugParts: string[] = [locale.code];
           let currentFolderId = page.page_folder_id;
           const folderSegments: string[] = [];
           while (currentFolderId) {
             const folder = (folders as PageFolder[]).find(f => f.id === currentFolderId);
             if (!folder) break;
-            folderSegments.unshift(folder.slug);
+            folderSegments.unshift(lt[`folder:${folder.id}:slug`] || folder.slug);
             currentFolderId = folder.page_folder_id;
           }
           slugParts.push(...folderSegments);
-          slugParts.push(itemSlug);
+          const translatedSlug = itemId ? lt[`cms:${itemId}:field:key:slug`] : undefined;
+          slugParts.push(translatedSlug || itemSlug);
           const localePath = slugParts.map(normalizeSlugSegment).filter(Boolean).join('/');
           if (localePath) routes.push(localePath);
         }

--- a/lib/services/collectionService.ts
+++ b/lib/services/collectionService.ts
@@ -76,6 +76,7 @@ export interface PublishCollectionResult {
     deletedItemsCount: number;
     deletedItemSlugs: string[];
     renamedItemOldSlugs: string[];
+    unpublishedItemSlugs: string[];
   };
   timing?: {
     collections: OperationTiming;
@@ -137,6 +138,7 @@ export async function publishCollectionWithItems(
       deletedItemsCount: 0,
       deletedItemSlugs: [],
       renamedItemOldSlugs: [],
+      unpublishedItemSlugs: [],
     },
     timing: {
       collections: { durationMs: 0, count: 0 },
@@ -194,7 +196,7 @@ export async function publishCollectionWithItems(
 
       // Step 3: Publish selected items
       const itemsStart = performance.now();
-      const { itemsCount, valuesCount, itemsDurationMs, valuesDurationMs, renamedItemOldSlugs } = await publishSelectedItems(
+      const { itemsCount, valuesCount, itemsDurationMs, valuesDurationMs, renamedItemOldSlugs, unpublishedItemSlugs } = await publishSelectedItems(
         collectionId,
         itemIds,
         prefetched,
@@ -202,6 +204,7 @@ export async function publishCollectionWithItems(
       result.published.itemsCount = itemsCount;
       result.published.valuesCount = valuesCount;
       result.published.renamedItemOldSlugs = renamedItemOldSlugs;
+      result.published.unpublishedItemSlugs = unpublishedItemSlugs;
       result.timing!.items = {
         durationMs: itemsDurationMs,
         count: itemsCount,
@@ -460,7 +463,7 @@ async function publishSelectedItems(
   collectionId: string,
   itemIds?: string[],
   prefetched?: CollectionPrefetch,
-): Promise<{ itemsCount: number; valuesCount: number; itemsDurationMs: number; valuesDurationMs: number; renamedItemOldSlugs: string[] }> {
+): Promise<{ itemsCount: number; valuesCount: number; itemsDurationMs: number; valuesDurationMs: number; renamedItemOldSlugs: string[]; unpublishedItemSlugs: string[] }> {
   const client = await getSupabaseAdmin();
 
   if (!client) {
@@ -478,7 +481,7 @@ async function publishSelectedItems(
   }
 
   if (itemsToPublish.length === 0) {
-    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [] };
+    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [], unpublishedItemSlugs: [] };
   }
 
   // Batch fetch all draft items to publish. When the caller bulk-prefetched the
@@ -491,16 +494,50 @@ async function publishSelectedItems(
     : await getItemsByIds(itemsToPublish, false);
 
   if (draftItems.length === 0) {
-    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [] };
+    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [], unpublishedItemSlugs: [] };
   }
 
   // Separate publishable from non-publishable items
   const publishableItems = draftItems.filter(item => item.is_publishable);
   const nonPublishableItems = draftItems.filter(item => !item.is_publishable);
 
-  // Remove published versions of non-publishable items
+  // Remove published versions of non-publishable items. Snapshot their published
+  // slugs first so the publish route can invalidate the now-dead URLs — without
+  // this the CDN keeps serving the unpublished page as a 200 (cache never
+  // expires under revalidate: false).
+  const unpublishedItemSlugs: string[] = [];
   if (nonPublishableItems.length > 0) {
     const nonPublishableIds = nonPublishableItems.map(item => item.id);
+
+    try {
+      const slugField = prefetched
+        ? prefetched.draftFields.find(f => f.key === 'slug') ?? null
+        : (await client
+          .from('collection_fields')
+          .select('id')
+          .eq('collection_id', collectionId)
+          .eq('key', 'slug')
+          .is('deleted_at', null)
+          .limit(1)
+          .single()).data;
+
+      if (slugField) {
+        for (let i = 0; i < nonPublishableIds.length; i += 500) {
+          const batch = nonPublishableIds.slice(i, i + 500);
+          const { data } = await client
+            .from('collection_item_values')
+            .select('value')
+            .eq('field_id', slugField.id)
+            .eq('is_published', true)
+            .is('deleted_at', null)
+            .in('item_id', batch);
+          if (data) unpublishedItemSlugs.push(...data.map(v => v.value as string).filter(Boolean));
+        }
+      }
+    } catch {
+      // Non-fatal: proceed with unpublish even if the slug snapshot fails
+    }
+
     await client
       .from('collection_items')
       .delete()
@@ -509,7 +546,7 @@ async function publishSelectedItems(
   }
 
   if (publishableItems.length === 0) {
-    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [] };
+    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [], unpublishedItemSlugs };
   }
 
   // Fetch existing published items for comparison (use bulk-prefetched set when available)
@@ -624,7 +661,7 @@ async function publishSelectedItems(
   const valuesCount = await publishItemValuesBatch(itemIdsToPublishValues, draftValues, publishedValues);
   const valuesDurationMs = Math.round(performance.now() - valuesStart);
 
-  return { itemsCount: itemsToUpsert.length, valuesCount, itemsDurationMs, valuesDurationMs, renamedItemOldSlugs };
+  return { itemsCount: itemsToUpsert.length, valuesCount, itemsDurationMs, valuesDurationMs, renamedItemOldSlugs, unpublishedItemSlugs };
 }
 
 /**


### PR DESCRIPTION
## Summary

Unpublished and localized pages were getting indexed by search engines. Two root causes: missing pages rendered the custom error UI with an HTTP 200 (a soft 404), and localized URLs of unpublished CMS items kept serving stale cached pages because `revalidate: false` never expires without explicit invalidation.

## Changes

- Hand 404s to the `not-found` boundary so missing pages return a real HTTP 404 with `noindex`, instead of rendering the error UI with a 200
- Move the custom 404 rendering into `not-found.tsx` so tenants keep their designed error page on a proper status code
- Filter `getCollectionItemBySlug` by `is_publishable` for published lookups, so items flagged non-publishable never resolve
- Resolve translated slugs when invalidating dynamic CMS routes, so localized URLs are purged alongside the default locale
- Capture the slugs of items being unpublished during a site publish and feed them into cache invalidation, so their now-dead URLs are purged

## Test plan

- [x] `curl -I` a non-existent path returns 404 (was 200); response includes `noindex`
- [x] Published dynamic CMS pages serve 200 in default and localized locales
- [x] Unpublishing an item (per-item Draft toggle) flips both its EN and FR URLs to 404
- [x] Re-publishing the item flips both URLs back to 200
- [x] Unpublishing via the full Publish button flips both EN and FR URLs to 404
- [x] Other items in the same collection are unaffected