### PR TITLE
fix: prevent publish failure on projects with many translations or CMS items

### DIFF
--- a/lib/repositories/collectionRepository.ts
+++ b/lib/repositories/collectionRepository.ts
@@ -1,5 +1,6 @@
 import { getSupabaseAdmin, getTenantIdFromHeaders } from '@/lib/supabase-server';
 import { getKnexClient } from '@/lib/knex-client';
+import { SUPABASE_IN_FILTER_CHUNK_SIZE } from '@/lib/supabase-constants';
 import type { Collection, CreateCollectionData, UpdateCollectionData } from '@/types';
 import { randomUUID } from 'crypto';
 
@@ -347,18 +348,23 @@ export async function deleteCollection(id: string, isPublished: boolean = false)
   if (items && items.length > 0) {
     const itemIds = items.map(item => item.id);
 
-    const { error: valuesError } = await client
-      .from('collection_item_values')
-      .update({
-        deleted_at: now,
-        updated_at: now,
-      })
-      .in('item_id', itemIds)
-      .eq('is_published', isPublished)
-      .is('deleted_at', null);
+    // Chunk the id list so large `.in()` filters don't overflow the request URL
+    // length limit (which returns 400 Bad Request).
+    for (let i = 0; i < itemIds.length; i += SUPABASE_IN_FILTER_CHUNK_SIZE) {
+      const idsChunk = itemIds.slice(i, i + SUPABASE_IN_FILTER_CHUNK_SIZE);
+      const { error: valuesError } = await client
+        .from('collection_item_values')
+        .update({
+          deleted_at: now,
+          updated_at: now,
+        })
+        .in('item_id', idsChunk)
+        .eq('is_published', isPublished)
+        .is('deleted_at', null);
 
-    if (valuesError) {
-      console.error('Error soft-deleting collection item values:', valuesError);
+      if (valuesError) {
+        console.error('Error soft-deleting collection item values:', valuesError);
+      }
     }
   }
 }

--- a/lib/services/collectionService.ts
+++ b/lib/services/collectionService.ts
@@ -14,7 +14,7 @@
 import { withTransaction } from '../database/transaction';
 import { getSupabaseAdmin, getTenantIdFromHeaders } from '@/lib/supabase-server';
 import { getKnexClient } from '@/lib/knex-client';
-import { SUPABASE_WRITE_BATCH_SIZE } from '@/lib/supabase-constants';
+import { SUPABASE_IN_FILTER_CHUNK_SIZE, SUPABASE_WRITE_BATCH_SIZE } from '@/lib/supabase-constants';
 import { getCollectionById, hardDeleteCollection } from '@/lib/repositories/collectionRepository';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { getItemsByCollectionId, getAllItemsByCollectionId, getItemsByIds } from '@/lib/repositories/collectionItemRepository';
@@ -538,11 +538,14 @@ async function publishSelectedItems(
       // Non-fatal: proceed with unpublish even if the slug snapshot fails
     }
 
