### PR TITLE
feat: allow editing custom attributes

### DIFF
--- a/app/(builder)/ycode/components/CustomAttributeRow.tsx
+++ b/app/(builder)/ycode/components/CustomAttributeRow.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import Icon from '@/components/ui/icon';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
+
+interface CustomAttributeRowProps {
+  name: string;
+  value: string;
+  onEdit: (oldName: string, newName: string, newValue: string) => void;
+  onRemove: (name: string) => void;
+}
+
+/**
+ * Renders a single custom attribute with an actions menu to edit or delete it.
+ * Editing opens an inline popover prefilled with the attribute's name and value.
+ */
+export default function CustomAttributeRow({
+  name,
+  value,
+  onEdit,
+  onRemove,
+}: CustomAttributeRowProps) {
+  const [editOpen, setEditOpen] = useState(false);
+  const [editName, setEditName] = useState('');
+  const [editValue, setEditValue] = useState('');
+
+  const handleStartEdit = () => {
+    setEditName(name);
+    setEditValue(value);
+    // Delay opening the popover until the dropdown has fully closed
+    setTimeout(() => setEditOpen(true), 150);
+  };
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEditName(e.target.value.replace(/\s+/g, '-'));
+  };
+
+  const handleSave = () => {
+    if (!editName.trim()) return;
+    onEdit(name, editName.trim(), editValue);
+    setEditOpen(false);
+  };
+
+  return (
+    <Popover
+      open={editOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          setEditOpen(false);
+          setEditName('');
+          setEditValue('');
+        }
+      }}
+    >
+      <PopoverAnchor asChild>
+        <div className="flex items-center justify-between pl-3 pr-1 h-8 bg-muted text-muted-foreground rounded-lg">
+          <span className="truncate">{name}=&quot;{value}&quot;</span>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="xs">
+                <Icon name="more" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onSelect={handleStartEdit}>
+                Edit
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => onRemove(name)}>
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        className="w-64"
+        align="end"
+        onFocusOutside={(e) => e.preventDefault()}
+      >
+        <div className="flex flex-col gap-2">
+          <div className="grid grid-cols-3">
+            <Label variant="muted">Name</Label>
+            <div className="col-span-2 *:w-full">
+              <Input
+                value={editName}
+                onChange={handleNameChange}
+                placeholder="e.g., data-id"
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleSave();
+                  }
+                }}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-3">
+            <Label>Value</Label>
+            <div className="col-span-2 *:w-full">
+              <Input
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                placeholder="e.g., 123"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleSave();
+                  }
+                }}
+              />
+            </div>
+          </div>
+
+          <Button
+            onClick={handleSave}
+            disabled={!editName.trim()}
+            size="sm"
+            variant="secondary"
+          >
+            Save attribute
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -34,6 +34,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 // 4. Internal components
 import AddAttributeModal from './AddAttributeModal';
 import BackgroundsControls from './BackgroundsControls';
+import CustomAttributeRow from './CustomAttributeRow';
 import BorderControls from './BorderControls';
 import ComponentVariablesDialog from './ComponentVariablesDialog';
 import EffectControls from './EffectControls';
@@ -1838,6 +1839,23 @@ const RightSidebar = React.memo(function RightSidebar({
     }
   };
 
+  // Handle editing custom attribute (supports renaming the attribute key)
+  const handleEditAttribute = (oldName: string, newName: string, newValue: string) => {
+    if (!selectedLayerId || !newName.trim()) return;
+    const currentSettings = selectedLayer?.settings || {};
+    const currentAttributes = { ...currentSettings.customAttributes };
+    if (oldName !== newName) {
+      delete currentAttributes[oldName];
+    }
+    currentAttributes[newName] = newValue;
+    handleLayerUpdate(selectedLayerId, {
+      settings: {
+        ...currentSettings,
+        customAttributes: currentAttributes
+      }
+    });
+  };
+
   if (!selectedLayerId || !selectedLayer) {
     return (
       <div className="w-64 shrink-0 bg-background border-l flex items-center justify-center h-screen">
@@ -2997,20 +3015,13 @@ const RightSidebar = React.memo(function RightSidebar({
               {selectedLayer?.settings?.customAttributes && (
                 <div className="flex flex-col gap-1">
                   {Object.entries(selectedLayer.settings.customAttributes).map(([name, value]) => (
-                    <div
+                    <CustomAttributeRow
                       key={name}
-                      className="flex items-center justify-between pl-3 pr-1 h-8 bg-muted text-muted-foreground rounded-lg"
-                    >
-                      <span>{name}=&quot;{value as string}&quot;</span>
-                      <span
-                        role="button"
-                        tabIndex={0}
-                        className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
-                        onClick={() => handleRemoveAttribute(name)}
-                      >
-                        <Icon name="x" className="size-2.5" />
-                      </span>
-                    </div>
+                      name={name}
+                      value={value as string}
+                      onEdit={handleEditAttribute}
+                      onRemove={handleRemoveAttribute}
+                    />
                   ))}
                 </div>
               )}


### PR DESCRIPTION
## Summary

Custom attributes on an element could only be added or deleted. This adds the ability to edit an existing custom attribute in place, so its name and value can be changed without removing and re-adding it.

## Changes

- Replace the inline delete button in the custom attributes panel with a "..." menu offering Edit and Delete
- Add `CustomAttributeRow` component with an inline edit popover prefilled with the attribute's name and value (reuses the Popover + DropdownMenu pattern from `SelectOptionsSettings`)
- Add `handleEditAttribute` in `RightSidebar` to update an attribute, including renaming its key

## Test plan

- [ ] Select an element and add a custom attribute
- [ ] Open the "..." menu and choose Edit — confirm the popover is prefilled
- [ ] Change the value and save — verify it updates in the list and on the element
- [ ] Edit and rename the attribute key — verify the old key is removed and the new one applied
- [ ] Open the "..." menu and choose Delete — verify the attribute is removed