### PR TITLE
fix: prevent day shift on date-only dynamic variables

### DIFF
--- a/lib/cms-variables-utils.ts
+++ b/lib/cms-variables-utils.ts
@@ -7,7 +7,7 @@
 
 import type { CollectionField, InlineVariable } from '@/types';
 import { isDateFieldType } from '@/lib/collection-field-utils';
-import { formatDateInTimezone } from '@/lib/date-format-utils';
+import { formatDateInTimezone, formatDateOnly } from '@/lib/date-format-utils';
 import { extractPlainTextFromTiptap } from '@/lib/tiptap-utils';
 import { formatDateWithPreset, formatNumberWithPreset } from '@/lib/variable-format-utils';
 import { PAGINATION_VARIABLE_LABELS } from '@/lib/pagination-text-utils';
@@ -48,6 +48,11 @@ export function formatFieldValue(
   if (isDateFieldType(fieldType) && typeof value === 'string') {
     if (format) {
       return formatDateWithPreset(value, format, timezone);
+    }
+    // date_only values are timezone-neutral calendar dates: format without
+    // timezone conversion so the day never shifts.
+    if (fieldType === 'date_only') {
+      return formatDateOnly(value);
     }
     return formatDateInTimezone(value, timezone, 'display');
   }

--- a/lib/variable-format-utils.ts
+++ b/lib/variable-format-utils.ts
@@ -6,7 +6,7 @@
  */
 
 import type { CollectionFieldType } from '@/types';
-import { isDateFieldType } from '@/lib/collection-field-utils';
+import { isDateFieldType, isDateOnlyString } from '@/lib/collection-field-utils';
 
 // ─── Date Format Presets ────────────────────────────────────────────
 
@@ -406,10 +406,15 @@ export function formatDateWithPreset(
   const dateObj = typeof value === 'string' ? new Date(value) : value;
   if (isNaN(dateObj.getTime())) return '';
 
+  // date_only values are timezone-neutral calendar dates (`YYYY-MM-DD` parses as
+  // UTC midnight). Formatting them in the project timezone would shift the day, so
+  // pin the display timezone to UTC to preserve the stored calendar date.
+  const effectiveTimezone = typeof value === 'string' && isDateOnlyString(value) ? 'UTC' : timezone;
+
   const preset = presetId ? datePresetMap.get(presetId) : datePresetMap.get('date-long');
   if (!preset) {
     return new Intl.DateTimeFormat('en-US', {
-      timeZone: timezone,
+      timeZone: effectiveTimezone,
       month: 'long',
       day: 'numeric',
       year: 'numeric',
@@ -418,7 +423,7 @@ export function formatDateWithPreset(
 
   try {
     const formatter = new Intl.DateTimeFormat(preset.locale || 'en-US', {
-      timeZone: timezone,
+      timeZone: effectiveTimezone,
       ...preset.options,
     });
     const result = preset.extractPart


### PR DESCRIPTION
## Summary

A `date_only` collection field showed the correct date in the collection editor but a day earlier on the canvas and published pages (e.g. "February 1, 2026" in the editor vs "January 31, 2026" on the page). This fixes the off-by-one so all views agree.

## Changes

- Format `date_only` dynamic variables as timezone-neutral calendar dates: `formatDateWithPreset` now pins the display timezone to UTC for `YYYY-MM-DD` values, preserving the stored day for every preset (e.g. `date-long`). Datetime (`date`) fields still use the project timezone.
- Route the no-preset `date_only` fallback in `formatFieldValue` through `formatDateOnly`, which also correctly omits the time component.

## Root cause

`formatDateWithPreset` parsed `"2026-02-01"` via `new Date(...)` (UTC midnight) and then formatted it in the project timezone. In any timezone west of UTC that instant lands on the previous calendar day. The editor renders the raw string into `<input type="date">`, so it was unaffected — hence the mismatch.

## Test plan

- [ ] Set the project timezone to one behind UTC (e.g. America/New_York)
- [ ] Add a `date_only` field value and bind it as a dynamic variable with the `date-long` format
- [ ] Confirm canvas, published page, and the collection editor all show the same date
- [ ] Confirm datetime (`date`) fields still display in the project timezone
- [ ] Confirm a `date_only` variable with no format preset shows the date without a time