### PR TITLE
fix: add slides to sliders while editing a component

### DIFF
--- a/app/(builder)/ycode/components/ComponentVariantsSection.tsx
+++ b/app/(builder)/ycode/components/ComponentVariantsSection.tsx
@@ -239,7 +239,7 @@ export default function ComponentVariantsSection({
   return (
     <section className="border-b pb-4">
       <header className="py-5 flex justify-between shrink-0 z-20">
-        <span className="font-medium">Variants</span>
+        <span className="font-medium">Component variants</span>
         <div className="-my-1">
           <Button
             size="xs"

--- a/app/(builder)/ycode/components/LeftSidebar.tsx
+++ b/app/(builder)/ycode/components/LeftSidebar.tsx
@@ -405,7 +405,7 @@ const LeftSidebar = React.memo(function LeftSidebar({
                 />
               )}
               <header className="py-5 flex justify-between shrink-0 z-20">
-                <span className="font-medium">Layers</span>
+                <span className="font-medium">{editingComponentId && editingComponent ? editingComponent.name : 'Layers'}</span>
                 {!readOnly && (
                   <div className="-my-1">
                     <Button

--- a/app/(builder)/ycode/components/SliderSettings.tsx
+++ b/app/(builder)/ycode/components/SliderSettings.tsx
@@ -24,12 +24,13 @@ import {
 import SettingsPanel from './SettingsPanel';
 import ToggleGroup from './ToggleGroup';
 
-import { findAncestorByName, getCollectionVariable } from '@/lib/layer-utils';
+import { addChildToLayerTree, findAncestorByName, getCollectionVariable } from '@/lib/layer-utils';
 import { isSliderLayerName, DEFAULT_SLIDER_SETTINGS, createSlideLayer } from '@/lib/templates/utilities';
 import { EFFECTS_WITH_PER_VIEW } from '@/lib/slider-utils';
 import { slidePrev, slideNext } from '@/hooks/use-canvas-slider';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { usePagesStore } from '@/stores/usePagesStore';
+import { useComponentsStore } from '@/stores/useComponentsStore';
 import { useCollectionLayerStore } from '@/stores/useCollectionLayerStore';
 import {
   MULTI_ASSET_COLLECTION_ID,
@@ -96,8 +97,11 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldG
   const handleNext = useCallback(() => slideNext(sliderLayerId), [sliderLayerId]);
 
   const currentPageId = useEditorStore((state) => state.currentPageId);
+  const editingComponentId = useEditorStore((state) => state.editingComponentId);
+  const editingComponentVariantId = useEditorStore((state) => state.editingComponentVariantId);
   const setSliderSnapCount = useEditorStore((state) => state.setSliderSnapCount);
   const addLayerWithId = usePagesStore((state) => state.addLayerWithId);
+  const updateComponentDraft = useComponentsStore((state) => state.updateComponentDraft);
   const setSelectedLayerId = useEditorStore((state) => state.setSelectedLayerId);
   const clearLayerData = useCollectionLayerStore((state) => state.clearLayerData);
 
@@ -118,15 +122,28 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldG
   }, [fieldGroups]);
 
   const handleAddSlide = useCallback(() => {
-    if (!currentPageId || !sliderLayer) return;
-    if (!slidesLayer) return;
+    if (!sliderLayer || !slidesLayer) return;
     const slideNumber = (slidesLayer.children?.length ?? 0) + 1;
     const slide = createSlideLayer(`Slide ${slideNumber}`, '/ycode/layouts/assets/placeholder-2.webp');
-    if (slide) {
+    if (!slide) return;
+
+    // When editing a component, write to the component draft — not the page store,
+    // whose tree doesn't contain the slider being edited (would silently no-op).
+    if (editingComponentId) {
+      const drafts = useComponentsStore.getState().componentDrafts[editingComponentId];
+      if (!drafts) return;
+      const variantId = editingComponentVariantId && drafts[editingComponentVariantId]
+        ? editingComponentVariantId
+        : Object.keys(drafts)[0];
+      if (!variantId) return;
+      const newLayers = addChildToLayerTree(drafts[variantId], slidesLayer.id, slide);
+      updateComponentDraft(editingComponentId, variantId, newLayers);
+    } else {
+      if (!currentPageId) return;
       addLayerWithId(currentPageId, slidesLayer.id, slide);
-      requestAnimationFrame(() => setSelectedLayerId(slide.id));
     }
-  }, [currentPageId, sliderLayer, slidesLayer, addLayerWithId, setSelectedLayerId]);
+    requestAnimationFrame(() => setSelectedLayerId(slide.id));
+  }, [currentPageId, editingComponentId, editingComponentVariantId, sliderLayer, slidesLayer, addLayerWithId, updateComponentDraft, setSelectedLayerId]);
 
   /**
    * Switch slides content source between static, regular collection, and CMS multi-image.

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -4355,6 +4355,23 @@ export function updateLayerProps(
   });
 }
 
+/** Append a child to the parent layer with `parentId`, returning a new tree. */
+export function addChildToLayerTree(
+  layers: Layer[],
+  parentId: string,
+  child: Layer
+): Layer[] {
+  return layers.map(layer => {
+    if (layer.id === parentId) {
+      return { ...layer, children: [...(layer.children || []), child] };
+    }
+    if (layer.children && layer.children.length > 0) {
+      return { ...layer, children: addChildToLayerTree(layer.children, parentId, child) };
+    }
+    return layer;
+  });
+}
+
 /**
  * Find all layers with a custom anchor ID (settings.id takes priority over attributes.id).
  * Deduplicates by anchor ID since an `#id` link resolves to the first match, so a


### PR DESCRIPTION
## Summary

Fixes the slider "+" add-slide button doing nothing (and appearing to deselect the layer) when a slider is edited inside a component. Also polishes the left sidebar in component-edit mode.

## Changes

- Route add-slide to the component draft when editing a component. Previously it always wrote to the page store, which doesn't contain the slider being edited — the insert silently no-oped and the selection pointed at an orphan layer, showing "Select layer" (looked like a deselect).
- Add a reusable `addChildToLayerTree` utility for appending a child into a layer tree.
- Show the component name (instead of "Layers") in the left sidebar header while editing a component; falls back to "Layers" on pages.
- Rename the variants section header from "Variants" to "Component variants".

## Test plan

- [ ] Edit a component containing a slider → click "+" → new slide is added and selected
- [ ] On a normal page, "+" still adds and selects a slide as before
- [ ] Switching a slider to a CMS source still hides "+"
- [ ] While editing a component, the left sidebar header shows the component name and the variants section reads "Component variants"
- [ ] On a page, the header still reads "Layers"