### PR TITLE
fix: sync all Airtable items past the 1000-row cap

### DIFF
--- a/lib/apps/airtable/sync-service.ts
+++ b/lib/apps/airtable/sync-service.ts
@@ -20,7 +20,7 @@ import { uploadFile } from '@/lib/file-upload';
 import { getFieldsByCollectionId, getFieldsByKeyAcrossCollections, createField } from '@/lib/repositories/collectionFieldRepository';
 import {
   createItemsBulk,
-  getItemsByCollectionId,
+  getAllItemsByCollectionId,
 } from '@/lib/repositories/collectionItemRepository';
 import {
   insertValuesBulk,
@@ -773,8 +773,12 @@ async function prepareSyncState(connection: AirtableConnection): Promise<SyncSta
   const { collectionId, recordIdFieldId } = connection;
   const result: SyncResult = { created: 0, updated: 0, deleted: 0, errors: [], syncedAt: new Date().toISOString() };
 
-  const [{ items: existingItems }, fields] = await Promise.all([
-    getItemsByCollectionId(collectionId),
+  // Use getAllItemsByCollectionId (paginates past PostgREST's 1000-row cap) so
+  // reconciliation sees every item. A truncated list makes items beyond the cap
+  // look "missing", so they're never matched (and the dedup guard then blocks
+  // re-creating them), leaving their values permanently stale.
+  const [existingItems, fields] = await Promise.all([
+    getAllItemsByCollectionId(collectionId),
     getFieldsByCollectionId(collectionId),
   ]);
 


### PR DESCRIPTION
## Summary

Airtable syncs silently skipped data in collections with more than 1000 items. New values added in Airtable (e.g. link fields) never appeared in the CMS, and a re-sync didn't help.

## Changes

- Load existing items in `prepareSyncState` via `getAllItemsByCollectionId` (which paginates past PostgREST's default 1000-row cap) instead of `getItemsByCollectionId`, which inherited the cap.

## Root cause

`getItemsByCollectionId(collectionId)` returns at most 1000 rows by default. For collections over that size, the overflow items were absent from `existingItems`, so reconciliation couldn't match them to their Airtable records. They were then classified as new, and the dedup guard (`getExistingAirtableRecordIds`) filtered them out of creation — so they were neither updated nor created, leaving their values permanently stale.

## Test plan

- [ ] Connect an Airtable table with >1000 rows
- [ ] Add/change a value on a record beyond the first 1000 (e.g. a URL/link field)
- [ ] Run a sync and confirm the value appears in the CMS
- [ ] Confirm records within the first 1000 still sync correctly
- [ ] Confirm full sync still soft-deletes records removed in Airtable