### PR TITLE
feat: add ellipsis option to sizing overflow

### DIFF
--- a/app/(builder)/ycode/components/SizingControls.tsx
+++ b/app/(builder)/ycode/components/SizingControls.tsx
@@ -645,6 +645,7 @@ const SizingControls = memo(function SizingControls({ layer, onLayerUpdate }: Si
                 <SelectItem value="visible">Visible</SelectItem>
                 <SelectItem value="hidden">Hidden</SelectItem>
                 <SelectItem value="scroll">Scroll</SelectItem>
+                <SelectItem value="ellipsis">Ellipsis</SelectItem>
                 <SelectItem value="auto">Auto</SelectItem>
               </SelectGroup>
             </SelectContent>

--- a/hooks/use-design-sync.ts
+++ b/hooks/use-design-sync.ts
@@ -622,6 +622,9 @@ function mapClassToDesignValue(className: string, property: string): string | un
       'transition-transform': 'transform',
       'transition-none': 'none',
     },
+    overflow: {
+      'truncate': 'ellipsis',
+    },
   };
 
   if (fullClassMappings[property]?.[cleanClass]) {

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -99,7 +99,7 @@ export const designSchema = z.object({
     minHeight: z.string().optional(),
     maxWidth: z.string().optional(),
     maxHeight: z.string().optional(),
-    overflow: z.string().optional().describe('visible | hidden | scroll | auto'),
+    overflow: z.string().optional().describe('visible | hidden | scroll | auto | ellipsis (single-line text-ellipsis)'),
     aspectRatio: z.string().nullable().optional(),
     objectFit: z.string().nullable().optional(),
     objectPosition: z.string().nullable().optional().describe('top | bottom | left | right | center | left-top | right-top | left-bottom | right-bottom'),

--- a/lib/tailwind-class-mapper.ts
+++ b/lib/tailwind-class-mapper.ts
@@ -280,7 +280,7 @@ const CLASS_PROPERTY_MAP: Record<string, RegExp> = {
   minHeight: /^min-h-(\[.+\]|\d+|px|full|screen|min|max|fit)$/,
   maxWidth: /^max-w-(\[.+\]|none|xs|sm|md|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|full|min|max|fit|prose|screen-sm|screen-md|screen-lg|screen-xl|screen-2xl)$/,
   maxHeight: /^max-h-(\[.+\]|\d+|px|full|screen|min|max|fit)$/,
-  overflow: /^overflow-(visible|hidden|clip|scroll|auto|x-visible|x-hidden|x-clip|x-scroll|x-auto|y-visible|y-hidden|y-clip|y-scroll|y-auto)$/,
+  overflow: /^(truncate|overflow-(visible|hidden|clip|scroll|auto|x-visible|x-hidden|x-clip|x-scroll|x-auto|y-visible|y-hidden|y-clip|y-scroll|y-auto))$/,
   aspectRatio: /^aspect-(\[.+\]|auto|square|video)$/,
   objectFit: /^object-(contain|cover|fill|none|scale-down)$/,
   objectPosition: /^object-(left-top|right-top|left-bottom|right-bottom|top|bottom|left|right|center|\[.+\])$/,
@@ -865,6 +865,7 @@ export function propertyToClass(
 
     // Overflow
     if (property === 'overflow') {
+      if (value === 'ellipsis') return 'truncate'; // overflow-hidden + text-ellipsis + whitespace-nowrap
       return `overflow-${value}`; // overflow-visible, overflow-hidden, overflow-scroll, overflow-auto
     }
 
@@ -1700,7 +1701,9 @@ export function classesToDesign(classes: string | string[]): Layer['design'] {
     }
 
     // Overflow
-    if (cls.startsWith('overflow-')) {
+    if (cls === 'truncate') {
+      design.sizing!.overflow = 'ellipsis';
+    } else if (cls.startsWith('overflow-')) {
       const match = cls.match(/^overflow-(visible|hidden|clip|scroll|auto|x-visible|x-hidden|x-clip|x-scroll|x-auto|y-visible|y-hidden|y-clip|y-scroll|y-auto)$/);
       if (match) {
         design.sizing!.overflow = match[1];


### PR DESCRIPTION
## Summary

Adds an **Ellipsis** option to the Sizing → Overflow dropdown so text can be truncated to a single line with a trailing ellipsis, without leaving the design panel.

## Changes

- Add `Ellipsis` item to the Overflow `Select` in `SizingControls`
- Map the `ellipsis` overflow value to Tailwind's `truncate` class (`overflow-hidden text-ellipsis whitespace-nowrap`) for generation and reverse parsing
- Recognize `truncate` as part of the `overflow` property for conflict resolution and class round-tripping
- Update the MCP design schema description for `overflow` to include `ellipsis`

## Test plan

- [ ] Select a text layer, set Overflow → Ellipsis, confirm `truncate` is applied and long text shows an ellipsis on a single line
- [ ] Reload the page and confirm the dropdown still reflects "Ellipsis"
- [ ] Switch from Ellipsis to another overflow value and confirm `truncate` is removed (no leftover classes)
- [ ] Note: inside a flex container the text element may also need `min-w-0` to shrink and trigger the ellipsis