### PR TITLE
fix: keep card links clickable when they contain buttons

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1682,30 +1682,51 @@ const LayerItemImpl: React.FC<{
     return filterDisabledSliderLayers(children, layer.settings);
   }, [layer.name, layer.settings, children]);
 
-  const subtreeHasInteractiveDescendants = useMemo(() => {
-    const interactiveTags = new Set(['a', 'button', 'input', 'select', 'textarea']);
+  // Detect descendants that can't live inside an <a> and can't be safely
+  // downgraded: real anchors, form controls, or anything with its own link.
+  // Plain <button>s are excluded — styling is class-driven, so inside a link we
+  // render them as <div> (see the isInsideLink downgrade below) instead of
+  // breaking the wrapping link.
+  const subtreeHasHardInteractive = useMemo(() => {
+    const hardTags = new Set(['a', 'input', 'select', 'textarea']);
 
     const visit = (nodes?: Layer[]): boolean => {
       if (!nodes?.length) return false;
-
       return nodes.some((node) => {
         if (!node) return false;
-
         const childTag = node.settings?.tag || node.name || 'div';
         const childHasLink = isValidLinkSettings(node.variables?.link);
-
-        return interactiveTags.has(childTag) || childHasLink || visit(node.children);
+        return hardTags.has(childTag) || childHasLink || visit(node.children);
       });
     };
 
     return visit(effectiveChildren);
   }, [effectiveChildren]);
 
-  // Browsers repair invalid interactive nesting (<a><button>, <a><a>, etc.)
-  // differently during SSR, which can cause hydration mismatches.
-  if (!isEditMode && htmlTag === 'a' && subtreeHasInteractiveDescendants) {
+  // <a><button>/<a><a>/etc. is invalid HTML; browsers repair it differently
+  // during SSR, causing hydration mismatches. Plain buttons are downgraded to
+  // <div> (below), so we only fall back to a non-link <div> when the subtree
+  // contains hard interactive content that can't be downgraded.
+  if (!isEditMode && htmlTag === 'a' && subtreeHasHardInteractive) {
     htmlTag = 'div';
   }
+
+  // Inside a link, render <button> as a styled <div> to keep the wrapping <a>
+  // valid (its appearance is driven by classes, not the button element).
+  if (!isEditMode && isInsideLink && htmlTag === 'button') {
+    htmlTag = 'div';
+  }
+
+  // Container layers that aren't a div/button/<a> (e.g. an <article> or <section>
+  // with a link) wrap their content in <a class="contents">. Soft buttons inside
+  // are downgraded (children receive isInsideLink), so only hard interactive
+  // content blocks the wrap. Computed early so children render as inside-a-link.
+  const willWrapWithLink = !isButtonWithLink
+    && !isDivWithLink
+    && !isInsideLink
+    && htmlTag !== 'a'
+    && !subtreeHasHardInteractive
+    && isValidLinkSettings(layer.variables?.link);
 
   // Use sortable for drag and drop
   const {
@@ -3374,7 +3395,7 @@ const LayerItemImpl: React.FC<{
                     parentComponentVariables={parentComponentVariables}
                     editingComponentVariables={editingComponentVariables}
                     isInsideForm={isInsideForm || htmlTag === 'form'}
-                    isInsideLink={isInsideLink || htmlTag === 'a'}
+                    isInsideLink={isInsideLink || htmlTag === 'a' || willWrapWithLink}
                     parentFormSettings={htmlTag === 'form' ? layer.settings?.form : parentFormSettings}
                     pages={pages}
                     folders={folders}
@@ -3453,7 +3474,7 @@ const LayerItemImpl: React.FC<{
               parentComponentVariables={parentComponentVariables}
               editingComponentVariables={editingComponentVariables}
               isInsideForm={isInsideForm || htmlTag === 'form'}
-              isInsideLink={isInsideLink || htmlTag === 'a'}
+              isInsideLink={isInsideLink || htmlTag === 'a' || willWrapWithLink}
               parentFormSettings={htmlTag === 'form' ? layer.settings?.form : parentFormSettings}
               components={componentsProp}
               ancestorComponentIds={effectiveAncestorIds}
@@ -3522,7 +3543,7 @@ const LayerItemImpl: React.FC<{
             parentComponentVariables={parentComponentVariables}
             editingComponentVariables={editingComponentVariables}
             isInsideForm={isInsideForm || htmlTag === 'form'}
-            isInsideLink={isInsideLink || htmlTag === 'a'}
+            isInsideLink={isInsideLink || htmlTag === 'a' || willWrapWithLink}
             parentFormSettings={htmlTag === 'form' ? layer.settings?.form : parentFormSettings}
             pages={pages}
             folders={folders}
@@ -3564,12 +3585,7 @@ const LayerItemImpl: React.FC<{
   // Skip for buttons/divs — they render as <a> directly (see isButtonWithLink, isDivWithLink)
   // Skip for <a> layers — they already render as <a> and nesting <a> inside <a> is invalid HTML
   const linkSettings = layer.variables?.link;
-  const shouldWrapWithLink = !isButtonWithLink
-    && !isDivWithLink
-    && !isInsideLink
-    && htmlTag !== 'a'
-    && !subtreeHasInteractiveDescendants
-    && isValidLinkSettings(linkSettings);
+  const shouldWrapWithLink = willWrapWithLink;
 
   if (shouldWrapWithLink && linkSettings) {
     if (isEditMode) {

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -709,30 +709,51 @@ const LayerItem: React.FC<{
     return filterDisabledSliderLayers(children, layer.settings);
   }, [layer.name, layer.settings, children]);
 
-  const subtreeHasInteractiveDescendants = useMemo(() => {
-    const interactiveTags = new Set(['a', 'button', 'input', 'select', 'textarea']);
+  // Detect descendants that can't live inside an <a> and can't be safely
+  // downgraded: real anchors, form controls, or anything with its own link.
+  // Plain <button>s are excluded — styling is class-driven, so inside a link we
+  // render them as <div> (see the isInsideLink downgrade below) instead of
+  // breaking the wrapping link.
+  const subtreeHasHardInteractive = useMemo(() => {
+    const hardTags = new Set(['a', 'input', 'select', 'textarea']);
 
     const visit = (nodes?: Layer[]): boolean => {
       if (!nodes?.length) return false;
-
       return nodes.some((node) => {
         if (!node) return false;
-
         const childTag = node.settings?.tag || node.name || 'div';
         const childHasLink = isValidLinkSettings(node.variables?.link);
-
-        return interactiveTags.has(childTag) || childHasLink || visit(node.children);
+        return hardTags.has(childTag) || childHasLink || visit(node.children);
       });
     };
 
     return visit(effectiveChildren);
   }, [effectiveChildren]);
 
-  // Browsers repair invalid interactive nesting (<a><button>, <a><a>, etc.)
-  // differently during SSR, which can cause hydration mismatches.
-  if (htmlTag === 'a' && subtreeHasInteractiveDescendants) {
+  // <a><button>/<a><a>/etc. is invalid HTML; browsers repair it differently
+  // during SSR, causing hydration mismatches. Plain buttons are downgraded to
+  // <div> (below), so we only fall back to a non-link <div> when the subtree
+  // contains hard interactive content that can't be downgraded.
+  if (htmlTag === 'a' && subtreeHasHardInteractive) {
     htmlTag = 'div';
   }
+
+  // Inside a link, render <button> as a styled <div> to keep the wrapping <a>
+  // valid (its appearance is driven by classes, not the button element).
+  if (isInsideLink && htmlTag === 'button') {
+    htmlTag = 'div';
+  }
+
+  // Container layers that aren't a div/button/<a> (e.g. an <article> or <section>
+  // with a link) wrap their content in <a class="contents">. Soft buttons inside
+  // are downgraded (children receive isInsideLink), so only hard interactive
+  // content blocks the wrap. Computed early so children render as inside-a-link.
+  const willWrapWithLink = !isButtonWithLink
+    && !isDivWithLink
+    && !isInsideLink
+    && htmlTag !== 'a'
+    && !subtreeHasHardInteractive
+    && isValidLinkSettings(layer.variables?.link);
 
   // Public renderer never needs the canvas slider hook; live sliders are
   // initialized by SliderInitializer (loaded only when slider layers exist).
@@ -1751,7 +1772,7 @@ const LayerItem: React.FC<{
               {...sharedRendererProps}
               localeSelectorFormat={format}
               isInsideForm={isInsideForm || htmlTag === 'form'}
-              isInsideLink={isInsideLink || htmlTag === 'a'}
+              isInsideLink={isInsideLink || htmlTag === 'a' || willWrapWithLink}
               parentFormSettings={htmlTag === 'form' ? layer.settings?.form : parentFormSettings}
               ancestorComponentIds={effectiveAncestorIds}
             />
@@ -1779,7 +1800,7 @@ const LayerItem: React.FC<{
             layers={effectiveChildren}
             {...sharedRendererProps}
             isInsideForm={isInsideForm || htmlTag === 'form'}
-            isInsideLink={isInsideLink || htmlTag === 'a'}
+            isInsideLink={isInsideLink || htmlTag === 'a' || willWrapWithLink}
             parentFormSettings={htmlTag === 'form' ? layer.settings?.form : parentFormSettings}
             ancestorComponentIds={effectiveAncestorIds}
             isSlideChild={layer.name === 'slides'}
@@ -1811,12 +1832,7 @@ const LayerItem: React.FC<{
   // Skip for buttons/divs — they render as <a> directly (see isButtonWithLink, isDivWithLink)
   // Skip for <a> layers — they already render as <a> and nesting <a> inside <a> is invalid HTML
   const linkSettings = layer.variables?.link;
-  const shouldWrapWithLink = !isButtonWithLink
-    && !isDivWithLink
-    && !isInsideLink
-    && htmlTag !== 'a'
-    && !subtreeHasInteractiveDescendants
-    && isValidLinkSettings(linkSettings);
+  const shouldWrapWithLink = willWrapWithLink;
 
   if (shouldWrapWithLink && linkSettings) {
     const linkAttrs = resolveLinkAttrs(linkSettings, layerLinkContext);


### PR DESCRIPTION
## Summary

Links placed on container layers (cards, collection items, etc.) silently disappeared when the container held a nested button. To avoid invalid `<a><button>` nesting and hydration mismatches, the wrapping `<a>` was downgraded to a plain `<div>`, dropping the link entirely. The whole card was meant to be clickable but wasn't.

## Changes

- Replace the broad `subtreeHasInteractiveDescendants` check with `subtreeHasHardInteractive`, which only flags descendants that genuinely can't live inside an `<a>` and can't be downgraded: real anchors, form controls (`input`/`select`/`textarea`), or any element with its own link.
- Inside a link, render plain `<button>` layers as styled `<div>`s (appearance is class-driven), so the wrapping `<a>` stays valid HTML.
- Compute the wrap decision early (`willWrapWithLink`) so non-`div`/`button` containers (e.g. `<article>`/`<section>` collection items with a link) propagate `isInsideLink` to children before they render, ensuring nested buttons downgrade correctly.
- Mirror the same logic in the editor renderer's non-edit path so canvas, preview, and published output stay consistent.

## Notes

- The static HTML export path (`layerToHtml` in `lib/page-fetcher.ts`) has a separate, pre-existing limitation (its own simplified link resolution that doesn't resolve dynamic page links and still produces `<a><button>`). It is intentionally out of scope here and unaffected by this change.

## Test plan

- [ ] Card (`div`) with a link containing a button → renders as `<a>` with the button as a styled `<div>`; whole card is clickable
- [ ] Collection item (`article`/`section`) with a `current-collection` link containing a button → wraps content in `<a class="contents">`, link resolves to the item slug
- [ ] Container link containing a real `<a>` or form control → falls back to non-link `<div>` (no invalid nesting), inner interactive element still works
- [ ] Plain button (no surrounding link) → still renders as `<button>`
- [ ] No hydration warnings in preview/published; editor canvas unchanged