### PR TITLE
fix: support link fields as image and video sources

### DIFF
--- a/lib/collection-field-utils.ts
+++ b/lib/collection-field-utils.ts
@@ -826,8 +826,8 @@ export const ASSET_FIELD_TYPES: CollectionFieldType[] = ['image', 'audio', 'vide
 /** Field types that can be bound to color design properties */
 export const COLOR_FIELD_TYPES: CollectionFieldType[] = ['color'];
 
-/** Field types that can be bound to image layers (image fields) */
-export const IMAGE_FIELD_TYPES: CollectionFieldType[] = ['image'];
+/** Field types that can be bound to image layers (image fields, or link/url fields holding an image URL) */
+export const IMAGE_FIELD_TYPES: CollectionFieldType[] = ['image', 'link'];
 
 /** Field types that can be bound to audio layers (audio fields) */
 export const AUDIO_FIELD_TYPES: CollectionFieldType[] = ['audio'];

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -72,6 +72,22 @@ function createResolvedAssetVariable(
   fallback: FieldVariable
 ): FieldVariable | AssetVariable | DynamicTextVariable {
   if (!resolvedValue) return fallback;
+
+  // A link/url field bound as a media source stores a serialized
+  // CollectionLinkValue. Unwrap it to the underlying URL (literal src) or
+  // asset id before building the variable; otherwise the JSON blob would be
+  // treated as an asset id and fail to resolve.
+  const linkValue = parseCollectionLinkValue(resolvedValue);
+  if (linkValue) {
+    if (linkValue.type === 'url') {
+      return linkValue.url ? createDynamicTextVariable(linkValue.url) : fallback;
+    }
+    if (linkValue.type === 'asset') {
+      return linkValue.asset?.id ? createAssetVariable(linkValue.asset.id) : fallback;
+    }
+    return fallback;
+  }
+
   return isVirtualAssetField(fieldId)
     ? createDynamicTextVariable(resolvedValue)
     : createAssetVariable(resolvedValue);

--- a/lib/variable-utils.ts
+++ b/lib/variable-utils.ts
@@ -13,6 +13,7 @@ import { resolveInlineVariablesFromData } from '@/lib/inline-variables';
 import { buildFieldVariablePath, resolveFieldFromSources } from '@/lib/cms-variables-utils';
 import { DEFAULT_ASSETS } from '@/lib/asset-constants';
 import { buildSvgDataUrl } from '@/lib/asset-utils';
+import { parseCollectionLinkValue } from '@/lib/link-utils';
 import { stringToTiptapContent } from '@/lib/text-format-utils';
 
 /** Canonical empty componentOverrides structure — use when setting/resetting overrides */
@@ -270,6 +271,19 @@ export function getVariableStringValue(
 }
 
 /**
+ * Unwrap a resolved field value to a media URL/asset id. Link/url fields store a
+ * serialized CollectionLinkValue; when bound as an image/video source we need the
+ * underlying URL (or asset id) rather than the JSON blob. Non-link values pass through.
+ */
+function unwrapLinkFieldUrl(resolvedValue: string): string {
+  const linkValue = parseCollectionLinkValue(resolvedValue);
+  if (!linkValue) return resolvedValue;
+  if (linkValue.type === 'url') return linkValue.url || '';
+  if (linkValue.type === 'asset') return linkValue.asset?.id || '';
+  return '';
+}
+
+/**
  * Get image URL from image src variable
  * - AssetVariable -> gets asset URL from store
  * - FieldVariable -> resolves field value using source-aware resolution (page or collection)
@@ -326,11 +340,19 @@ export function getImageUrlFromVariable(
       collectionItemData,
       pageCollectionItemData
     );
-    if (!resolvedValue) return undefined;
+    // Empty/null CMS value - fall back to the default placeholder image.
+    if (!resolvedValue) return useDefault ? DEFAULT_ASSETS.IMAGE : undefined;
+
+    // A link/url field bound as an image source stores a serialized
+    // CollectionLinkValue, not a bare URL — unwrap it to the underlying URL.
+    const unwrapped = unwrapLinkFieldUrl(resolvedValue);
+
+    // Link field with no usable URL/asset - fall back to the default image.
+    if (!unwrapped) return useDefault ? DEFAULT_ASSETS.IMAGE : undefined;
 
     // The field value may be an asset ID - look up the asset to get the URL
     if (getAsset) {
-      const asset = getAsset(resolvedValue);
+      const asset = getAsset(unwrapped);
       if (asset?.public_url) {
         return asset.public_url;
       }
@@ -341,7 +363,7 @@ export function getImageUrlFromVariable(
 
     // If getAsset is not available or asset not found, return the raw value
     // (might be a URL in text fields)
-    return resolvedValue;
+    return unwrapped;
   }
 
   if (isDynamicTextVariable(src)) {
@@ -409,11 +431,19 @@ export function getVideoUrlFromVariable(
       collectionItemData,
       pageCollectionItemData
     );
-    if (!resolvedValue) return undefined;
+    // Empty/null CMS value - fall back to the default placeholder if enabled.
+    if (!resolvedValue) return useDefault ? DEFAULT_ASSETS.VIDEO : undefined;
+
+    // A link/url field bound as a video source stores a serialized
+    // CollectionLinkValue — unwrap it to the underlying URL/asset id.
+    const unwrapped = unwrapLinkFieldUrl(resolvedValue);
+
+    // Link field with no usable URL/asset - fall back to the default if enabled.
+    if (!unwrapped) return useDefault ? DEFAULT_ASSETS.VIDEO : undefined;
 
     // The field value may be an asset ID - look up the asset to get the URL
     if (getAsset) {
-      const asset = getAsset(resolvedValue);
+      const asset = getAsset(unwrapped);
       if (asset?.public_url) {
         return asset.public_url;
       }
@@ -421,7 +451,7 @@ export function getVideoUrlFromVariable(
 
     // If getAsset is not available or asset not found, return the raw value
     // (might be a URL in text fields)
-    return resolvedValue;
+    return unwrapped;
   }
 
   if (isDynamicTextVariable(src)) {


### PR DESCRIPTION
## Summary

CMS link/URL fields could not be used as image or video sources in the builder, and a field-bound media element with an empty CMS value rendered as broken. This lets link/URL fields hold a media URL and falls back to the default placeholder when the value is empty.

## Changes

- Add `link` to `IMAGE_FIELD_TYPES` so the field selector offers link/URL fields for image, background, lightbox and page-settings bindings
- Unwrap serialized `CollectionLinkValue` values to the underlying URL or asset id when resolving image and video sources
- Show the default image/video placeholder when the resolved CMS value is empty or has no usable URL/asset

## Test plan

- [ ] Bind an image layer's source to a CMS link/URL field and confirm it appears as an option in the field selector
- [ ] Verify the image renders correctly in the builder canvas and in the preview/published page
- [ ] Set the CMS link field to empty/null and confirm the default placeholder image is shown (not a broken image)
- [ ] Repeat for a background image bound to a link field
- [ ] Verify a regular image field binding still works unchanged