### PR TITLE
fix: render localized collection text in repeated collections

### DIFF
--- a/lib/localisation-utils.ts
+++ b/lib/localisation-utils.ts
@@ -892,6 +892,14 @@ export function injectTranslatedText(
     const textTranslation = getTranslationByKey(translations, textTranslationKey);
 
     const textValue = getTranslationValue(textTranslation, valueOptions);
+    // A layer-level text translation whose value is a rich-text doc still
+    // containing an unresolved `dynamicVariable` node is a binding artefact
+    // (the translation UI re-captured the field binding, not real translated
+    // text). Injecting it raw overwrites the already collection-resolved text
+    // with an unresolvable node, rendering empty. The actual localization for
+    // such bindings comes from the CMS field translation applied during
+    // collection resolution, so skip the layer translation in this case.
+    const textReintroducesDynamicVariable = richTextHasDynamicVariable(textValue);
     // Only inject when the layer actually has a text variable to translate.
     // Stale/orphan translation rows (e.g. legacy migration artefacts that
     // point at an ancestor div/section without `variables.text`) would
@@ -909,6 +917,7 @@ export function injectTranslatedText(
     const hasComponentVariableBinding = !!(layer.variables?.text as any)?.id;
     if (
       textValue
+      && !textReintroducesDynamicVariable
       && layer.variables?.text
       && !(layer as any)._textFromOverride
       && !hasComponentVariableBinding
@@ -938,6 +947,7 @@ export function injectTranslatedText(
       }
     } else if (
       textValue
+      && !textReintroducesDynamicVariable
       && hasComponentVariableBinding
       && !(layer as any)._textFromOverride
     ) {
@@ -1173,6 +1183,16 @@ export function looksLikeTiptapJson(value: string | null | undefined): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Whether a serialized rich-text value still contains an unresolved
+ * `dynamicVariable` node (a field/collection binding). Such values must not be
+ * injected as layer text — the binding renders empty outside the collection
+ * resolution pipeline.
+ */
+export function richTextHasDynamicVariable(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.includes('"dynamicVariable"');
 }
 
 /**

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -273,6 +273,9 @@ interface TranslationLoadContext {
   isPublished: boolean;
   tenantId?: string;
   loadedItemIds: Set<string>;
+  // In-flight loads keyed by item id. Concurrent resolutions of the same item
+  // await the same fetch instead of skipping it before rows are merged.
+  inFlight: Map<string, Promise<void>>;
 }
 
 const translationLoadContexts = new WeakMap<object, TranslationLoadContext>();
@@ -289,6 +292,7 @@ function registerTranslationContext(
     isPublished,
     tenantId,
     loadedItemIds: new Set(),
+    inFlight: new Map(),
   });
 }
 
@@ -309,22 +313,46 @@ export async function ensureCmsTranslations(
   const ctx = translationLoadContexts.get(translations);
   if (!ctx) return;
 
-  const missing: string[] = [];
+  // Partition requested ids: those needing a fresh fetch vs. those already
+  // being fetched by a concurrent caller (whose promise we must await).
+  const toFetch: string[] = [];
+  const waits: Promise<void>[] = [];
   for (const id of itemIds) {
-    if (id && !ctx.loadedItemIds.has(id)) {
-      ctx.loadedItemIds.add(id);
-      missing.push(id);
+    if (!id || ctx.loadedItemIds.has(id)) continue;
+    const existing = ctx.inFlight.get(id);
+    if (existing) {
+      waits.push(existing);
+    } else {
+      toFetch.push(id);
     }
   }
-  if (missing.length === 0) return;
 
-  try {
-    const rows = await getCmsTranslationsForItems(ctx.localeId, ctx.isPublished, missing, ctx.tenantId);
-    for (const row of rows) {
-      translations[getTranslatableKey(row)] = row;
+  if (toFetch.length > 0) {
+    // Mark loaded ids only AFTER rows are merged, so concurrent callers don't
+    // run applyCmsTranslations against a map that hasn't received the rows yet.
+    const loadPromise = (async () => {
+      try {
+        const rows = await getCmsTranslationsForItems(ctx.localeId, ctx.isPublished, toFetch, ctx.tenantId);
+        for (const row of rows) {
+          translations[getTranslatableKey(row)] = row;
+        }
+      } catch (error) {
+        console.error('Failed to load scoped CMS translations:', error);
+      } finally {
+        for (const id of toFetch) {
+          ctx.loadedItemIds.add(id);
+          ctx.inFlight.delete(id);
+        }
+      }
+    })();
+    for (const id of toFetch) {
+      ctx.inFlight.set(id, loadPromise);
     }
-  } catch (error) {
-    console.error('Failed to load scoped CMS translations:', error);
+    waits.push(loadPromise);
+  }
+
+  if (waits.length > 0) {
+    await Promise.all(waits);
   }
 }
 


### PR DESCRIPTION
## Summary

On non-default locales, translated collection text (e.g. a footer category list) rendered blank even though the same collection rendered correctly elsewhere on the page and the translations were saved and published. Two compounding bugs in the server-side localization pipeline caused this.

## Changes

- **Fix race in `ensureCmsTranslations`** (`lib/page-fetcher.ts`): item IDs were marked loaded *before* the async CMS-translation fetch resolved. Concurrent resolutions of the same item then skipped the fetch and ran `applyCmsTranslations` against a map missing the rows, falling back to the default locale. Now concurrent callers await a shared in-flight load, and IDs are marked loaded only after rows merge.
- **Fix clobber in `injectTranslatedText`** (`lib/localisation-utils.ts`): a layer-level text translation that only re-states a `dynamicVariable` field binding overwrote the already collection-resolved text with an unresolvable node, rendering empty. Such binding-only translations are now skipped — localization for bound fields comes from the CMS field translation during resolution. Added a `richTextHasDynamicVariable()` helper.

## Test plan

- [ ] On a multi-locale site, render a non-default locale page containing a collection list that is also used elsewhere (e.g. footer + main section); confirm all items show translated text
- [ ] Confirm the default locale still renders correctly (no regression)
- [ ] Confirm a normal (non-binding) layer text translation still applies