### PR TITLE
fix: upload base64 images on CSV import instead of inlining

### DIFF
--- a/app/(builder)/ycode/api/collections/import/process/route.ts
+++ b/app/(builder)/ycode/api/collections/import/process/route.ts
@@ -35,6 +35,8 @@ interface UploadedAsset {
 
 /** Encode a URL that may contain unencoded characters like spaces. */
 function sanitizeUrl(url: string): string {
+  // Data URIs are already self-contained and can be huge — never re-parse them.
+  if (url.startsWith('data:')) return url;
   try {
     return new URL(url).href;
   } catch {
@@ -44,6 +46,7 @@ function sanitizeUrl(url: string): string {
 
 /** Extract a decoded filename from a URL, or empty string if none found. */
 function extractFilenameFromUrl(url: string): string {
+  if (url.startsWith('data:')) return '';
   try {
     const segment = new URL(sanitizeUrl(url)).pathname.split('/').pop();
     if (segment && segment.includes('.')) {

--- a/lib/csv-utils.ts
+++ b/lib/csv-utils.ts
@@ -38,6 +38,31 @@ export function isValidUrl(value: string): boolean {
   }
 }
 
+/** Check if a value is a base64-encoded data image URI (e.g. `data:image/png;base64,...`) */
+export function isDataImageUrl(value: string): boolean {
+  return /^data:image\/[^;,]+;base64,/i.test(value.trim());
+}
+
+/** Decoded parts of a base64 data image URI */
+export interface ParsedDataImage {
+  mimeType: string;
+  base64: string;
+  extension: string;
+}
+
+/**
+ * Decode a base64 data image URI into its mime type, base64 payload and file extension.
+ * Returns null when the value is not a valid base64 data image.
+ */
+export function parseDataImageUri(value: string): ParsedDataImage | null {
+  const match = value.trim().match(/^data:(image\/[^;,]+);base64,([\s\S]*)$/);
+  if (!match) return null;
+  const mimeType = match[1];
+  const base64 = match[2];
+  if (!base64) return null;
+  return { mimeType, base64, extension: mimeType.split('/')[1]?.split('+')[0] || 'bin' };
+}
+
 // ============================================================================
 // Helper utilities
 // ============================================================================
@@ -695,8 +720,11 @@ export function extractRichTextImageUrls(json: string): RichTextImageRef[] {
     const refs: RichTextImageRef[] = [];
     walkTipTapNodes(doc, (node) => {
       const attrs = node.attrs as Record<string, unknown> | undefined;
-      if (node.type === 'richTextImage' && attrs?.src && isValidUrl(attrs.src as string)) {
-        refs.push({ src: attrs.src as string });
+      const src = attrs?.src as string | undefined;
+      // Remote URLs (downloaded) and inline base64 data images (decoded) are both
+      // uploaded to the asset manager so they never get stored inline in content.
+      if (node.type === 'richTextImage' && src && (isValidUrl(src) || isDataImageUrl(src))) {
+        refs.push({ src });
       }
     });
     return refs;


### PR DESCRIPTION
## Summary

CSV imports could embed inline base64 images (`data:image/...;base64,...`) directly in rich-text content, producing multi-megabyte collection values that exceed the serverless response payload limit and crash the published dynamic page. This makes the importer treat base64 images the same as remote image URLs — decode, upload to the asset manager (with WebP conversion), and replace the inline data with a hosted URL.

## Changes

- Add `isDataImageUrl` and `parseDataImageUri` helpers to `csv-utils`
- Make `extractRichTextImageUrls` also collect `data:image` srcs so they are uploaded and rewritten (previously only `http(s)` URLs were handled, leaving base64 inline)
- Guard `sanitizeUrl` / `extractFilenameFromUrl` against `data:` URIs so huge data strings aren't needlessly re-parsed by `new URL()`

Base64 images now flow through the existing download/upload path (`fetch` decodes `data:` URLs natively), so they become hosted WebP assets with the rich-text node pointing at the asset.

## Test plan

- [ ] Import a CSV with a rich-text column containing an inline base64 `<img>` — verify the image is uploaded as an asset and the stored content references the hosted URL (no `data:image` remains)
- [ ] Import a CSV with a rich-text column containing a remote image URL — verify existing behavior is unchanged (still downloaded + hosted)
- [ ] Import a CSV with no images — verify no regression
- [ ] Confirm the published page for an imported item with images renders correctly