### PR TITLE
fix: reflect page locale on published pages instead of always English

### DIFF
--- a/app/(builder)/layout.tsx
+++ b/app/(builder)/layout.tsx
@@ -18,7 +18,7 @@ export default function BuilderLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <RootLayoutShell bodyClassName={`${inter.variable} font-sans antialiased text-xs`}>
+    <RootLayoutShell lang="en" bodyClassName={`${inter.variable} font-sans antialiased text-xs`}>
       {children}
     </RootLayoutShell>
   );

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -777,6 +777,7 @@ export default async function PageRenderer({
         data-layer-id="body"
         data-layer-type="div"
         data-is-empty={hasLayers ? 'false' : 'true'}
+        lang={(locale?.code || availableLocales.find((l) => l.is_default)?.code) || undefined}
       >
         <LayerRendererPublic
           layers={childLayers}

--- a/components/RootLayoutShell.tsx
+++ b/components/RootLayoutShell.tsx
@@ -18,15 +18,22 @@ interface RootLayoutShellProps {
    * public published sites should use to avoid shipping the builder's UI font.
    */
   bodyClassName?: string;
+  /**
+   * Language for the <html lang> attribute. Omitted for public published sites
+   * so the per-page locale (set on the content wrapper by PageRenderer) is the
+   * source of truth instead of a hardcoded `en`.
+   */
+  lang?: string;
 }
 
 export default function RootLayoutShell({
   children,
   headElements,
   bodyClassName = 'font-sans antialiased',
+  lang,
 }: RootLayoutShellProps) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang={lang} suppressHydrationWarning>
       <head>
         {headElements}
       </head>


### PR DESCRIPTION
## Summary

Published pages always rendered `<html lang="en">` regardless of the page's actual locale (closes #358). On non-English sites this caused hreflang mismatch warnings in SEO tools and an incorrect language for screen readers.

The shared `(site)` layout renders `<html>` but has no per-route params, and reading the locale there would require `headers()` — which forces every published page dynamic and breaks static caching / cloud ISR. So the locale is set on the per-page content wrapper that `PageRenderer` already renders (it has the resolved locale), keeping pages fully static.

## Changes

- Set `lang` on the `<main id="ybody">` content wrapper in `PageRenderer` from the resolved page locale, falling back to the default locale for unprefixed (default-locale) pages
- Drop the hardcoded `lang="en"` on `<html>`; make `RootLayoutShell`'s `lang` an optional prop with no default
- Builder layout passes `lang="en"` explicitly so the editor UI is unchanged

## Test plan

- [ ] On a non-English default-locale site, view a default page → content wrapper reports the default locale code
- [ ] On a multi-locale site, view a `/{locale}/…` page → reports that locale's code
- [ ] Confirm published pages remain statically cached (no switch to dynamic rendering)
- [ ] Builder UI still renders `<html lang="en">`
- [ ] Site with no locales configured → no `lang` attribute (no regression)