### PR TITLE
fix: undo/redo not working when editing component variants

### DIFF
--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -791,6 +791,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
   } = useUndoRedo({
     entityType: undoRedoEntityType,
     entityId: undoRedoEntityId,
+    variantId: editingComponentId ? activeComponentVariantId : null,
     autoInit: true,
   });
 

--- a/database/migrations/20260706000001_widen_versions_entity_id.ts
+++ b/database/migrations/20260706000001_widen_versions_entity_id.ts
@@ -1,0 +1,61 @@
+import { Knex } from 'knex';
+
+/**
+ * Migration: Widen versions.entity_id from uuid to text
+ *
+ * Undo/redo history for components is now scoped per variant, keyed by
+ * `${componentId}:${variantId}`. That composite value is not a valid UUID, so
+ * the entity_id column must accept free-form text. Page and layer-style ids
+ * remain plain UUID strings and stay valid as text.
+ *
+ * Idempotent: only alters the column when it is still typed as uuid.
+ */
+export async function up(knex: Knex): Promise<void> {
+  const result = await knex.raw(`
+    SELECT data_type
+    FROM information_schema.columns
+    WHERE table_name = 'versions' AND column_name = 'entity_id'
+  `);
+
+  const dataType: string | undefined = result?.rows?.[0]?.data_type;
+
+  if (dataType && dataType.toLowerCase() === 'uuid') {
+    await knex.raw(`
+      ALTER TABLE versions
+      ALTER COLUMN entity_id TYPE text USING entity_id::text;
+    `);
+  }
+
+  // Drop legacy component versions keyed by a bare componentId. History is now
+  // scoped per variant (`componentId:variantId`), so these rows are orphaned
+  // and would never be read. Idempotent — a re-run finds nothing to delete.
+  await knex.raw(`
+    DELETE FROM versions
+    WHERE entity_type = 'component'
+      AND entity_id::text NOT LIKE '%:%';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const result = await knex.raw(`
+    SELECT data_type
+    FROM information_schema.columns
+    WHERE table_name = 'versions' AND column_name = 'entity_id'
+  `);
+
+  const dataType: string | undefined = result?.rows?.[0]?.data_type;
+
+  if (dataType && dataType.toLowerCase() !== 'uuid') {
+    // Drop rows whose entity_id is not a valid UUID (e.g. per-variant component
+    // history) so the column can be converted back to uuid.
+    await knex.raw(`
+      DELETE FROM versions
+      WHERE entity_id !~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$';
+    `);
+
+    await knex.raw(`
+      ALTER TABLE versions
+      ALTER COLUMN entity_id TYPE uuid USING entity_id::uuid;
+    `);
+  }
+}

--- a/hooks/use-undo-redo.ts
+++ b/hooks/use-undo-redo.ts
@@ -11,7 +11,7 @@ import { usePagesStore } from '@/stores/usePagesStore';
 import { useComponentsStore } from '@/stores/useComponentsStore';
 import { useLayerStylesStore } from '@/stores/useLayerStylesStore';
 import { applyPatch, createPatch, createInversePatch, isPatchEmpty, doesPatchChangeState, generatePatchDescription, JsonPatch } from '@/lib/version-utils';
-import { markUndoRedoSave } from '@/lib/version-tracking';
+import { markUndoRedoSave, componentVersionEntityId } from '@/lib/version-tracking';
 import { generatePageLayersHash } from '@/lib/hash-utils';
 import { stripUIProperties } from '@/lib/layer-utils';
 import { useEditorStore } from '@/stores/useEditorStore';
@@ -110,6 +110,12 @@ interface UseUndoRedoOptions {
   entityType: VersionEntityType;
   /** Entity ID (page_id, component_id, or style_id) */
   entityId: string | null;
+  /**
+   * Active component variant being edited. Undo/redo is scoped per variant so
+   * editing a non-primary variant has its own history. Ignored for non-component
+   * entities.
+   */
+  variantId?: string | null;
   /** Whether to auto-initialize on mount */
   autoInit?: boolean;
 }
@@ -190,6 +196,7 @@ function trimBuffer(buffer: LocalChange[]): void {
 export function useUndoRedo({
   entityType,
   entityId,
+  variantId = null,
   autoInit = true,
 }: UseUndoRedoOptions): UseUndoRedoReturn {
   const {
@@ -202,8 +209,18 @@ export function useUndoRedo({
     setUndoRedoInProgress,
   } = useVersionsStore();
 
+  // Version bookkeeping id. Components scope history per variant so a
+  // non-primary variant edit gets its own undo/redo stack; other entities use
+  // the plain entity id. `entityId` still refers to the real component/page id
+  // when reading or writing the underlying draft.
+  const versionEntityId = useMemo(() => {
+    if (!entityId) return null;
+    if (entityType === 'component') return componentVersionEntityId(entityId, variantId);
+    return entityId;
+  }, [entityType, entityId, variantId]);
+
   // Subscribe directly to the entity state to properly react to changes
-  const entityKey = entityId ? `${entityType}:${entityId}` : null;
+  const entityKey = versionEntityId ? `${entityType}:${versionEntityId}` : null;
   const entityState = useVersionsStore((state) => {
     if (!entityKey) return null;
     // Access the entity state directly - this ensures proper reactivity
@@ -216,11 +233,25 @@ export function useUndoRedo({
   const updateComponentDraft = useComponentsStore((state) => state.updateComponentDraft);
   const styles = useLayerStylesStore((state) => state.styles);
 
-  // Entity key for caching
+  // Entity key for caching (variant-scoped for components)
   const cacheKey = useMemo(() => {
-    if (!entityId) return null;
-    return `${entityType}:${entityId}`;
-  }, [entityType, entityId]);
+    if (!versionEntityId) return null;
+    return `${entityType}:${versionEntityId}`;
+  }, [entityType, versionEntityId]);
+
+  // Resolve which component variant undo/redo should read/write. Prefers the
+  // active variant, then the persisted primary variant, then the first draft.
+  const resolveComponentVariantId = useCallback(
+    (componentId: string, variantDrafts: Record<string, Layer[]>): string | null => {
+      if (variantId && variantDrafts[variantId]) return variantId;
+      const componentEntry = useComponentsStore.getState().getComponentById(componentId);
+      if (componentEntry?.variants && componentEntry.variants.length > 0) {
+        return componentEntry.variants[0].id;
+      }
+      return Object.keys(variantDrafts)[0] || null;
+    },
+    [variantId]
+  );
 
   // Get current state based on entity type
   const getCurrentState = useCallback((): any => {
@@ -232,17 +263,14 @@ export function useUndoRedo({
         return draft?.layers || [];
       }
       case 'component': {
-        // Undo/redo currently tracks the component's primary variant. Saving
-        // already records the primary variant's layer tree as the version
-        // payload; reading from the same variant keeps the two consistent.
+        // Track the variant currently being edited so undo/redo operates on the
+        // same layer tree the canvas shows. Fall back to the primary variant
+        // when no variant is supplied.
         const variantDrafts = componentDrafts[entityId];
         if (!variantDrafts) return [];
-        const componentEntry = useComponentsStore.getState().getComponentById(entityId);
-        const primaryVariantId = componentEntry?.variants && componentEntry.variants.length > 0
-          ? componentEntry.variants[0].id
-          : Object.keys(variantDrafts)[0];
-        if (!primaryVariantId) return [];
-        return variantDrafts[primaryVariantId] || [];
+        const targetVariantId = resolveComponentVariantId(entityId, variantDrafts);
+        if (!targetVariantId) return [];
+        return variantDrafts[targetVariantId] || [];
       }
       case 'layer_style': {
         const style = styles.find((s) => s.id === entityId);
@@ -251,7 +279,7 @@ export function useUndoRedo({
       default:
         return null;
     }
-  }, [entityType, entityId, draftsByPageId, componentDrafts, styles]);
+  }, [entityType, entityId, draftsByPageId, componentDrafts, styles, resolveComponentVariantId]);
 
   // Apply state based on entity type
   const applyState = useCallback(
@@ -273,14 +301,13 @@ export function useUndoRedo({
               console.error('   Layer IDs in state:', layerIds);
             }
           }
-          // Apply to the component's primary variant — see getCurrentState.
+          // Apply to the variant being edited — see getCurrentState.
           const variantDrafts = useComponentsStore.getState().componentDrafts[entityId];
-          const componentEntry = useComponentsStore.getState().getComponentById(entityId);
-          const primaryVariantId = componentEntry?.variants && componentEntry.variants.length > 0
-            ? componentEntry.variants[0].id
-            : (variantDrafts ? Object.keys(variantDrafts)[0] : null);
-          if (primaryVariantId) {
-            updateComponentDraft(entityId, primaryVariantId, state as Layer[]);
+          const targetVariantId = variantDrafts
+            ? resolveComponentVariantId(entityId, variantDrafts)
+            : null;
+          if (targetVariantId) {
+            updateComponentDraft(entityId, targetVariantId, state as Layer[]);
           }
           break;
         }
@@ -297,12 +324,12 @@ export function useUndoRedo({
         }
       }
     },
-    [entityType, entityId, setDraftLayers, updateComponentDraft]
+    [entityType, entityId, setDraftLayers, updateComponentDraft, resolveComponentVariantId]
   );
 
   // Initialize entity state - only when entityId changes
   const initialize = useCallback(async () => {
-    if (!entityId || !cacheKey) return;
+    if (!entityId || !cacheKey || !versionEntityId) return;
 
     // Mark entity as initializing to prevent false change detection
     initializingEntities.add(cacheKey);
@@ -327,29 +354,31 @@ export function useUndoRedo({
       localRedoBuffer.delete(cacheKey);
 
       // Only initialize version history if not already initialized
-      const existingState = useVersionsStore.getState().entityStates[`${entityType}:${entityId}`];
+      const existingState = useVersionsStore.getState().entityStates[`${entityType}:${versionEntityId}`];
       if (existingState && (existingState.undoStack.length > 0 || existingState.redoStack.length > 0)) {
         // Already initialized, don't reset version history
         return;
       }
 
-      initEntityState(entityType, entityId);
+      initEntityState(entityType, versionEntityId);
 
-      // Calculate hash to determine position in history
+      // Calculate hash to determine position in history. Components assume
+      // "at latest" on load (no hash), matching prior behavior — their history
+      // is now scoped per variant.
       let currentHash: string | undefined;
 
       if (currentState && entityType === 'page_layers') {
         currentHash = generatePageLayersHash({ layers: currentState, generated_css: null });
       }
 
-      await loadVersionHistory(entityType, entityId, currentHash);
+      await loadVersionHistory(entityType, versionEntityId, currentHash);
     } finally {
       // Clear initializing flag after a longer delay to ensure all async operations complete
       setTimeout(() => {
         initializingEntities.delete(cacheKey);
       }, 100);
     }
-  }, [entityType, entityId, initEntityState, loadVersionHistory, cacheKey, getCurrentState]);
+  }, [entityType, entityId, versionEntityId, initEntityState, loadVersionHistory, cacheKey, getCurrentState]);
 
   // Auto-initialize on mount - only run once per entityId
   useEffect(() => {
@@ -473,13 +502,15 @@ export function useUndoRedo({
       setLocalRedoCount(0);
 
       // Also clear database redo stack immediately (don't wait for save)
-      useVersionsStore.getState().clearRedoStack(entityType, entityId);
+      if (versionEntityId) {
+        useVersionsStore.getState().clearRedoStack(entityType, versionEntityId);
+      }
 
       // Update previous state cache with the (full, unstripped) current state
       setCachedState(cacheKey, currentState);
 
     }
-  }, [cacheKey, entityId, entityType, getCurrentState, draftsByPageId, componentDrafts, styles]);
+  }, [cacheKey, entityId, entityType, versionEntityId, getCurrentState, draftsByPageId, componentDrafts, styles]);
 
   // Track buffer size in state to trigger re-renders
   const [localUndoCount, setLocalUndoCount] = useState(0);
@@ -498,10 +529,10 @@ export function useUndoRedo({
 
   // Undo operation
   const undo = useCallback(async (): Promise<boolean> => {
-    if (!entityId || !canUndo) return false;
+    if (!entityId || !versionEntityId || !canUndo) return false;
 
     // Prevent concurrent undo/redo operations using synchronous lock
-    const lockKey = `${entityType}:${entityId}`;
+    const lockKey = `${entityType}:${versionEntityId}`;
     if (operationLocks.get(lockKey)) {
       return false;
     }
@@ -557,7 +588,7 @@ export function useUndoRedo({
       }
 
       // No local changes, use database undo
-      const version = await storeUndo(entityType, entityId);
+      const version = await storeUndo(entityType, versionEntityId);
 
       if (!version) {
         return false;
@@ -592,7 +623,7 @@ export function useUndoRedo({
         }
 
         // Mark this entity so auto-save won't create a new version
-        markUndoRedoSave(entityType, entityId);
+        markUndoRedoSave(entityType, versionEntityId);
 
         await applyState(restoredState);
 
@@ -628,7 +659,7 @@ export function useUndoRedo({
         }
 
         // Mark this entity so auto-save won't create a new version
-        markUndoRedoSave(entityType, entityId);
+        markUndoRedoSave(entityType, versionEntityId);
 
         await applyState(version.snapshot);
         if (cacheKey) {
@@ -649,18 +680,18 @@ export function useUndoRedo({
       console.error('Undo failed:', error);
       return false;
     } finally {
-      const lockKey = `${entityType}:${entityId}`;
+      const lockKey = `${entityType}:${versionEntityId}`;
       operationLocks.delete(lockKey);
       setUndoRedoInProgress(false);
     }
-  }, [entityType, entityId, canUndo, storeUndo, getCurrentState, applyState, cacheKey, setUndoRedoInProgress]);
+  }, [entityType, entityId, versionEntityId, canUndo, storeUndo, getCurrentState, applyState, cacheKey, setUndoRedoInProgress]);
 
   // Redo operation
   const redo = useCallback(async (): Promise<boolean> => {
-    if (!entityId || !canRedo) return false;
+    if (!entityId || !versionEntityId || !canRedo) return false;
 
     // Prevent concurrent undo/redo operations using synchronous lock
-    const lockKey = `${entityType}:${entityId}`;
+    const lockKey = `${entityType}:${versionEntityId}`;
     if (operationLocks.get(lockKey)) {
       return false;
     }
@@ -706,12 +737,12 @@ export function useUndoRedo({
       }
 
       // No local redo, use database redo
-      const version = await storeRedo(entityType, entityId);
+      const version = await storeRedo(entityType, versionEntityId);
 
       if (version === null) {
         // version === null means "restore to latest"
         // Mark this entity so auto-save won't create a new version
-        markUndoRedoSave(entityType, entityId);
+        markUndoRedoSave(entityType, versionEntityId);
 
         // Reload from database
         if (entityType === 'page_layers') {
@@ -764,7 +795,7 @@ export function useUndoRedo({
         }
 
         // Mark this entity so auto-save won't create a new version
-        markUndoRedoSave(entityType, entityId);
+        markUndoRedoSave(entityType, versionEntityId);
 
         await applyState(newState);
 
@@ -790,11 +821,11 @@ export function useUndoRedo({
       console.error('Redo failed:', error);
       return false;
     } finally {
-      const lockKey = `${entityType}:${entityId}`;
+      const lockKey = `${entityType}:${versionEntityId}`;
       operationLocks.delete(lockKey);
       setUndoRedoInProgress(false);
     }
-  }, [entityType, entityId, canRedo, storeRedo, getCurrentState, applyState, cacheKey, setUndoRedoInProgress]);
+  }, [entityType, entityId, versionEntityId, canRedo, storeRedo, getCurrentState, applyState, cacheKey, setUndoRedoInProgress]);
 
   // Record a change
   const recordChange = useCallback(
@@ -839,7 +870,7 @@ export function useUndoRedo({
         // Note: snapshot is determined server-side based on version count
         const versionData: CreateVersionData = {
           entity_type: entityType,
-          entity_id: entityId,
+          entity_id: versionEntityId ?? entityId,
           action_type: 'update',
           description: finalDescription,
           redo: redoPatch,
@@ -870,7 +901,7 @@ export function useUndoRedo({
         console.error('Failed to record change:', error);
       }
     },
-    [entityType, entityId, getSessionId, recordVersion, cacheKey]
+    [entityType, entityId, versionEntityId, getSessionId, recordVersion, cacheKey]
   );
 
   return {

--- a/lib/version-tracking.ts
+++ b/lib/version-tracking.ts
@@ -24,6 +24,15 @@ function getCacheKey(entityType: VersionEntityType, entityId: string): string {
   return `${entityType}:${entityId}`;
 }
 
+/**
+ * Build the version-tracking entity id for a component variant. Each variant
+ * keeps its own undo/redo history, keyed by `${componentId}:${variantId}`, so
+ * edits to a non-primary variant are tracked independently.
+ */
+export function componentVersionEntityId(componentId: string, variantId?: string | null): string {
+  return variantId ? `${componentId}:${variantId}` : componentId;
+}
+
 /** Get the cached previous state, parsing the stored JSON. */
 export function getPreviousState(entityType: VersionEntityType, entityId: string): any | null {
   const stored = previousStatesCache.get(getCacheKey(entityType, entityId));

--- a/stores/useComponentsStore.ts
+++ b/stores/useComponentsStore.ts
@@ -528,14 +528,17 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
         for (const variant of variants) {
           variantDrafts[variant.id] = JSON.parse(JSON.stringify(variant.layers ?? []));
         }
-        // Layers used for version tracking — track the primary variant for now.
-        const primaryLayers = variantDrafts[variants[0].id] ?? [];
 
-        // Mark entity as initializing BEFORE updating store to prevent false change detection
+        // Mark each variant as initializing BEFORE updating store to prevent
+        // false change detection. Undo/redo is scoped per variant.
         try {
           const { markEntityInitializing, updatePreviousState } = await import('@/hooks/use-undo-redo');
-          markEntityInitializing('component', componentId);
-          updatePreviousState('component', componentId, primaryLayers);
+          const { componentVersionEntityId } = await import('@/lib/version-tracking');
+          for (const variant of variants) {
+            const versionId = componentVersionEntityId(componentId, variant.id);
+            markEntityInitializing('component', versionId);
+            updatePreviousState('component', versionId, variantDrafts[variant.id]);
+          }
         } catch (err) {
           console.error('Failed to mark component as initializing:', err);
         }
@@ -551,9 +554,15 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
           },
         }));
 
-        // Initialize version tracking with loaded state
-        import('@/lib/version-tracking').then(({ initializeVersionTracking }) => {
-          initializeVersionTracking('component', componentId, primaryLayers);
+        // Initialize version tracking with loaded state (per variant)
+        import('@/lib/version-tracking').then(({ initializeVersionTracking, componentVersionEntityId }) => {
+          for (const variant of variants) {
+            initializeVersionTracking(
+              'component',
+              componentVersionEntityId(componentId, variant.id),
+              variantDrafts[variant.id]
+            );
+          }
         }).catch((err) => {
           console.error('Failed to initialize component version tracking:', err);
         });
@@ -673,9 +682,17 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
             isSaving: false,
           }));
 
-          // Record version for undo/redo only if variants match what we saved.
-          import('@/lib/version-tracking').then(({ recordVersionViaApi }) => {
-            recordVersionViaApi('component', componentId, layersBeingSaved);
+          // Record a version per variant for undo/redo. Each variant has its
+          // own history; unchanged variants produce an empty patch and are
+          // skipped inside recordVersionViaApi.
+          import('@/lib/version-tracking').then(({ recordVersionViaApi, componentVersionEntityId }) => {
+            for (const variant of variantsBeingSaved) {
+              recordVersionViaApi(
+                'component',
+                componentVersionEntityId(componentId, variant.id),
+                variant.layers
+              );
+            }
           }).catch((err) => {
             console.error('Failed to record component version:', err);
           });


### PR DESCRIPTION
## Summary

Undo/redo did nothing when editing a component in the builder unless you happened to be on the first (default) variant. History was hard-coded to the primary variant, so edits to any other variant were never tracked, applied, or saved to history.

## Changes

- Scope component undo/redo per variant, keyed by `componentId:variantId`, so each variant has its own independent history
- Read, apply, and record undo state against the variant currently open on the canvas instead of always the primary variant
- Seed undo tracking and record versions for every variant in the component draft
- Widen `versions.entity_id` from `uuid` to `text` to allow composite ids, and drop orphaned legacy component versions keyed by a bare `componentId`

## Test plan

- [ ] Edit the default variant of a component, make a change, undo/redo — works as before
- [ ] Switch to a non-default variant, make a change, undo/redo — now works
- [ ] Make changes on two different variants, undo on each — histories stay independent (no cross-variant bleed)
- [ ] Edit → wait for auto-save → undo (exercises DB version history, not just the local buffer)
- [ ] Exit component edit mode and confirm page undo/redo still works
- [ ] Run the migration and confirm old component versions are removed and page/layer-style versions are untouched