### PR TITLE
fix: parse string style in custom attributes

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -10,7 +10,7 @@ import { useAuthStore } from '@/stores/useAuthStore';
 import type { Layer, Locale, ComponentVariable, FormSettings, LinkSettings, Breakpoint, CollectionItemWithValues, CollectionField, Component } from '@/types';
 import type { UseLiveLayerUpdatesReturn } from '@/hooks/use-live-layer-updates';
 import type { UseLiveComponentUpdatesReturn } from '@/hooks/use-live-component-updates';
-import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEditable, isTextContentLayer, isRichTextLayer, getCollectionVariable, evaluateVisibility, findAncestorByName, filterDisabledSliderLayers, getLayerCmsFieldBinding, findLayerById } from '@/lib/layer-utils';
+import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEditable, isTextContentLayer, isRichTextLayer, getCollectionVariable, evaluateVisibility, findAncestorByName, filterDisabledSliderLayers, getLayerCmsFieldBinding, findLayerById, applyCustomAttributes } from '@/lib/layer-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
@@ -2223,9 +2223,7 @@ const LayerItemImpl: React.FC<{
 
     // Apply custom attributes from settings (map HTML attr names to JSX equivalents)
     if (layer.settings?.customAttributes) {
-      Object.entries(layer.settings.customAttributes).forEach(([name, value]) => {
-        elementProps[HTML_TO_REACT_ATTRS[name.toLowerCase()] || name] = value;
-      });
+      applyCustomAttributes(elementProps, layer.settings.customAttributes);
     }
 
     // Select with placeholder: set defaultValue so React shows the placeholder option
@@ -2896,9 +2894,7 @@ const LayerItemImpl: React.FC<{
 
           // Apply custom attributes from settings (map HTML attr names to JSX equivalents)
           if (layer.settings?.customAttributes) {
-            Object.entries(layer.settings.customAttributes).forEach(([name, value]) => {
-              iframeProps[HTML_TO_REACT_ATTRS[name.toLowerCase()] || name] = value;
-            });
+            applyCustomAttributes(iframeProps, layer.settings.customAttributes);
           }
 
           // Only add editor event handlers in edit mode (client-side only)

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -16,7 +16,7 @@
 import React, { useEffect, useCallback, useMemo, useRef, Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import type { Layer, Locale, FormSettings, Component, DesignColorVariable, PasswordProtectionContext } from '@/types';
-import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextContentLayer, getCollectionVariable, filterDisabledSliderLayers } from '@/lib/layer-utils';
+import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextContentLayer, getCollectionVariable, filterDisabledSliderLayers, applyCustomAttributes } from '@/lib/layer-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
@@ -969,9 +969,7 @@ const LayerItem: React.FC<{
 
     // Apply custom attributes from settings (map HTML attr names to JSX equivalents)
     if (layer.settings?.customAttributes) {
-      Object.entries(layer.settings.customAttributes).forEach(([name, value]) => {
-        elementProps[HTML_TO_REACT_ATTRS[name.toLowerCase()] || name] = value;
-      });
+      applyCustomAttributes(elementProps, layer.settings.customAttributes);
     }
 
     // Select with placeholder: set defaultValue so React shows the placeholder option
@@ -1488,9 +1486,7 @@ const LayerItem: React.FC<{
 
           // Apply custom attributes from settings (map HTML attr names to JSX equivalents)
           if (layer.settings?.customAttributes) {
-            Object.entries(layer.settings.customAttributes).forEach(([name, value]) => {
-              iframeProps[HTML_TO_REACT_ATTRS[name.toLowerCase()] || name] = value;
-            });
+            applyCustomAttributes(iframeProps, layer.settings.customAttributes);
           }
 
           return (

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -15,9 +15,51 @@ import { parseMultiReferenceValue, normalizeBooleanValue } from '@/lib/collectio
 import { getInheritedValue } from '@/lib/tailwind-class-mapper';
 import cloneDeep from 'lodash/cloneDeep';
 import { layerHasLink, hasLinkInTree, hasRichTextLinks } from '@/lib/link-utils';
+import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
 
 // Alias for backwards compatibility within this file
 const hasLinkSettings = layerHasLink;
+
+/**
+ * Parse an inline CSS style string into a React style object.
+ * Splits on the first colon per rule so values containing colons (e.g. urls) survive.
+ * CSS custom properties (--var) are preserved verbatim; other props are camelCased.
+ */
+export function parseStyleStringToObject(style: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const rule of style.split(';')) {
+    const trimmed = rule.trim();
+    if (!trimmed) continue;
+    const colonIndex = trimmed.indexOf(':');
+    if (colonIndex === -1) continue;
+    const prop = trimmed.slice(0, colonIndex).trim();
+    const value = trimmed.slice(colonIndex + 1).trim();
+    if (!prop || !value) continue;
+    const key = prop.startsWith('--') ? prop : prop.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+    result[key] = value;
+  }
+  return result;
+}
+
+/**
+ * Apply user-defined custom attributes onto a React props object, mapping HTML
+ * attribute names to their JSX equivalents. A string `style` attribute is parsed
+ * into an object and merged with any existing style (React rejects style strings).
+ */
+export function applyCustomAttributes(
+  target: Record<string, unknown>,
+  customAttributes: Record<string, string>,
+): void {
+  for (const [name, value] of Object.entries(customAttributes)) {
+    const jsxName = HTML_TO_REACT_ATTRS[name.toLowerCase()] || name;
+    if (jsxName === 'style' && typeof value === 'string') {
+      const existing = (typeof target.style === 'object' && target.style ? target.style : {}) as Record<string, string>;
+      target.style = { ...existing, ...parseStyleStringToObject(value) };
+      continue;
+    }
+    target[jsxName] = value;
+  }
+}
 
 // ─── Cached Layer Index ───
 


### PR DESCRIPTION
## Summary

A layer's `style` custom attribute is stored as a raw CSS string, but it was being applied directly to React's `style` prop, which requires an object. On render paths that spread props without overriding `style` (e.g. images, inputs, iframes), the string leaked to the DOM and crashed server-side rendering with `The style prop expects a mapping from style properties to values, not a string`.

## Changes

- Add `parseStyleStringToObject()` util that parses an inline CSS string into a React style object (splits on the first colon so values with colons like URLs survive; preserves `--custom-properties` verbatim).
- Add `applyCustomAttributes()` util that maps HTML attribute names to their JSX equivalents and, for a string `style`, parses and merges it into any existing computed style.
- Replace the four duplicated `customAttributes` loops (element + iframe) in `LayerRenderer` and `LayerRendererPublic` with the shared helper.

## Test plan

- [ ] Add a custom attribute `style` = `color: red; margin-top: 10px` to a layer — element styles correctly, no console error on canvas
- [ ] Open the page in preview/published render — no server-side `style prop` error
- [ ] `style` value with a colon, e.g. `background: url(https://x/y)` — full URL preserved
- [ ] CSS variable, e.g. `--accent: #f00` — preserved without camelCasing
- [ ] Custom attr style merges with the layer's existing computed styles