-    await client
-      .from('collection_items')
-      .delete()
-      .in('id', nonPublishableIds)
-      .eq('is_published', true);
+    for (let i = 0; i < nonPublishableIds.length; i += SUPABASE_IN_FILTER_CHUNK_SIZE) {
+      const idsChunk = nonPublishableIds.slice(i, i + SUPABASE_IN_FILTER_CHUNK_SIZE);
+      await client
+        .from('collection_items')
+        .delete()
+        .in('id', idsChunk)
+        .eq('is_published', true);
+    }
   }
 
   if (publishableItems.length === 0) {
@@ -1182,24 +1185,30 @@ export async function groupItemsByCollection(
     return new Map();
   }
 
-  const { data: items, error } = await client
-    .from('collection_items')
-    .select('id, collection_id')
-    .eq('is_published', false)
-    .in('id', itemIds);
+  // Chunk the id list so large `.in()` filters don't overflow the request URL
+  // length limit (which returns 400 Bad Request).
+  const items: Array<{ id: string; collection_id: string }> = [];
+  for (let i = 0; i < itemIds.length; i += SUPABASE_IN_FILTER_CHUNK_SIZE) {
+    const idsChunk = itemIds.slice(i, i + SUPABASE_IN_FILTER_CHUNK_SIZE);
+    const { data, error } = await client
+      .from('collection_items')
+      .select('id, collection_id')
+      .eq('is_published', false)
+      .in('id', idsChunk);
 
-  if (error) {
-    throw new Error(`Failed to fetch collection items: ${error.message}`);
-  }
+    if (error) {
+      throw new Error(`Failed to fetch collection items: ${error.message}`);
+    }
 
-  if (!items) {
-    return new Map();
+    if (data) {
+      items.push(...data);
+    }
   }
 
   // Group items by collection
   const itemsByCollection = new Map<string, string[]>();
 
-  items.forEach((item: any) => {
+  items.forEach((item) => {
     const existing = itemsByCollection.get(item.collection_id) || [];
     existing.push(item.id);
     itemsByCollection.set(item.collection_id, existing);

--- a/lib/services/localisationService.ts
+++ b/lib/services/localisationService.ts
@@ -8,7 +8,7 @@
  */
 
 import { getSupabaseAdmin } from '@/lib/supabase-server';
-import { SUPABASE_WRITE_BATCH_SIZE } from '@/lib/supabase-constants';
+import { SUPABASE_IN_FILTER_CHUNK_SIZE, SUPABASE_WRITE_BATCH_SIZE } from '@/lib/supabase-constants';
 import { getAllTranslationRows } from '@/lib/repositories/translationRepository';
 import type { Locale, Translation, TranslationSourceType } from '@/types';
 
@@ -344,18 +344,24 @@ export async function publishLocalisation(): Promise<PublishLocalisationResult> 
     const activeDraftTranslations = allDraftTranslations.filter((t: Translation) => t.deleted_at === null);
     const softDeletedDraftTranslations = allDraftTranslations.filter((t: Translation) => t.deleted_at !== null);
 
-    // Step 5: Soft-delete published versions of soft-deleted draft translations (single query)
+    // Step 5: Soft-delete published versions of soft-deleted draft translations.
+    // Chunk the id list so large `.in()` filters don't overflow the request URL
+    // length limit (which returns 400 Bad Request).
     if (softDeletedDraftTranslations.length > 0) {
       const translationIds = softDeletedDraftTranslations.map((translation: Translation) => translation.id);
-      const { error: deleteTranslationsError } = await client
-        .from('translations')
-        .update({ deleted_at: deletedAt })
-        .in('id', translationIds)
-        .eq('is_published', true)
-        .is('deleted_at', null);
 
-      if (deleteTranslationsError) {
-        throw new Error(`Failed to soft-delete translations: ${deleteTranslationsError.message}`);
+      for (let i = 0; i < translationIds.length; i += SUPABASE_IN_FILTER_CHUNK_SIZE) {
+        const idsChunk = translationIds.slice(i, i + SUPABASE_IN_FILTER_CHUNK_SIZE);
+        const { error: deleteTranslationsError } = await client
+          .from('translations')
+          .update({ deleted_at: deletedAt })
+          .in('id', idsChunk)
+          .eq('is_published', true)
+          .is('deleted_at', null);
+
+        if (deleteTranslationsError) {
+          throw new Error(`Failed to soft-delete translations: ${deleteTranslationsError.message}`);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Publishing on projects with a large number of translations or collection items failed with a "Bad Request" error. The cause was passing large id lists into a single PostgREST `.in()` filter, which overflows the request URL length limit and returns 400. This chunks those filters so publishing scales with content volume.

## Changes

- Chunk the translations soft-delete in localisation publishing (the original failure)
- Chunk the collection-item delete and the `groupItemsByCollection` lookup during collection publishing
- Chunk the item-values soft-delete when a collection is deleted
- Reuse the existing `SUPABASE_IN_FILTER_CHUNK_SIZE` constant for all of the above

## Test plan

- [ ] Publish a project with thousands of translations — completes without "Bad Request"
- [ ] Unpublish (set to draft) many collection items, then publish — live versions are removed
- [ ] Publish a collection with thousands of items via item-level publish
- [ ] Delete a collection with many items — items and values are soft-deleted
- [ ] Confirm small projects still publish unchanged