### PR TITLE
fix: emit self-referencing canonical link tag

### DIFF
--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -296,6 +296,13 @@ export async function generatePageMetadata(
   // absolute URLs as strings here instead of relying on metadataBase.
   let siteBaseUrl: string | null = null;
 
+  // URL of the current page, shared by canonical and og:url. Prefer an absolute
+  // URL built from the resolved base (canonical / primary domain / Vercel env)
+  // so it's correct on Vercel and cloud even when the route doesn't set
+  // `metadataBase`. Falls back to the relative path locally (no base
+  // configured), which Next.js resolves against `metadataBase` when available.
+  let pageUrl: string | undefined;
+
   // Always fetch global settings — preview mode reads draft assets so the
   // favicon and web clip render before the user publishes.
   const seoSettings = options.globalSeoSettings || await fetchGlobalPageSettings(isPreview);
@@ -306,6 +313,12 @@ export async function generatePageMetadata(
       primaryDomainUrl,
     });
 
+    pageUrl = pagePath === undefined
+      ? undefined
+      : siteBaseUrl
+        ? buildAbsolutePageUrl(siteBaseUrl, pagePath)
+        : pagePath;
+
     // Add Google Site Verification meta tag
     if (seoSettings.googleSiteVerification) {
       metadata.verification = {
@@ -314,10 +327,10 @@ export async function generatePageMetadata(
     }
 
     // Add canonical URL
-    if (seoSettings.globalCanonicalUrl && pagePath !== undefined) {
+    if (pageUrl !== undefined) {
       metadata.alternates = {
         ...metadata.alternates,
-        canonical: buildAbsolutePageUrl(seoSettings.globalCanonicalUrl, pagePath),
+        canonical: pageUrl,
       };
     }
 
@@ -355,17 +368,6 @@ export async function generatePageMetadata(
         : seoSettings.webClipUrl;
     }
   }
-
-  // URL of the current page for og:url. Prefer an absolute URL built from the
-  // resolved base (canonical / primary domain / Vercel env) so it's correct on
-  // Vercel and cloud even when the route doesn't set `metadataBase`. Falls back
-  // to the relative path locally (no base configured), which Next.js resolves
-  // against `metadataBase` when available.
-  const pageUrl = pagePath === undefined
-    ? undefined
-    : siteBaseUrl
-      ? buildAbsolutePageUrl(siteBaseUrl, pagePath)
-      : pagePath;
 
   // Add Open Graph and Twitter Card metadata (not for error pages)
   if (!isErrorPage) {


### PR DESCRIPTION
## Summary

Pages only emitted `<link rel="canonical">` when a global canonical URL was explicitly configured. This makes every page self-referencing-canonical by default, derived from the same resolved page URL as `og:url`.

## Changes

- Emit `<link rel="canonical">` for every (non-preview) page using the shared page URL
- Resolve to an absolute URL when a base is available (global canonical URL, primary domain, or Vercel env) and fall back to the relative path locally (resolved by Next.js against `metadataBase`)
- Reuse the `og:url` resolution logic instead of duplicating it

## Notes

- Localized pages self-canonicalize correctly (the path comes from the requested slug); hreflang alternates continue to link the locale cluster
- Error pages remain `noindex`, so the canonical there is inert

## Test plan

- [ ] Load a page without a configured canonical URL and confirm `<link rel="canonical">` is present
- [ ] With a canonical URL or primary domain configured, confirm canonical is absolute and matches `og:url`
- [ ] Confirm a localized page's canonical points to its own localized URL
- [ ] Confirm hreflang alternates are unchanged