### PR TITLE
fix: render slider slides correctly on tablet and mobile

### DIFF
--- a/components/SliderInitializer.tsx
+++ b/components/SliderInitializer.tsx
@@ -27,6 +27,18 @@ export default function SliderInitializer() {
   useEffect(() => {
     loadSwiperCss(document);
 
+    // Sliders initialized while hidden (e.g. `hidden max-lg:flex`) measure their
+    // slides as zero-width; a media-query `display` change doesn't fire a window
+    // resize, so Swiper never recalculates. Watch each slider's size and call
+    // `update()` once it becomes visible so slides pick up their real widths.
+    const swiperByElement = new WeakMap<Element, Swiper>();
+    const resizeObserver = new ResizeObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.contentRect.width <= 0) return;
+        swiperByElement.get(entry.target)?.update();
+      });
+    });
+
     const initSliders = () => {
       const sliderElements = document.querySelectorAll<HTMLElement>(
         `[data-slider-id]:not([${INITIALIZED_ATTR}])`,
@@ -61,6 +73,8 @@ export default function SliderInitializer() {
 
           el.setAttribute(INITIALIZED_ATTR, '');
           swiperInstancesRef.current.push(swiper);
+          swiperByElement.set(el, swiper);
+          resizeObserver.observe(el);
         } catch {
           console.error('Failed to initialize slider:', el.getAttribute('data-slider-id'));
         }
@@ -79,6 +93,7 @@ export default function SliderInitializer() {
 
     return () => {
       window.removeEventListener(ITEMS_INJECTED_EVENT, handleItemsInjected);
+      resizeObserver.disconnect();
       swiperInstancesRef.current.forEach((swiper) => swiper.destroy(true, true));
       swiperInstancesRef.current = [];
     };

--- a/public/swiper-minimal.css
+++ b/public/swiper-minimal.css
@@ -12,6 +12,18 @@
 .swiper-vertical { touch-action: pan-x; }
 .swiper-slide-invisible-blank { visibility: hidden; }
 
+/*
+ * Slides default to Tailwind `h-full` (height:100%). When the slider itself has
+ * no definite height (e.g. `h-[100%]` on tablet/mobile), the percentage-height
+ * chain becomes circular and slides collapse to 0 — the first slide appears
+ * blank. Auto height lets flexbox stretch every slide to the tallest one, which
+ * still fills a definite-height container (e.g. desktop `h-[600px]`) identically.
+ * Effect sliders (cube/flip/cards/3D) keep their own explicit height rules.
+ */
+.swiper:not(.swiper-cube):not(.swiper-flip):not(.swiper-cards):not(.swiper-3d) > .swiper-wrapper > .swiper-slide {
+  height: auto;
+}
+
 .swiper-autoheight,
 .swiper-autoheight .swiper-slide { height: auto; }
 .swiper-autoheight .swiper-wrapper {


### PR DESCRIPTION
## Summary

Fixes sliders where the first slide appears blank on tablet/mobile. When a slider has no definite height at smaller breakpoints (e.g. `h-[100%]` instead of the desktop `h-[600px]`), the slides' `h-full` creates a circular percentage-height chain and they collapse to `height: 0`, so the visible slide renders empty.

## Changes

- Give non-effect slides `height: auto` in the minimal Swiper CSS so flexbox stretches every slide to the tallest one. This fills a definite-height container identically (desktop unchanged) and fixes the collapse when the height is indefinite. Scoped to exclude cube/flip/cards/3D effect sliders that rely on explicit `height: 100%`.
- Add a `ResizeObserver` in `SliderInitializer` that calls `swiper.update()` when a slider gains width, so sliders initialized while hidden (`hidden max-lg:flex`) recalculate their metrics once shown — a media-query `display` change doesn't fire a window resize.

## Test plan

- [ ] View a page with a slider that is hidden on desktop and shown on tablet/mobile (`hidden max-lg:flex`) with mobile height `h-[100%]` — first slide renders at full height
- [ ] Confirm desktop sliders with a fixed height (e.g. `h-[600px]`) are unchanged
- [ ] Resize the viewport across the tablet/desktop breakpoint — slides stay correctly sized
- [ ] Verify cube/flip/cards/coverflow effect sliders still render correctly
- [ ] Verify sliders inside collection/filter items (re-scan on inject) still initialize