### PR TITLE
feat: add align self controls for flex/grid children

### DIFF
--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -62,6 +62,7 @@ import RichTextEditor from './RichTextEditor';
 import ComponentVariableLabel, { VARIABLE_TYPE_ICONS } from './ComponentVariableLabel';
 import InteractionsPanel from './InteractionsPanel';
 import LayoutControls from './LayoutControls';
+import SelfLayoutControls from './SelfLayoutControls';
 import LayerStylesPanel from './LayerStylesPanel';
 import PositionControls from './PositionControls';
 import TransformControls from './TransformControls';
@@ -353,6 +354,14 @@ const RightSidebar = React.memo(function RightSidebar({
     if (!selectedLayerId) return false;
     const result = indexedFindLayerWithParent(layerIndexes, selectedLayerId);
     return result?.parent === null;
+  }, [selectedLayerId, layerIndexes]);
+
+  // Parent of the selected layer - drives the align-self control (its axis and
+  // visibility depend on the parent's flex/grid layout, not the layer's own)
+  const selectedLayerParent: Layer | null = useMemo(() => {
+    if (!selectedLayerId) return null;
+    const result = indexedFindLayerWithParent(layerIndexes, selectedLayerId);
+    return result?.parent ?? null;
   }, [selectedLayerId, layerIndexes]);
 
   // Check if selected collection is nested inside another collection
@@ -1954,6 +1963,13 @@ const RightSidebar = React.memo(function RightSidebar({
 
           {shouldShowControl('layout', selectedLayer) && !showTextStyleControls && (
             <LayoutControls layer={controlLayer} onLayerUpdate={controlUpdate} />
+          )}
+
+          {!showTextStyleControls && (
+            <SelfLayoutControls
+              layer={controlLayer} parentLayer={selectedLayerParent}
+              onLayerUpdate={controlUpdate}
+            />
           )}
 
           {shouldShowControl('spacing', selectedLayer) && (

--- a/app/(builder)/ycode/components/SelfLayoutControls.tsx
+++ b/app/(builder)/ycode/components/SelfLayoutControls.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { memo } from 'react';
+import { Label } from '@/components/ui/label';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import Icon from '@/components/ui/icon';
+import { useDesignSync } from '@/hooks/use-design-sync';
+import { useEditorStore } from '@/stores/useEditorStore';
+import type { Layer } from '@/types';
+
+interface SelfLayoutControlsProps {
+  layer: Layer | null;
+  parentLayer?: Layer | null;
+  onLayerUpdate: (layerId: string, updates: Partial<Layer>) => void;
+}
+
+const noop = () => {};
+
+/**
+ * Child-in-parent layout controls (align-self). Rendered for any layer whose
+ * parent is a flex/grid container, independent of the layer's own layout panel.
+ */
+const SelfLayoutControls = memo(function SelfLayoutControls({ layer, parentLayer = null, onLayerUpdate }: SelfLayoutControlsProps) {
+  const activeBreakpoint = useEditorStore((s) => s.activeBreakpoint);
+  const activeUIState = useEditorStore((s) => s.activeUIState);
+
+  const { updateDesignProperty, getDesignProperty } = useDesignSync({
+    layer,
+    onLayerUpdate,
+    activeBreakpoint,
+    activeUIState,
+  });
+
+  // Read-only sync for the parent to resolve its layout (align-self axis and
+  // visibility depend on the parent's flex/grid direction, not this layer's)
+  const { getDesignProperty: getParentDesignProperty } = useDesignSync({
+    layer: parentLayer,
+    onLayerUpdate: noop,
+    activeBreakpoint,
+    activeUIState,
+  });
+
+  const alignSelf = getDesignProperty('layout', 'alignSelf') || 'auto';
+
+  const parentDisplay = parentLayer ? (getParentDesignProperty('layout', 'display') || '') : '';
+  const parentFlexDirection = getParentDesignProperty('layout', 'flexDirection') || 'row';
+  const isParentFlex = parentDisplay === 'flex' || parentDisplay === 'inline-flex';
+  const isParentGrid = parentDisplay === 'grid' || parentDisplay === 'inline-grid';
+  const isParentColumnAxis = isParentFlex && (parentFlexDirection === 'column' || parentFlexDirection === 'column-reverse');
+
+  if (!isParentFlex && !isParentGrid) return null;
+
+  // 'auto' clears the override to keep classes clean
+  const handleAlignSelfChange = (value: string) => {
+    updateDesignProperty('layout', 'alignSelf', value === 'auto' ? null : value);
+  };
+
+  return (
+    <div className="py-5">
+      <header className="py-4 -mt-4 flex items-center gap-1.5">
+        <Label>Self layout</Label>
+        <Label variant="muted">{isParentGrid ? 'Grid container' : 'Flex container'}</Label>
+      </header>
+
+      <div className="grid grid-cols-3">
+          <Label variant="muted">Self align</Label>
+          <div className="col-span-2">
+              <Tabs
+                value={alignSelf}
+                onValueChange={handleAlignSelfChange}
+                className="w-full"
+              >
+                  <TabsList className="w-full">
+                      <TabsTrigger value="auto">Auto</TabsTrigger>
+                      <TabsTrigger value="start">
+                          <Icon name="alignStart" className={isParentColumnAxis ? '-rotate-90' : ''} />
+                      </TabsTrigger>
+                      <TabsTrigger value="center">
+                          <Icon name="alignCenter" className={isParentColumnAxis ? '-rotate-90' : ''} />
+                      </TabsTrigger>
+                      <TabsTrigger value="end">
+                          <Icon name="alignEnd" className={isParentColumnAxis ? '-rotate-90' : ''} />
+                      </TabsTrigger>
+                      <TabsTrigger value="stretch">
+                          <Icon name="alignStretch" className={isParentColumnAxis ? '-rotate-90' : ''} />
+                      </TabsTrigger>
+                  </TabsList>
+              </Tabs>
+          </div>
+      </div>
+    </div>
+  );
+});
+export default SelfLayoutControls;

--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -88,6 +88,7 @@ Each layer's \`design\` object controls its appearance. Use update_layer_design 
 - flexDirection: "row" | "column" | "row-reverse" | "column-reverse"
 - justifyContent: "start" | "end" | "center" | "between" | "around" | "evenly"
 - alignItems: "start" | "end" | "center" | "baseline" | "stretch"
+- alignSelf: "auto" | "start" | "end" | "center" | "baseline" | "stretch" (per-child override of parent alignItems)
 - gap: CSS value ("16px", "1rem")
 - gridTemplateColumns: "4" (bare integer count, normalized to repeat(N, 1fr)), "1fr 1fr 1fr", "repeat(3, 1fr)"
 

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -127,6 +127,7 @@ const DESIGN_REFERENCE_JSON = JSON.stringify({
       flexDirection: { type: 'enum', values: ['row', 'column', 'row-reverse', 'column-reverse'] },
       justifyContent: { type: 'enum', values: ['start', 'end', 'center', 'between', 'around', 'evenly'] },
       alignItems: { type: 'enum', values: ['start', 'end', 'center', 'baseline', 'stretch'] },
+      alignSelf: { type: 'enum', values: ['auto', 'start', 'end', 'center', 'baseline', 'stretch'] },
       gap: { type: 'css_value', examples: ['16px', '1rem'] },
       gridTemplateColumns: { type: 'string', examples: ['4', '1fr 1fr 1fr', 'repeat(3, 1fr)'], description: 'A bare integer is accepted and normalized to repeat(N, 1fr).' },
     },

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -53,6 +53,7 @@ export const designSchema = z.object({
     flexWrap: z.string().optional(),
     justifyContent: z.string().optional(),
     alignItems: z.string().optional(),
+    alignSelf: z.string().optional(),
     gap: z.string().optional(),
     columnGap: z.string().optional(),
     rowGap: z.string().optional(),

--- a/lib/mcp/utils.ts
+++ b/lib/mcp/utils.ts
@@ -352,7 +352,7 @@ function normalizeDesignValues(
       'space-evenly': 'evenly',
     };
 
-    for (const prop of ['justifyContent', 'alignItems', 'alignContent'] as const) {
+    for (const prop of ['justifyContent', 'alignItems', 'alignSelf', 'alignContent'] as const) {
       const val = layout[prop];
       if (typeof val === 'string' && flexValueMap[val]) {
         layout[prop] = flexValueMap[val];

--- a/lib/tailwind-class-mapper.ts
+++ b/lib/tailwind-class-mapper.ts
@@ -250,6 +250,7 @@ const CLASS_PROPERTY_MAP: Record<string, RegExp> = {
   flexWrap: /^flex-(wrap|wrap-reverse|nowrap)$/,
   justifyContent: /^justify-(start|end|center|between|around|evenly|stretch)$/,
   alignItems: /^items-(start|end|center|baseline|stretch)$/,
+  alignSelf: /^self-(auto|start|end|center|baseline|stretch)$/,
   alignContent: /^content-(start|end|center|between|around|evenly|stretch)$/,
   gap: /^gap-(\[.+\]|\d+|px|0\.5|1\.5|2\.5|3\.5)$/,
   columnGap: /^gap-x-(\[.+\]|\d+|px|0\.5|1\.5|2\.5|3\.5)$/,
@@ -715,6 +716,13 @@ export function propertyToClass(
           'flex-end': 'end',
         };
         return `items-${itemsMap[value] || value}`;
+      }
+      case 'alignSelf': {
+        const selfMap: Record<string, string> = {
+          'flex-start': 'start',
+          'flex-end': 'end',
+        };
+        return `self-${selfMap[value] || value}`;
       }
       case 'alignContent': {
         const contentMap: Record<string, string> = {
@@ -1438,6 +1446,14 @@ export function classesToDesign(classes: string | string[]): Layer['design'] {
       const value = cls.replace('items-', '');
       if (['start', 'end', 'center', 'baseline', 'stretch'].includes(value)) {
         design.layout!.alignItems = value;
+      }
+    }
+
+    // Align Self
+    if (cls.startsWith('self-')) {
+      const value = cls.replace('self-', '');
+      if (['auto', 'start', 'end', 'center', 'baseline', 'stretch'].includes(value)) {
+        design.layout!.alignSelf = value;
       }
     }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -17,6 +17,7 @@ export interface LayoutDesign {
   flexWrap?: string;
   justifyContent?: string;
   alignItems?: string;
+  alignSelf?: string;
   gap?: string;
   columnGap?: string;
   rowGap?: string;


### PR DESCRIPTION
## Summary

Adds UI controls for the `alignSelf` design property so a single child can override how it aligns inside its flex/grid parent — for example, un-stretching a badge, pill, or button placed in a flex column — directly in the builder instead of via code or the AI agent. Closes #424.

## Changes

- Add `alignSelf` to the layout design model (`types/index.ts`) and to the Tailwind class mapper (generate + parse of `self-*`)
- Expose `alignSelf` to the AI agent via the MCP schema, reference, and instructions, and normalize `flex-start`/`flex-end` values
- Add a dedicated "Self layout" section (`SelfLayoutControls`) that renders for any layer whose parent is a flex/grid container — including text layers, which don't show the main Layout panel
- Resolve the axis from the parent's flex direction and rotate the align icons accordingly
- `Auto` clears the override (no class emitted) to keep classes clean

## Test plan

- [ ] Select a child of a flex row/column container — the "Self layout" section appears with the parent type shown in muted text
- [ ] Set start/center/end/stretch and confirm the child aligns correctly and the `self-*` class round-trips
- [ ] Select `Auto` and confirm the override class is removed
- [ ] Select a text layer inside a flex/grid parent — the section still appears (the rest of the Layout panel stays hidden)
- [ ] Select a child of a plain block parent — the section does not appear
- [ ] Verify icons rotate to match a column-axis parent