### PR TITLE
fix: render nested reference collections on canvas

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1567,12 +1567,21 @@ const LayerItemImpl: React.FC<{
     const hasStaticFilters = !!collectionVariable.filters?.groups?.some(
       g => g.conditions.some(c => !c.inputLayerId)
     );
+    // Reference/inverse collections narrow the fetched pool client-side by the
+    // parent item's reference value, so the full candidate set must be loaded.
+    // The default page size can omit the specific referenced rows (e.g. a region
+    // sorted near the end of a large collection), hiding the nested layer.
+    const isReferenceFiltered = !!collectionVariable.source_field_id && (
+      collectionVariable.source_field_type === 'reference' ||
+      collectionVariable.source_field_type === 'multi_reference' ||
+      collectionVariable.source_field_type === 'inverse_reference'
+    );
     const pagination = collectionVariable.pagination;
     const isPaginated = !!pagination?.enabled && (pagination.mode === 'pages' || pagination.mode === 'load_more');
 
     let fetchLimit: number | undefined;
     let fetchOffset: number | undefined;
-    if (hasStaticFilters) {
+    if (hasStaticFilters || isReferenceFiltered) {
       fetchLimit = FILTERED_FETCH_LIMIT;
       fetchOffset = 0;
     } else if (isPaginated) {
@@ -1595,6 +1604,7 @@ const LayerItemImpl: React.FC<{
     isEditMode,
     collectionVariable?.id,
     collectionVariable?.source_field_type,
+    collectionVariable?.source_field_id,
     collectionVariable?.sort_by,
     collectionVariable?.sort_order,
     collectionVariable?.sort_by_inputLayerId,


### PR DESCRIPTION
## Summary

Nested reference-based collection layers (e.g. badges) rendered correctly in preview but appeared empty on the canvas. The outer collection showed its items, but the inner reference collection inside each item loaded nothing.

## Changes

- Fetch the full candidate pool for collection layers driven by a `reference`, `multi_reference`, or `inverse_reference` source field, matching the behavior already used for layers with static filters
- Previously only static-filter layers got the high-limit fetch, so reference layers fell back to the default page size (25) and could miss referenced rows sorted near the end of a large collection
- Add `source_field_id` to the fetch effect dependencies so the fetch re-runs when it changes

## Test plan

- [ ] Open a page/component on canvas with a nested reference collection whose target collection has more items than the default page size
- [ ] Confirm the nested layer (e.g. badges) renders its referenced items on canvas
- [ ] Confirm canvas now matches preview output
- [ ] Verify non-reference collections (plain, static-filtered, paginated) still load as before