### PR TITLE
fix: prevent partial sizing classes while typing custom values

### DIFF
--- a/lib/tailwind-class-mapper.ts
+++ b/lib/tailwind-class-mapper.ts
@@ -274,12 +274,15 @@ const CLASS_PROPERTY_MAP: Record<string, RegExp> = {
   marginLeft: /^ml-(\[.+\]|\d+|px|auto|0\.5|1\.5|2\.5|3\.5)$/,
 
   // Sizing
-  width: /^w-(\[.+\]|\d+\/\d+|\d+|px|auto|full|screen|min|max|fit)$/,
-  height: /^h-(\[.+\]|\d+\/\d+|\d+|px|auto|full|screen|min|max|fit)$/,
-  minWidth: /^min-w-(\[.+\]|\d+|px|full|min|max|fit)$/,
-  minHeight: /^min-h-(\[.+\]|\d+|px|full|screen|min|max|fit)$/,
-  maxWidth: /^max-w-(\[.+\]|none|xs|sm|md|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|full|min|max|fit|prose|screen-sm|screen-md|screen-lg|screen-xl|screen-2xl)$/,
-  maxHeight: /^max-h-(\[.+\]|\d+|px|full|screen|min|max|fit)$/,
+  // Match any value after the prefix (including partial keywords typed live,
+  // e.g. h-a, h-au, h-aut) so in-progress classes are replaced instead of
+  // accumulating. Each prefix is exclusive to its property in Tailwind.
+  width: /^w-.+$/,
+  height: /^h-.+$/,
+  minWidth: /^min-w-.+$/,
+  minHeight: /^min-h-.+$/,
+  maxWidth: /^max-w-.+$/,
+  maxHeight: /^max-h-.+$/,
   overflow: /^(truncate|overflow-(visible|hidden|clip|scroll|auto|x-visible|x-hidden|x-clip|x-scroll|x-auto|y-visible|y-hidden|y-clip|y-scroll|y-auto))$/,
   aspectRatio: /^aspect-(\[.+\]|auto|square|video)$/,
   objectFit: /^object-(contain|cover|fill|none|scale-down)$/,


### PR DESCRIPTION
## Summary

Typing a custom sizing value (e.g. `auto` in Height) generated invalid partial Tailwind classes for each keystroke — `h-a`, `h-au`, `h-aut` — which piled up alongside the final `h-auto` instead of being replaced.

## Changes

- Broaden the `width`, `height`, `minWidth`, `minHeight`, `maxWidth`, and `maxHeight` conflict patterns to match any value after their prefix
- Ensures in-progress partial classes are replaced by the next keystroke instead of accumulating, so only the final valid class remains
- Mirrors the existing approach already used for `fontSize`

## Test plan

- [ ] Select a layer, type `auto` slowly in the Height field — only `h-auto` should be applied (no `h-a`/`h-au`/`h-aut`)
- [ ] Repeat for Width, Min/Max width, Min/Max height
- [ ] Type a numeric value like `200` — should produce `h-[200px]` with no leftover partials
- [ ] Switch breakpoints/states and confirm sizing values still resolve correctly