### PR TITLE
fix: correct heading style for component text overrides on canvas

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -1141,7 +1141,14 @@ const LayerItemImpl: React.FC<{
       if (valueToRender !== undefined) {
         // Value is typed as ComponentVariableValue - check if it's a text variable (has 'type' property)
         if ('type' in valueToRender && valueToRender.type === 'dynamic_rich_text') {
-          return renderRichText(valueToRender as any, collectionLayerData, pageCollectionItemData || undefined, layer.textStyles, useSpanForParagraphs, isEditMode, linkContext, timezone, effectiveLayerDataMap, allComponents, renderComponentBlock, effectiveAncestorIds, isSimpleTextLayer, globalsMeta);
+          // For heading/text layers, flatten multi-paragraph content so the
+          // wrapper's typography applies instead of inner block styles — matches
+          // the public/preview renderer and the other rich-text branches.
+          const richTextValue = valueToRender as any;
+          const variable = isSimpleTextLayer
+            ? { ...richTextValue, data: { ...richTextValue.data, content: flattenTiptapParagraphs(richTextValue.data.content) } }
+            : richTextValue;
+          return renderRichText(variable as any, collectionLayerData, pageCollectionItemData || undefined, layer.textStyles, useSpanForParagraphs, isEditMode, linkContext, timezone, effectiveLayerDataMap, allComponents, renderComponentBlock, effectiveAncestorIds, isSimpleTextLayer, globalsMeta);
         }
         if ('type' in valueToRender && valueToRender.type === 'dynamic_text') {
           return (valueToRender as any).data.content;


### PR DESCRIPTION
## Summary

Setting a per-instance text override on a component heading made the heading render with the wrong style on the page canvas (builder edit mode), while the component canvas and published/preview output looked correct.

## Root cause

Component text overrides are stored as rich-text (Tiptap) docs. Three branches render this content for a heading/text layer; two already flatten multi-paragraph content so the layer wrapper's typography applies, but the override/default-value branch did not. As a result, inner block nodes rendered with their own text styles instead of the heading wrapper's classes. The preview/public path flattens (overrides are baked + flattened server-side), which is why only the page canvas was affected.

## Changes

- Flatten multi-paragraph override rich text for simple text layers (headings/text) in the edit-mode override branch of `LayerRenderer`, matching the sibling rich-text branches and the public renderer

## Test plan

- [ ] On a page, add a component with a heading bound to a text variable
- [ ] Set a per-instance text override on the heading
- [ ] Verify the heading style on the page canvas matches the component canvas and the published preview
- [ ] Verify a multi-line override renders as a single flattened line on heading/text layers
- [ ] Verify non-simple (rich-text) layers still render multi-paragraph content