### PR TITLE
feat: allow loop effect for page load animations

### DIFF
--- a/app/(builder)/ycode/components/InteractionsPanel.tsx
+++ b/app/(builder)/ycode/components/InteractionsPanel.tsx
@@ -1336,8 +1336,8 @@ export default function InteractionsPanel({
               </div>
             </div>
 
-            {/* Loop - only show for non-scroll triggers */}
-            {['click', 'hover'].includes(selectedInteraction.trigger) && (
+            {/* Effect - show for triggers that support looping (load has no toggle) */}
+            {['click', 'hover', 'load'].includes(selectedInteraction.trigger) && (
               <div className="grid grid-cols-3 items-center">
                 <Label variant="muted">Effect</Label>
                 <div className="col-span-2">
@@ -1364,7 +1364,9 @@ export default function InteractionsPanel({
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="reset">Reset and run once</SelectItem>
-                      <SelectItem value="reverse">Toggle and run once</SelectItem>
+                      {selectedInteraction.trigger !== 'load' && (
+                        <SelectItem value="reverse">Toggle and run once</SelectItem>
+                      )}
                       <SelectItem value="loop">Loop - Reset and restart</SelectItem>
                       <SelectItem value="loop-reverse">Loop - Toggle and restart</SelectItem>
                     </SelectContent>


### PR DESCRIPTION
## Summary

Page load animations could only run once because the Effect dropdown was limited to click and hover triggers. The runtime already supports looping on page load, so this exposes the loop options for the Page load trigger.

## Changes

- Show the Effect dropdown for the `load` trigger (previously only `click`/`hover`)
- Offer Reset and run once, Loop - Reset and restart, and Loop - Toggle and restart for page load
- Hide the "Toggle and run once" option for page load, since toggling has no meaning without a re-trigger

## Test plan

- [ ] Add a Page load interaction to a layer and confirm the Effect dropdown appears
- [ ] Select "Loop - Reset and restart" and verify the animation loops continuously
- [ ] Select "Loop - Toggle and restart" and verify it plays back and forth (yoyo)
- [ ] Confirm "Toggle and run once" is not offered for page load
- [ ] Verify click/hover Effect options are unchanged