### PR TITLE
fix: allow folder navigation in asset picker with selected icon

### DIFF
--- a/app/(builder)/ycode/components/FileManagerDialog.tsx
+++ b/app/(builder)/ycode/components/FileManagerDialog.tsx
@@ -1029,11 +1029,22 @@ export default function FileManagerDialog({
     setSelectedAssetIds(new Set());
   }, [selectedFolderId]);
 
+  // Navigate to the asset's folder only once per open session, so manual
+  // folder navigation isn't reset when the asset cache (assetsById) updates
+  const hasNavigatedToAssetRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) {
+      hasNavigatedToAssetRef.current = false;
+    }
+  }, [open]);
+
   // When dialog opens with an assetId, navigate to that asset's folder
   useEffect(() => {
-    if (open && assetId) {
+    if (open && assetId && !hasNavigatedToAssetRef.current) {
       const asset = assetsById[assetId] || getAsset(assetId);
       if (asset) {
+        hasNavigatedToAssetRef.current = true;
         const assetFolderId = asset.asset_folder_id || null;
 
         // Set the folder as selected


### PR DESCRIPTION
## Summary

When a layer (or component icon override) already has an asset selected, opening the file manager to change it made it impossible to browse to a different folder — the picker instantly snapped back to the asset's current folder on every click.

## Changes

- Navigate to the selected asset's folder only once per open session instead of on every asset-cache update
- Reset the one-time navigation flag when the dialog closes, so reopening still jumps to the current asset's folder

## Test plan

- [ ] Select a layer/component with an icon (or image) override that points to an asset inside a folder
- [ ] Click "Change file" to open the file manager — it should open on the asset's folder
- [ ] Navigate to a different folder — it should stay there and not snap back
- [ ] Close and reopen the picker — it should jump back to the current asset's folder