### PR TITLE
fix: publish images when publishing CMS items

### DIFF
--- a/app/(builder)/ycode/api/collections/[id]/publish/route.ts
+++ b/app/(builder)/ycode/api/collections/[id]/publish/route.ts
@@ -22,6 +22,7 @@ export const revalidate = 0;
  *       fieldsCount: number;
  *       itemsCount: number;
  *       valuesCount: number;
+ *       assetsCount: number;
  *     };
  *     errors?: string[];
  *   }

--- a/lib/collection-asset-utils.ts
+++ b/lib/collection-asset-utils.ts
@@ -1,0 +1,47 @@
+import { isValidUUID } from '@/lib/utils';
+
+/**
+ * Walk arbitrary JSON (e.g. Tiptap rich-text or link field values) and collect
+ * embedded asset IDs. Asset-bearing nodes expose their id as `attrs.assetId`.
+ */
+function collectEmbeddedAssetIds(rawValue: string, out: Set<string>): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawValue);
+  } catch {
+    return;
+  }
+
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    const assetId = (node as { attrs?: { assetId?: unknown } }).attrs?.assetId;
+    if (typeof assetId === 'string' && isValidUUID(assetId)) out.add(assetId);
+    const content = (node as { content?: unknown }).content;
+    if (Array.isArray(content)) content.forEach(walk);
+  };
+
+  walk(parsed);
+}
+
+/**
+ * Collect candidate asset IDs referenced by collection item values, so they can
+ * be published alongside the items. Covers direct asset fields (image/file/video/
+ * audio — stored as a bare UUID) and assets embedded in rich-text/link content.
+ *
+ * Non-asset UUIDs (e.g. reference fields) are harmless: the caller passes these
+ * to `publishAssets`, which only acts on IDs matching an unpublished draft asset.
+ */
+export function collectItemValueAssetIds(values: Array<{ value: string | null }>): string[] {
+  const assetIds = new Set<string>();
+
+  for (const { value } of values) {
+    if (!value) continue;
+    if (isValidUUID(value)) {
+      assetIds.add(value);
+    } else {
+      collectEmbeddedAssetIds(value, assetIds);
+    }
+  }
+
+  return Array.from(assetIds);
+}

--- a/lib/repositories/collectionItemValueRepository.ts
+++ b/lib/repositories/collectionItemValueRepository.ts
@@ -795,6 +795,21 @@ export async function publishValues(item_id: string): Promise<number> {
   const hash = generateCollectionItemContentHash(draftValues.map(v => ({ field_id: v.field_id, value: v.value })));
   await updateContentHash(item_id, true, hash);
 
+  // Publish assets referenced by this item (e.g. CMS thumbnails or rich-text
+  // images) so they get a published row in the same operation. Without this, a
+  // single-item publish (Set as published / staged item) leaves images as drafts
+  // and the live page renders the default placeholder until a later full publish.
+  try {
+    const { collectItemValueAssetIds } = await import('@/lib/collection-asset-utils');
+    const { publishAssets } = await import('@/lib/repositories/assetRepository');
+    const assetIds = collectItemValueAssetIds(draftValues);
+    if (assetIds.length > 0) {
+      await publishAssets(assetIds);
+    }
+  } catch {
+    // Non-fatal: asset publishing failure should not roll back value publishing
+  }
+
   return draftValues.length;
 }
 

--- a/lib/services/collectionService.ts
+++ b/lib/services/collectionService.ts
@@ -19,6 +19,8 @@ import { getCollectionById, hardDeleteCollection } from '@/lib/repositories/coll
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { getItemsByCollectionId, getAllItemsByCollectionId, getItemsByIds } from '@/lib/repositories/collectionItemRepository';
 import { getValueRowsForItems, type PublishValueRow } from '@/lib/repositories/collectionItemValueRepository';
