### PR TITLE
fix: preserve font weight and family when editing styled text

### DIFF
--- a/lib/tailwind-class-mapper.ts
+++ b/lib/tailwind-class-mapper.ts
@@ -571,6 +571,19 @@ export function removeConflictingClasses(
       }
     }
 
+    // Special handling for font-[...] arbitrary values
+    // Distinguish fontWeight (numeric, e.g. font-[700]) from fontFamily
+    // (non-numeric, e.g. font-[Gelasio_Regular]) — both match each other's
+    // pattern via \[.+\], so keep the mismatched one instead of removing it.
+    if (baseClass.startsWith('font-[')) {
+      const value = extractArbitraryValue(baseClass);
+      if (value) {
+        const isNumeric = /^\d/.test(value);
+        if (property === 'fontWeight' && !isNumeric) return true;
+        if (property === 'fontFamily' && isNumeric) return true;
+      }
+    }
+
     // Background-image CSS variable classes are always backgroundImage
     if (BG_IMG_VAR_RE.test(baseClass)) {
       if (property === 'backgroundColor') return true;
@@ -1224,6 +1237,19 @@ export function getAffectedProperties(className: string): string[] {
         properties.push('fontSize');
         return properties;
       }
+    }
+  }
+
+  // Special handling for font-[...] arbitrary values
+  // Must distinguish between fontWeight (numeric, e.g. font-[700]) and
+  // fontFamily (non-numeric, e.g. font-[Gelasio_Regular]). Both share the
+  // font-[…] namespace, so without this an arbitrary weight would be treated
+  // as a family (and vice versa) and strip its sibling typography class.
+  if (baseClass.startsWith('font-[')) {
+    const value = extractArbitraryValue(baseClass);
+    if (value) {
+      properties.push(/^\d/.test(value) ? 'fontWeight' : 'fontFamily');
+      return properties;
     }
   }
 


### PR DESCRIPTION
## Summary

Editing typography on a text layer that has a style applied could silently lose settings: changing the font size stripped the font weight, and setting a weight like Bold reset the font to a system default. This fixes the class conflict logic so weight and family no longer clobber each other.

## Changes

- Disambiguate arbitrary `font-[…]` classes in `getAffectedProperties` and `removeConflictingClasses`: numeric values (e.g. `font-[700]`) are font-weight, others (e.g. `font-[Gelasio_Regular]`) are font-family
- Mirrors the existing smart handling already used for the shared `text-[…]` and `bg-[…]` namespaces

## Test plan

- [ ] Apply a text/heading style that uses a custom font, then change the font size — the weight stays
- [ ] Set the weight to Bold on a custom-font layer — the font family stays (no fallback to system sans-serif)
- [ ] Reload the page / re-open the layer — weight and family both persist
- [ ] Verify built-in fonts (`font-sans`, `font-serif`, `font-mono`) and named weights (`font-bold`) still behave