### PR TITLE
fix: preserve native text copy in builder

### DIFF
--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -82,6 +82,7 @@ import type { ExternalPastePlacement } from '@/stores/useExternalPasteStore';
 
 // 6. Utils/lib
 import { findHomepage } from '@/lib/page-utils';
+import { hasTextSelection } from '@/lib/utils';
 import { getStyleIds } from '@/lib/layer-style-resolve';
 import { findLayerById, getClassesString, removeLayerById, canCopyLayer, canDeleteLayer, regenerateIdsWithInteractionRemapping, findParentAndIndex, insertLayerAfter, updateLayerProps, getLayerIndexes, removeRichTextSublayer, canPasteIntoParent, canHaveChildren, LINK_NESTING_ERROR } from '@/lib/layer-utils';
 import { cloneDeep } from 'lodash';
@@ -1713,8 +1714,9 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         }
 
         // Copy: Cmd/Ctrl + C (supports multi-select)
+        // Skip when the user has a plain-text selection so native copy works.
         if ((e.metaKey || e.ctrlKey) && e.key === 'c' && !isContentOnlyRole) {
-          if (!isInputFocused && (currentPageId || editingComponentId)) {
+          if (!isInputFocused && !hasTextSelection() && (currentPageId || editingComponentId)) {
             e.preventDefault();
 
             // Get layers from the correct context
@@ -1758,8 +1760,9 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
         }
 
         // Cut: Cmd/Ctrl + X (supports multi-select)
+        // Skip when the user has a plain-text selection so native cut works.
         if ((e.metaKey || e.ctrlKey) && e.key === 'x' && !isContentOnlyRole) {
-          if (!isInputFocused && (currentPageId || editingComponentId)) {
+          if (!isInputFocused && !hasTextSelection() && (currentPageId || editingComponentId)) {
             e.preventDefault();
 
             // Get layers from the correct context

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,6 +10,15 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
+ * Whether the user currently has a non-empty text selection.
+ * Used to avoid hijacking Cmd/Ctrl+C when the user is copying plain text.
+ */
+export function hasTextSelection(): boolean {
+  if (typeof window === 'undefined') return false;
+  return (window.getSelection()?.toString().trim().length ?? 0) > 0;
+}
+
+/**
  * Input Sanitization Utilities
  * Centralized helpers for cleaning user input values
  */


### PR DESCRIPTION
## Summary

Copying text in the builder always copied the selected layer's JSON metadata instead of the highlighted text. This broke plain-text copy in places like the domains page where users need to copy DNS records.

## Changes

- Add a `hasTextSelection()` helper to `lib/utils.ts`
- Skip the builder's `Cmd/Ctrl+C` and `Cmd/Ctrl+X` layer shortcuts when a non-empty text selection exists, letting the browser's native copy/cut run

## Test plan

- [ ] Select plain text (e.g. DNS records) in the builder and press Cmd+C — the text is copied
- [ ] With no text selected, select a layer and press Cmd+C — the layer is still copied
- [ ] Cmd+X with a text selection performs a native cut; with a layer selected it still cuts the layer
- [ ] Paste behaves as before in both cases