### PR TITLE
fix: correct component canvas centering and empty space

### DIFF
--- a/app/(builder)/ycode/components/Canvas.tsx
+++ b/app/(builder)/ycode/components/Canvas.tsx
@@ -18,7 +18,7 @@ import { createRoot, Root } from 'react-dom/client';
 import LayerRenderer from '@/components/LayerRenderer';
 import { serializeLayers, getClassesString } from '@/lib/layer-utils';
 import { collectEditorHiddenLayerIds } from '@/lib/animation-utils';
-import { getCanvasIframeHtml, updateViewportOverrides, measureContentExtent, isNonContentLayer } from '@/lib/canvas-utils';
+import { getCanvasIframeHtml, updateViewportOverrides, measureContentExtent, isNonContentLayer, getClippedLayerRect } from '@/lib/canvas-utils';
 import { CanvasPortalProvider } from '@/lib/canvas-portal-context';
 import { cn } from '@/lib/utils';
 import { loadSwiperCss } from '@/lib/slider-utils';
@@ -848,8 +848,13 @@ const Canvas = React.memo(function Canvas({
             // the iframe height and would balloon the canvas. Revealed dropdowns
             // keep a real rect and are measured so the height recalculates.
             if (win && isNonContentLayer(node, win)) return;
-            maxChildWidth = Math.max(maxChildWidth, rect.right - bodyRect.left);
-            maxChildBottom = Math.max(maxChildBottom, rect.bottom - bodyRect.top);
+            // Clamp to clipping ancestors so layers hidden by an overflow-hidden
+            // container (e.g. stacked tab panels inside `max-h-[720px] overflow-hidden`)
+            // don't inflate the measured extent with empty space.
+            const clipped = win ? getClippedLayerRect(node, body, win) : rect;
+            if (clipped.width <= 0 || clipped.height <= 0) return;
+            maxChildWidth = Math.max(maxChildWidth, clipped.right - bodyRect.left);
+            maxChildBottom = Math.max(maxChildBottom, clipped.bottom - bodyRect.top);
           });
 
           onContentWidthChange(maxChildWidth);

--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -2619,9 +2619,12 @@ const CenterCanvas = React.memo(function CenterCanvas({
               minWidth: '100%',
               minHeight: '100%',
               // When editing a component, center the canvas inside the scroll area.
+              // Rely on minHeight (not a fixed height) so the container grows with
+              // tall content — a fixed height:100% would keep the centered child
+              // overflowing past the unreachable top edge (flexbox centering clip).
               // Page editing keeps default block flow so absolute overlays anchor at the top.
               ...(editingComponentId
-                ? { display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }
+                ? { display: 'flex', alignItems: 'center', justifyContent: 'center' }
                 : null),
             }}
           >

--- a/lib/canvas-utils.ts
+++ b/lib/canvas-utils.ts
@@ -236,6 +236,48 @@ export function isNonContentLayer(node: HTMLElement, win: Window): boolean {
   return win.getComputedStyle(node).position === 'fixed';
 }
 
+/** Visible rectangle of a layer after intersecting with its clipping ancestors. */
+export interface ClippedRect {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Compute a layer's rect clamped to any `overflow` clipping ancestors up to
+ * (but excluding) `boundary`. `getBoundingClientRect` ignores ancestor overflow,
+ * so children clipped by an `overflow-hidden`/`max-h` container would otherwise
+ * inflate content-extent measurement. Clamping keeps the measured extent to what
+ * is actually visible while still letting absolutely-positioned elements escape
+ * their non-clipping ancestors.
+ */
+export function getClippedLayerRect(node: HTMLElement, boundary: Element, win: Window): ClippedRect {
+  const rect = node.getBoundingClientRect();
+  let { top, left, right, bottom } = rect;
+
+  let el = node.parentElement;
+  while (el && el !== boundary) {
+    const style = win.getComputedStyle(el);
+    if (style.overflowX !== 'visible' || style.overflowY !== 'visible') {
+      const ancestorRect = el.getBoundingClientRect();
+      if (style.overflowX !== 'visible') {
+        left = Math.max(left, ancestorRect.left);
+        right = Math.min(right, ancestorRect.right);
+      }
+      if (style.overflowY !== 'visible') {
+        top = Math.max(top, ancestorRect.top);
+        bottom = Math.min(bottom, ancestorRect.bottom);
+      }
+    }
+    el = el.parentElement;
+  }
+
+  return { top, left, right, bottom, width: Math.max(0, right - left), height: Math.max(0, bottom - top) };
+}
+
 /**
  * Shared HTML template for canvas-style iframes with Tailwind Browser CDN.
  * Used by both the editor Canvas and the thumbnail capture hook.


### PR DESCRIPTION
## Summary

When editing a component in the builder, its content was not vertically centered and showed a large block of empty space beneath it. Both issues were specific to component-edit mode.

## Changes

- Clamp component content measurement to `overflow`-clipping ancestors, so panels hidden by an `overflow-hidden`/`max-h` container (e.g. stacked tab panels) no longer inflate the measured height with empty space. Absolutely-positioned elements that escape non-clipping ancestors are still measured.
- Add a `getClippedLayerRect` helper for the clamped bounding box.
- Remove the fixed `height: 100%` on the component-editing centering wrapper, relying on the existing `min-height: 100%`. Short components center; tall components grow instead of being clipped past an unreachable top edge.

## Scope / risk

- Both changes only affect **component-edit mode**: the centering style is gated on `editingComponentId`, and the new measurement path runs only when `onContentWidthChange` is provided (component mode only).
- Page editing, preview, and published rendering use the separate `measureContentExtent` path and are untouched.

## Test plan

- [ ] Open a tall component (stacked tabs) — canvas fits content, no empty space below
- [ ] Open a short component — content stays vertically centered in the canvas
- [ ] Reveal an absolutely-positioned element (dropdown/tooltip) — canvas expands to include it
- [ ] Confirm page editing, preview, and published pages are visually unchanged