### PR TITLE
fix: detach component using the active variant layers

### DIFF
--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -34,7 +34,7 @@ import MigrationChecker from '@/components/MigrationChecker';
 import BuilderLoading from '@/components/BuilderLoading';
 import { Toaster } from '@/components/ui/sonner';
 import { toast } from 'sonner';
-import { checkCircularReference } from '@/lib/component-utils';
+import { checkCircularReference, detachSpecificLayerFromComponent } from '@/lib/component-utils';
 
 // Right sidebar is always visible in editor mode - load eagerly to avoid delay
 import RightSidebar from '../components/RightSidebar';
@@ -2018,47 +2018,15 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
             if (layer?.componentId) {
               const { getComponentById } = useComponentsStore.getState();
               const component = getComponentById(layer.componentId);
-
-              if (!component || !component.layers || component.layers.length === 0) {
-                // If component not found or has no layers, just remove the componentId
-                updateLayer(currentPageId, selectedLayerId, {
-                  componentId: undefined,
-                  componentOverrides: undefined,
-                });
-              } else {
-                // Replace layer with component's layers (detach)
-                const detachDraft = usePagesStore.getState().draftsByPageId[currentPageId];
-                if (detachDraft) {
-                  const replaceLayerWithComponentLayers = (layers: Layer[]): Layer[] => {
-                    return layers.flatMap(currentLayer => {
-                      if (currentLayer.id === selectedLayerId) {
-                        // Deep clone and regenerate IDs
-                        const clonedLayers = JSON.parse(JSON.stringify(component.layers));
-                        return clonedLayers.map((l: Layer) => ({
-                          ...l,
-                          id: crypto.randomUUID(),
-                          children: l.children ? regenerateChildIds(l.children) : undefined,
-                        }));
-                      }
-                      if (currentLayer.children) {
-                        return { ...currentLayer, children: replaceLayerWithComponentLayers(currentLayer.children) };
-                      }
-                      return currentLayer;
-                    });
-                  };
-
-                  const regenerateChildIds = (children: Layer[]): Layer[] => {
-                    return children.map(child => ({
-                      ...child,
-                      id: crypto.randomUUID(),
-                      children: child.children ? regenerateChildIds(child.children) : undefined,
-                    }));
-                  };
-
-                  const newLayers = replaceLayerWithComponentLayers(detachDraft.layers);
-                  setDraftLayers(currentPageId, newLayers);
-                  setSelectedLayerId(null);
-                }
+              const detachDraft = usePagesStore.getState().draftsByPageId[currentPageId];
+              if (detachDraft) {
+                const newLayers = detachSpecificLayerFromComponent(
+                  detachDraft.layers,
+                  selectedLayerId,
+                  component || undefined
+                );
+                setDraftLayers(currentPageId, newLayers);
+                setSelectedLayerId(null);
               }
             }
           }

--- a/lib/component-utils.ts
+++ b/lib/component-utils.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Layer, Component } from '@/types';
+import { getComponentVariantLayers } from './component-variant-utils';
 import { regenerateIdsWithInteractionRemapping } from './layer-utils';
 
 /**
@@ -379,14 +380,20 @@ export function detachSpecificLayerFromComponent(
  * @returns Array of layers (component children with new IDs, or stripped layer)
  */
 function replaceLayerWithComponentChildren(layer: Layer, component?: Component): Layer[] {
+  // Use the layers of the variant the instance is actually using, falling back
+  // to the primary variant (or legacy `component.layers`) when none is set.
+  const variantLayers = component
+    ? getComponentVariantLayers(component, layer.componentVariantId)
+    : [];
+
   // If we don't have the component data, just strip the componentId
-  if (!component || !component.layers || component.layers.length === 0) {
-    const { componentId: _, componentOverrides: __, ...rest } = layer;
+  if (!component || variantLayers.length === 0) {
+    const { componentId: _, componentVariantId: __, componentOverrides: ___, ...rest } = layer;
     return [rest as Layer];
   }
 
-  // Clone the component's layers with new IDs and return them
-  const cloned = JSON.parse(JSON.stringify(component.layers)) as Layer[];
+  // Clone the variant's layers with new IDs and return them
+  const cloned = JSON.parse(JSON.stringify(variantLayers)) as Layer[];
   return cloned.map(regenerateIdsWithInteractionRemapping);
 }
 


### PR DESCRIPTION
## Summary

Detaching a component instance inlined the wrong layers: it always cloned the component's primary (default) variant instead of the variant the instance was actually displaying. After detach, the layers no longer matched what the user saw on the canvas.

## Changes

- Resolve detach layers from the instance's `componentVariantId` via `getComponentVariantLayers`, falling back to the primary/legacy variant when none is set
- Fix applies to all detach entry points (context menu, instance sidebar, and component deletion) since they share the same helper
- Replace the duplicate inline detach logic behind the ⌥⌘B shortcut with the shared, variant-aware util (also gains proper interaction-reference remapping)

## Test plan

- [ ] Create a component with multiple variants that differ in layers
- [ ] Place an instance and switch it to a non-default variant
- [ ] Detach via context menu — inlined layers match the selected variant
- [ ] Detach via the instance sidebar — same result
- [ ] Detach via ⌥⌘B — same result
- [ ] Delete a component used by a non-default-variant instance — inlined layers match that variant