### PR TITLE
fix: keep nested component links when resolving overrides

### DIFF
--- a/lib/resolve-components.ts
+++ b/lib/resolve-components.ts
@@ -430,27 +430,34 @@ export function applyComponentOverrides(
     // Check if this layer has a link variable linked
     const linkedLinkVariableId = (layer.variables?.link as any)?.variable_id;
     if (linkedLinkVariableId) {
-      // Check for override first, then fall back to variable's default value.
-      // Use `!== undefined` (not `??`) so an explicit `null` override (user cleared
-      // the link via "No link") is respected instead of reverting to the default.
       const overrideValue = overrides?.link?.[linkedLinkVariableId];
       const variableDef = componentVariables?.find(v => v.id === linkedLinkVariableId);
-      const linkValue = (overrideValue !== undefined ? overrideValue : variableDef?.default_value) as any;
 
-      if (linkValue) {
-        // Apply the value to this layer's link variable, keeping the variable_id for reference
-        updatedLayer = {
-          ...updatedLayer,
-          variables: {
-            ...updatedLayer.variables,
-            link: { ...linkValue, variable_id: linkedLinkVariableId },
-          },
-        };
-      } else {
-        // Explicit "No link" — strip any inherited link settings from the layer
-        // so the rendered element has no href / link wrapper.
-        const { link: _ignored, ...restVariables } = updatedLayer.variables ?? {};
-        updatedLayer = { ...updatedLayer, variables: restVariables };
+      // Only resolve when the link variable belongs to THIS component's scope
+      // (an override exists here or a matching variable is defined). A link that
+      // was already resolved for a nested component instance keeps its
+      // `variable_id` for reference — skipping out-of-scope ids stops an outer
+      // component pass from stripping a valid nested link it doesn't own.
+      if (overrideValue !== undefined || variableDef) {
+        // Use `!== undefined` (not `??`) so an explicit `null` override (user cleared
+        // the link via "No link") is respected instead of reverting to the default.
+        const linkValue = (overrideValue !== undefined ? overrideValue : variableDef?.default_value) as any;
+
+        if (linkValue) {
+          // Apply the value to this layer's link variable, keeping the variable_id for reference
+          updatedLayer = {
+            ...updatedLayer,
+            variables: {
+              ...updatedLayer.variables,
+              link: { ...linkValue, variable_id: linkedLinkVariableId },
+            },
+          };
+        } else {
+          // Explicit "No link" — strip any inherited link settings from the layer
+          // so the rendered element has no href / link wrapper.
+          const { link: _ignored, ...restVariables } = updatedLayer.variables ?? {};
+          updatedLayer = { ...updatedLayer, variables: restVariables };
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

A nested component instance could lose its resolved link (e.g. the login/signup links in the Navigation component rendered without an `href`) because an outer component override pass re-ran link resolution for link variables it didn't own and stripped them.

## Changes

- Scope link override resolution in `applyComponentOverrides` to the owning component: only resolve when an override exists for the variable in the current pass or a matching component variable is defined
- Leave out-of-scope link variable ids untouched so an already-resolved nested link keeps its value

## Test plan

- [ ] Render a page with a component that exposes a link variable and verify the link still resolves (correct `href`)
- [ ] Render a component nested inside another component with link overrides and confirm the inner link is preserved
- [ ] Clear a link via "No link" and confirm the rendered element has no `href`