### PR TITLE
fix: invalid DOM property warning for custom attributes

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -12,6 +12,7 @@ import type { UseLiveLayerUpdatesReturn } from '@/hooks/use-live-layer-updates';
 import type { UseLiveComponentUpdatesReturn } from '@/hooks/use-live-component-updates';
 import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEditable, isTextContentLayer, isRichTextLayer, getCollectionVariable, evaluateVisibility, findAncestorByName, filterDisabledSliderLayers, getLayerCmsFieldBinding, findLayerById } from '@/lib/layer-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
+import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
 import { useCanvasSlider } from '@/hooks/use-canvas-slider';
 import { resolveFieldFromSources } from '@/lib/cms-variables-utils';
@@ -1967,13 +1968,6 @@ const LayerItemImpl: React.FC<{
     const Tag = htmlTag as any;
     const { style: attrStyle, ...otherAttributes } = effectiveLayer.attributes || {};
 
-    // Map HTML attributes to React JSX equivalents
-    const htmlToJsxAttrMap: Record<string, string> = {
-      'for': 'htmlFor',
-      'class': 'className',
-      'autofocus': 'autoFocus',
-    };
-
     // Convert string boolean values to actual booleans and map HTML attrs to JSX
     const normalizedAttributes = Object.fromEntries(
       Object.entries(otherAttributes)
@@ -1984,7 +1978,7 @@ const LayerItemImpl: React.FC<{
         })
         .map(([key, value]) => {
           // Map HTML attribute names to JSX equivalents
-          const jsxKey = htmlToJsxAttrMap[key] || key;
+          const jsxKey = HTML_TO_REACT_ATTRS[key.toLowerCase()] || key;
 
           // If value is already a boolean, keep it
           if (typeof value === 'boolean') {
@@ -2216,10 +2210,10 @@ const LayerItemImpl: React.FC<{
       elementProps.id = layer.attributes.id;
     }
 
-    // Apply custom attributes from settings
+    // Apply custom attributes from settings (map HTML attr names to JSX equivalents)
     if (layer.settings?.customAttributes) {
       Object.entries(layer.settings.customAttributes).forEach(([name, value]) => {
-        elementProps[name] = value;
+        elementProps[HTML_TO_REACT_ATTRS[name.toLowerCase()] || name] = value;
       });
     }
 
@@ -2889,10 +2883,10 @@ const LayerItemImpl: React.FC<{
             iframeProps.id = layer.attributes.id;
           }
 
-          // Apply custom attributes from settings
+          // Apply custom attributes from settings (map HTML attr names to JSX equivalents)
           if (layer.settings?.customAttributes) {
             Object.entries(layer.settings.customAttributes).forEach(([name, value]) => {
-              iframeProps[name] = value;
+              iframeProps[HTML_TO_REACT_ATTRS[name.toLowerCase()] || name] = value;
             });
           }
 

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -18,6 +18,7 @@ import dynamic from 'next/dynamic';
 import type { Layer, Locale, FormSettings, Component, DesignColorVariable, PasswordProtectionContext } from '@/types';
 import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextContentLayer, getCollectionVariable, filterDisabledSliderLayers } from '@/lib/layer-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
+import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
 import { getDynamicTextContent, getImageUrlFromVariable, getVideoUrlFromVariable, getIframeUrlFromVariable, isFieldVariable, isAssetVariable, isStaticTextVariable, isDynamicTextVariable, getStaticTextContent, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
 import { getTranslatedAssetId, getTranslatedText } from '@/lib/locale-runtime';
@@ -780,13 +781,6 @@ const LayerItem: React.FC<{
     const Tag = htmlTag as any;
     const { style: attrStyle, ...otherAttributes } = effectiveLayer.attributes || {};
 
-    // Map HTML attributes to React JSX equivalents
-    const htmlToJsxAttrMap: Record<string, string> = {
-      'for': 'htmlFor',
-      'class': 'className',
-      'autofocus': 'autoFocus',
-    };
-
     // Convert string boolean values to actual booleans and map HTML attrs to JSX
     const normalizedAttributes = Object.fromEntries(
       Object.entries(otherAttributes)
@@ -797,7 +791,7 @@ const LayerItem: React.FC<{
         })
         .map(([key, value]) => {
           // Map HTML attribute names to JSX equivalents
-          const jsxKey = htmlToJsxAttrMap[key] || key;
+          const jsxKey = HTML_TO_REACT_ATTRS[key.toLowerCase()] || key;
 
           // If value is already a boolean, keep it
           if (typeof value === 'boolean') {
@@ -972,10 +966,10 @@ const LayerItem: React.FC<{
       elementProps.id = layer.attributes.id;
     }
 
-    // Apply custom attributes from settings
+    // Apply custom attributes from settings (map HTML attr names to JSX equivalents)
     if (layer.settings?.customAttributes) {
       Object.entries(layer.settings.customAttributes).forEach(([name, value]) => {
-        elementProps[name] = value;
+        elementProps[HTML_TO_REACT_ATTRS[name.toLowerCase()] || name] = value;
       });
     }
 
@@ -1491,10 +1485,10 @@ const LayerItem: React.FC<{
             iframeProps.id = layer.attributes.id;
           }
 
-          // Apply custom attributes from settings
+          // Apply custom attributes from settings (map HTML attr names to JSX equivalents)
           if (layer.settings?.customAttributes) {
             Object.entries(layer.settings.customAttributes).forEach(([name, value]) => {
-              iframeProps[name] = value;
+              iframeProps[HTML_TO_REACT_ATTRS[name.toLowerCase()] || name] = value;
             });
           }
 

--- a/lib/parse-head-html.ts
+++ b/lib/parse-head-html.ts
@@ -1,8 +1,14 @@
 import React from 'react';
 
-const HTML_TO_REACT_ATTRS: Record<string, string> = {
+/**
+ * Maps lowercase HTML attribute names to their React/JSX camelCase equivalents.
+ * Shared by head-HTML parsing and the layer renderers so imported markup never
+ * leaks invalid DOM props (e.g. `fetchpriority`) onto React elements.
+ */
+export const HTML_TO_REACT_ATTRS: Record<string, string> = {
   'class': 'className',
   'for': 'htmlFor',
+  'autofocus': 'autoFocus',
   'crossorigin': 'crossOrigin',
   'charset': 'charSet',
   'http-equiv': 'httpEquiv',


### PR DESCRIPTION
## Summary

Custom attributes set on layers (stored in `layer.settings.customAttributes`) were applied to React elements verbatim. Imported/migrated layers that stored attributes in lowercase HTML form (e.g. `fetchpriority`, `crossorigin`) triggered React's "Invalid DOM property" console warning and rendered as unrecognized props.

## Changes

- Route `customAttributes` through the shared `HTML_TO_REACT_ATTRS` map in both renderers (element + iframe paths), converting `fetchpriority`→`fetchPriority`, `crossorigin`→`crossOrigin`, etc.
- Export and reuse `HTML_TO_REACT_ATTRS` from `lib/parse-head-html.ts`, removing the duplicated per-renderer `htmlToJsxAttrMap` objects.
- Case-insensitive lookup so any casing of stored attributes maps correctly; already-valid attrs (e.g. `decoding`) pass through untouched.

## Test plan

- [ ] Open the canvas on a page with an image that has a custom `fetchpriority` attribute — no console warning
- [ ] Verify the published page renders the same image without warnings
- [ ] Confirm custom attributes like `crossorigin`, `referrerpolicy`, `tabindex` map to their JSX equivalents
- [ ] Confirm valid lowercase attrs (`decoding`, `loading`) still render correctly