### PR TITLE
feat: add syntax highlighting to custom code

### DIFF
--- a/app/(builder)/ycode/components/HTMLEmbedSettings.tsx
+++ b/app/(builder)/ycode/components/HTMLEmbedSettings.tsx
@@ -8,7 +8,7 @@
 
 import React, { useState, useCallback } from 'react';
 
-import { Textarea } from '@/components/ui/textarea';
+import { CodeEditor } from '@/components/ui/code-editor';
 import SettingsPanel from './SettingsPanel';
 import type { Layer } from '@/types';
 
@@ -48,12 +48,11 @@ export default function HTMLEmbedSettings({ layer, onLayerUpdate }: HTMLEmbedSet
       onToggle={() => setIsOpen(!isOpen)}
     >
       <div className="flex flex-col gap-3">
-        <Textarea
+        <CodeEditor
           value={currentCode}
-          onChange={(e) => handleCodeChange(e.target.value)}
+          onValueChange={handleCodeChange}
           placeholder="<div>Add your custom code here</div>"
-          className="font-mono text-xs min-h-[200px] max-h-[20vh] overflow-y-auto resize-none"
-          spellCheck={false}
+          className="min-h-50 max-h-[20vh]"
         />
       </div>
     </SettingsPanel>

--- a/app/(builder)/ycode/components/PageSettingsPanel.tsx
+++ b/app/(builder)/ycode/components/PageSettingsPanel.tsx
@@ -42,6 +42,7 @@ import Icon from '@/components/ui/icon';
 import { getPageIcon, isHomepage, buildSlugPath, buildFolderPath, folderHasIndexPage, generateUniqueSlug, generateSlug, sanitizeSlug, isReservedRootSlug } from '@/lib/page-utils';
 import { isAssetOfType, ASSET_CATEGORIES } from '@/lib/asset-utils';
 import { Textarea } from '@/components/ui/textarea';
+import { CodeEditor } from '@/components/ui/code-editor';
 import { useAsset } from '@/hooks/use-asset';
 import { useEditorStore } from '@/stores/useEditorStore';
 import RichTextEditor from './RichTextEditor';
@@ -1867,10 +1868,10 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
                         Add custom code to the &lt;head&gt; section of the page. It can be useful when you want to add custom meta tags, analytics, or custom CSS.
                       </FieldDescription>
                       <div className="relative">
-                        <Textarea
-                          ref={(el) => { customCodeHeadRef.current = el; }}
+                        <CodeEditor
+                          textareaRef={customCodeHeadRef}
                           value={customCodeHead}
-                          onChange={(e) => setCustomCodeHead(e.target.value)}
+                          onValueChange={setCustomCodeHead}
                           placeholder="<script>...</script>"
                           className="min-h-48 w-full"
                         />
@@ -1896,10 +1897,10 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
                         Add custom code before the closing &lt;/body&gt; tag. It can be useful when you want to add custom scripts that need to run after the page loads.
                       </FieldDescription>
                       <div className="relative">
-                        <Textarea
-                          ref={(el) => { customCodeBodyRef.current = el; }}
+                        <CodeEditor
+                          textareaRef={customCodeBodyRef}
                           value={customCodeBody}
-                          onChange={(e) => setCustomCodeBody(e.target.value)}
+                          onValueChange={setCustomCodeBody}
                           placeholder="<script>...</script>"
                           className="min-h-48 w-full"
                         />

--- a/app/(builder)/ycode/components/RichTextHtmlEmbedDialog.tsx
+++ b/app/(builder)/ycode/components/RichTextHtmlEmbedDialog.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
+import { CodeEditor } from '@/components/ui/code-editor';
 import {
   Dialog,
   DialogContent,
@@ -43,12 +43,11 @@ export default function RichTextHtmlEmbedDialog({
         <DialogHeader>
           <DialogTitle className="text-base">Edit HTML Embed</DialogTitle>
         </DialogHeader>
-        <Textarea
+        <CodeEditor
           value={localCode}
-          onChange={(e) => setLocalCode(e.target.value)}
+          onValueChange={setLocalCode}
           placeholder="<div>Add your custom HTML or <script> here</div>"
-          className="font-mono text-xs min-h-[200px] max-h-[40vh] overflow-y-auto resize-none"
-          spellCheck={false}
+          className="min-h-50 max-h-[40vh]"
         />
         <DialogFooter>
           <Button

--- a/app/(builder)/ycode/settings/general/page.tsx
+++ b/app/(builder)/ycode/settings/general/page.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/select';
 import { ButtonGroup } from '@/components/ui/button-group';
 import { Button } from '@/components/ui/button';
+import { CodeEditor } from '@/components/ui/code-editor';
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
@@ -745,10 +746,9 @@ export default function GeneralSettingsPage() {
                   <FieldDescription>
                     Enter code that will be injected into the &lt;head&gt; tag on every page of your site.
                   </FieldDescription>
-                  <Textarea
-                    id="global-code-head"
+                  <CodeEditor
                     value={customCodeHead}
-                    onChange={(e) => setCustomCodeHead(e.target.value)}
+                    onValueChange={setCustomCodeHead}
                     placeholder={'<script src="..."></script>\n<link rel="stylesheet" href="...">'}
                     className="min-h-30"
                   />
@@ -761,10 +761,9 @@ export default function GeneralSettingsPage() {
                   <FieldDescription>
                     Enter code that will be injected before the &lt;/body&gt; tag on every page of your site.
                   </FieldDescription>
-                  <Textarea
-                    id="global-code-body"
+                  <CodeEditor
                     value={customCodeBody}
-                    onChange={(e) => setCustomCodeBody(e.target.value)}
+                    onValueChange={setCustomCodeBody}
                     placeholder={'<script>...</script>'}
                     className="min-h-30"
                   />

--- a/components/ui/code-editor.tsx
+++ b/components/ui/code-editor.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import React, { useInsertionEffect } from 'react';
+import React, { useEffect, useInsertionEffect, useRef } from 'react';
 import Editor from 'react-simple-code-editor';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-markup';
+import 'prismjs/components/prism-clike';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-css-extras';
 import { cn } from '@/lib/utils';
 
 interface CodeEditorProps {
@@ -13,10 +17,19 @@ interface CodeEditorProps {
   placeholder?: string;
   className?: string;
   autoFocus?: boolean;
+  /** Exposes the internal textarea (e.g. to insert text at the cursor). */
+  textareaRef?: React.RefObject<HTMLTextAreaElement | null>;
+}
+
+/** Renders leading spaces of each line as middle dots for visible indentation. */
+function showIndentDots(html: string): string {
+  return html.replace(/^ +/gm, (spaces) =>
+    `<span class="code-editor-indent">${'·'.repeat(spaces.length)}</span>`,
+  );
 }
 
 function highlightHtml(code: string): string {
-  return Prism.highlight(code, Prism.languages.markup, 'markup');
+  return showIndentDots(Prism.highlight(code, Prism.languages.markup, 'markup'));
 }
 
 const STYLE_ID = 'code-editor-prism-theme';
@@ -30,6 +43,31 @@ const prismCss = `
 .code-editor-root .token.doctype { color: #5c6370; }
 .code-editor-root .token.prolog { color: #5c6370; }
 .code-editor-root .token.cdata { color: #5c6370; }
+.code-editor-root .token.keyword { color: #c678dd; }
+.code-editor-root .token.boolean,
+.code-editor-root .token.number,
+.code-editor-root .token.constant { color: #d19a66; }
+.code-editor-root .token.string,
+.code-editor-root .token.char,
+.code-editor-root .token.attr-value .token.value { color: #98c379; }
+.code-editor-root .token.function,
+.code-editor-root .token.class-name { color: #61afef; }
+.code-editor-root .token.operator { color: #56b6c2; }
+.code-editor-root .token.property { color: #56b6c2; }
+.code-editor-root .token.selector { color: #e5c07b; }
+.code-editor-root .token.selector .token.class,
+.code-editor-root .token.selector .token.id { color: #d19a66; }
+.code-editor-root .token.selector .token.pseudo-class,
+.code-editor-root .token.selector .token.pseudo-element,
+.code-editor-root .token.selector .token.attribute { color: #56b6c2; }
+.code-editor-root .token.selector .token.combinator { color: #abb2bf; }
+.code-editor-root .token.builtin { color: #56b6c2; }
+.code-editor-root .token.regex,
+.code-editor-root .token.important { color: #d19a66; }
+.code-editor-root .token.variable { color: #e06c75; }
+.code-editor-root .token.parameter { color: #e06c75; }
+.code-editor-root .token.function-variable { color: #61afef; }
+.code-editor-root .code-editor-indent { color: #454b57; }
 `;
 
 let styleInjected = false;
@@ -53,11 +91,21 @@ export function CodeEditor({
   placeholder = '',
   className,
   autoFocus = false,
+  textareaRef,
 }: CodeEditorProps) {
   useInsertionEffect(ensurePrismStyles, []);
 
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const textarea = rootRef.current?.querySelector('textarea') ?? null;
+    if (textarea) textarea.spellcheck = false;
+    if (textareaRef) textareaRef.current = textarea;
+  });
+
   return (
     <div
+      ref={rootRef}
       className={cn(
         'code-editor-root rounded-lg border border-transparent bg-input overflow-auto font-mono text-xs',
         readOnly && 'cursor-default',


### PR DESCRIPTION
## Summary

Custom code was edited in plain textareas with no syntax highlighting, making it hard to spot mistakes. This replaces those textareas with the existing Prism-based `CodeEditor` so every custom-code input gets highlighting for HTML, embedded JS (`<script>`) and CSS (`<style>`). Closes #337.

## Changes

- Reuse the shared `CodeEditor` for all custom code inputs: page settings (head/body), global settings (head/body), the HTML embed element, and the rich text HTML embed dialog
- Enable embedded language highlighting by loading `prism-javascript`, `prism-css`, and `prism-css-extras` (JS in `<script>`, CSS in `<style>`)
- Add token colors for JS/CSS (keywords, strings, functions, numbers, operators), with distinct colors for CSS selectors, classes/IDs, properties, and JS parameters
- Render leading indentation spaces as subtle middle dots
- Expose the editor's internal textarea via a `textareaRef` prop so the CMS `{{field}}` variable insertion in page settings keeps working

## Test plan

- [ ] Page settings → Custom code: head/body show highlighting; CMS `{{field}}` insertion still works on dynamic pages
- [ ] Global settings → Custom code: head/body show highlighting and save correctly
- [ ] HTML embed element: code highlights and updates the layer
- [ ] Rich text HTML embed dialog: code highlights and saves
- [ ] Verify HTML, embedded `<script>` JS, and `<style>` CSS are all highlighted
- [ ] Confirm indentation dots render and cursor alignment is correct