### PR TITLE
fix: sanitize CMS collection item slugs

### DIFF
--- a/app/(builder)/ycode/components/CollectionItemSheet.tsx
+++ b/app/(builder)/ycode/components/CollectionItemSheet.tsx
@@ -53,6 +53,7 @@ import { useLocalizationMode } from '@/hooks/use-localization-mode';
 import { useLiveCollectionUpdates } from '@/hooks/use-live-collection-updates';
 import { useResourceLock } from '@/hooks/use-resource-lock';
 import { slugify, normalizeBooleanValue, parseMultiReferenceValue } from '@/lib/collection-utils';
+import { sanitizeSlug } from '@/lib/page-utils';
 import { isAssetFieldType, isMultipleAssetField, getFileManagerCategory, getAssetFieldLabel, getAssetFieldTypeLabel, isValidAssetForField, findStatusFieldId } from '@/lib/collection-field-utils';
 import type { StatusAction } from '@/lib/collection-field-utils';
 import { CollectionStatusPill, parseStatusValue } from './CollectionStatusPill';
@@ -470,6 +471,12 @@ export default function CollectionItemSheet({
         values[field.id] = normalizeBooleanValue(values[field.id]);
       }
     });
+
+    // Normalize the slug to a valid URL segment before validation/save so a
+    // pasted leading slash, spaces or invalid chars can't break routing.
+    if (slugField && typeof values[slugField.id] === 'string') {
+      values[slugField.id] = slugify(values[slugField.id]);
+    }
 
     let hasErrors = false;
 
@@ -1103,6 +1110,18 @@ export default function CollectionItemSheet({
                               value={formField.value}
                               onChange={formField.onChange}
                               onBlur={formField.onBlur}
+                            />
+                          ) : field.key === 'slug' ? (
+                            <Input
+                              placeholder={field.default || `Enter ${field.name.toLowerCase()}...`}
+                              autoComplete="off"
+                              name={formField.name}
+                              value={formField.value}
+                              onChange={(e) => formField.onChange(sanitizeSlug(e.target.value, true))}
+                              onBlur={(e) => {
+                                formField.onChange(sanitizeSlug(e.target.value, false));
+                                formField.onBlur();
+                              }}
                             />
                           ) : (
                             <Input

--- a/lib/repositories/collectionItemValueRepository.ts
+++ b/lib/repositories/collectionItemValueRepository.ts
@@ -3,7 +3,7 @@ import { SUPABASE_QUERY_LIMIT } from '@/lib/supabase-constants';
 import { getKnexClient } from '@/lib/knex-client';
 import type { CollectionItemValue, CollectionFieldType } from '@/types';
 import { isValidUUID } from '@/lib/utils';
-import { castValue, valueToString } from '../collection-utils';
+import { castValue, valueToString, slugify } from '../collection-utils';
 import { generateCollectionItemContentHash } from '../hash-utils';
 import { randomUUID } from 'crypto';
 import { deleteTranslationsInBulk, markTranslationsIncomplete } from '@/lib/repositories/translationRepository';
@@ -583,7 +583,13 @@ export async function setValuesByFieldName(
 
   for (const [fieldId, value] of Object.entries(values)) {
     const type = fieldMap[fieldId] || fieldType[fieldId] || 'text';
-    valuesToSet[fieldId] = valueToString(value, type);
+    let stringValue = valueToString(value, type);
+    // Normalize slug values to a valid URL segment so a stray leading slash,
+    // spaces or invalid chars can't break dynamic page routing.
+    if (stringValue && fieldKeyMap[fieldId] === 'slug') {
+      stringValue = slugify(stringValue);
+    }
+    valuesToSet[fieldId] = stringValue;
   }
 
   // Auto-bump the virtual `updated_at` field whenever values are being set,


### PR DESCRIPTION
## Summary

A published article 404'd on the live site because its CMS slug was saved with a stray leading slash (`/best-affiliate-marketing-programs`). Dynamic page routing matches the URL segment against the stored slug with an exact equality, so the slash broke resolution. This adds slug normalization so invalid slugs can no longer be saved.

## Changes

- Sanitize slug values server-side in `setValuesByFieldName` (covers every write path: builder UI, v1 API, Airtable sync, imports, MCP)
- Live-sanitize the slug input in `CollectionItemSheet` as the user types, and normalize on submit before validation/save
- Reuse existing `slugify` / `sanitizeSlug` utilities (strip leading/trailing slashes, lowercase, transliterate, replace invalid chars)

## Test plan

- [ ] Create a CMS item, paste `/foo-bar` into the slug → saves as `foo-bar`
- [ ] Type a slug with spaces/uppercase → normalized to a valid URL segment
- [ ] Auto-slug from Name still works for new items
- [ ] Slug uniqueness validation runs against the normalized value
- [ ] Confirm the dynamic page for the item resolves (no 404)