### PR TITLE
fix: save component text edits on the first attempt

### DIFF
--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -1484,7 +1484,11 @@ const CenterCanvas = React.memo(function CenterCanvas({
     // of mutating the layer tree.
     if (selectedLocale && !selectedLocale.is_default) return;
 
-    if (editingComponentId && activeComponentVariantId) {
+    if (editingComponentId) {
+      // While editing a component, never fall through to the page draft — doing
+      // so would write the component's inner-layer edit onto the page (or drop
+      // it). If the variant can't be resolved yet, skip rather than corrupt.
+      if (!activeComponentVariantId) return;
       const { componentDrafts, updateComponentDraft } = useComponentsStore.getState();
       const currentDraft = componentDrafts[editingComponentId]?.[activeComponentVariantId] || [];
       updateComponentDraft(editingComponentId, activeComponentVariantId, updateLayerProps(currentDraft, layerId, updates));

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -64,6 +64,7 @@ import { useClipboardStore } from '@/stores/useClipboardStore';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { usePagesStore, consumePageMcpSync } from '@/stores/usePagesStore';
 import { useComponentsStore } from '@/stores/useComponentsStore';
+import { useCanvasTextEditorStore } from '@/stores/useCanvasTextEditorStore';
 import { useLayerStylesStore } from '@/stores/useLayerStylesStore';
 import { useCollaborationPresenceStore, getResourceLockKey, RESOURCE_TYPES } from '@/stores/useCollaborationPresenceStore';
 import { useSettingsStore } from '@/stores/useSettingsStore';
@@ -1329,7 +1330,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
   // Exit component edit mode handler
   const handleExitComponentEditMode = useCallback(async () => {
     const { editingComponentId, returnToPageId, setEditingComponentId, returnToLayerId, getReturnDestination, setSelectedLayerId: setLayerIdFromStore } = useEditorStore.getState();
-    const { saveComponentDraft, clearComponentDraft, getComponentById, saveTimeouts, loadComponentDraft } = useComponentsStore.getState();
+    const { saveComponentDraft, clearComponentDraft, getComponentById, loadComponentDraft } = useComponentsStore.getState();
     const { updateComponentOnLayers } = usePagesStore.getState();
 
     if (!editingComponentId || isExitingComponentModeRef.current) return;
@@ -1338,9 +1339,23 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
     isExitingComponentModeRef.current = true;
 
     try {
-      // Clear any pending auto-save timeout to avoid duplicate saves
-      if (saveTimeouts[editingComponentId]) {
-        clearTimeout(saveTimeouts[editingComponentId]);
+      // Inline text editing commits its content lazily (on blur/unmount), so a
+      // pending edit hasn't reached the component draft yet. Finish it now —
+      // while edit mode is still active — so the latest content is written into
+      // the draft (and marks it dirty) before we save below. Without this the
+      // first exit persists stale content and the edit only "sticks" on a
+      // subsequent attempt once the editor has already flushed.
+      const { isEditing, requestFinish } = useCanvasTextEditorStore.getState();
+      if (isEditing) {
+        requestFinish();
+      }
+
+      // Clear any pending auto-save timeout to avoid duplicate saves. Read it
+      // fresh because finishing inline editing above may have scheduled a new
+      // one via updateComponentDraft.
+      const pendingSaveTimeout = useComponentsStore.getState().saveTimeouts[editingComponentId];
+      if (pendingSaveTimeout) {
+        clearTimeout(pendingSaveTimeout);
       }
 
       // Capture whether this draft has any unpersisted edits before saving,


### PR DESCRIPTION
## Summary

Editing a component (e.g. changing inline text) and going back did not save the change on the first attempt — it only "stuck" after repeating the edit a second time. Inline text editing commits its content lazily (on blur/unmount), so when exiting the component the pending edit had not yet reached the component draft. The exit handler saved and cleared the draft first, persisting stale content and dropping the change.

## Changes

- Finish any active inline text editing in `handleExitComponentEditMode` before saving, so the latest content is committed into the component draft (and marks it dirty) while edit mode is still active
- Re-read the pending auto-save timeout fresh on exit, since finishing the edit can schedule a new one
- Harden `handleCanvasLayerUpdate` so a component edit is never routed to the page draft when the active variant can't be resolved (skip instead of corrupting the page)

## Test plan

- [ ] Enter a component, edit a text layer, click "Return to page" immediately, then re-open the component — the change is present on the first attempt
- [ ] Edit text inside a nested component and exit — change persists
- [ ] Change a design property (color/spacing/typography) in a component and exit — still saves correctly
- [ ] Confirm the component instances on the page reflect the edit after exiting

Made with [Cursor](https://cursor.com)