### PR TITLE
feat: allow editable regional locale codes

### DIFF
--- a/app/(builder)/ycode/components/HeaderBar.tsx
+++ b/app/(builder)/ycode/components/HeaderBar.tsx
@@ -6,7 +6,6 @@ import { useEditorUrl } from '@/hooks/use-editor-url';
 import { findHomepage } from '@/lib/page-utils';
 import { getTranslationValue } from '@/lib/localisation-utils';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -32,6 +31,7 @@ import type { Page } from '@/types';
 import type { User } from '@supabase/supabase-js';
 import ActiveUsersInHeader from './ActiveUsersInHeader';
 import InviteUserButton from './InviteUserButton';
+import { LocaleSelector } from './LocaleSelector';
 import PublishPopover from './PublishPopover';
 import { Label } from '@/components/ui/label';
 import Icon from '@/components/ui/icon';
@@ -110,9 +110,7 @@ export default function HeaderBar({
 
   const locales = useLocalisationStore((s) => s.locales);
   const selectedLocaleId = useLocalisationStore((s) => s.selectedLocaleId);
-  const setSelectedLocaleId = useLocalisationStore((s) => s.setSelectedLocaleId);
   const translations = useLocalisationStore((s) => s.translations);
-  const loadTranslations = useLocalisationStore((s) => s.loadTranslations);
   const { navigateToLayers, navigateToCollection, navigateToCollections, updateQueryParams, routeType } = useEditorUrl();
 
   // Optimistic nav button state - set immediately on click, cleared when URL catches up
@@ -620,49 +618,7 @@ export default function HeaderBar({
       </div>
 
       <div className="flex gap-1.5 items-center justify-center">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button size="xs" variant="ghost">
-              <Icon name="globe" />
-              {selectedLocale ? selectedLocale.code.toUpperCase() : 'EN'}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {canManageSettings && !pathname?.startsWith('/ycode/localization') && (
-              <>
-                <DropdownMenuItem
-                  onClick={() => router.push('/ycode/localization')}
-                >
-                  Manage locales
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-              </>
-            )}
-            <DropdownMenuRadioGroup
-              value={selectedLocaleId || ''}
-              onValueChange={(value) => {
-                setSelectedLocaleId(value);
-                // Eager-load translations so the canvas reflects the new locale
-                // without waiting for component-level effects to run. The store
-                // short-circuits for the default locale and for cached locales.
-                loadTranslations(value);
-              }}
-            >
-              {locales.map((locale) => (
-                <DropdownMenuRadioItem key={locale.id} value={locale.id}>
-                  <span className="flex items-center gap-3">
-                    {locale.label}
-                    {locale.is_default && (
-                      <Badge variant="secondary" className="text-[10px] mr-5">
-                        Default
-                      </Badge>
-                    )}
-                  </span>
-                </DropdownMenuRadioItem>
-              ))}
-            </DropdownMenuRadioGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <LocaleSelector />
 
         <div className="h-5">
           <Separator orientation="vertical" />

--- a/app/(builder)/ycode/components/LocaleSelector.tsx
+++ b/app/(builder)/ycode/components/LocaleSelector.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { memo } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import Icon from '@/components/ui/icon';
+import { useLocalisationStore } from '@/stores/useLocalisationStore';
+import { useRole } from '@/hooks/use-role';
+
+/**
+ * Locale switcher for the header. Kept as its own memoized component that only
+ * subscribes to locale state (never `translations`) so an async translation
+ * load doesn't re-render it and interrupt the dropdown's close animation.
+ */
+function LocaleSelectorComponent() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { canManageSettings } = useRole();
+
+  const locales = useLocalisationStore((s) => s.locales);
+  const selectedLocaleId = useLocalisationStore((s) => s.selectedLocaleId);
+  const setSelectedLocaleId = useLocalisationStore((s) => s.setSelectedLocaleId);
+  const loadTranslations = useLocalisationStore((s) => s.loadTranslations);
+
+  const selectedLocale = selectedLocaleId
+    ? locales.find((l) => l.id === selectedLocaleId) || null
+    : null;
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button size="xs" variant="ghost">
+          <Icon name="globe" />
+          {selectedLocale ? selectedLocale.code.toUpperCase() : 'EN'}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {canManageSettings && !pathname?.startsWith('/ycode/localization') && (
+          <>
+            <DropdownMenuItem onClick={() => router.push('/ycode/localization')}>
+              Manage locales & translations
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
+        <DropdownMenuRadioGroup
+          value={selectedLocaleId || ''}
+          onValueChange={(value) => {
+            setSelectedLocaleId(value);
+            // Eager-load translations so the canvas reflects the new locale
+            // without waiting for component-level effects to run. The store
+            // short-circuits for the default locale and for cached locales.
+            loadTranslations(value);
+          }}
+        >
+          {locales.map((locale) => (
+            <DropdownMenuRadioItem
+              key={locale.id} value={locale.id}
+              className="pr-8"
+            >
+              <span className="flex items-center gap-2 w-full">
+                <span className="bg-secondary text-secondary-foreground text-[10px] font-semibold py-0.5 px-1.5 rounded-[6px] uppercase shrink-0">
+                  {locale.code}
+                </span>
+                {locale.label}{locale.is_default && (<><span className="px-px">–</span>Default locale</>)}
+              </span>
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export const LocaleSelector = memo(LocaleSelectorComponent);

--- a/app/(builder)/ycode/components/LocalizationContent.tsx
+++ b/app/(builder)/ycode/components/LocalizationContent.tsx
@@ -15,7 +15,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
 import { InputAutocomplete } from '@/components/ui/input-autocomplete';
-import { LOCALES, extractPageTranslatableItems, extractFolderTranslatableItems, extractComponentTranslatableItems, extractCmsTranslatableItems } from '@/lib/localisation-utils';
+import { LOCALES, sanitizeRegionCode, buildLocaleCode, parseLocaleCode, isValidLocaleCode, extractPageTranslatableItems, extractFolderTranslatableItems, extractComponentTranslatableItems, extractCmsTranslatableItems } from '@/lib/localisation-utils';
 import { findLayerById } from '@/lib/layer-utils';
 import { buildFieldGroupsForLayer } from '@/lib/collection-field-utils';
 import type { TranslatableItem } from '@/lib/localisation-utils';
@@ -41,6 +41,8 @@ interface ModalState {
   isEditMode: boolean;
   editingLocaleId: string | null;
   selectedLanguage: LocaleOption | null;
+  localeCode: string;
+  regionCode: string;
   customLocaleName: string;
   isDefaultLocale: boolean;
   localeSearch: string;
@@ -51,6 +53,8 @@ const initialModalState: ModalState = {
   isEditMode: false,
   editingLocaleId: null,
   selectedLanguage: null,
+  localeCode: '',
+  regionCode: '',
   customLocaleName: '',
   isDefaultLocale: false,
   localeSearch: '',
@@ -470,14 +474,30 @@ export default function LocalizationContent({ children }: LocalizationContentPro
   const existingLocaleCodes = new Set(locales.map(l => l.code));
   const availableLocales = LOCALES.filter(l => !existingLocaleCodes.has(l.code));
 
+  // Combine the picker-driven base language with the editable region subtag,
+  // then validate the result against its BCP-47 shape and existing locales
+  // (excluding the one currently being edited).
+  const fullLocaleCode = buildLocaleCode(modalState.localeCode, modalState.regionCode);
+  const isDuplicateLocaleCode = locales.some(
+    l => l.code === fullLocaleCode && l.id !== modalState.editingLocaleId
+  );
+  const isLocaleCodeValid = !!modalState.localeCode && isValidLocaleCode(fullLocaleCode) && !isDuplicateLocaleCode;
+
+  const localeCodeError = (() => {
+    if (!modalState.localeCode || !modalState.regionCode) return null;
+    if (isDuplicateLocaleCode) return 'This locale code already exists.';
+    if (!isValidLocaleCode(fullLocaleCode)) return 'Enter a valid region like "BE".';
+    return null;
+  })();
+
   const handleAddLocale = async () => {
-    if (!modalState.selectedLanguage || !modalState.customLocaleName.trim()) {
+    if (!isLocaleCodeValid || !modalState.customLocaleName.trim()) {
       return;
     }
 
     try {
       const newLocale = await createLocale({
-        code: modalState.selectedLanguage.code,
+        code: fullLocaleCode,
         label: modalState.customLocaleName.trim(),
         is_default: modalState.isDefaultLocale,
       });
@@ -492,12 +512,13 @@ export default function LocalizationContent({ children }: LocalizationContentPro
   };
 
   const handleUpdateLocale = async () => {
-    if (!modalState.editingLocaleId || !modalState.customLocaleName.trim()) {
+    if (!modalState.editingLocaleId || !isLocaleCodeValid || !modalState.customLocaleName.trim()) {
       return;
     }
 
     try {
       await updateLocale(modalState.editingLocaleId, {
+        code: fullLocaleCode,
         label: modalState.customLocaleName.trim(),
         is_default: modalState.isDefaultLocale,
       });
@@ -524,14 +545,18 @@ export default function LocalizationContent({ children }: LocalizationContentPro
   const handleOpenEditDialog = (locale: Locale) => {
     clearError();
 
-    // Set the selected language to show in the disabled selector
-    const localeOption = LOCALES.find(l => l.code === locale.code);
+    // Split the stored code into its base language and region parts so each
+    // maps to its own input.
+    const { language, region } = parseLocaleCode(locale.code);
+    const localeOption = LOCALES.find(l => l.code === language);
 
     setModalState({
       isOpen: true,
       isEditMode: true,
       editingLocaleId: locale.id,
       customLocaleName: locale.label,
+      localeCode: language,
+      regionCode: region,
       isDefaultLocale: locale.is_default,
       selectedLanguage: localeOption || null,
       localeSearch: localeOption?.label || '',
@@ -551,15 +576,21 @@ export default function LocalizationContent({ children }: LocalizationContentPro
         ...prev,
         selectedLanguage: null,
         localeSearch: '',
+        localeCode: '',
+        regionCode: '',
         customLocaleName: '',
       }));
       return;
     }
 
+    const { language, region } = parseLocaleCode(locale.code);
+
     setModalState(prev => ({
       ...prev,
       localeSearch: locale.label,
       selectedLanguage: locale,
+      localeCode: language,
+      regionCode: region,
       customLocaleName: locale.label,
     }));
   };
@@ -602,7 +633,7 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                   onClick={() => setSelectedLocaleId(locale.id)}
                 >
                   <div className="flex items-center flex-1 outline-none focus:outline-none select-none text-left text-xs gap-1.5 min-w-0">
-                    <span className="bg-secondary text-[10px] font-semibold py-0.5 px-1.5 rounded-[6px] uppercase shrink-0">{locale.code}</span>
+                    <span className="bg-secondary text-secondary-foreground text-[10px] font-semibold py-0.5 px-1.5 rounded-[6px] uppercase shrink-0">{locale.code}</span>
                     <Label className="cursor-[inherit] min-w-0 flex-1">
                       <div className="truncate">{locale.label}</div>
                     </Label>
@@ -1129,26 +1160,47 @@ export default function LocalizationContent({ children }: LocalizationContentPro
               />
             </div>
 
-            <div className="flex gap-3">
-              <div className="flex flex-col gap-2 flex-1">
-                <Label htmlFor="name">Custom name</Label>
-                <Input
-                  id="name"
-                  value={modalState.customLocaleName}
-                  onChange={(e) => setModalState(prev => ({ ...prev, customLocaleName: e.target.value }))}
-                  placeholder="Custom name"
-                />
+            <div className="flex flex-col gap-2">
+              <div className="flex gap-3">
+                <div className="flex flex-col gap-2 flex-1">
+                  <div className="flex items-center gap-2">
+                    <Label htmlFor="name">Custom name</Label>
+                    {fullLocaleCode && (
+                      <span className="text-xs text-muted-foreground uppercase">{fullLocaleCode}</span>
+                    )}
+                  </div>
+                  <Input
+                    id="name"
+                    value={modalState.customLocaleName}
+                    onChange={(e) => setModalState(prev => ({ ...prev, customLocaleName: e.target.value }))}
+                    placeholder="Custom name"
+                  />
+                </div>
+                <div className="flex flex-col gap-2 w-24">
+                  <Label htmlFor="code" className="whitespace-nowrap">Locale code</Label>
+                  <Input
+                    id="code"
+                    value={modalState.localeCode}
+                    disabled
+                    placeholder="Code"
+                    className={modalState.localeCode ? 'uppercase' : ''}
+                  />
+                </div>
+                <div className="flex flex-col gap-2 w-24">
+                  <Label htmlFor="region" className="whitespace-nowrap">Regional code</Label>
+                  <Input
+                    id="region"
+                    value={modalState.regionCode}
+                    onChange={(e) => setModalState(prev => ({ ...prev, regionCode: sanitizeRegionCode(e.target.value) }))}
+                    placeholder="e.g. BE"
+                    disabled={!modalState.localeCode}
+                    className={cn(modalState.regionCode && 'uppercase', localeCodeError && 'border-destructive')}
+                  />
+                </div>
               </div>
-              <div className="flex flex-col gap-2 flex-1">
-                <Label htmlFor="code">Locale code</Label>
-                <Input
-                  id="code"
-                  value={modalState.selectedLanguage?.code || ''}
-                  disabled
-                  placeholder="Code"
-                  className={modalState.selectedLanguage?.code ? 'uppercase' : ''}
-                />
-              </div>
+              {localeCodeError && (
+                <span className="text-xs text-destructive">{localeCodeError}</span>
+              )}
             </div>
 
             {(() => {
@@ -1237,8 +1289,8 @@ export default function LocalizationContent({ children }: LocalizationContentPro
                 onClick={modalState.isEditMode ? handleUpdateLocale : handleAddLocale}
                 disabled={
                   modalState.isEditMode
-                    ? !modalState.customLocaleName.trim() || isLoading.update
-                    : !modalState.selectedLanguage || !modalState.customLocaleName.trim() || isLoading.create
+                    ? !isLocaleCodeValid || !modalState.customLocaleName.trim() || isLoading.update
+                    : !isLocaleCodeValid || !modalState.customLocaleName.trim() || isLoading.create
                 }
                 size="sm"
               >

--- a/lib/localisation-utils.ts
+++ b/lib/localisation-utils.ts
@@ -262,6 +262,42 @@ export function isLocaleCodeSupported(code: string): boolean {
 }
 
 /**
+ * Strip characters that aren't valid in a region subtag and lowercase the rest.
+ * Keeps only letters and digits (e.g. "BE" -> "be", "419" stays "419").
+ */
+export function sanitizeRegionCode(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/**
+ * Combine a base language code and optional region subtag into a full locale code.
+ * e.g. ("nl", "be") -> "nl-be", ("nl", "") -> "nl".
+ */
+export function buildLocaleCode(language: string, region: string): string {
+  return region ? `${language}-${region}` : language;
+}
+
+/**
+ * Split a locale code into its language and region parts at the first hyphen.
+ * e.g. "fr-ca" -> { language: "fr", region: "ca" }, "nl" -> { language: "nl", region: "" }.
+ */
+export function parseLocaleCode(code: string): { language: string; region: string } {
+  const dashIndex = code.indexOf('-');
+  if (dashIndex === -1) {
+    return { language: code, region: '' };
+  }
+  return { language: code.slice(0, dashIndex), region: code.slice(dashIndex + 1) };
+}
+
+/**
+ * Validate a BCP-47-style locale code: a 2-3 letter language, optionally
+ * followed by hyphen-separated region/script subtags (e.g. "nl", "nl-be", "zh-hans-cn").
+ */
+export function isValidLocaleCode(code: string): boolean {
+  return /^[a-z]{2,3}(-[a-z0-9]{2,4})*$/.test(code);
+}
+
+/**
  * Check if a locale is right-to-left
  */
 export function isLocaleRtl(locale: LocaleOption): boolean {


### PR DESCRIPTION
## Summary

Lets users target regional locales (e.g. `nl-BE`, `it-CH`) for SEO by making the locale code editable, instead of being limited to the fixed language picker list. Addresses ycode/ycode#412.

## Changes

- Split the Add/Edit locale dialog into a picker-driven **Locale code** (language) and an editable **Regional code** field, combined into the stored code (e.g. `nl` + `BE` → `nl-be`)
- Show the combined code live next to the "Custom name" label, with inline validation for shape and duplicates
- Add reusable helpers in `localisation-utils`: `sanitizeRegionCode`, `buildLocaleCode`, `parseLocaleCode`, `isValidLocaleCode`
- Display the locale code pill in the header locale selector options (and fix the pill's white-on-white contrast in the localization sidebar when selected)
- Extract a memoized `LocaleSelector` component so the async translation load no longer re-renders the header and interrupts the dropdown's close animation

## Test plan

- [ ] Add a locale: pick a language, type a region (e.g. `BE`) → saves as `nl-be`, pill shows `NL-BE`
- [ ] Edit an existing locale's regional code and confirm it persists after reload
- [ ] Duplicate/invalid code shows the inline error and disables Save
- [ ] Select a locale in the header for the first time (uncached) → dropdown closes cleanly, no flicker
- [ ] Publish, then verify the localized URL (`/nl-be/...`), preview URL, and hreflang tags use the new code
- [ ] Verify the code pill is readable in both light and dark mode, selected and unselected