### PR TITLE
fix: align hreflang URLs with canonical format

### DIFF
--- a/lib/hreflang-utils.ts
+++ b/lib/hreflang-utils.ts
@@ -9,6 +9,7 @@
 import type { Locale, Page, PageFolder, Translation } from '@/types';
 import { buildSlugPath, buildLocalizedSlugPath } from './page-utils';
 import { getTranslatableKey } from './locale-runtime';
+import { buildAbsolutePageUrl } from './url-utils';
 
 export interface HreflangAlternate {
   hreflang: string;
@@ -37,7 +38,7 @@ function buildDynamicDefaultUrl(
 ): string {
   const folderPath = buildSlugPath(page, folders, 'page', '').replace(/\/$/, '');
   const itemPath = folderPath ? `${folderPath}/${slugValue}` : `/${slugValue}`;
-  return `${baseUrl}${itemPath}`;
+  return buildAbsolutePageUrl(baseUrl, itemPath);
 }
 
 /** Build a localized absolute URL for a dynamic item in a non-default locale. */
@@ -69,7 +70,7 @@ function buildDynamicLocalizedUrl(
     ? `${localizedFolderPath}/${translatedSlug}`
     : `/${locale.code}/${translatedSlug}`;
 
-  return `${baseUrl}${localizedItemPath}`;
+  return buildAbsolutePageUrl(baseUrl, localizedItemPath);
 }
 
 /**
@@ -103,7 +104,7 @@ export function buildPageHreflangAlternates(params: {
 
   const defaultUrl = dynamicSlug
     ? buildDynamicDefaultUrl(page, folders, baseUrl, dynamicSlug.defaultValue)
-    : `${baseUrl}${buildSlugPath(page, folders, 'page')}`;
+    : buildAbsolutePageUrl(baseUrl, buildSlugPath(page, folders, 'page'));
 
   const alternates: HreflangAlternate[] = [];
 
@@ -115,7 +116,7 @@ export function buildPageHreflangAlternates(params: {
     const translations = translationsByLocale.get(locale.id);
     const href = dynamicSlug
       ? buildDynamicLocalizedUrl(page, folders, baseUrl, locale, translations, dynamicSlug)
-      : `${baseUrl}${buildLocalizedSlugPath(page, folders, 'page', locale, translations)}`;
+      : buildAbsolutePageUrl(baseUrl, buildLocalizedSlugPath(page, folders, 'page', locale, translations));
     alternates.push({ hreflang: locale.code, href });
   }
 

--- a/lib/page-utils.ts
+++ b/lib/page-utils.ts
@@ -266,9 +266,12 @@ export function buildLocalizedSlugPath(
     }
   }
 
-  // Add locale code prefix
-  const pathWithoutLocale = '/' + slugParts.map(normalizeSlugSegment).filter(Boolean).join('/');
-  return `/${locale.code}${pathWithoutLocale}`;
+  // Add locale code prefix. Index pages have no slug segments, so the localized
+  // homepage is `/<locale>` (no trailing slash) to match its canonical URL.
+  const localizedSegments = slugParts.map(normalizeSlugSegment).filter(Boolean);
+  return localizedSegments.length > 0
+    ? `/${locale.code}/${localizedSegments.join('/')}`
+    : `/${locale.code}`;
 }
 
 /**

--- a/lib/sitemap-utils.ts
+++ b/lib/sitemap-utils.ts
@@ -16,6 +16,7 @@ import type {
 import { buildSlugPath } from './page-utils';
 import { buildPageHreflangAlternates } from './hreflang-utils';
 import type { HreflangAlternate } from './hreflang-utils';
+import { buildAbsolutePageUrl } from './url-utils';
 
 export interface SitemapUrl {
   loc: string;
@@ -49,7 +50,7 @@ function buildStaticPageUrls(
 
   // Build the default (base) URL
   const defaultPath = buildSlugPath(page, folders, 'page');
-  const defaultUrl = `${baseUrl}${defaultPath}`;
+  const defaultUrl = buildAbsolutePageUrl(baseUrl, defaultPath);
 
   const sitemapUrl: SitemapUrl = {
     loc: defaultUrl,
@@ -109,7 +110,7 @@ function buildDynamicPageUrls(
     if (!slugValue) continue;
 
     const itemPath = folderPath ? `${folderPath}/${slugValue}` : `/${slugValue}`;
-    const itemUrl = `${baseUrl}${itemPath}`;
+    const itemUrl = buildAbsolutePageUrl(baseUrl, itemPath);
 
     const sitemapUrl: SitemapUrl = {
       loc: itemUrl,


### PR DESCRIPTION
## Summary

On multilingual sites, the native server-rendered hreflang annotations did not match the canonical URL: the homepage and localized homepages emitted a trailing slash (e.g. `/de/`) while the canonical had none (`/de`). When hreflang URLs point at a different (redirecting) URL than the canonical, search engines can ignore the entire hreflang cluster.

This aligns hreflang (and sitemap) URLs with the exact canonical format.

## Changes

- Build localized index page paths without a trailing slash (`/<locale>` instead of `/<locale>/`)
- Route hreflang `href` URLs through the same normalizer used by the canonical, so the default homepage collapses to the bare base and every alternate matches its canonical
- Apply the same normalizer to sitemap `loc` URLs so the sitemap stays consistent with canonical/hreflang
- Covers home, localized, static, and dynamic pages

## Test plan

- [ ] View source on the default homepage: canonical and `en`/`x-default` hreflang both have no trailing slash
- [ ] View source on a localized homepage: canonical and the self hreflang match exactly (no trailing slash)
- [ ] Check a static and a dynamic page: all hreflang `href`s match their canonical
- [ ] Verify the generated sitemap `<loc>` and `xhtml:link` entries match the canonical format