+import { publishAssets } from '@/lib/repositories/assetRepository';
+import { collectItemValueAssetIds } from '@/lib/collection-asset-utils';
 import type { Collection, CollectionField, CollectionItem } from '@/types';
 
 /**
@@ -73,6 +75,7 @@ export interface PublishCollectionResult {
     fieldsCount: number;
     itemsCount: number;
     valuesCount: number;
+    assetsCount: number;
     deletedItemsCount: number;
     deletedItemSlugs: string[];
     renamedItemOldSlugs: string[];
@@ -135,6 +138,7 @@ export async function publishCollectionWithItems(
       fieldsCount: 0,
       itemsCount: 0,
       valuesCount: 0,
+      assetsCount: 0,
       deletedItemsCount: 0,
       deletedItemSlugs: [],
       renamedItemOldSlugs: [],
@@ -196,13 +200,14 @@ export async function publishCollectionWithItems(
 
       // Step 3: Publish selected items
       const itemsStart = performance.now();
-      const { itemsCount, valuesCount, itemsDurationMs, valuesDurationMs, renamedItemOldSlugs, unpublishedItemSlugs } = await publishSelectedItems(
+      const { itemsCount, valuesCount, assetsCount, itemsDurationMs, valuesDurationMs, renamedItemOldSlugs, unpublishedItemSlugs } = await publishSelectedItems(
         collectionId,
         itemIds,
         prefetched,
       );
       result.published.itemsCount = itemsCount;
       result.published.valuesCount = valuesCount;
+      result.published.assetsCount = assetsCount;
       result.published.renamedItemOldSlugs = renamedItemOldSlugs;
       result.published.unpublishedItemSlugs = unpublishedItemSlugs;
       result.timing!.items = {
@@ -457,13 +462,13 @@ async function publishAllFields(
  *
  * @param collectionId - Collection UUID
  * @param itemIds - Optional array of item IDs to publish. If omitted, publishes all items that need publishing
- * @returns Counts and timing of published items and values
+ * @returns Counts and timing of published items, values, and referenced assets
  */
 async function publishSelectedItems(
   collectionId: string,
   itemIds?: string[],
   prefetched?: CollectionPrefetch,
-): Promise<{ itemsCount: number; valuesCount: number; itemsDurationMs: number; valuesDurationMs: number; renamedItemOldSlugs: string[]; unpublishedItemSlugs: string[] }> {
+): Promise<{ itemsCount: number; valuesCount: number; assetsCount: number; itemsDurationMs: number; valuesDurationMs: number; renamedItemOldSlugs: string[]; unpublishedItemSlugs: string[] }> {
   const client = await getSupabaseAdmin();
 
   if (!client) {
@@ -481,7 +486,7 @@ async function publishSelectedItems(
   }
 
   if (itemsToPublish.length === 0) {
-    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [], unpublishedItemSlugs: [] };
+    return { itemsCount: 0, valuesCount: 0, assetsCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [], unpublishedItemSlugs: [] };
   }
 
   // Batch fetch all draft items to publish. When the caller bulk-prefetched the
@@ -494,7 +499,7 @@ async function publishSelectedItems(
     : await getItemsByIds(itemsToPublish, false);
 
   if (draftItems.length === 0) {
-    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [], unpublishedItemSlugs: [] };
+    return { itemsCount: 0, valuesCount: 0, assetsCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [], unpublishedItemSlugs: [] };
   }
 
   // Separate publishable from non-publishable items
@@ -549,7 +554,7 @@ async function publishSelectedItems(
   }
 
   if (publishableItems.length === 0) {
-    return { itemsCount: 0, valuesCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [], unpublishedItemSlugs };
+    return { itemsCount: 0, valuesCount: 0, assetsCount: 0, itemsDurationMs: 0, valuesDurationMs: 0, renamedItemOldSlugs: [], unpublishedItemSlugs };
   }
 
   // Fetch existing published items for comparison (use bulk-prefetched set when available)
@@ -664,7 +669,23 @@ async function publishSelectedItems(
   const valuesCount = await publishItemValuesBatch(itemIdsToPublishValues, draftValues, publishedValues);
   const valuesDurationMs = Math.round(performance.now() - valuesStart);
 
-  return { itemsCount: itemsToUpsert.length, valuesCount, itemsDurationMs, valuesDurationMs, renamedItemOldSlugs, unpublishedItemSlugs };
+  // Publish assets referenced by the published items so newly uploaded images
+  // (e.g. CMS thumbnails or rich-text images) get a published row in the same
+  // operation. Without this, a single collection/item publish leaves the assets
+  // as drafts and the live page renders the default placeholder until a later
+  // full publish eventually publishes them.
+  let assetsCount = 0;
+  try {
+    const assetIds = collectItemValueAssetIds(draftValues);
+    if (assetIds.length > 0) {
+      const assetsResult = await publishAssets(assetIds);
+      assetsCount = assetsResult.count;
+    }
+  } catch {
+    // Non-fatal: asset publishing failure should not roll back item publishing
+  }
+
+  return { itemsCount: itemsToUpsert.length, valuesCount, assetsCount, itemsDurationMs, valuesDurationMs, renamedItemOldSlugs, unpublishedItemSlugs };
 }
 
 /**


### PR DESCRIPTION
## Summary

Newly added CMS items (e.g. articles) showed a broken/placeholder image on the live site until a later full publish. Publishing an item copied its field values but not the assets those values referenced, so the image stayed a draft and the page rendered the default SVG placeholder.

## Changes

- Add shared util `collectItemValueAssetIds` that gathers asset IDs referenced by item values — direct asset fields (image/video/audio/file, stored as a bare UUID) and assets embedded in rich-text content.
- Publish referenced assets inside `publishValues`, covering both the single-item "Set as published" flow and the bulk item publish route.
- Publish referenced assets in the collection-level publish path (`publishSelectedItems`).
- Non-asset UUIDs (e.g. reference fields) are harmless: `publishAssets` only acts on IDs matching an unpublished draft asset.

All three publish paths (full-site, collection, single/bulk item) now publish assets atomically with the items.

## Test plan

- [x] Seed a draft-only image asset referenced by an unpublished item, run the real publish path, verify the asset gets a published row (and the item renders its image instead of the placeholder)
- [ ] Add a new CMS item with an image and use "Set as published" — image appears immediately on the live page
- [ ] Publish a collection with new items containing images — images render
- [ ] Publish an item whose rich-text contains an embedded image — embedded image renders