### PR TITLE
fix: support font sizes without a leading zero

### DIFF
--- a/lib/tailwind-class-mapper.ts
+++ b/lib/tailwind-class-mapper.ts
@@ -191,8 +191,8 @@ function formatMeasurementClass(
     return `${prefix}-[${value}]`;
   }
 
-  // For values starting with a digit but not caught above
-  if (value.match(/^\d/)) {
+  // For values starting with a digit or leading decimal point (e.g. ".875rem")
+  if (value.match(/^\.?\d/)) {
     return `${prefix}-[${value}]`;
   }
 
@@ -739,10 +739,10 @@ export function propertyToClass(
         // Google/custom fonts: replace spaces with underscores for Tailwind arbitrary values
         return `font-[${value.replace(/\s+/g, '_')}]`;
       case 'lineHeight':
-        return value.match(/^\d/) ? `leading-[${value}]` : `leading-${value}`;
+        return value.match(/^\.?\d/) ? `leading-[${value}]` : `leading-${value}`;
       case 'letterSpacing':
-        // Check if value starts with digit/minus and doesn't already have a unit
-        if (value.match(/^-?\d/)) {
+        // Check if value starts with digit/minus/decimal and doesn't already have a unit
+        if (value.match(/^-?\.?\d/)) {
           // Check if value already has a unit (ends with letters or %)
           const hasUnit = /[a-z%]$/i.test(value);
           return hasUnit ? `tracking-[${value}]` : `tracking-[${value}em]`;


### PR DESCRIPTION
## Summary

Fixes #394. Typing a fractional measurement without a leading zero (e.g. `.875rem`) for font size caused the field to go blank and revert to zero. Only `0.875rem` worked.

## Changes

- Wrap measurement values with a leading decimal point as Tailwind arbitrary values (`.875rem` → `text-[.875rem]`) instead of producing the invalid unwrapped class `text-.875rem`
- Apply the same leading-decimal handling to the `lineHeight` and `letterSpacing` conversions

## Test plan

- [ ] Create a text block and set Size to `.75rem` — value is kept (no revert to zero)
- [ ] Set Size to `0.75rem` — still works as before
- [ ] Confirm the same for line height and letter spacing (e.g. `.5em`)