### PR TITLE
feat: make pagination count and info text translatable

### DIFF
--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -68,6 +68,7 @@ import { getCollectionVariable, canDeleteLayer, findLayerById, findParentCollect
 import { CANVAS_BORDER, CANVAS_PADDING, updateViewportOverrides } from '@/lib/canvas-utils';
 import { BREAKPOINTS } from '@/lib/breakpoint-utils';
 import { buildFieldGroupsForLayer, flattenFieldGroups, filterFieldGroupsByType, SIMPLE_TEXT_FIELD_TYPES } from '@/lib/collection-field-utils';
+import { getPaginationLayerKind, PAGINATION_VARIABLE_LABELS, type PaginationVariableKey } from '@/lib/pagination-text-utils';
 import { buildFieldVariableData } from '@/lib/variable-format-utils';
 import { getRichTextValue } from '@/lib/tiptap-utils';
 import { DropContainerIndicator, DropLineIndicator } from '@/components/DropIndicators';
@@ -79,7 +80,7 @@ import { setDragCursor, clearDragCursor } from '@/lib/drag-cursor';
 import type { Layer, Page, CollectionField, Asset } from '@/types';
 import {
   DropdownMenu,
-  DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut,
+  DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuShortcut,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu';
 import {
@@ -1369,6 +1370,14 @@ const CenterCanvas = React.memo(function CenterCanvas({
     [fieldGroups],
   );
 
+  // Pagination count/info layers expose dynamic number variables to insert.
+  const paginationVariableKeys = useMemo<PaginationVariableKey[]>(() => {
+    const kind = getPaginationLayerKind(editingLayerId);
+    if (kind === 'count') return ['shown', 'total'];
+    if (kind === 'info') return ['current', 'pages'];
+    return [];
+  }, [editingLayerId]);
+
   // Create assets map for Canvas (asset ID -> asset)
   const assetsMap = useMemo(() => {
     const map: Record<string, Asset> = {};
@@ -2434,7 +2443,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
           </ToggleGroup>
 
           {/* Inline Variable Button */}
-          {textFieldGroups.length > 0 && (
+          {(textFieldGroups.length > 0 || paginationVariableKeys.length > 0) && (
             <ToggleGroup
               type="single"
               size="xs"
@@ -2456,12 +2465,31 @@ const CenterCanvas = React.memo(function CenterCanvas({
                   </ToggleGroupItem>
                 </DropdownMenuTrigger>
 
-                {fieldGroups && (
-                  <DropdownMenuContent
-                    className="w-56 py-1 px-1 max-h-none!"
-                    align="start"
-                    sideOffset={4}
-                  >
+                <DropdownMenuContent
+                  className="w-56 py-1 px-1 max-h-none!"
+                  align="start"
+                  sideOffset={4}
+                >
+                  {paginationVariableKeys.length > 0 && (
+                    <>
+                      <DropdownMenuLabel className="text-xs text-foreground/80">Pagination</DropdownMenuLabel>
+                      {paginationVariableKeys.map((key) => (
+                        <DropdownMenuItem
+                          key={key}
+                          className="gap-2"
+                          onClick={() => {
+                            addFieldVariable({ type: 'pagination', data: { key } });
+                            setTextEditorVariableDropdownOpen(false);
+                          }}
+                        >
+                          <Icon name="hash" className="size-3 text-muted-foreground shrink-0" />
+                          <span className="truncate">{PAGINATION_VARIABLE_LABELS[key]}</span>
+                        </DropdownMenuItem>
+                      ))}
+                      {textFieldGroups.length > 0 && <DropdownMenuSeparator />}
+                    </>
+                  )}
+                  {fieldGroups && textFieldGroups.length > 0 && (
                     <CollectionFieldSelector
                       fieldGroups={textFieldGroups}
                       allFields={collectionFieldsFromStore}
@@ -2477,8 +2505,8 @@ const CenterCanvas = React.memo(function CenterCanvas({
                         setTextEditorVariableDropdownOpen(false);
                       }}
                     />
-                  </DropdownMenuContent>
-                )}
+                  )}
+                </DropdownMenuContent>
               </DropdownMenu>
             </ToggleGroup>
           )}

--- a/app/(builder)/ycode/components/LocalizationContent.tsx
+++ b/app/(builder)/ycode/components/LocalizationContent.tsx
@@ -110,6 +110,19 @@ export default function LocalizationContent({ children }: LocalizationContentPro
     return buildFieldGroupsForLayer(layerId, layers, page || null, allFields, collections);
   };
 
+  /**
+   * Resolve the layer behind a translation item so the editor gets layer context
+   * (e.g. to expose pagination variables for count/info layers).
+   */
+  const findLayerForTranslationItem = (
+    item: TranslatableItem,
+    layers: Layer[],
+  ): Layer | null => {
+    const match = item.content_key.match(/^layer:([^:]+):/);
+    if (!match) return null;
+    return findLayerById(layers, match[1]) || null;
+  };
+
   // URL management
   const router = useRouter();
   const pathname = usePathname();
@@ -665,6 +678,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                 </InputGroup>
               </div>
 
+              {/*
               <div className="ml-auto">
                 <Button
                   size="sm"
@@ -674,6 +688,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                   Auto-translate
                 </Button>
               </div>
+              */}
             </div>
 
             {/* Loading state */}
@@ -785,6 +800,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                                     updateTranslationStatus={updateTranslationStatus}
                                     deleteTranslation={deleteTranslation}
                                     fieldGroups={buildFieldGroupsForTranslationItem(item, layers, page)}
+                                    layer={findLayerForTranslationItem(item, layers)}
                                     allFields={allFields}
                                     collections={collections}
                                     pages={storePages}
@@ -935,6 +951,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                                   updateTranslationStatus={updateTranslationStatus}
                                   deleteTranslation={deleteTranslation}
                                   fieldGroups={buildFieldGroupsForTranslationItem(item, layers)}
+                                  layer={findLayerForTranslationItem(item, layers)}
                                   allFields={allFields}
                                   collections={collections}
                                 />

--- a/app/(builder)/ycode/components/RichTextEditor.tsx
+++ b/app/(builder)/ycode/components/RichTextEditor.tsx
@@ -39,7 +39,7 @@ import {
   convertContentToValue,
   getVariableLabel,
 } from '@/lib/cms-variables-utils';
-import type { FieldVariable } from '@/types';
+import type { FieldVariable, InlineVariable } from '@/types';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import Icon from '@/components/ui/icon';
@@ -54,6 +54,9 @@ import {
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import {
@@ -66,6 +69,7 @@ import {
 import { CollectionFieldSelector, type FieldSourceType } from './CollectionFieldSelector';
 import { flattenFieldGroups, filterFieldGroupsByType, RICH_TEXT_ONLY_FIELD_TYPES, type FieldGroup } from '@/lib/collection-field-utils';
 import { buildFieldVariableData } from '@/lib/variable-format-utils';
+import { getPaginationLayerKind, PAGINATION_VARIABLE_LABELS, type PaginationVariableKey } from '@/lib/pagination-text-utils';
 import { createDynamicVariableNodeView } from '@/lib/dynamic-variable-view';
 import { RichTextComponent } from '@/lib/tiptap-extensions/rich-text-component';
 import { RichTextLink, getLinkSettingsFromMark } from '@/lib/tiptap-extensions/rich-text-link';
@@ -124,7 +128,7 @@ interface RichTextEditorProps {
 }
 
 export interface RichTextEditorHandle {
-  addFieldVariable: (variableData: FieldVariable) => void;
+  addFieldVariable: (variableData: InlineVariable) => void;
 }
 
 export type { FieldVariable } from '@/types';
@@ -462,7 +466,17 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
     () => filterFieldGroupsByType(fieldGroups, allowedFieldTypes),
     [fieldGroups, allowedFieldTypes]
   );
-  const canShowVariables = textFieldGroups.length > 0;
+
+  // Pagination count/info layers expose dynamic number variables (Shown/Total or
+  // Current page/Total pages) so they can be placed and translated within the text.
+  const paginationVariableKeys = useMemo<PaginationVariableKey[]>(() => {
+    const kind = getPaginationLayerKind(layer?.id);
+    if (kind === 'count') return ['shown', 'total'];
+    if (kind === 'info') return ['current', 'pages'];
+    return [];
+  }, [layer?.id]);
+
+  const canShowVariables = textFieldGroups.length > 0 || paginationVariableKeys.length > 0;
 
   const extensions = useMemo(() => {
     const baseExtensions = [
@@ -811,7 +825,7 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
   }, [editor, withFormatting, imagePopoverOpen]);
 
   // Internal function to add a field variable
-  const addFieldVariableInternal = useCallback((variableData: FieldVariable) => {
+  const addFieldVariableInternal = useCallback((variableData: InlineVariable) => {
     if (!editor) return;
 
     // Save current cursor position
@@ -924,6 +938,41 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
 
     setIsDropdownOpen(false);
   };
+
+  const handlePaginationSelect = (key: PaginationVariableKey) => {
+    addFieldVariableInternal({ type: 'pagination', data: { key } });
+    setIsDropdownOpen(false);
+  };
+
+  // Shared dropdown body: pagination variables (when applicable) above CMS fields.
+  const variablesDropdownInner = (
+    <>
+      {paginationVariableKeys.length > 0 && (
+        <>
+          <DropdownMenuLabel className="text-xs text-foreground/80">Pagination</DropdownMenuLabel>
+          {paginationVariableKeys.map((key) => (
+            <DropdownMenuItem
+              key={key}
+              className="gap-2"
+              onClick={() => handlePaginationSelect(key)}
+            >
+              <Icon name="hash" className="size-3 text-muted-foreground shrink-0" />
+              <span className="truncate">{PAGINATION_VARIABLE_LABELS[key]}</span>
+            </DropdownMenuItem>
+          ))}
+          {textFieldGroups.length > 0 && <DropdownMenuSeparator />}
+        </>
+      )}
+      {textFieldGroups.length > 0 && (
+        <CollectionFieldSelector
+          fieldGroups={textFieldGroups}
+          allFields={allFields || {}}
+          collections={collections || []}
+          onSelect={handleFieldSelect}
+        />
+      )}
+    </>
+  );
 
   return (
     <div className={cn('flex-1 rich-text-editor relative', isFullVariant && 'flex flex-col gap-2', fullHeight && 'min-h-0')}>
@@ -1127,12 +1176,7 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
                     align="start"
                     sideOffset={4}
                   >
-                    <CollectionFieldSelector
-                      fieldGroups={textFieldGroups}
-                      allFields={allFields || {}}
-                      collections={collections || []}
-                      onSelect={handleFieldSelect}
-                    />
+                    {variablesDropdownInner}
                   </DropdownMenuContent>
                 )}
               </DropdownMenu>
@@ -1438,12 +1482,7 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
                 align="start"
                 sideOffset={4}
               >
-                <CollectionFieldSelector
-                  fieldGroups={textFieldGroups}
-                  allFields={allFields || {}}
-                  collections={collections || []}
-                  onSelect={handleFieldSelect}
-                />
+                {variablesDropdownInner}
               </DropdownMenuContent>
             )}
           </DropdownMenu>
@@ -1691,12 +1730,7 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
                 align="end"
                 sideOffset={4}
               >
-                <CollectionFieldSelector
-                  fieldGroups={textFieldGroups}
-                  allFields={allFields || {}}
-                  collections={collections || []}
-                  onSelect={handleFieldSelect}
-                />
+                {variablesDropdownInner}
               </DropdownMenuContent>
             )}
           </DropdownMenu>

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -100,6 +100,7 @@ import { sanitizeHtmlId } from '@/lib/html-utils';
 import { isFieldVariable, getCollectionVariable, findParentCollectionLayer, findAllParentCollectionLayers, isTextEditable, isTextContentLayer, isRichTextLayer, isHeadingLayer, findLayerWithParent, resetBindingsOnCollectionSourceChange, isInputInsideFilter, resolveFilterInputId, getLayerIndexes, indexedFindLayerById, indexedFindLayerWithParent, indexedFindParentCollectionLayer } from '@/lib/layer-utils';
 import { detachSpecificLayerFromComponent } from '@/lib/component-utils';
 import { convertContentToValue, parseValueToContent } from '@/lib/cms-variables-utils';
+import { defaultPaginationCountDoc, defaultPaginationInfoDoc } from '@/lib/pagination-text-utils';
 import { createTextComponentVariableValue } from '@/lib/variable-utils';
 import { getRichTextValue, extractPlainTextFromTiptap, getSoleCmsFieldBinding } from '@/lib/tiptap-utils';
 import { DEFAULT_TEXT_STYLES, getTextStyle, getTiptapTextContent } from '@/lib/text-format-utils';
@@ -1422,9 +1423,11 @@ const RightSidebar = React.memo(function RightSidebar({
         children: [
           {
             id: `${collectionLayerId}-pagination-prev-text`,
-            name: 'span',
+            name: 'text',
             customName: 'Previous Text',
+            settings: { tag: 'span' },
             classes: '',
+            restrictions: { editText: true },
             variables: {
               text: {
                 type: 'dynamic_text',
@@ -1436,13 +1439,15 @@ const RightSidebar = React.memo(function RightSidebar({
       } as Layer,
       {
         id: `${collectionLayerId}-pagination-info`,
-        name: 'span',
+        name: 'text',
         customName: 'Page Info',
+        settings: { tag: 'span' },
         classes: 'text-sm text-[#4b5563]',
+        restrictions: { editText: true },
         variables: {
           text: {
-            type: 'dynamic_text',
-            data: { content: 'Page 1 of 1' }
+            type: 'dynamic_rich_text',
+            data: { content: defaultPaginationInfoDoc() }
           }
         }
       } as Layer,
@@ -1459,9 +1464,11 @@ const RightSidebar = React.memo(function RightSidebar({
         children: [
           {
             id: `${collectionLayerId}-pagination-next-text`,
-            name: 'span',
+            name: 'text',
             customName: 'Next Text',
+            settings: { tag: 'span' },
             classes: '',
+            restrictions: { editText: true },
             variables: {
               text: {
                 type: 'dynamic_text',
@@ -1498,9 +1505,11 @@ const RightSidebar = React.memo(function RightSidebar({
         children: [
           {
             id: `${collectionLayerId}-pagination-loadmore-text`,
-            name: 'span',
+            name: 'text',
             customName: 'Load More Text',
+            settings: { tag: 'span' },
             classes: '',
+            restrictions: { editText: true },
             variables: {
               text: {
                 type: 'dynamic_text',
@@ -1512,13 +1521,15 @@ const RightSidebar = React.memo(function RightSidebar({
       } as Layer,
       {
         id: `${collectionLayerId}-pagination-count`,
-        name: 'span',
+        name: 'text',
         customName: 'Items Count',
+        settings: { tag: 'span' },
         classes: 'text-sm text-[#4b5563]',
+        restrictions: { editText: true },
         variables: {
           text: {
-            type: 'dynamic_text',
-            data: { content: 'Showing items' }
+            type: 'dynamic_rich_text',
+            data: { content: defaultPaginationCountDoc() }
           }
         }
       } as Layer,
@@ -2397,6 +2408,7 @@ const RightSidebar = React.memo(function RightSidebar({
                           fieldGroups={fieldGroups}
                           allFields={fields}
                           collections={collections}
+                          layer={selectedLayer}
                           allowedFieldTypes={SIMPLE_TEXT_FIELD_TYPES}
                         />
                       ) : (

--- a/app/(builder)/ycode/components/TranslationRow.tsx
+++ b/app/(builder)/ycode/components/TranslationRow.tsx
@@ -14,7 +14,7 @@ import { tiptapDocToCanonicalString } from '@/lib/tiptap-utils';
 import { parseValueToContent } from '@/lib/cms-variables-utils';
 import { flattenFieldGroups, SIMPLE_TEXT_FIELD_TYPES } from '@/lib/collection-field-utils';
 import type { TranslatableItem } from '@/lib/localisation-utils';
-import type { Translation, CollectionField, Collection, CreateTranslationData, UpdateTranslationData, Page, PageFolder, Asset } from '@/types';
+import type { Translation, CollectionField, Collection, CreateTranslationData, UpdateTranslationData, Page, PageFolder, Asset, Layer } from '@/types';
 import { useAsset } from '@/hooks/use-asset';
 import { getAssetIcon, isAssetOfType, getAssetCategoryFromMimeType, ASSET_CATEGORIES } from '@/lib/asset-utils';
 import { buildAssetFolderPath } from '@/lib/asset-folder-utils';
@@ -37,6 +37,8 @@ interface TranslationRowProps {
   deleteTranslation: (translation: Translation) => Promise<void>;
   // Optional: For pages with CMS fields and inline variables support
   fieldGroups?: FieldGroup[];
+  /** Resolved layer for the item (provides context like pagination variables) */
+  layer?: Layer | null;
   allFields?: Record<string, CollectionField[]>;
   collections?: Collection[];
   // For slug validation
@@ -61,6 +63,7 @@ export default function TranslationRow({
   updateTranslationStatus,
   deleteTranslation,
   fieldGroups,
+  layer,
   allFields,
   collections,
   pages = [],
@@ -680,6 +683,7 @@ export default function TranslationRow({
                 }
                 className={`min-h-7 [&_.ProseMirror]:py-1 [&_.ProseMirror]:px-2.5 [&_.ProseMirror]:bg-transparent!`}
                 fieldGroups={fieldGroups}
+                layer={layer}
                 allFields={allFields}
                 collections={collections}
                 withFormatting={true}
@@ -700,6 +704,7 @@ export default function TranslationRow({
                   validationError ? '[&_.ProseMirror]:border-destructive!' : ''
                 }`}
                 fieldGroups={fieldGroups}
+                layer={layer}
                 allFields={allFields}
                 collections={collections}
                 allowedFieldTypes={SIMPLE_TEXT_FIELD_TYPES}

--- a/components/FilterableCollection.tsx
+++ b/components/FilterableCollection.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useLayoutEffect, useRef, useCallback, useState } from
 import { useFilterStore } from '@/stores/useFilterStore';
 import { LOAD_MORE_APPENDED_ATTR } from '@/components/LoadMoreCollection';
 import { hasDynamicDateRule } from '@/lib/collection-field-utils';
+import { resolvePaginationString } from '@/lib/pagination-text-utils';
 import type { ConditionalVisibility, Layer } from '@/types';
 
 interface FilterableCollectionProps {
@@ -523,7 +524,10 @@ export default function FilterableCollection({
       if (ssrPaginationTextRef.current === null) {
         ssrPaginationTextRef.current = infoEl.textContent || '';
       }
-      infoEl.textContent = `Page ${page} of ${totalPages}`;
+      const template = infoEl.getAttribute('data-pagination-template');
+      infoEl.textContent = template
+        ? resolvePaginationString(template, { shown: 0, total: 0, current: page, pages: totalPages })
+        : `Page ${page} of ${totalPages}`;
     }
 
     const prevBtn = wrapper.querySelector(`[data-pagination-action="prev"]`) as HTMLElement | null;
@@ -568,7 +572,11 @@ export default function FilterableCollection({
       if (ssrCountTextRef.current === null) {
         ssrCountTextRef.current = countEl.textContent || '';
       }
-      countEl.textContent = `Showing ${loaded} of ${total}`;
+      const template = countEl.getAttribute('data-pagination-template');
+      const shown = Math.min(loaded, total);
+      countEl.textContent = template
+        ? resolvePaginationString(template, { shown, total, current: 1, pages: 1 })
+        : `Showing ${shown} of ${total}`;
     }
 
     const loadMoreBtn = wrapper.querySelector(`[data-pagination-action="load_more"]`) as HTMLElement | null;

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -7,7 +7,7 @@ import LayerLockIndicator from '@/components/collaboration/LayerLockIndicator';
 import EditingIndicator from '@/components/collaboration/EditingIndicator';
 import { useCollaborationPresenceStore, getResourceLockKey, RESOURCE_TYPES } from '@/stores/useCollaborationPresenceStore';
 import { useAuthStore } from '@/stores/useAuthStore';
-import type { Layer, Locale, ComponentVariable, FormSettings, LinkSettings, Breakpoint, CollectionItemWithValues, CollectionField, Component } from '@/types';
+import type { Layer, Locale, ComponentVariable, FormSettings, LinkSettings, Breakpoint, CollectionItemWithValues, CollectionField, Component, DynamicTextVariable, DynamicRichTextVariable } from '@/types';
 import type { UseLiveLayerUpdatesReturn } from '@/hooks/use-live-layer-updates';
 import type { UseLiveComponentUpdatesReturn } from '@/hooks/use-live-component-updates';
 import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEditable, isTextContentLayer, isRichTextLayer, getCollectionVariable, evaluateVisibility, findAncestorByName, filterDisabledSliderLayers, getLayerCmsFieldBinding, findLayerById, applyCustomAttributes } from '@/lib/layer-utils';
@@ -27,6 +27,7 @@ import { buildImageSizes, generateImageSrcset, getOptimizedImageUrl, getSvgAspec
 import { useEditorStore } from '@/stores/useEditorStore';
 import { toast } from 'sonner';
 import { resolveInlineVariablesFromData } from '@/lib/inline-variables';
+import { hasPaginationVariables, paginationTextVariableToTemplate, resolvePaginationTextVariable } from '@/lib/pagination-text-utils';
 import { renderRichText, hasBlockElementsWithInlineVariables, getTextStyleClasses, flattenTiptapParagraphs, type RichTextLinkContext, type RenderComponentBlockFn } from '@/lib/text-format-utils';
 import { hasComponentOrVariable, extractPlainTextFromTiptap } from '@/lib/tiptap-utils';
 import LayerContextMenu from '@/app/(builder)/ycode/components/LayerContextMenu';
@@ -1022,17 +1023,33 @@ const LayerItemImpl: React.FC<{
 
   const computedPaginationText = useMemo<string | undefined>(() => {
     if (!paginationContextTarget || paginationContextTarget.kind === 'wrapper') return undefined;
+    // While actively editing, let the text editor render the template (with chips).
+    if (isEditing) return undefined;
+    // Not yet resolved (loading / pagination off): render the layer's own stored
+    // content instead of blanking it, so legacy "Page X of Y" text still shows.
     if (paginationDisplayTotal === undefined) return undefined;
     if (paginationDisplayTotal <= 0) return '';
     const pagination = getCollectionVariable(paginationLinkedCollectionLayer!)?.pagination;
     const itemsPerPage = pagination?.items_per_page || 10;
-    if (paginationContextTarget.kind === 'count') {
-      const shown = Math.min(itemsPerPage, paginationDisplayTotal);
-      return `Showing ${shown} of ${paginationDisplayTotal}`;
+    const numbers = {
+      shown: Math.min(itemsPerPage, paginationDisplayTotal),
+      total: paginationDisplayTotal,
+      current: 1,
+      pages: Math.max(1, Math.ceil(paginationDisplayTotal / itemsPerPage)),
+    };
+    const textVar = layer.variables?.text;
+    // Modern templates embed `pagination` chips — resolve them to numbers.
+    if (hasPaginationVariables(textVar)) {
+      return paginationTextVariableToTemplate(
+        resolvePaginationTextVariable(textVar as DynamicTextVariable | DynamicRichTextVariable, numbers)
+      );
     }
-    const totalPages = Math.max(1, Math.ceil(paginationDisplayTotal / itemsPerPage));
-    return `Page 1 of ${totalPages}`;
-  }, [paginationContextTarget, paginationLinkedCollectionLayer, paginationDisplayTotal]);
+    // Legacy content without chips: keep the hardcoded text.
+    if (paginationContextTarget.kind === 'count') {
+      return `Showing ${numbers.shown} of ${numbers.total}`;
+    }
+    return `Page ${numbers.current} of ${numbers.pages}`;
+  }, [paginationContextTarget, paginationLinkedCollectionLayer, paginationDisplayTotal, isEditing, layer.variables?.text]);
 
   // Resolve text and image URLs with field binding support
   const textContent = (() => {

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -15,7 +15,7 @@
 
 import React, { useEffect, useCallback, useMemo, useRef, Suspense } from 'react';
 import dynamic from 'next/dynamic';
-import type { Layer, Locale, FormSettings, Component, DesignColorVariable, PasswordProtectionContext } from '@/types';
+import type { Layer, Locale, FormSettings, Component, DesignColorVariable, PasswordProtectionContext, DynamicTextVariable, DynamicRichTextVariable } from '@/types';
 import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextContentLayer, getCollectionVariable, filterDisabledSliderLayers, applyCustomAttributes } from '@/lib/layer-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
@@ -25,6 +25,7 @@ import { getTranslatedAssetId, getTranslatedText } from '@/lib/locale-runtime';
 import { isValidLinkSettings, generateLinkHref, resolveLinkAttrs, isLinkAtCollectionBoundary, isLinkToCurrentPage, type LinkResolutionContext } from '@/lib/link-utils';
 import { DEFAULT_ASSETS, buildImageSizes, generateImageSrcset, getOptimizedImageUrl, getSvgAspectRatioStyle, parseImageDimension } from '@/lib/asset-utils';
 import { resolveInlineVariablesFromData } from '@/lib/inline-variables';
+import { getPaginationLayerKind, paginationTextVariableToTemplate, resolvePaginationTextVariable } from '@/lib/pagination-text-utils';
 import { mergeGlobalsIntoFieldData, type GlobalFieldMeta } from '@/lib/collection-field-utils';
 import { extractPlainTextFromTiptap } from '@/lib/tiptap-utils';
 import { renderRichText, hasBlockElementsWithInlineVariables, getTextStyleClasses, flattenTiptapParagraphs, type RichTextLinkContext, type RenderComponentBlockFn } from '@/lib/text-format-utils';
@@ -465,7 +466,14 @@ const LayerItem: React.FC<{
 
   // Check if we need to override the tag for rich text with block elements
   // Tags like <p>, <h1>-<h6> cannot contain block elements like <ul>/<ol>
-  const textVariable = layer.variables?.text;
+  // Pagination count/info layers resolve their `pagination` inline variables to
+  // live numbers here (after translation injection), keeping the words editable.
+  const rawTextVariable = layer.variables?.text;
+  const paginationKind = getPaginationLayerKind(layer.id);
+  const paginationNumbers = layer._paginationNumbers;
+  const textVariable = (paginationKind && paginationNumbers && rawTextVariable)
+    ? resolvePaginationTextVariable(rawTextVariable as DynamicTextVariable | DynamicRichTextVariable, paginationNumbers)
+    : rawTextVariable;
   let useSpanForParagraphs = false;
 
   // Detect block-level expansion (lists, tables, headings, embedded components,
@@ -991,6 +999,13 @@ const LayerItem: React.FC<{
     // Apply custom attributes from settings (map HTML attr names to JSX equivalents)
     if (layer.settings?.customAttributes) {
       applyCustomAttributes(elementProps, layer.settings.customAttributes);
+    }
+
+    // Pagination count/info layers: expose the (translated) template so the
+    // client runtime can re-resolve the numbers after load-more/filter/page nav.
+    if (paginationKind && paginationNumbers) {
+      const template = paginationTextVariableToTemplate(rawTextVariable);
+      if (template) elementProps['data-pagination-template'] = template;
     }
 
     // Select with placeholder: set defaultValue so React shows the placeholder option

--- a/components/LoadMoreCollection.tsx
+++ b/components/LoadMoreCollection.tsx
@@ -11,6 +11,7 @@
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { ITEMS_INJECTED_EVENT, type ItemsInjectedDetail } from '@/components/FilterableCollection';
+import { resolvePaginationString } from '@/lib/pagination-text-utils';
 import type { CollectionPaginationMeta, CollectionItem, Layer } from '@/types';
 
 interface LoadMoreCollectionProps {
@@ -177,7 +178,15 @@ export default function LoadMoreCollection({
 
     const countElement = wrapper?.querySelector(`[data-layer-id$="-pagination-count"]`);
     if (countElement) {
-      countElement.textContent = `Showing ${loadedCount} of ${totalItems}`;
+      // Prefer the (translated) template so the locale's wording is preserved;
+      // fall back to the English default for legacy pages without a template.
+      const template = countElement.getAttribute('data-pagination-template');
+      // loadedCount starts at itemsPerPage, which can exceed the actual total
+      // (e.g. 10 per page but only 6 items) — cap it so we never show "10 of 6".
+      const shown = Math.min(loadedCount, totalItems);
+      countElement.textContent = template
+        ? resolvePaginationString(template, { shown, total: totalItems, current: 1, pages: 1 })
+        : `Showing ${shown} of ${totalItems}`;
     }
 
     const loadMoreButton = wrapper?.querySelector(

--- a/lib/cms-variables-utils.ts
+++ b/lib/cms-variables-utils.ts
@@ -10,6 +10,7 @@ import { isDateFieldType } from '@/lib/collection-field-utils';
 import { formatDateInTimezone } from '@/lib/date-format-utils';
 import { extractPlainTextFromTiptap } from '@/lib/tiptap-utils';
 import { formatDateWithPreset, formatNumberWithPreset } from '@/lib/variable-format-utils';
+import { PAGINATION_VARIABLE_LABELS } from '@/lib/pagination-text-utils';
 
 /**
  * Format a field value for display based on field type
@@ -170,6 +171,9 @@ export function getVariableLabel(
     }
 
     return rootField?.name || '[Deleted Field]';
+  }
+  if (variable.type === 'pagination' && variable.data?.key) {
+    return PAGINATION_VARIABLE_LABELS[variable.data.key] || 'Pagination';
   }
   return variable.type;
 }

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -32,6 +32,7 @@ import type { LinkResolutionContext } from '@/lib/link-utils';
 import { getLinkSettingsFromMark } from '@/lib/tiptap-extensions/rich-text-link';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
 import { resolveInlineVariables, resolveInlineVariablesFromData } from '@/lib/inline-variables';
+import { buildPaginationNumbers, getPaginationLayerKind, hasPaginationVariables, paginationTextVariableToTemplate, resolvePaginationTextVariable } from '@/lib/pagination-text-utils';
 import { formatFieldValue, resolveFieldFromSources } from '@/lib/cms-variables-utils';
 import { buildLayerTranslationKey, getTranslationByKey, hasValidTranslationValue, getTranslationValue, injectTranslatedText, applyCmsTranslations, translateComponentOverrides } from '@/lib/localisation-utils';
 import { formatDateFieldsInItemValues } from '@/lib/date-format-utils';
@@ -45,7 +46,7 @@ import { getMapboxAccessToken, getGoogleMapsEmbedApiKey } from '@/lib/map-server
 import { getAssetsByIds } from '@/lib/repositories/assetRepository';
 import { isVirtualAssetField, findDisplayField, hasDynamicDateRule, isDynamicDateCondition, buildGlobalsMetaMap, buildGlobalsValueMap, mergeGlobalsIntoFieldData, type GlobalFieldMeta } from '@/lib/collection-field-utils';
 import { getDefaultFormatId, isFormatValidForFieldType } from '@/lib/variable-format-utils';
-import type { DynamicVisibilityCondition, FieldVariable, AssetVariable, DynamicTextVariable, LinkSettings } from '@/types';
+import type { DynamicVisibilityCondition, FieldVariable, AssetVariable, DynamicTextVariable, DynamicRichTextVariable, LinkSettings } from '@/types';
 import type { DesignColorVariable } from '@/types';
 
 // Cached map provider tokens for synchronous use inside layerToHtml.
@@ -3330,27 +3331,34 @@ function updatePaginationLayerWithMeta(layer: Layer, meta: CollectionPaginationM
       : `${updatedLayer.classes || ''} hidden`.trim();
   }
 
+  const numbers = buildPaginationNumbers(meta);
+
   // Helper to recursively update layers
   function updateLayerRecursive(l: Layer): void {
     if (l.id?.endsWith('-pagination-info')) {
-      l.variables = {
-        ...l.variables,
-        text: {
-          type: 'dynamic_text',
-          data: { content: `Page ${currentPage} of ${totalPages}` }
-        }
-      };
+      // Modern templates embed `pagination` inline variables — stash the numbers
+      // so renderers (and the translated template) resolve them at display time.
+      // Legacy content without chips keeps the hardcoded replacement.
+      if (hasPaginationVariables(l.variables?.text)) {
+        l._paginationNumbers = numbers;
+      } else {
+        l.variables = {
+          ...l.variables,
+          text: { type: 'dynamic_text', data: { content: `Page ${currentPage} of ${totalPages}` } }
+        };
+      }
     }
 
     if (l.id?.endsWith('-pagination-count')) {
-      const shownItems = Math.min(itemsPerPage, totalItems);
-      l.variables = {
-        ...l.variables,
-        text: {
-          type: 'dynamic_text',
-          data: { content: `Showing ${shownItems} of ${totalItems}` }
-        }
-      };
+      if (hasPaginationVariables(l.variables?.text)) {
+        l._paginationNumbers = numbers;
+      } else {
+        const shownItems = Math.min(itemsPerPage, totalItems);
+        l.variables = {
+          ...l.variables,
+          text: { type: 'dynamic_text', data: { content: `Showing ${shownItems} of ${totalItems}` } }
+        };
+      }
     }
 
     // Update previous button state
@@ -3436,8 +3444,10 @@ export function generatePaginationWrapper(
         children: [
           {
             id: `${collectionLayerId}-pagination-prev-text`,
-            name: 'span',
+            name: 'text',
+            settings: { tag: 'span' },
             classes: '',
+            restrictions: { editText: true },
             variables: {
               text: {
                 type: 'dynamic_text',
@@ -3450,8 +3460,10 @@ export function generatePaginationWrapper(
       // Page indicator
       {
         id: `${collectionLayerId}-pagination-info`,
-        name: 'span',
+        name: 'text',
+        settings: { tag: 'span' },
         classes: 'text-sm text-[#4b5563]',
+        restrictions: { editText: true },
         variables: {
           text: {
             type: 'dynamic_text',
@@ -3476,8 +3488,10 @@ export function generatePaginationWrapper(
         children: [
           {
             id: `${collectionLayerId}-pagination-next-text`,
-            name: 'span',
+            name: 'text',
+            settings: { tag: 'span' },
             classes: '',
+            restrictions: { editText: true },
             variables: {
               text: {
                 type: 'dynamic_text',
@@ -4949,6 +4963,13 @@ export function layerToHtml(
     attrs.push('selected');
   }
 
+  // Pagination count/info layers: expose the (translated) template so the
+  // client runtime can re-resolve the numbers after load-more/filter/page nav.
+  if (getPaginationLayerKind(layer.id) && layer._paginationNumbers) {
+    const template = paginationTextVariableToTemplate(layer.variables?.text);
+    if (template) attrs.push(`data-pagination-template="${escapeHtml(template)}"`);
+  }
+
   // For buttons/divs rendered as <a>, resolve link href and add attributes directly
   if ((isButtonWithLink || isDivWithLink) && buttonLinkSettings) {
     let btnLinkHref = '';
@@ -5039,8 +5060,15 @@ export function layerToHtml(
       .join('')
     : '';
 
-  // Get text content from variables.text
-  const textVariable = layer.variables?.text;
+  // Get text content from variables.text. For pagination count/info layers,
+  // resolve the `pagination` inline variables to live numbers first.
+  let textVariable = layer.variables?.text;
+  if (textVariable && layer._paginationNumbers && getPaginationLayerKind(layer.id)) {
+    textVariable = resolvePaginationTextVariable(
+      textVariable as DynamicTextVariable | DynamicRichTextVariable,
+      layer._paginationNumbers,
+    );
+  }
   let textContent = '';
   let isRichText = false;
 

--- a/lib/pagination-text-utils.ts
+++ b/lib/pagination-text-utils.ts
@@ -1,0 +1,190 @@
+/**
+ * Pagination Text Utilities
+ *
+ * Pagination count/info texts ("Showing 6 of 20", "Page 1 of 3") embed the live
+ * numbers as `pagination` inline variables so the surrounding words stay editable
+ * and translatable. These helpers build the default templates and resolve the
+ * variables to numbers at render time.
+ *
+ * CLIENT-SAFE: pure string/object manipulation, no server-only imports.
+ */
+
+import type {
+  CollectionPaginationMeta,
+  DynamicRichTextVariable,
+  DynamicTextVariable,
+  PaginationNumbers,
+} from '@/types';
+
+export type PaginationVariableKey = keyof PaginationNumbers;
+
+/** Human-readable chip labels shown in the editor / translation UI. */
+export const PAGINATION_VARIABLE_LABELS: Record<PaginationVariableKey, string> = {
+  shown: 'Shown items',
+  total: 'Total items',
+  current: 'Current page',
+  pages: 'Total pages',
+};
+
+const INLINE_VARIABLE_REGEX = /<ycode-inline-variable>([\s\S]*?)<\/ycode-inline-variable>/g;
+
+/** Build a Tiptap `dynamicVariable` chip node for a pagination key. */
+export function paginationVariableNode(key: PaginationVariableKey) {
+  return {
+    type: 'dynamicVariable',
+    attrs: {
+      variable: { type: 'pagination', data: { key } },
+      label: PAGINATION_VARIABLE_LABELS[key],
+    },
+  };
+}
+
+/** Build a single-paragraph Tiptap doc from text/chip parts. */
+function paginationDoc(parts: Array<{ text: string } | ReturnType<typeof paginationVariableNode>>) {
+  const content = parts.map((part) =>
+    'text' in part ? { type: 'text', text: part.text } : part
+  );
+  return { type: 'doc', content: [{ type: 'paragraph', content }] };
+}
+
+/** Default "Showing {shown} of {total}" doc for the load-more count layer. */
+export function defaultPaginationCountDoc() {
+  return paginationDoc([
+    { text: 'Showing ' },
+    paginationVariableNode('shown'),
+    { text: ' of ' },
+    paginationVariableNode('total'),
+  ]);
+}
+
+/** Default "Page {current} of {pages}" doc for the pages info layer. */
+export function defaultPaginationInfoDoc() {
+  return paginationDoc([
+    { text: 'Page ' },
+    paginationVariableNode('current'),
+    { text: ' of ' },
+    paginationVariableNode('pages'),
+  ]);
+}
+
+/** Identify whether a layer id is a pagination count/info text layer. */
+export function getPaginationLayerKind(id: string | undefined | null): 'count' | 'info' | null {
+  if (!id) return null;
+  if (id.endsWith('-pagination-count')) return 'count';
+  if (id.endsWith('-pagination-info')) return 'info';
+  return null;
+}
+
+/** Compute the live numbers from pagination meta (optionally overriding `shown`). */
+export function buildPaginationNumbers(
+  meta: Pick<CollectionPaginationMeta, 'currentPage' | 'totalPages' | 'totalItems' | 'itemsPerPage'>,
+  shownOverride?: number,
+): PaginationNumbers {
+  return {
+    shown: shownOverride ?? Math.min(meta.itemsPerPage, meta.totalItems),
+    total: meta.totalItems,
+    current: meta.currentPage,
+    pages: meta.totalPages,
+  };
+}
+
+/** Whether a text variable contains any `pagination` inline variable. */
+export function hasPaginationVariables(
+  textVar: DynamicTextVariable | DynamicRichTextVariable | undefined | null,
+): boolean {
+  if (!textVar) return false;
+  if (textVar.type === 'dynamic_text' && typeof textVar.data.content === 'string') {
+    return textVar.data.content.includes('"type":"pagination"');
+  }
+  if (textVar.type === 'dynamic_rich_text') {
+    return JSON.stringify(textVar.data.content || {}).includes('"type":"pagination"');
+  }
+  return false;
+}
+
+/** Replace `pagination` inline-variable tokens in a plain string with numbers. */
+export function resolvePaginationString(text: string, numbers: PaginationNumbers): string {
+  if (!text) return text;
+  return text.replace(INLINE_VARIABLE_REGEX, (match, content) => {
+    try {
+      const parsed = JSON.parse(String(content).trim());
+      if (parsed?.type === 'pagination' && parsed?.data?.key in numbers) {
+        return String(numbers[parsed.data.key as PaginationVariableKey]);
+      }
+    } catch {
+      // Not valid JSON — leave untouched
+    }
+    return match;
+  });
+}
+
+/** Replace `pagination` dynamicVariable nodes in a Tiptap doc with text nodes. */
+export function resolvePaginationDoc(doc: unknown, numbers: PaginationNumbers): unknown {
+  const walk = (node: any): any => {
+    if (Array.isArray(node)) return node.map(walk);
+    if (node && typeof node === 'object') {
+      if (
+        node.type === 'dynamicVariable' &&
+        node.attrs?.variable?.type === 'pagination' &&
+        node.attrs.variable.data?.key in numbers
+      ) {
+        return { type: 'text', text: String(numbers[node.attrs.variable.data.key as PaginationVariableKey]) };
+      }
+      const next: any = { ...node };
+      if (Array.isArray(node.content)) next.content = node.content.map(walk);
+      return next;
+    }
+    return node;
+  };
+  return walk(doc);
+}
+
+/**
+ * Serialize a text variable to a canonical token string (text + inline-variable
+ * tokens). Used to hand the translated template to the client load-more runtime
+ * so it can re-resolve the count after appending items.
+ */
+export function paginationTextVariableToTemplate(
+  textVar: DynamicTextVariable | DynamicRichTextVariable | undefined | null,
+): string {
+  if (!textVar) return '';
+  if (textVar.type === 'dynamic_text' && typeof textVar.data.content === 'string') {
+    return textVar.data.content;
+  }
+  if (textVar.type === 'dynamic_rich_text' && textVar.data.content && typeof textVar.data.content === 'object') {
+    let result = '';
+    const walk = (node: any): void => {
+      if (Array.isArray(node)) {
+        node.forEach(walk);
+        return;
+      }
+      if (!node || typeof node !== 'object') return;
+      if (node.type === 'text') {
+        result += node.text || '';
+      } else if (node.type === 'dynamicVariable' && node.attrs?.variable) {
+        result += `<ycode-inline-variable>${JSON.stringify(node.attrs.variable)}</ycode-inline-variable>`;
+      } else if (Array.isArray(node.content)) {
+        node.content.forEach(walk);
+      }
+    };
+    walk((textVar.data.content as any).content);
+    return result;
+  }
+  return '';
+}
+
+/**
+ * Resolve all `pagination` inline variables in a text variable to live numbers.
+ * Handles both `dynamic_text` strings and `dynamic_rich_text` Tiptap docs.
+ */
+export function resolvePaginationTextVariable<
+  T extends DynamicTextVariable | DynamicRichTextVariable
+>(textVar: T, numbers: PaginationNumbers): T {
+  if (textVar.type === 'dynamic_text' && typeof textVar.data.content === 'string') {
+    return { ...textVar, data: { ...textVar.data, content: resolvePaginationString(textVar.data.content, numbers) } };
+  }
+  if (textVar.type === 'dynamic_rich_text' && textVar.data.content && typeof textVar.data.content === 'object') {
+    return { ...textVar, data: { ...textVar.data, content: resolvePaginationDoc(textVar.data.content, numbers) } };
+  }
+  return textVar;
+}

--- a/stores/useCanvasTextEditorStore.ts
+++ b/stores/useCanvasTextEditorStore.ts
@@ -7,7 +7,7 @@
 
 import { create } from 'zustand';
 import type { Editor } from '@tiptap/react';
-import type { FieldVariable } from '@/types';
+import type { InlineVariable } from '@/types';
 import { getVariableLabel } from '@/lib/cms-variables-utils';
 import type { CollectionField } from '@/types';
 import { useEditorStore } from './useEditorStore';
@@ -78,7 +78,7 @@ interface CanvasTextEditorActions {
   focusEditor: () => void;
   /** Add a field variable at the current cursor position */
   addFieldVariable: (
-    variableData: FieldVariable,
+    variableData: InlineVariable,
     fields?: CollectionField[],
     allFields?: Record<string, CollectionField[]>
   ) => void;

--- a/types/index.ts
+++ b/types/index.ts
@@ -485,6 +485,9 @@ export interface Layer {
   _originalLayerId?: string;
   // SSR-only property for pagination metadata (when pagination is enabled)
   _paginationMeta?: CollectionPaginationMeta;
+  // SSR-only property: live pagination numbers stashed on the count/info text
+  // layers so renderers can resolve `pagination` inline variables at display time
+  _paginationNumbers?: PaginationNumbers;
   // SSR-only property for dynamic inline styles from CMS color field bindings
   _dynamicStyles?: Record<string, string>;
   // SSR-only property: when a conditionalVisibility rule references a date
@@ -1272,7 +1275,7 @@ export interface ColorVariable {
 
 export interface VariableType {
   id?: string; // Reference to ComponentVariable.id (for component variable linking)
-  type: 'field' | 'asset' | 'video'  | 'dynamic_rich_text' | 'dynamic_text'| 'static_text';
+  type: 'field' | 'asset' | 'video'  | 'dynamic_rich_text' | 'dynamic_text'| 'static_text' | 'pagination';
   data: object;
 }
 
@@ -1343,7 +1346,26 @@ export interface StaticTextVariable extends VariableType {
   };
 }
 
-export type InlineVariable = FieldVariable;
+// Pagination Variable, an inline variable that resolves to a live pagination
+// number (items shown/total, current/total pages) at render time. Lets the
+// pagination count/info texts ("Showing 6 of 20", "Page 1 of 3") be edited and
+// translated while keeping the numbers dynamic.
+export interface PaginationVariable extends VariableType {
+  type: 'pagination';
+  data: {
+    key: 'shown' | 'total' | 'current' | 'pages';
+  };
+}
+
+export type InlineVariable = FieldVariable | PaginationVariable;
+
+/** Live pagination numbers used to resolve `pagination` inline variables. */
+export interface PaginationNumbers {
+  shown: number;
+  total: number;
+  current: number;
+  pages: number;
+}
 
 // Image settings value for component variables
 export interface ImageSettingsValue {


### PR DESCRIPTION
## Summary

Pagination "Showing X of Y" and "Page X of Y" text is now fully translatable. The dynamic numbers are stored as pagination inline-variable chips inside `dynamic_rich_text`, so the surrounding words can be edited and translated per locale while the numbers still resolve at render time.

## Changes

- Add a `pagination` inline-variable type (`shown`, `total`, `current`, `pages`) with a resolver utility in `lib/pagination-text-utils.ts`
- Generate chip-based default content for pagination count/info layers in the right sidebar
- Resolve pagination chips at render time across SSR (`page-fetcher`), public (`LayerRendererPublic`), and canvas (`LayerRenderer`)
- Re-resolve the translated template client-side in `LoadMoreCollection` and `FilterableCollection`, capping the shown count at the total
- Add a database-icon dropdown to insert pagination variables in the sidebar, canvas, and localization editors
- Keep backward compatibility with legacy `dynamic_text` pagination layers
- Comment out the disabled Auto-translate button on the localization page

## Test plan

- [ ] Add a collection with pagination (load more and previous/next) and verify "Showing X of Y" / "Page X of Y" render correctly
- [ ] Edit the surrounding words in the default locale and confirm they persist
- [ ] Translate the text in another locale and confirm the numbers still resolve
- [ ] Load more items and confirm the shown count updates and never exceeds the total
- [ ] Insert pagination variables via the database icon in sidebar, canvas, and localization editors
- [ ] Confirm legacy pagination pages still render correctly