### PR TITLE
fix: add missing og:url meta tag

### DIFF
--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -20,7 +20,7 @@ import { buildSvgDataUrl, getAssetProxyUrl } from '@/lib/asset-utils';
 import { generateColorVariablesCss } from '@/lib/repositories/colorVariableRepository';
 import { buildPageHreflangAlternates } from '@/lib/hreflang-utils';
 import { getTranslatableKey } from '@/lib/locale-runtime';
-import { getSiteBaseUrl } from '@/lib/url-utils';
+import { buildAbsolutePageUrl, getSiteBaseUrl } from '@/lib/url-utils';
 
 /** Languages map shape Next.js expects under `metadata.alternates.languages`. */
 type MetadataLanguages = NonNullable<NonNullable<Metadata['alternates']>['languages']>;
@@ -315,14 +315,9 @@ export async function generatePageMetadata(
 
     // Add canonical URL
     if (seoSettings.globalCanonicalUrl && pagePath !== undefined) {
-      const canonicalBase = seoSettings.globalCanonicalUrl.replace(/\/$/, '');
-      const canonicalUrl = pagePath === '/' || pagePath === ''
-        ? canonicalBase
-        : `${canonicalBase}${pagePath.startsWith('/') ? pagePath : '/' + pagePath}`;
-
       metadata.alternates = {
         ...metadata.alternates,
-        canonical: canonicalUrl,
+        canonical: buildAbsolutePageUrl(seoSettings.globalCanonicalUrl, pagePath),
       };
     }
 
@@ -361,33 +356,49 @@ export async function generatePageMetadata(
     }
   }
 
+  // URL of the current page for og:url. Prefer an absolute URL built from the
+  // resolved base (canonical / primary domain / Vercel env) so it's correct on
+  // Vercel and cloud even when the route doesn't set `metadataBase`. Falls back
+  // to the relative path locally (no base configured), which Next.js resolves
+  // against `metadataBase` when available.
+  const pageUrl = pagePath === undefined
+    ? undefined
+    : siteBaseUrl
+      ? buildAbsolutePageUrl(siteBaseUrl, pagePath)
+      : pagePath;
+
   // Add Open Graph and Twitter Card metadata (not for error pages)
-  if (seo?.image && !isErrorPage) {
+  if (!isErrorPage) {
     // Resolve image URL (handles both Asset ID string and FieldVariable)
-    let imageUrl = await resolveImageUrl(seo.image, collectionItem);
+    let imageUrl = seo?.image ? await resolveImageUrl(seo.image, collectionItem) : null;
 
     // Make relative URLs absolute — social crawlers require absolute og:image URLs
     if (imageUrl && imageUrl.startsWith('/') && siteBaseUrl) {
       imageUrl = `${siteBaseUrl}${imageUrl}`;
     }
 
-    if (imageUrl) {
+    if (imageUrl || pageUrl !== undefined) {
       metadata.openGraph = {
         title,
         description,
-        images: [
-          {
-            url: imageUrl,
-            width: 1200,
-            height: 630,
-          },
-        ],
+        ...(pageUrl !== undefined ? { url: pageUrl } : {}),
+        ...(imageUrl
+          ? {
+            images: [
+              {
+                url: imageUrl,
+                width: 1200,
+                height: 630,
+              },
+            ],
+          }
+          : {}),
       };
       metadata.twitter = {
-        card: 'summary_large_image',
+        card: imageUrl ? 'summary_large_image' : 'summary',
         title,
         description,
-        images: [imageUrl],
+        ...(imageUrl ? { images: [imageUrl] } : {}),
       };
     }
   }

--- a/lib/url-utils.ts
+++ b/lib/url-utils.ts
@@ -18,3 +18,15 @@ export function getSiteBaseUrl(options?: {
 
   return raw ? raw.replace(/\/$/, '') : null;
 }
+
+/**
+ * Join a base URL with a page path into an absolute URL.
+ * Returns the base (without trailing slash) for the homepage path.
+ */
+export function buildAbsolutePageUrl(baseUrl: string, pagePath: string): string {
+  const base = baseUrl.replace(/\/$/, '');
+  if (pagePath === '/' || pagePath === '') {
+    return base;
+  }
+  return `${base}${pagePath.startsWith('/') ? pagePath : '/' + pagePath}`;
+}


### PR DESCRIPTION
## Summary

The `og:url` Open Graph tag was never emitted because `openGraph.url` was not set in the page metadata. This adds it so social crawlers and link previews get a canonical page URL.

## Changes

- Set `openGraph.url` from the current page path, building an absolute URL from the resolved base (canonical URL, primary domain, or Vercel env) when available and falling back to the relative path locally
- Render Open Graph/Twitter tags when an image **or** a page URL is available (previously image-only), so `og:url` appears even without an OG image
- Add `buildAbsolutePageUrl` helper in `url-utils` and reuse it for the canonical URL to drop duplicated path-joining logic

## Test plan

- [ ] Load a published page and confirm `<meta property="og:url">` is present
- [ ] With a canonical URL or primary domain configured, confirm `og:url` is absolute and correct
- [ ] Confirm the canonical link tag is unchanged
- [ ] Confirm pages without an OG image still emit `og:url`