### PR TITLE
fix: update homepage on published site after transferring it to another page

### DIFF
--- a/lib/repositories/pageRepository.ts
+++ b/lib/repositories/pageRepository.ts
@@ -211,7 +211,7 @@ async function transferIndexPage(
   // This prevents draft pages from being modified when creating published index pages
   let query = client
     .from('pages')
-    .select('id, name, slug')
+    .select('id, name, slug, settings, is_dynamic, error_page')
     .eq('is_index', true)
     .eq('is_published', isPublished)
     .is('deleted_at', null)
@@ -239,10 +239,21 @@ async function transferIndexPage(
     // If the existing index page already has a slug (shouldn't happen but might in edge cases),
     // we don't need to generate a new one - just unset is_index
     if (existingIndex.slug && existingIndex.slug.trim() !== '') {
+      // Recompute content_hash so publish detects the demotion (is_index changed)
+      const demotedHash = generatePageMetadataHash({
+        name: existingIndex.name,
+        slug: existingIndex.slug,
+        settings: existingIndex.settings,
+        is_index: false,
+        is_dynamic: existingIndex.is_dynamic ?? false,
+        error_page: existingIndex.error_page ?? null,
+      });
+
       const { error: updateError } = await client
         .from('pages')
         .update({
           is_index: false,
+          content_hash: demotedHash,
           updated_at: new Date().toISOString()
         })
         .eq('id', existingIndex.id)
@@ -289,12 +300,23 @@ async function transferIndexPage(
       }
     }
 
+    // Recompute content_hash so publish detects the demotion (is_index + slug changed)
+    const demotedHash = generatePageMetadataHash({
+      name: existingIndex.name,
+      slug: newSlug,
+      settings: existingIndex.settings,
+      is_index: false,
+      is_dynamic: existingIndex.is_dynamic ?? false,
+      error_page: existingIndex.error_page ?? null,
+    });
+
     // Update the old index page: unset is_index and set slug
     const { error: updateError } = await client
       .from('pages')
       .update({
         is_index: false,
         slug: newSlug,
+        content_hash: demotedHash,
         updated_at: new Date().toISOString()
       })
       .eq('id', existingIndex.id)


### PR DESCRIPTION
## Summary

Transferring the homepage (root index page) to another page did not update the homepage on the published website. The demoted old homepage was silently skipped at publish time, so the live site kept serving stale data and the old homepage's new URL 404'd.

## Root cause

`transferIndexPage` flips `is_index` and assigns a new slug on the demoted page but never recomputed its `content_hash`. Publish change-detection relies solely on `content_hash` (plus folder), so the demoted page looked unchanged: it wasn't republished at its new slug, wasn't included in `changedPageIds`, and its route cache was never invalidated.

## Changes

- Recompute `content_hash` (via `generatePageMetadataHash`) for the demoted page in both `transferIndexPage` branches, using its new `is_index: false` / slug
- Expand the index-page lookup to select the fields the hash needs (`settings`, `is_dynamic`, `error_page`)

## Test plan

- [ ] Set page A as homepage, publish
- [ ] Set page B as homepage (demotes A), publish
- [ ] Confirm `/` serves page B on the published site
- [ ] Confirm page A is published at its new slug (no 404)
- [ ] Verify the demoted page's `content_hash` is non-null and reflects its demoted metadata