### PR TITLE
fix: improve component canvas with animated hidden layers

### DIFF
--- a/app/(builder)/ycode/components/Canvas.tsx
+++ b/app/(builder)/ycode/components/Canvas.tsx
@@ -18,7 +18,7 @@ import { createRoot, Root } from 'react-dom/client';
 import LayerRenderer from '@/components/LayerRenderer';
 import { serializeLayers, getClassesString } from '@/lib/layer-utils';
 import { collectEditorHiddenLayerIds } from '@/lib/animation-utils';
-import { getCanvasIframeHtml, updateViewportOverrides, measureContentExtent } from '@/lib/canvas-utils';
+import { getCanvasIframeHtml, updateViewportOverrides, measureContentExtent, isNonContentLayer } from '@/lib/canvas-utils';
 import { CanvasPortalProvider } from '@/lib/canvas-portal-context';
 import { cn } from '@/lib/utils';
 import { loadSwiperCss } from '@/lib/slider-utils';
@@ -409,7 +409,11 @@ const Canvas = React.memo(function Canvas({
   }, [enrichedPageCollectionItemDataRaw]);
 
   // Collect layer IDs that should be hidden on canvas (display: hidden with on-load)
-  // Exclude layers that are force-visible (targets of the active interaction)
+  // Exclude layers that are force-visible (targets of the active interaction).
+  // NOTE: this must NOT depend on selectedLayerId — it's a dependency of the
+  // iframe root.render() effect, so adding selection here forces a full (slow)
+  // iframe re-render on every click. Reveal-on-select is handled reactively
+  // inside LayerRenderer instead.
   const editorHiddenLayerIds = useMemo(() => {
     const hiddenMap = collectEditorHiddenLayerIds(resolvedLayers);
     if (forceVisibleLayerIds && forceVisibleLayerIds.length > 0) {
@@ -831,13 +835,19 @@ const Canvas = React.memo(function Canvas({
         const canvasBody = doc.getElementById('canvas-body');
         if (canvasBody && canvasBody.children.length > 0) {
           const bodyRect = body.getBoundingClientRect();
+          const win = doc.defaultView;
           let maxChildWidth = 0;
           let maxChildBottom = 0;
 
           const allLayers = canvasBody.querySelectorAll('[data-layer-id]');
           allLayers.forEach(el => {
-            const rect = (el as HTMLElement).getBoundingClientRect();
+            const node = el as HTMLElement;
+            const rect = node.getBoundingClientRect();
             if (rect.width === 0 && rect.height === 0) return;
+            // Ignore fixed overlays/backdrops (e.g. `fixed h-full`) — they track
+            // the iframe height and would balloon the canvas. Revealed dropdowns
+            // keep a real rect and are measured so the height recalculates.
+            if (win && isNonContentLayer(node, win)) return;
             maxChildWidth = Math.max(maxChildWidth, rect.right - bodyRect.left);
             maxChildBottom = Math.max(maxChildBottom, rect.bottom - bodyRect.top);
           });

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -616,6 +616,12 @@ const CenterCanvas = React.memo(function CenterCanvas({
   // Track whether zoom calculation is ready (prevents flash of wrong zoom on initial load)
   const [isCanvasReady, setIsCanvasReady] = useState(false);
 
+  // Hide the component canvas while its auto-zoom settles. Opening a component
+  // runs several measurement passes (width/height) that each re-fit the zoom;
+  // revealing only after dimensions hold steady avoids a visible size jump.
+  const [isComponentCanvasSettling, setIsComponentCanvasSettling] = useState(false);
+  const componentSettleTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
   // Optimize store subscriptions - use selective selectors (scoped to current page only)
   const currentDraft = usePagesStore((state) => currentPageId ? state.draftsByPageId[currentPageId] : null);
   const addLayerFromTemplate = usePagesStore((state) => state.addLayerFromTemplate);
@@ -720,6 +726,23 @@ const CenterCanvas = React.memo(function CenterCanvas({
   useEffect(() => {
     setReportedContentWidth(0);
   }, [editingComponentId]);
+
+  // On component open, hide the canvas so the initial multi-pass auto-zoom isn't
+  // visible. Only keyed on editingComponentId — NOT on dimensions — so reveals
+  // during normal editing don't re-hide and blink the canvas.
+  useEffect(() => {
+    setIsComponentCanvasSettling(!!editingComponentId);
+  }, [editingComponentId]);
+
+  // While settling (just opened), reveal once measured dimensions hold steady
+  // (debounced). Runs only while settling, so editing-time dimension changes
+  // don't trigger it. Fires even with no change via the settling dependency.
+  useEffect(() => {
+    if (!editingComponentId || !isComponentCanvasSettling) return;
+    clearTimeout(componentSettleTimerRef.current);
+    componentSettleTimerRef.current = setTimeout(() => setIsComponentCanvasSettling(false), 200);
+    return () => clearTimeout(componentSettleTimerRef.current);
+  }, [editingComponentId, isComponentCanvasSettling, reportedContentWidth, reportedContentHeight]);
 
   const collectionItemsFromStore = useCollectionsStore((state) => state.items);
   const collectionsFromStore = useCollectionsStore((state) => state.collections);
@@ -2574,7 +2597,8 @@ const CenterCanvas = React.memo(function CenterCanvas({
             elementPicker?.active && 'cursor-crosshair'
           )}
           style={{
-            opacity: isCanvasReady ? 1 : 0,
+            opacity: isCanvasReady && !isComponentCanvasSettling ? 1 : 0,
+            transition: 'opacity 120ms ease-out',
             scrollbarWidth: 'none', // Firefox
             msOverflowStyle: 'none', // IE/Edge
             WebkitOverflowScrolling: 'touch',

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -10,7 +10,7 @@ import { useAuthStore } from '@/stores/useAuthStore';
 import type { Layer, Locale, ComponentVariable, FormSettings, LinkSettings, Breakpoint, CollectionItemWithValues, CollectionField, Component, DynamicTextVariable, DynamicRichTextVariable } from '@/types';
 import type { UseLiveLayerUpdatesReturn } from '@/hooks/use-live-layer-updates';
 import type { UseLiveComponentUpdatesReturn } from '@/hooks/use-live-component-updates';
-import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEditable, isTextContentLayer, isRichTextLayer, getCollectionVariable, evaluateVisibility, findAncestorByName, filterDisabledSliderLayers, getLayerCmsFieldBinding, findLayerById, applyCustomAttributes } from '@/lib/layer-utils';
+import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEditable, isTextContentLayer, isRichTextLayer, getCollectionVariable, evaluateVisibility, findAncestorByName, filterDisabledSliderLayers, getLayerCmsFieldBinding, findLayerById, applyCustomAttributes, containsLayerId } from '@/lib/layer-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
@@ -480,6 +480,17 @@ const LayerItemImpl: React.FC<{
   const isEditing = editingLayerId === layer.id;
   const isDragging = activeLayerId === layer.id;
   const textEditable = isTextEditable(layer);
+
+  // Reveal an editor-hidden layer (e.g. an animated dropdown) when it OR a
+  // descendant is selected. Subscribed reactively so a hidden ancestor updates
+  // when a descendant is selected — its own `isSelected` wouldn't change then.
+  // Returns a stable `false` for non-hidden layers, so it never re-renders them.
+  const isEditorHidden = isEditMode && !!editorHiddenLayerIds?.has(layer.id);
+  const revealFromSelection = useEditorStore((state) => {
+    if (!isEditorHidden) return false;
+    const sel = state.selectedLayerId;
+    return sel ? containsLayerId(layer, sel) : false;
+  });
 
   const isEditor = useAuthStore((state) => state.role === 'editor');
 
@@ -2247,21 +2258,10 @@ const LayerItemImpl: React.FC<{
         (editorBreakpoint && hiddenBreakpoints.includes(editorBreakpoint));
 
       if (shouldHideOnBreakpoint) {
-        const shouldHide = parentComponentLayerId || (() => {
-          const storeSelectedId = useEditorStore.getState().selectedLayerId;
-          const isSelectedOrChildSelected = isSelected || (storeSelectedId && (() => {
-            const checkDescendants = (children: Layer[] | undefined): boolean => {
-              if (!children) return false;
-              for (const child of children) {
-                if (child.id === storeSelectedId) return true;
-                if (checkDescendants(child.children)) return true;
-              }
-              return false;
-            };
-            return checkDescendants(layer.children);
-          })());
-          return !isSelectedOrChildSelected;
-        })();
+        // Inside component instances internal layers can't be individually
+        // selected, so always hide. Otherwise reveal when this layer or a
+        // descendant is selected (subscribed reactively above).
+        const shouldHide = parentComponentLayerId ? true : !revealFromSelection;
 
         if (shouldHide) {
           const existingStyle = typeof elementProps.style === 'object' ? elementProps.style : {};

--- a/components/SelectionOverlay.tsx
+++ b/components/SelectionOverlay.tsx
@@ -213,9 +213,20 @@ export function SelectionOverlay({
     updateOutline(parentContainerRef.current, effectiveParentId, ctx.iframeDoc, ctx.iframeElement, ctx.containerElement, ctx.scale, PARENT_OUTLINE_CLASS);
   }, [getOutlineContext, hideAllOutlines, selectedLayerId, parentLayerId, updateOutline, activeSublayerIndex, activeListItemIndex, SELECTED_OUTLINE_CLASS, HOVERED_OUTLINE_CLASS, PARENT_OUTLINE_CLASS]);
 
-  // Initial update and updates when IDs change
+  // Initial update and updates when IDs change. Selecting a layer can reveal a
+  // previously hidden ancestor (display:none → visible) in the iframe's separate
+  // React root, which commits a frame or two after this effect runs — so the
+  // first measurement would land on the element's stale (hidden) rect. Re-run on
+  // the next frame and once more shortly after so the outline tracks the revealed
+  // element.
   useEffect(() => {
     updateAllOutlines();
+    const rafId = requestAnimationFrame(() => updateAllOutlines());
+    const timeoutId = setTimeout(() => updateAllOutlines(), 120);
+    return () => {
+      cancelAnimationFrame(rafId);
+      clearTimeout(timeoutId);
+    };
   }, [updateAllOutlines]);
 
   // Subscribe to hoveredLayerId changes without re-rendering. Uses a
@@ -332,6 +343,12 @@ export function SelectionOverlay({
     if (iframeDoc.body) {
       resizeObserver.observe(iframeDoc.body);
     }
+    // Also observe the iframe element itself. In component-edit mode the canvas
+    // is vertically centered and its height tracks content, so revealing/hiding
+    // a block resizes and re-centers the iframe — shifting every element's
+    // on-screen position. Observing the element catches that move so outlines
+    // re-measure to the new position (not just the body's internal size).
+    resizeObserver.observe(iframeElement);
 
     // Hide outlines during viewport switch, show after transition settles
     let viewportTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/lib/animation-utils.ts
+++ b/lib/animation-utils.ts
@@ -543,9 +543,42 @@ export interface EditorHiddenLayerInfo {
 }
 
 /**
+ * Whether a tween's on-load `from` state leaves the element hidden, so the
+ * editor should hide it by default and reveal it on selection. Covers explicit
+ * `display: hidden` (any trigger) plus toggle triggers (hover/click) whose
+ * resting state hides via opacity, scale-to-zero, or a translate that moves the
+ * element away (e.g. a slide-out dropdown clipped by an `overflow-hidden`
+ * wrapper). Intro triggers (load/scroll-into-view) reveal permanent content, so
+ * their transform/opacity `from` states must NOT hide it in the editor.
+ */
+function tweenHidesOnLoad(interaction: LayerInteraction, tween: InteractionTween): boolean {
+  const { trigger } = interaction;
+  const from = tween.from;
+  if (!from) return false;
+  const apply = tween.apply_styles;
+
+  if (from.display === 'hidden' && getEffectiveApplyStyle(trigger, 'display', apply) === 'on-load') {
+    return true;
+  }
+
+  if (trigger !== 'hover' && trigger !== 'click') return false;
+
+  const isOnLoad = (key: TweenPropertyKey) => getEffectiveApplyStyle(trigger, key, apply) === 'on-load';
+  const num = (v: unknown) => (v === null || v === undefined ? NaN : parseFloat(String(v)));
+
+  if (from.autoAlpha != null && isOnLoad('autoAlpha') && num(from.autoAlpha) === 0) return true;
+  if (from.scale != null && isOnLoad('scale') && num(from.scale) === 0) return true;
+  if (from.x != null && isOnLoad('x') && num(from.x) !== 0) return true;
+  if (from.y != null && isOnLoad('y') && num(from.y) !== 0) return true;
+
+  return false;
+}
+
+/**
  * Collect layer IDs that should be visually hidden on canvas in edit mode
- * These are layers with display: hidden animation and apply_styles: on-load
- * Returns a Map of layerId -> breakpoints (empty = all breakpoints)
+ * (display: hidden, or a toggle's on-load hidden resting state) so they're
+ * revealed only when selected. Returns a Map of layerId -> breakpoints
+ * (empty = all breakpoints).
  */
 export function collectEditorHiddenLayerIds(layers: Layer[]): Map<string, Breakpoint[]> {
   const hiddenLayerMap = new Map<string, Breakpoint[]>();
@@ -555,12 +588,7 @@ export function collectEditorHiddenLayerIds(layers: Layer[]): Map<string, Breakp
       if (layer.interactions) {
         layer.interactions.forEach((interaction) => {
           (interaction.tweens || []).forEach((tween) => {
-            // Check if display: hidden with effective on-load apply style
-            // (explicit on-load OR intro trigger like load/scroll-into-view)
-            if (
-              tween.from?.display === 'hidden' &&
-              getEffectiveApplyStyle(interaction.trigger, 'display', tween.apply_styles) === 'on-load'
-            ) {
+            if (tweenHidesOnLoad(interaction, tween)) {
               const breakpoints = interaction.timeline?.breakpoints || [];
               const existing = hiddenLayerMap.get(tween.layer_id);
 

--- a/lib/canvas-utils.ts
+++ b/lib/canvas-utils.ts
@@ -223,6 +223,20 @@ export function measureContentExtent(doc: Document): number {
 }
 
 /**
+ * True when a layer must be excluded from component content-extent measurement.
+ * `position: fixed` overlays/backdrops are pinned to the viewport, so a
+ * full-height backdrop (`fixed h-full`) measures as tall as the iframe — feeding
+ * back into the iframe height and ballooning the canvas. They never define the
+ * content extent, so they're skipped. Layers hidden on load (display:none)
+ * already measure as a zero-size rect and are filtered separately, so once a
+ * hidden-by-animation layer is revealed it is measured again and the canvas
+ * height recalculates to fit it.
+ */
+export function isNonContentLayer(node: HTMLElement, win: Window): boolean {
+  return win.getComputedStyle(node).position === 'fixed';
+}
+
+/**
  * Shared HTML template for canvas-style iframes with Tailwind Browser CDN.
  * Used by both the editor Canvas and the thumbnail capture hook.
  * @param mountId - The ID of the mount point div (default: 'canvas-mount')


### PR DESCRIPTION
## Summary

Editing a component that contains animation-hidden elements (e.g. hover dropdowns) had several canvas problems: the auto-zoom over-measured height, hidden panels were either always visible or never revealed when selected, the canvas flickered on open, and selection outlines drifted out of position when a block was shown/hidden.

## Changes

- Skip `position: fixed` overlays/backdrops when measuring component content extent, so a full-height backdrop no longer balloons the canvas height
- Treat toggle-triggered layers (hover/click) whose on-load resting state hides them via opacity, scale-to-zero, or an off-screen translate as editor-hidden — not just `display: hidden`
- Reveal an editor-hidden layer reactively when it or a descendant is selected, handled inside the layer renderer so it no longer forces a full (slow) iframe re-render on every click
- Hide the component canvas on open until its auto-zoom settles, avoiding a visible size jump — without re-hiding on edits
- Re-measure selection outlines when the centered component canvas resizes/recenters, so outlines stay aligned with revealed/hidden blocks

## Test plan

- [ ] Open a component with a hover dropdown — canvas fits without a large empty area and no flicker on open
- [ ] Select the dropdown layer (or a child of it) — the hidden panel is revealed immediately
- [ ] Deselect — the panel hides again
- [ ] With a panel revealed, confirm the selection/hover outlines sit exactly on the elements (correct position, not just size)
- [ ] Toggle a block's visibility and verify outlines follow as the canvas height changes
- [ ] Editing layers (typing, moving) does not blink the canvas