### PR TITLE
fix: support pagination and totals for multi-image collections

### DIFF
--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -2693,6 +2693,10 @@ const RightSidebar = React.memo(function RightSidebar({
                   {/* Sort By - only show if a real collection source is selected */}
                   {hasBoundCollectionSource(getCollectionVariable(selectedLayer)) && (
                     <>
+                      {/* Sort by/order are hidden for multi-asset: order is the
+                          image order in the field and there are no fields to sort by. */}
+                      {getCollectionVariable(selectedLayer)?.source_field_type !== 'multi_asset' && (
+                      <>
                       <div className="grid grid-cols-3">
                         <Label variant="muted">Sort by</Label>
                         <div className="col-span-2 *:w-full flex">
@@ -2799,6 +2803,8 @@ const RightSidebar = React.memo(function RightSidebar({
                               )}
                             </div>
                           </div>
+                      )}
+                      </>
                       )}
 
                       {/* Total Limit */}

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1381,6 +1381,7 @@ const LayerItemImpl: React.FC<{
   const layerData = useCollectionLayerStore((state) => state.layerData[layer.id]);
   const isLoadingLayerData = useCollectionLayerStore((state) => state.loading[layer.id]);
   const fetchLayerData = useCollectionLayerStore((state) => state.fetchLayerData);
+  const setLayerTotal = useCollectionLayerStore((state) => state.setLayerTotal);
   const fieldsByCollectionId = useCollectionsStore((state) => state.fields);
   const itemsByCollectionId = useCollectionsStore((state) => state.items);
   const referencedItemsByCollectionId = useCollectionLayerStore((state) => state.referencedItems);
@@ -1523,14 +1524,16 @@ const LayerItemImpl: React.FC<{
     // `limit`/`offset`. We slice unconditionally for paginated layers, and
     // when static filters are present for non-paginated ones (the API
     // returns the configured limit when there are no static filters, so no
-    // re-slicing is needed there).
+    // re-slicing is needed there). Multi-asset items are always built
+    // client-side (never fetched with limit/offset), so they must be sliced
+    // here too.
     const pagination = collectionVariable?.pagination;
     const isPaginated = !!pagination?.enabled && (pagination.mode === 'pages' || pagination.mode === 'load_more');
 
     if (isPaginated) {
       const itemsPerPage = pagination!.items_per_page || 10;
       items = items.slice(0, itemsPerPage);
-    } else if (hasStaticFilters) {
+    } else if (hasStaticFilters || sourceFieldType === 'multi_asset') {
       const offset = collectionVariable?.offset ?? 0;
       const limit = collectionVariable?.limit;
       if (offset || limit) {
@@ -1658,6 +1661,23 @@ const LayerItemImpl: React.FC<{
     fetchLayerData,
     layer.id,
   ]);
+
+  // Multi-asset layers build virtual items client-side, so fetchLayerData skips
+  // them and layerTotal stays empty — meaning sibling pagination layers ("Total
+  // items", "Page X of Y") can't resolve. Mirror SSR by publishing the asset
+  // count (uncapped; paginationDisplayTotal applies the maxTotal limit) here.
+  const multiAssetTotalCount = useMemo<number | null>(() => {
+    if (sourceFieldType !== 'multi_asset' || !sourceFieldId) return null;
+    const fieldValue = sourceFieldSource === 'page'
+      ? pageCollectionItemData?.[sourceFieldId]
+      : collectionLayerData?.[sourceFieldId];
+    return parseMultiAssetFieldValue(fieldValue).length;
+  }, [sourceFieldType, sourceFieldId, sourceFieldSource, pageCollectionItemData, collectionLayerData]);
+
+  useEffect(() => {
+    if (!isEditMode || multiAssetTotalCount === null) return;
+    setLayerTotal(layer.id, multiAssetTotalCount);
+  }, [isEditMode, multiAssetTotalCount, setLayerTotal, layer.id]);
 
   // For component instances in edit mode, use the component's layers as children
   // For published pages, children are already resolved server-side

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -44,7 +44,7 @@ import { generateInitialAnimationCSS } from '@/lib/animation-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS } from '@/lib/map-utils';
 import { getMapboxAccessToken, getGoogleMapsEmbedApiKey } from '@/lib/map-server';
 import { getAssetsByIds } from '@/lib/repositories/assetRepository';
-import { isVirtualAssetField, findDisplayField, hasDynamicDateRule, isDynamicDateCondition, buildGlobalsMetaMap, buildGlobalsValueMap, mergeGlobalsIntoFieldData, type GlobalFieldMeta } from '@/lib/collection-field-utils';
+import { isVirtualAssetField, findDisplayField, hasDynamicDateRule, isDynamicDateCondition, buildGlobalsMetaMap, buildGlobalsValueMap, mergeGlobalsIntoFieldData, MULTI_ASSET_COLLECTION_ID, type GlobalFieldMeta } from '@/lib/collection-field-utils';
 import { getDefaultFormatId, isFormatValidForFieldType } from '@/lib/variable-format-utils';
 import type { DynamicVisibilityCondition, FieldVariable, AssetVariable, DynamicTextVariable, DynamicRichTextVariable, LinkSettings } from '@/types';
 import type { DesignColorVariable } from '@/types';
@@ -2058,7 +2058,11 @@ function collectBoundFieldIds(layers: Layer[]): { fieldIds: Set<string>; fieldPa
 function collectAllCollectionIds(layers: Layer[]): Set<string> {
   const ids = new Set<string>();
   const scan = (layer: Layer) => {
-    if (layer.variables?.collection?.id) ids.add(layer.variables.collection.id);
+    // Skip the virtual multi-asset collection id — it's not a real DB collection,
+    // and querying it (invalid UUID) errors the whole batch item fetch, which
+    // would leave every real collection on the page with no items.
+    const collectionId = layer.variables?.collection?.id;
+    if (collectionId && collectionId !== MULTI_ASSET_COLLECTION_ID) ids.add(collectionId);
     if (layer.settings?.optionsSource?.collectionId) ids.add(layer.settings.optionsSource.collectionId);
     if (layer.children) layer.children.forEach(scan);
   };
@@ -2428,19 +2432,60 @@ export async function resolveCollectionLayers(
           // Handle multi-asset collections - build virtual items from asset IDs
           if (sourceFieldType === 'multi_asset' && sourceFieldId && itemValues) {
             const fieldValue = itemValues[sourceFieldId];
-            const assetIds = parseMultiAssetFieldValue(fieldValue);
+            let assetIds = parseMultiAssetFieldValue(fieldValue);
 
-            if (assetIds.length === 0) {
+            // Pagination mirrors the regular collection branch below: the asset
+            // ID array is the full result set, so totalItems/maxTotal/page
+            // slicing all operate on it directly.
+            const multiAssetPagination = collectionVariable.pagination;
+            const isMultiAssetPaginated = multiAssetPagination?.enabled
+              && (multiAssetPagination?.mode === 'pages' || multiAssetPagination?.mode === 'load_more');
+
+            let multiAssetLimit: number | undefined;
+            let multiAssetOffset: number | undefined;
+            let multiAssetCurrentPage = 1;
+            if (isMultiAssetPaginated) {
+              const itemsPerPage = multiAssetPagination!.items_per_page || 10;
+              multiAssetCurrentPage = paginationContext?.pageNumbers?.[layer.id]
+                ?? paginationContext?.defaultPage
+                ?? 1;
+              multiAssetLimit = itemsPerPage;
+              multiAssetOffset = (multiAssetCurrentPage - 1) * itemsPerPage;
+            } else {
+              multiAssetLimit = collectionVariable.limit;
+              multiAssetOffset = collectionVariable.offset;
+            }
+
+            // When paginated, `limit` is a hard cap on the total (matches the
+            // regular collection branch); otherwise it acts as a per-page limit.
+            const multiAssetMaxTotal = isMultiAssetPaginated
+              && typeof collectionVariable.limit === 'number' && collectionVariable.limit > 0
+              ? collectionVariable.limit
+              : undefined;
+            if (multiAssetMaxTotal != null && assetIds.length > multiAssetMaxTotal) {
+              assetIds = assetIds.slice(0, multiAssetMaxTotal);
+            }
+
+            const multiAssetTotal = assetIds.length;
+
+            if (multiAssetTotal === 0 && !isMultiAssetPaginated) {
               // No assets - return layer without children
               return { ...layer, children: [] };
             }
 
-            // Fetch all assets at once (returns Record<string, Asset>)
-            const assetsById = await getAssetsByIds(assetIds, isPublished);
+            // Slice to the current page (mirrors DB pagination).
+            let pageAssetIds = assetIds;
+            if (multiAssetLimit || multiAssetOffset) {
+              const start = multiAssetOffset || 0;
+              pageAssetIds = assetIds.slice(start, multiAssetLimit ? start + multiAssetLimit : undefined);
+            }
+
+            // Fetch only the assets shown on this page (returns Record<string, Asset>)
+            const assetsById = await getAssetsByIds(pageAssetIds, isPublished);
 
             // Clone the layer for each asset (like regular collections)
             const clonedLayers: Layer[] = await Promise.all(
-              assetIds.map(async (assetId) => {
+              pageAssetIds.map(async (assetId) => {
                 const asset = assetsById[assetId];
                 if (!asset) return null;
 
@@ -2507,6 +2552,26 @@ export async function resolveCollectionLayers(
               })
             ).then(results => results.filter((item): item is Layer => item !== null));
 
+            // Build pagination metadata so sibling pagination layers ("Total
+            // items", "Page X of Y", Prev/Next) resolve against the asset count.
+            let multiAssetPaginationMeta: CollectionPaginationMeta | undefined;
+            if (isMultiAssetPaginated && multiAssetPagination) {
+              const itemsPerPage = multiAssetPagination.items_per_page || 10;
+              multiAssetPaginationMeta = {
+                currentPage: multiAssetCurrentPage,
+                totalPages: Math.ceil(multiAssetTotal / itemsPerPage),
+                totalItems: multiAssetTotal,
+                itemsPerPage,
+                layerId: layer.id,
+                collectionId: collectionVariable.id,
+                mode: multiAssetPagination.mode,
+                itemIds: assetIds,
+                isPublished,
+                // No sort: multi-asset order is the image order in the field.
+                maxTotal: multiAssetMaxTotal,
+              };
+            }
+
             // Return a fragment layer containing all cloned items
             // _fragment is a special marker that LayerRenderer and layerToHtml handle
             return {
@@ -2521,6 +2586,7 @@ export async function resolveCollectionLayers(
                 ...layer.variables,
                 collection: undefined,
               },
+              _paginationMeta: multiAssetPaginationMeta,
             };
           }
 

--- a/stores/useCollectionLayerStore.ts
+++ b/stores/useCollectionLayerStore.ts
@@ -46,6 +46,7 @@ interface CollectionLayerActions {
   // Pagination actions
   fetchPage: (layerId: string, page: number) => Promise<{ items: CollectionItemWithValues[]; meta: CollectionPaginationMeta } | null>;
   setPaginationMeta: (layerId: string, meta: CollectionPaginationMeta) => void;
+  setLayerTotal: (layerId: string, total: number) => void;
 }
 
 type CollectionLayerStore = CollectionLayerState & CollectionLayerActions;
@@ -396,6 +397,16 @@ export const useCollectionLayerStore = create<CollectionLayerStore>((set, get) =
     set((state) => ({
       paginationMeta: { ...state.paginationMeta, [layerId]: meta },
     }));
+  },
+
+  // Set the total matching rows for a layer. Used by multi-asset collection
+  // layers, which build virtual items client-side instead of fetching via
+  // fetchLayerData (so layerTotal is never populated by the normal flow).
+  setLayerTotal: (layerId, total) => {
+    set((state) => {
+      if (state.layerTotal[layerId] === total) return state;
+      return { layerTotal: { ...state.layerTotal, [layerId]: total } };
+    });
   },
 
   // Fetch a specific page for a layer with pagination


### PR DESCRIPTION
## Summary

Collection layers bound to a multi-image (multi-asset) field never showed a working total item count, ignored the configured total limit, and broke pagination — both on the canvas and on generated/public pages. On top of that, having such a layer on a page silently wiped out every other real collection's items during server rendering.

## Changes

- Skip the virtual multi-asset collection id when collecting collection ids for the SSR data fetch — querying it against the `uuid` column errored the whole batch and left every real collection on the page empty
- Compute totals, apply the total limit cap, and slice by page for multi-asset collections during server rendering
- Attach pagination metadata so sibling pagination layers (Total items, Page X of Y, Prev/Next) resolve against the asset count
- Publish the asset count to the layer total in the editor so the canvas matches generated pages
- Hide the Sort by / Sort order controls for multi-asset sources (image order comes from the field, with no fields to sort by)

## Test plan

- [ ] Bind a collection layer to a multi-image field and confirm the configured total limit is respected on the canvas
- [ ] Add a Total items / Page X of Y layer and confirm counts reflect the number of images
- [ ] Enable pagination and verify pages slice correctly and Prev/Next work
- [ ] Open Preview and a published page — confirm the same items render as on the canvas
- [ ] Put a multi-image collection layer on the same page as a normal collection and confirm both render
- [ ] Confirm Sort by/order controls are hidden for multi-image sources only