### PR TITLE
feat: add object position control for images

### DIFF
--- a/app/(builder)/ycode/components/SizingControls.tsx
+++ b/app/(builder)/ycode/components/SizingControls.tsx
@@ -13,6 +13,7 @@ import Icon from '@/components/ui/icon';
 import { Input } from '@/components/ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
 import { Label } from '@/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import SettingsPanel from './SettingsPanel';
@@ -28,6 +29,27 @@ interface SizingControlsProps {
   layer: Layer | null;
   onLayerUpdate: (layerId: string, updates: Partial<Layer>) => void;
 }
+
+// Round only the outer corner of each grid corner cell so the 3x3 grid reads as one rounded block
+const OBJECT_POSITION_CORNERS: Record<string, string> = {
+  'left-top': 'rounded-tl-lg',
+  'right-top': 'rounded-tr-lg',
+  'left-bottom': 'rounded-bl-lg',
+  'right-bottom': 'rounded-br-lg',
+};
+
+// 3x3 focal point grid: cell position maps to the image alignment value
+const OBJECT_POSITIONS: { value: string; label: string; icon: React.ComponentProps<typeof Icon>['name'] }[] = [
+  { value: 'left-top', label: 'Top left', icon: 'arrow-left-up' },
+  { value: 'top', label: 'Top center', icon: 'arrow-up' },
+  { value: 'right-top', label: 'Top right', icon: 'arrow-right-up' },
+  { value: 'left', label: 'Center left', icon: 'arrow-left' },
+  { value: 'center', label: 'Center', icon: 'circle' },
+  { value: 'right', label: 'Center right', icon: 'arrow-right' },
+  { value: 'left-bottom', label: 'Bottom left', icon: 'arrow-left-down' },
+  { value: 'bottom', label: 'Bottom center', icon: 'arrow-down' },
+  { value: 'right-bottom', label: 'Bottom right', icon: 'arrow-right-down' },
+];
 
 const SizingControls = memo(function SizingControls({ layer, onLayerUpdate }: SizingControlsProps) {
   const activeBreakpoint = useEditorStore((s) => s.activeBreakpoint);
@@ -51,6 +73,7 @@ const SizingControls = memo(function SizingControls({ layer, onLayerUpdate }: Si
   const overflow = getDesignProperty('sizing', 'overflow') || 'visible';
   const aspectRatio = getDesignProperty('sizing', 'aspectRatio') || '';
   const objectFit = getDesignProperty('sizing', 'objectFit') || '';
+  const objectPosition = getDesignProperty('sizing', 'objectPosition') || '';
   const gridColumnSpan = getDesignProperty('sizing', 'gridColumnSpan') || '';
   const gridRowSpan = getDesignProperty('sizing', 'gridRowSpan') || '';
 
@@ -292,6 +315,11 @@ const SizingControls = memo(function SizingControls({ layer, onLayerUpdate }: Si
   // Handle object-fit change
   const handleObjectFitChange = (value: string) => {
     updateDesignProperty('sizing', 'objectFit', value || null);
+  };
+
+  // Handle object-position change (center is the browser default, so clear it)
+  const handleObjectPositionChange = (value: string) => {
+    updateDesignProperty('sizing', 'objectPosition', value === 'center' ? null : value);
   };
 
   // Handle grid column span change
@@ -625,11 +653,11 @@ const SizingControls = memo(function SizingControls({ layer, onLayerUpdate }: Si
       </div>
 
       {(['image', 'video'].includes(layer?.name || '')) && (
-        <div className="grid grid-cols-3 items-start">
-          <Label variant="muted" className="h-8">Object fit</Label>
-          <div className="col-span-2 flex flex-col gap-2">
+        <div className="grid grid-cols-3 items-center">
+          <Label variant="muted">Object fit</Label>
+          <div className="col-span-2 flex items-center gap-1">
             <Select value={objectFit} onValueChange={handleObjectFitChange}>
-              <SelectTrigger>
+              <SelectTrigger className="flex-1">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -642,6 +670,39 @@ const SizingControls = memo(function SizingControls({ layer, onLayerUpdate }: Si
                 </SelectGroup>
               </SelectContent>
             </Select>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="input"
+                  size="icon-sm"
+                  className="rounded-lg"
+                  aria-label="Object position"
+                  title="Object position"
+                >
+                  <Icon name={(OBJECT_POSITIONS.find((p) => p.value === (objectPosition || 'center'))?.icon) || 'circle'} />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-2 my-0.5" align="end">
+                <div className="grid grid-cols-3 gap-1">
+                  {OBJECT_POSITIONS.map((position) => {
+                    const isActive = (objectPosition || 'center') === position.value;
+                    return (
+                      <Button
+                        key={position.value}
+                        variant={isActive ? 'secondary' : 'outline'}
+                        size="icon-sm"
+                        className={`rounded-none ${OBJECT_POSITION_CORNERS[position.value] || ''}`}
+                        aria-label={position.label}
+                        title={position.label}
+                        onClick={() => handleObjectPositionChange(position.value)}
+                      >
+                        <Icon name={position.icon} className={isActive ? 'text-foreground' : 'opacity-40'} />
+                      </Button>
+                    );
+                  })}
+                </div>
+              </PopoverContent>
+            </Popover>
           </div>
         </div>
       )}

--- a/components/ui/icon.tsx
+++ b/components/ui/icon.tsx
@@ -19,6 +19,7 @@ export interface IconProps extends React.SVGProps<SVGSVGElement> {
     | 'slide-bullets' | 'slide-bullet' | 'slide-navigation' | 'slide-fraction' | 'loop-alternate' | 'loop-repeat' | 'listItem' | 'external-link'
     | 'settings' | 'center-block' | 'code-block' | 'table' | 'table-row' | 'table-cell' | 'add-column' | 'add-row' | 'delete-column' | 'delete-row' | 'delete-table' | 'header' | 'body'
     | 'webflow' | 'figma' | 'space'
+    | 'arrow-left-up' | 'arrow-up' | 'arrow-right-up' | 'arrow-left' | 'arrow-right' | 'arrow-left-down' | 'arrow-down' | 'arrow-right-down' | 'circle'
   );
 }
 
@@ -1050,6 +1051,55 @@ const ICONS: Record<IconProps['name'], React.ReactNode> = {
   space: (
     <g transform="scale(0.5)">
       <path d="M4 9V13H20V9H22V14C22 14.5523 21.5523 15 21 15H3C2.44772 15 2 14.5523 2 14V9H4Z" />
+    </g>
+  ),
+  // Remix line icons (0 0 24 24 source) scaled into the icon's 0 0 12 12 box.
+  'arrow-left-up': (
+    <g transform="scale(0.5)">
+      <path d="M9.41421 8L18.0208 16.6066L16.6066 18.0208L8 9.41421V17H6V6H17V8H9.41421Z" />
+    </g>
+  ),
+  'arrow-up': (
+    <g transform="scale(0.5)">
+      <path d="M13.0001 7.82843V20H11.0001V7.82843L5.63614 13.1924L4.22192 11.7782L12.0001 4L19.7783 11.7782L18.3641 13.1924L13.0001 7.82843Z" />
+    </g>
+  ),
+  'arrow-right-up': (
+    <g transform="scale(0.5)">
+      <path d="M16.0037 9.41421L7.39712 18.0208L5.98291 16.6066L14.5895 8H7.00373V6H18.0037V17H16.0037V9.41421Z" />
+    </g>
+  ),
+  'arrow-left': (
+    <g transform="scale(0.5)">
+      <path d="M7.82843 10.9999H20V12.9999H7.82843L13.1924 18.3638L11.7782 19.778L4 11.9999L11.7782 4.22168L13.1924 5.63589L7.82843 10.9999Z" />
+    </g>
+  ),
+  'arrow-right': (
+    <g transform="scale(0.5)">
+      <path d="M16.1716 10.9999L10.8076 5.63589L12.2218 4.22168L20 11.9999L12.2218 19.778L10.8076 18.3638L16.1716 12.9999H4V10.9999H16.1716Z" />
+    </g>
+  ),
+  'arrow-left-down': (
+    <g transform="scale(0.5)">
+      <path d="M9 13.589L17.6066 4.98242L19.0208 6.39664L10.4142 15.0032H18V17.0032H7V6.00324H9V13.589Z" />
+    </g>
+  ),
+  'arrow-down': (
+    <g transform="scale(0.5)">
+      <path d="M13.0001 16.1716L18.3641 10.8076L19.7783 12.2218L12.0001 20L4.22192 12.2218L5.63614 10.8076L11.0001 16.1716V4H13.0001V16.1716Z" />
+    </g>
+  ),
+  'arrow-right-down': (
+    <g transform="scale(0.5)">
+      <path d="M14.5895 16.0032L5.98291 7.39664L7.39712 5.98242L16.0037 14.589V7.00324H18.0037V18.0032H7.00373V16.0032H14.5895Z" />
+    </g>
+  ),
+  circle: (
+    <g transform="translate(1.8 1.8) scale(0.35)">
+      <path
+        fillRule="evenodd"
+        d="M2 12a10 10 0 1 0 20 0 10 10 0 1 0-20 0ZM5.5 12a6.5 6.5 0 1 1 13 0 6.5 6.5 0 0 1-13 0Z"
+      />
     </g>
   ),
 };

--- a/lib/import/css.ts
+++ b/lib/import/css.ts
@@ -104,6 +104,13 @@ const OBJECT_FIT_MAP: Record<string, string> = {
   contain: 'object-contain', cover: 'object-cover', fill: 'object-fill',
   none: 'object-none', 'scale-down': 'object-scale-down',
 };
+const OBJECT_POSITION_MAP: Record<string, string> = {
+  top: 'object-top', bottom: 'object-bottom', left: 'object-left', right: 'object-right',
+  center: 'object-center', 'left top': 'object-left-top', 'top left': 'object-left-top',
+  'right top': 'object-right-top', 'top right': 'object-right-top',
+  'left bottom': 'object-left-bottom', 'bottom left': 'object-left-bottom',
+  'right bottom': 'object-right-bottom', 'bottom right': 'object-right-bottom',
+};
 const BORDER_STYLE_VALUES = new Set(['solid', 'dashed', 'dotted', 'double', 'none']);
 const SIDE_ABBR: Record<string, string> = { top: 't', right: 'r', bottom: 'b', left: 'l' };
 
@@ -145,13 +152,14 @@ function mapDeclaration(prop: string, val: string): string[] {
                             prop === 'overflow' ? OVERFLOW_MAP[val] :
                               prop === 'cursor' ? CURSOR_MAP[val] :
                                 prop === 'object-fit' ? OBJECT_FIT_MAP[val] :
-                                  prop === 'font-style' && val === 'italic' ? 'italic' :
-                                    prop === 'font-style' && val === 'normal' ? 'not-italic' :
-                                      prop === 'pointer-events' && val === 'none' ? 'pointer-events-none' :
-                                        prop === 'pointer-events' && val === 'auto' ? 'pointer-events-auto' :
-                                          prop === 'word-break' && val === 'break-all' ? 'break-all' :
-                                            prop === 'overflow-wrap' && val === 'break-word' ? 'break-words' :
-                                              null;
+                                  prop === 'object-position' ? OBJECT_POSITION_MAP[val] :
+                                    prop === 'font-style' && val === 'italic' ? 'italic' :
+                                      prop === 'font-style' && val === 'normal' ? 'not-italic' :
+                                        prop === 'pointer-events' && val === 'none' ? 'pointer-events-none' :
+                                          prop === 'pointer-events' && val === 'auto' ? 'pointer-events-auto' :
+                                            prop === 'word-break' && val === 'break-all' ? 'break-all' :
+                                              prop === 'overflow-wrap' && val === 'break-word' ? 'break-words' :
+                                                null;
 
   if (mapped) { out.push(mapped); return out; }
 

--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -110,6 +110,7 @@ Each layer's \`design\` object controls its appearance. Use update_layer_design 
 - maxWidth: "1280px"
 - aspectRatio: "16/9", "1/1"
 - objectFit: "cover" | "contain" (for images)
+- objectPosition: "center" | "top" | "bottom" | "left" | "right" | "left-top" | "right-top" | "left-bottom" | "right-bottom" (focal point for cropped images)
 
 **borders** — Borders and radius
 - borderWidth: "1px"

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -102,6 +102,7 @@ export const designSchema = z.object({
     overflow: z.string().optional().describe('visible | hidden | scroll | auto'),
     aspectRatio: z.string().nullable().optional(),
     objectFit: z.string().nullable().optional(),
+    objectPosition: z.string().nullable().optional().describe('top | bottom | left | right | center | left-top | right-top | left-bottom | right-bottom'),
     gridColumnSpan: z.string().nullable().optional().describe('Grid column span, e.g. "2" or "span 3"'),
     gridRowSpan: z.string().nullable().optional().describe('Grid row span, e.g. "2" or "span 3"'),
   }).optional(),

--- a/lib/tailwind-class-mapper.ts
+++ b/lib/tailwind-class-mapper.ts
@@ -283,6 +283,7 @@ const CLASS_PROPERTY_MAP: Record<string, RegExp> = {
   overflow: /^overflow-(visible|hidden|clip|scroll|auto|x-visible|x-hidden|x-clip|x-scroll|x-auto|y-visible|y-hidden|y-clip|y-scroll|y-auto)$/,
   aspectRatio: /^aspect-(\[.+\]|auto|square|video)$/,
   objectFit: /^object-(contain|cover|fill|none|scale-down)$/,
+  objectPosition: /^object-(left-top|right-top|left-bottom|right-bottom|top|bottom|left|right|center|\[.+\])$/,
   gridColumnSpan: /^col-span-(1|2|3|4|5|6|7|8|9|10|11|12|auto|full)$/,
   gridRowSpan: /^row-span-(1|2|3|4|5|6|7|8|9|10|11|12|auto|full)$/,
 
@@ -875,6 +876,11 @@ export function propertyToClass(
 
     // Object Fit
     if (property === 'objectFit') {
+      return `object-${value}`;
+    }
+
+    // Object Position
+    if (property === 'objectPosition') {
       return `object-${value}`;
     }
 
@@ -1666,9 +1672,14 @@ export function classesToDesign(classes: string | string[]): Layer['design'] {
 
     // Object Fit
     if (cls.startsWith('object-')) {
-      const match = cls.match(/^object-(contain|cover|fill|none|scale-down)$/);
-      if (match) {
-        design.sizing!.objectFit = match[1];
+      const fitMatch = cls.match(/^object-(contain|cover|fill|none|scale-down)$/);
+      if (fitMatch) {
+        design.sizing!.objectFit = fitMatch[1];
+      }
+      // Object Position (disjoint value set from object-fit)
+      const positionMatch = cls.match(/^object-(left-top|right-top|left-bottom|right-bottom|top|bottom|left|right|center|\[.+\])$/);
+      if (positionMatch) {
+        design.sizing!.objectPosition = positionMatch[1];
       }
     }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -72,6 +72,7 @@ export interface SizingDesign {
   overflow?: string;
   aspectRatio?: string | null;
   objectFit?: string | null;
+  objectPosition?: string | null;
   gridColumnSpan?: string | null;
   gridRowSpan?: string | null;
 }


### PR DESCRIPTION
## Summary

Reintroduces the image alignment control that existed in legacy Ycode. Image (and video) layers now have an **Object position** picker next to Object fit, so cropped images can keep the important part of the frame in view (e.g. a face) instead of always cropping from the center.

## Changes

- Add `objectPosition` to the sizing design system, wired through the full pipeline (type, Tailwind class mapping, reverse class parsing, CSS import, MCP schema/instructions)
- Add an Object position control in Sizing: a crosshair-style button next to Object fit that opens a popover with a 3×3 focal-point grid; each cell maps to a Tailwind `object-*` alignment and shows a directional icon, with the active cell highlighted
- Selecting Center clears the class since it's the browser default
- Add Remix line directional icons (`arrow-*`) and a `circle` icon to the shared Icon component

## Test plan

- [ ] Select an image layer with `object-cover`, open the Object position popover, pick each of the 9 positions and confirm the `object-*` class updates on the canvas
- [ ] Verify the published output reflects the chosen alignment
- [ ] Confirm picking Center removes the class
- [ ] Verify per-breakpoint overrides work (set a different position on mobile vs desktop)
- [ ] Confirm the control is hidden for non-image/video layers