### PR TITLE
fix: improve layer context menu behavior and canvas isolation

### DIFF
--- a/components/ui/context-menu.tsx
+++ b/components/ui/context-menu.tsx
@@ -7,6 +7,41 @@ import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import Icon from '@/components/ui/icon';
 
+/**
+ * Shares the "armed" flag between {@link ContextMenuContent} and its items so a
+ * single release-guard can neutralise the first pointerup after the menu opens.
+ */
+const ContextMenuReleaseGuard = React.createContext<React.MutableRefObject<boolean> | null>(null);
+
+/**
+ * Overrides applied when the menu is portaled into a foreign container (e.g. the
+ * canvas iframe body). Neutralises typography inherited from the edited page's
+ * font classes and forces a max z-index so page layers can't paint over it.
+ */
+const PORTAL_MENU_STYLE: React.CSSProperties = {
+  fontFamily:
+    'var(--font-inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif)',
+  fontSize: '16px',
+  fontWeight: 400,
+  fontStyle: 'normal',
+  lineHeight: 'normal',
+  letterSpacing: 'normal',
+  textTransform: 'none',
+  zIndex: 2147483647,
+};
+
+/**
+ * Re-arms the release guard on every menu open. Rendered inside the Radix
+ * content subtree (mounted/unmounted with the menu), so its mount effect runs
+ * once per open regardless of the outer wrapper's persistence.
+ */
+function ArmReleaseGuard({ armedRef }: { armedRef: React.MutableRefObject<boolean> }) {
+  React.useLayoutEffect(() => {
+    armedRef.current = true;
+  }, [armedRef]);
+  return null;
+}
+
 function ContextMenu({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
@@ -81,6 +116,7 @@ function ContextMenuSubTrigger({
 function ContextMenuSubContent({
   className,
   container,
+  style,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.SubContent> & {
   container?: HTMLElement | null
@@ -92,6 +128,7 @@ function ContextMenuSubContent({
         'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg p-1 shadow-lg',
         className
       )}
+      style={container ? { ...PORTAL_MENU_STYLE, ...style } : style}
       {...props}
     />
   );
@@ -110,10 +147,25 @@ function ContextMenuSubContent({
 function ContextMenuContent({
   className,
   container,
+  children,
+  style,
+  onPointerDown,
+  onPointerUp,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Content> & {
   container?: HTMLElement | null
 }) {
+  // When the menu opens near a screen edge, Radix repositions it so an item
+  // lands under the cursor. Releasing the right-click then fires a pointerup on
+  // that item (with no prior pointerdown), which Radix treats as a selection —
+  // instantly closing the menu. We arm a guard on open and swallow that first
+  // release; a fresh pointerdown (intentional press) disarms it.
+  const armedRef = React.useRef(false);
+
+  const disarm = React.useCallback(() => {
+    armedRef.current = false;
+  }, []);
+
   return (
     <ContextMenuPrimitive.Portal container={container ?? undefined}>
       <ContextMenuPrimitive.Content
@@ -122,8 +174,22 @@ function ContextMenuContent({
           'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg p-1 shadow-md',
           className
         )}
+        style={container ? { ...PORTAL_MENU_STYLE, ...style } : style}
+        onPointerDown={(event) => {
+          onPointerDown?.(event);
+          disarm();
+        }}
+        onPointerUp={(event) => {
+          onPointerUp?.(event);
+          disarm();
+        }}
         {...props}
-      />
+      >
+        <ContextMenuReleaseGuard.Provider value={armedRef}>
+          <ArmReleaseGuard armedRef={armedRef} />
+          {children}
+        </ContextMenuReleaseGuard.Provider>
+      </ContextMenuPrimitive.Content>
     </ContextMenuPrimitive.Portal>
   );
 }
@@ -132,11 +198,14 @@ function ContextMenuItem({
   className,
   inset,
   variant = 'default',
+  onPointerUp,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
   inset?: boolean
   variant?: 'default' | 'destructive'
 }) {
+  const armedRef = React.useContext(ContextMenuReleaseGuard);
+
   return (
     <ContextMenuPrimitive.Item
       data-slot='context-menu-item'
@@ -146,6 +215,15 @@ function ContextMenuItem({
         'focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*=\'text-\'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
         className
       )}
+      onPointerUp={(event) => {
+        onPointerUp?.(event);
+        // Swallow the pointerup that ends the opening right-click. preventDefault
+        // stops Radix's onPointerUp from firing a synthetic click (selection).
+        if (!event.defaultPrevented && armedRef?.current) {
+          event.preventDefault();
+          armedRef.current = false;
+        }
+      }}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

Fixes two issues with the layer context menu and hardens its rendering inside the canvas iframe.

## Changes

- Fix the context menu instantly selecting an item and closing when right-clicking a layer near the bottom/edge of the screen (Radix repositions the menu under the cursor, and the right-click release fired a selection). The first pointerup after opening is now guarded, matching native OS behavior.
- Isolate the canvas context menu's typography so it no longer inherits the edited page's font family and size — it now always renders in the editor UI font.
- Force the portaled canvas menu to a max z-index so page layers can never paint over it.

The fixes live in the shared `components/ui/context-menu.tsx`, so they apply to every context menu (layer tree, canvas, pages, collection items).

## Test plan

- [ ] Right-click a layer near the bottom edge of the layer tree — the menu opens and stays open (no instant selection)
- [ ] Right-click a layer in the canvas — the menu uses the editor UI font, not the page's font
- [ ] Right-click a layer on a page with high z-index / fixed elements — the menu renders above them
- [ ] Normal clicks on menu items still select and close as expected