### PR TITLE
feat: resolve CMS variables in custom code

### DIFF
--- a/app/(builder)/ycode/components/PageSettingsPanel.tsx
+++ b/app/(builder)/ycode/components/PageSettingsPanel.tsx
@@ -9,7 +9,7 @@
 import React, { useState, useEffect, useMemo, useRef, useImperativeHandle, useCallback } from 'react';
 import Image from 'next/image';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
-import type { Page, PageSettings, Asset, FieldVariable } from '@/types';
+import type { Page, PageSettings, Asset, FieldVariable, CollectionField } from '@/types';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
@@ -32,7 +32,12 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select';
-import * as SelectPrimitive from '@radix-ui/react-select';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu';
+import { CollectionFieldSelector } from './CollectionFieldSelector';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Spinner } from '@/components/ui/spinner';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
@@ -48,7 +53,7 @@ import { useEditorStore } from '@/stores/useEditorStore';
 import RichTextEditor from './RichTextEditor';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
-import { getFieldIcon, IMAGE_FIELD_TYPES, RICH_TEXT_FIELD_TYPES } from '@/lib/collection-field-utils';
+import { getFieldIcon, IMAGE_FIELD_TYPES, RICH_TEXT_FIELD_TYPES, DISPLAYABLE_FIELD_TYPES, type FieldGroup as CollectionFieldGroup } from '@/lib/collection-field-utils';
 
 export interface PageSettingsPanelHandle {
   checkUnsavedChanges: () => Promise<boolean>;
@@ -131,8 +136,6 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
 
   const [customCodeHead, setCustomCodeHead] = useState('');
   const [customCodeBody, setCustomCodeBody] = useState('');
-  const [headVariableSelectKey, setHeadVariableSelectKey] = useState(0);
-  const [bodyVariableSelectKey, setBodyVariableSelectKey] = useState(0);
   const customCodeHeadRef = useRef<HTMLTextAreaElement | null>(null);
   const customCodeBodyRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -295,6 +298,30 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
     return collectionFields.map(field => `{{${field.name}}}`).join(', ');
   }, [collectionFields]);
 
+  // Field group feeding the variable selector (reference fields expand into submenus)
+  const customCodeFieldGroups = useMemo<CollectionFieldGroup[]>(() => {
+    if (collectionFields.length === 0) return [];
+    return [{ fields: collectionFields }];
+  }, [collectionFields]);
+
+  // Build a {{Field}} / {{Reference.Field}} token from a selected field + relationship path (field IDs)
+  const buildFieldTokenPath = useCallback((fieldId: string, relationshipPath: string[]): string | null => {
+    let currentField: CollectionField | undefined = collectionFields.find(field => field.id === fieldId);
+    if (!currentField) return null;
+
+    const names = [currentField.name];
+    for (const relationshipFieldId of relationshipPath) {
+      const referencedCollectionId: string | null = currentField.reference_collection_id;
+      if (!referencedCollectionId) return null;
+      const nextField: CollectionField | undefined = (fields[referencedCollectionId] || []).find(field => field.id === relationshipFieldId);
+      if (!nextField) return null;
+      names.push(nextField.name);
+      currentField = nextField;
+    }
+
+    return names.join('.');
+  }, [collectionFields, fields]);
+
   // Helper function to insert text at cursor position in textarea
   const insertTextAtCursor = useCallback((textarea: HTMLTextAreaElement | null, text: string, setValue: (value: string) => void, currentValue: string) => {
     if (!textarea) return;
@@ -324,26 +351,16 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
     textareaRef,
     value,
     setValue,
-    selectKey,
-    setSelectKey,
   }: {
     textareaRef: React.RefObject<HTMLTextAreaElement | null>;
     value: string;
     setValue: (value: string) => void;
-    selectKey: number;
-    setSelectKey: (updater: (prev: number) => number) => void;
   }) => {
     if (!isDynamicPage || collectionFields.length === 0) return null;
 
     return (
-      <Select
-        key={selectKey}
-        onValueChange={(fieldName) => {
-          handleFieldVariableInsert(fieldName, textareaRef, setValue, value);
-          setSelectKey(prev => prev + 1);
-        }}
-      >
-        <SelectPrimitive.Trigger asChild>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
           <Button
             variant="secondary"
             size="sm"
@@ -351,17 +368,24 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
           >
             <Icon name="database" className="size-2.5" />
           </Button>
-        </SelectPrimitive.Trigger>
-        <SelectContent>
-          {collectionFields.map((field) => (
-            <SelectItem key={field.id} value={field.name}>
-              {field.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56 max-h-none!">
+          <CollectionFieldSelector
+            fieldGroups={customCodeFieldGroups}
+            allFields={fields}
+            collections={collections}
+            allowedTypes={DISPLAYABLE_FIELD_TYPES}
+            onSelect={(fieldId, relationshipPath) => {
+              const tokenPath = buildFieldTokenPath(fieldId, relationshipPath);
+              if (tokenPath) {
+                handleFieldVariableInsert(tokenPath, textareaRef, setValue, value);
+              }
+            }}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
     );
-  }, [isDynamicPage, collectionFields, handleFieldVariableInsert]);
+  }, [isDynamicPage, collectionFields, customCodeFieldGroups, fields, collections, buildFieldTokenPath, handleFieldVariableInsert]);
 
   // Check if there's a URL conflict warning: dynamic page + non-index pages in same folder
   const urlConflictWarning = useMemo(() => {
@@ -1856,7 +1880,7 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
                           <span>
                             The page CMS item values can be added to your custom codes (for example to improve SEO with JSON-LD) by adding
                             field names like <span className="text-foreground">{'{{Name}}'}</span>, which will be replaced with the value
-                            of the <span className="text-foreground">Name</span> field on each generated page.
+                            of the <span className="text-foreground">Name</span> field on each generated page. Image and file fields resolve to their URL.
                           </span>
                         </FieldDescription>
                       </Field>
@@ -1882,8 +1906,6 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
                                 textareaRef: customCodeHeadRef,
                                 value: customCodeHead,
                                 setValue: setCustomCodeHead,
-                                selectKey: headVariableSelectKey,
-                                setSelectKey: setHeadVariableSelectKey,
                               })}
                             </div>
                           </div>
@@ -1912,8 +1934,6 @@ const PageSettingsPanel = React.forwardRef<PageSettingsPanelHandle, PageSettings
                                 textareaRef: customCodeBodyRef,
                                 value: customCodeBody,
                                 setValue: setCustomCodeBody,
-                                selectKey: bodyVariableSelectKey,
-                                setSelectKey: setBodyVariableSelectKey,
                               })}
                             </div>
                           </div>

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -562,11 +562,11 @@ export default async function PageRenderer({
   const rawPageCustomCodeBody = page.settings?.custom_code?.body || '';
 
   const pageCustomCodeHead = page.is_dynamic && collectionItem
-    ? resolveCustomCodePlaceholders(rawPageCustomCodeHead, collectionItem, collectionFields)
+    ? await resolveCustomCodePlaceholders(rawPageCustomCodeHead, collectionItem, collectionFields, usePublishedData)
     : rawPageCustomCodeHead;
 
   const pageCustomCodeBody = page.is_dynamic && collectionItem
-    ? resolveCustomCodePlaceholders(rawPageCustomCodeBody, collectionItem, collectionFields)
+    ? await resolveCustomCodePlaceholders(rawPageCustomCodeBody, collectionItem, collectionFields, usePublishedData)
     : rawPageCustomCodeBody;
 
   const { bodyClasses, childLayers: rawChildLayers } = extractBodyLayer(resolvedLayers);

--- a/lib/apps/static-export/resolver.ts
+++ b/lib/apps/static-export/resolver.ts
@@ -91,7 +91,7 @@ export async function* resolvePages(
     if (!isDefaultLocale) return
     const data = (await fetchErrorPage(page.error_page, true)) as PageData | null
     if (data) {
-      const resolved = renderResolved(data.page, data, folders, pages, `${page.error_page}.html`, ctx)
+      const resolved = await renderResolved(data.page, data, folders, pages, `${page.error_page}.html`, ctx)
       if (resolved) yield resolved
     }
     return
@@ -109,7 +109,7 @@ export async function* resolvePages(
       outputKey = `${localePrefix}index.html`
     }
     if (data) {
-      const resolved = renderResolved(data.page, data, folders, pages, outputKey, ctx)
+      const resolved = await renderResolved(data.page, data, folders, pages, outputKey, ctx)
       if (resolved) yield resolved
     }
     return
@@ -139,7 +139,7 @@ export async function* resolvePages(
         continue
       }
       const outputKey = `${slugPath}/index.html`
-      const resolved = renderResolved(data.page, data, folders, pages, outputKey, ctx)
+      const resolved = await renderResolved(data.page, data, folders, pages, outputKey, ctx)
       if (resolved) yield resolved
     }
     return
@@ -155,18 +155,18 @@ export async function* resolvePages(
   const outputKey = isDefaultLocale
     ? computeOutputKey(page, folders)
     : (slugPath ? `${slugPath}/index.html` : `${localePrefix}index.html`)
-  const resolved = renderResolved(data.page, data, folders, pages, outputKey, ctx)
+  const resolved = await renderResolved(data.page, data, folders, pages, outputKey, ctx)
   if (resolved) yield resolved
 }
 
-function renderResolved(
+async function renderResolved(
   page: Page,
   data: PageData,
   folders: PageFolder[],
   pages: Page[],
   outputKey: string,
   ctx: LocaleContext,
-): ResolvedPage | null {
+): Promise<ResolvedPage | null> {
   if (!data.pageLayers?.layers) return null
   const layers = data.pageLayers.layers
   const bodyHtml = renderPageBody(layers, {
@@ -188,10 +188,10 @@ function renderResolved(
   const shouldResolvePlaceholders =
     page.is_dynamic && data.collectionItem && (data.collectionFields?.length ?? 0) > 0
   const pageCustomCodeHead = shouldResolvePlaceholders
-    ? resolveCustomCodePlaceholders(rawHead, data.collectionItem!, data.collectionFields!)
+    ? await resolveCustomCodePlaceholders(rawHead, data.collectionItem!, data.collectionFields!, true)
     : rawHead
   const pageCustomCodeBody = shouldResolvePlaceholders
-    ? resolveCustomCodePlaceholders(rawBody, data.collectionItem!, data.collectionFields!)
+    ? await resolveCustomCodePlaceholders(rawBody, data.collectionItem!, data.collectionFields!, true)
     : rawBody
 
   return {

--- a/lib/repositories/assetRepository.ts
+++ b/lib/repositories/assetRepository.ts
@@ -177,8 +177,8 @@ export async function getAllAssets(folderId?: string | null): Promise<Asset[]> {
  * @param id Asset ID
  * @param isPublished If true, get published version; if false, get draft version (default: false)
  */
-export async function getAssetById(id: string, isPublished: boolean = false): Promise<Asset | null> {
-  const client = await getSupabaseAdmin();
+export async function getAssetById(id: string, isPublished: boolean = false, tenantId?: string): Promise<Asset | null> {
+  const client = await getSupabaseAdmin(tenantId);
 
   if (!client) {
     throw new Error('Supabase not configured');

--- a/lib/repositories/collectionFieldRepository.ts
+++ b/lib/repositories/collectionFieldRepository.ts
@@ -87,13 +87,15 @@ export async function getAllFields(
  * @param collection_id - Collection UUID
  * @param is_published - Filter for draft (false) or published (true) fields. Defaults to false (draft).
  * @param filters - Optional search filters
+ * @param tenantId - Optional tenant scope (ignored in single-tenant deployments)
  */
 export async function getFieldsByCollectionId(
   collection_id: string,
   is_published: boolean = false,
-  filters?: FieldFilters
+  filters?: FieldFilters,
+  tenantId?: string
 ): Promise<CollectionField[]> {
-  const client = await getSupabaseAdmin();
+  const client = await getSupabaseAdmin(tenantId);
 
   if (!client) {
     throw new Error('Supabase client not configured');

--- a/lib/repositories/collectionItemRepository.ts
+++ b/lib/repositories/collectionItemRepository.ts
@@ -474,8 +474,8 @@ export async function getAllItemsByCollectionId(
  * @param id - Item UUID
  * @param isPublished - Get draft (false) or published (true) version. Defaults to false (draft).
  */
-export async function getItemById(id: string, isPublished: boolean = false): Promise<CollectionItem | null> {
-  const client = await getSupabaseAdmin();
+export async function getItemById(id: string, isPublished: boolean = false, tenantId?: string): Promise<CollectionItem | null> {
+  const client = await getSupabaseAdmin(tenantId);
 
   if (!client) {
     throw new Error('Supabase client not configured');
@@ -555,15 +555,15 @@ export async function getItemsByIds(ids: string[], isPublished: boolean = false,
  * @param id - Item UUID
  * @param is_published - Get draft (false) or published (true) values. Defaults to false (draft).
  */
-export async function getItemWithValues(id: string, is_published: boolean = false): Promise<CollectionItemWithValues | null> {
-  const client = await getSupabaseAdmin();
+export async function getItemWithValues(id: string, is_published: boolean = false, tenantId?: string): Promise<CollectionItemWithValues | null> {
+  const client = await getSupabaseAdmin(tenantId);
 
   if (!client) {
     throw new Error('Supabase client not configured');
   }
 
   // Get the item
-  const item = await getItemById(id, is_published);
+  const item = await getItemById(id, is_published, tenantId);
   if (!item) return null;
 
   // Build query for values with field type info

--- a/lib/repositories/settingsRepository.ts
+++ b/lib/repositories/settingsRepository.ts
@@ -47,10 +47,11 @@ export async function getAllSettings(): Promise<Setting[]> {
  * Get a setting by key
  *
  * @param key - The setting key
+ * @param tenantId - Optional tenant scope (ignored in single-tenant deployments)
  * @returns Promise resolving to the setting value or null if not found
  */
-export async function getSettingByKey(key: string): Promise<any | null> {
-  const client = await getSupabaseAdmin();
+export async function getSettingByKey(key: string, tenantId?: string): Promise<any | null> {
+  const client = await getSupabaseAdmin(tenantId);
   if (!client) {
     throw new Error('Failed to initialize Supabase client');
   }

--- a/lib/resolve-cms-variables.ts
+++ b/lib/resolve-cms-variables.ts
@@ -11,47 +11,158 @@
 import type { FieldVariable, CollectionItemWithValues, CollectionField } from '@/types';
 import { isValidUUID } from '@/lib/utils';
 import { getAssetProxyUrl } from '@/lib/asset-utils';
+import { isAssetFieldType, isMultipleAssetField } from '@/lib/collection-field-utils';
+import { buildAbsoluteAssetUrl, getSiteBaseUrl } from '@/lib/url-utils';
 
 // Re-export client-safe inline variable resolver
 export { resolveInlineVariables } from '@/lib/inline-variables';
 
+const PLACEHOLDER_REGEX = /\{\{([^}]+)\}\}/g;
+
+/** Lazily resolves the site base URL once, memoized per resolution pass. */
+type SiteBaseUrlResolver = () => Promise<string | null>;
+
 /**
- * Resolve {{FieldName}} placeholders in custom code
- * Replaces {{FieldName}} with actual field values from the collection item
- *
- * SERVER-ONLY: Requires collection fields to map field names to IDs
+ * Options for placeholder resolution. `tenantId`/`primaryDomainUrl` are ignored
+ * in single-tenant deployments and used by multi-tenant deployments to scope
+ * data access and resolve the correct per-tenant absolute URLs.
  */
-export function resolveCustomCodePlaceholders(
+export interface ResolveCustomCodeOptions {
+  tenantId?: string;
+  primaryDomainUrl?: string | null;
+}
+
+/**
+ * Resolve the site's canonical base URL from settings + environment (SERVER-ONLY).
+ */
+async function resolveSiteBaseUrl(options: ResolveCustomCodeOptions): Promise<string | null> {
+  const { getSettingByKey } = await import('@/lib/repositories/settingsRepository');
+  const globalCanonicalUrl = await getSettingByKey('global_canonical_url', options.tenantId).catch(() => null);
+  return getSiteBaseUrl({ globalCanonicalUrl, primaryDomainUrl: options.primaryDomainUrl });
+}
+
+/**
+ * Resolve a single field's stored value to its display string.
+ * Asset fields store the asset UUID, so they are resolved to an absolute public URL.
+ */
+async function resolveFieldDisplayValue(
+  field: CollectionField,
+  rawValue: string | undefined,
+  isPublished: boolean,
+  getBaseUrl: SiteBaseUrlResolver,
+  tenantId?: string
+): Promise<string> {
+  if (rawValue == null) return '';
+
+  if (isAssetFieldType(field.type) && !isMultipleAssetField(field)) {
+    const url = await resolveImageUrl(String(rawValue), null, isPublished, tenantId);
+    if (!url) return '';
+    return buildAbsoluteAssetUrl(await getBaseUrl(), url) ?? url;
+  }
+
+  return String(rawValue);
+}
+
+/**
+ * Resolve a dotted field path against a collection level, following reference
+ * fields into their referenced items ({{Field}}, {{Ref.Field}}, {{Ref.Ref.Field}}).
+ * Returns null when a field name is unknown (placeholder kept as-is).
+ */
+async function resolveFieldPath(
+  segments: string[],
+  fieldsByName: Map<string, CollectionField>,
+  values: Record<string, string>,
+  isPublished: boolean,
+  getBaseUrl: SiteBaseUrlResolver,
+  tenantId?: string
+): Promise<string | null> {
+  const field = fieldsByName.get(segments[0]);
+  if (!field) return null;
+
+  // Last segment: resolve to the field's display value (asset-aware).
+  if (segments.length === 1) {
+    return resolveFieldDisplayValue(field, values[field.id], isPublished, getBaseUrl, tenantId);
+  }
+
+  // Deeper segments require a single reference field to traverse.
+  if (field.type !== 'reference' || !field.reference_collection_id) {
+    return null;
+  }
+
+  const referencedItemId = values[field.id];
+  if (!referencedItemId || typeof referencedItemId !== 'string' || !isValidUUID(referencedItemId)) {
+    return '';
+  }
+
+  const { getFieldsByCollectionId } = await import('@/lib/repositories/collectionFieldRepository');
+  const { getItemWithValues } = await import('@/lib/repositories/collectionItemRepository');
+
+  const referencedItem = await getItemWithValues(referencedItemId, isPublished, tenantId);
+  if (!referencedItem) return '';
+
+  const referencedFields = await getFieldsByCollectionId(field.reference_collection_id, isPublished, undefined, tenantId);
+  const referencedFieldsByName = new Map(referencedFields.map(refField => [refField.name, refField]));
+
+  return resolveFieldPath(segments.slice(1), referencedFieldsByName, referencedItem.values, isPublished, getBaseUrl, tenantId);
+}
+
+/**
+ * Resolve a single placeholder token to its value, or null to keep it as-is.
+ * Supports top-level fields ({{Field}}) and reference paths ({{Ref.Field}}).
+ */
+async function resolvePlaceholderToken(
+  token: string,
+  collectionItem: CollectionItemWithValues,
+  fieldsByName: Map<string, CollectionField>,
+  isPublished: boolean,
+  getBaseUrl: SiteBaseUrlResolver,
+  tenantId?: string
+): Promise<string | null> {
+  const segments = token.split('.').map(segment => segment.trim());
+  if (segments.some(segment => segment.length === 0)) return null;
+
+  return resolveFieldPath(segments, fieldsByName, collectionItem.values, isPublished, getBaseUrl, tenantId);
+}
+
+/**
+ * Resolve {{FieldName}} placeholders in custom code with actual field values.
+ * Asset fields resolve to their public URL and references support the
+ * {{ReferenceField.NestedField}} syntax. Unknown fields are left untouched.
+ *
+ * SERVER-ONLY: Requires collection fields and database access.
+ */
+export async function resolveCustomCodePlaceholders(
   code: string,
   collectionItem: CollectionItemWithValues | null | undefined,
-  fields: CollectionField[]
-): string {
+  fields: CollectionField[],
+  isPublished: boolean = false,
+  options: ResolveCustomCodeOptions = {}
+): Promise<string> {
   if (!collectionItem || !collectionItem.values || !fields.length) {
     return code;
   }
 
-  // Create a map of field name -> field ID for quick lookup
-  const fieldNameToId = new Map<string, string>();
-  fields.forEach(field => {
-    fieldNameToId.set(field.name, field.id);
-  });
+  const fieldsByName = new Map(fields.map(field => [field.name, field]));
 
-  // Replace {{FieldName}} placeholders with actual values
-  return code.replace(/\{\{([^}]+)\}\}/g, (match, fieldName) => {
-    const trimmedFieldName = fieldName.trim();
-    const fieldId = fieldNameToId.get(trimmedFieldName);
+  // Resolve the site base URL at most once, and only when an asset placeholder
+  // actually needs to be absolutized.
+  let baseUrlPromise: Promise<string | null> | null = null;
+  const getBaseUrl: SiteBaseUrlResolver = () => {
+    if (!baseUrlPromise) baseUrlPromise = resolveSiteBaseUrl(options);
+    return baseUrlPromise;
+  };
 
-    if (!fieldId) {
-      // Field name not found, return placeholder as-is
-      return match;
-    }
+  // Resolve each unique placeholder once (null = leave the placeholder untouched).
+  const resolvedTokens = new Map<string, string | null>();
+  for (const [, rawToken] of code.matchAll(PLACEHOLDER_REGEX)) {
+    const token = rawToken.trim();
+    if (resolvedTokens.has(token)) continue;
+    resolvedTokens.set(token, await resolvePlaceholderToken(token, collectionItem, fieldsByName, isPublished, getBaseUrl, options.tenantId));
+  }
 
-    // Get the value from collection item
-    const fieldValue = collectionItem.values[fieldId];
-
-    // Return the value, or empty string if not found
-    // Convert to string if it's not already
-    return fieldValue != null ? String(fieldValue) : '';
+  return code.replace(PLACEHOLDER_REGEX, (match, rawToken) => {
+    const value = resolvedTokens.get(rawToken.trim());
+    return value == null ? match : value;
   });
 }
 
@@ -71,7 +182,8 @@ export function resolveCustomCodePlaceholders(
 export async function resolveFieldVariableToAssetUrl(
   fieldVariable: FieldVariable,
   collectionItem: CollectionItemWithValues | null | undefined,
-  isPublished: boolean = false
+  isPublished: boolean = false,
+  tenantId?: string
 ): Promise<string | null> {
   // Dynamic import to ensure server-only code is only loaded server-side
   const { getAssetById } = await import('@/lib/repositories/assetRepository');
@@ -96,7 +208,7 @@ export async function resolveFieldVariableToAssetUrl(
     return null;
   }
 
-  const asset = await getAssetById(assetId, isPublished);
+  const asset = await getAssetById(assetId, isPublished, tenantId);
   if (!asset) return null;
   return getAssetProxyUrl(asset) || asset.public_url || null;
 }
@@ -111,7 +223,8 @@ export async function resolveFieldVariableToAssetUrl(
 export async function resolveImageUrl(
   image: string | FieldVariable | null,
   collectionItem: CollectionItemWithValues | null | undefined,
-  isPublished: boolean = false
+  isPublished: boolean = false,
+  tenantId?: string
 ): Promise<string | null> {
   // Dynamic import to ensure server-only code is only loaded server-side
   const { getAssetById } = await import('@/lib/repositories/assetRepository');
@@ -128,14 +241,14 @@ export async function resolveImageUrl(
       return null;
     }
 
-    const asset = await getAssetById(image, isPublished);
+    const asset = await getAssetById(image, isPublished, tenantId);
     if (!asset) return null;
     return getAssetProxyUrl(asset) || asset.public_url || null;
   }
 
   // If it's a FieldVariable, resolve it
   if (image.type === 'field') {
-    return await resolveFieldVariableToAssetUrl(image, collectionItem, isPublished);
+    return await resolveFieldVariableToAssetUrl(image, collectionItem, isPublished, tenantId);
   }
 
   return null;

--- a/lib/url-utils.ts
+++ b/lib/url-utils.ts
@@ -30,3 +30,13 @@ export function buildAbsolutePageUrl(baseUrl: string, pagePath: string): string 
   }
   return `${base}${pagePath.startsWith('/') ? pagePath : '/' + pagePath}`;
 }
+
+/**
+ * Prefix a relative URL (e.g. asset proxy path `/a/...`) with the site base URL.
+ * Leaves already-absolute or non-root URLs (http, data:, etc.) untouched, and
+ * returns the URL as-is when no base URL is available.
+ */
+export function buildAbsoluteAssetUrl(baseUrl: string | null, url: string | null): string | null {
+  if (!url || !baseUrl || !url.startsWith('/')) return url;
+  return `${baseUrl.replace(/\/$/, '')}${url}`;
+}


### PR DESCRIPTION
## Summary

Dynamic page custom code (head/body) now resolves `{{Field}}` placeholders against the page's collection item, so custom code such as JSON-LD and social/meta tags can use real per-item values. Asset fields resolve to absolute URLs, references are supported with dot notation, and the variable picker exposes nested reference fields directly.

## Changes

- Resolve asset (image/file) fields to **absolute** public URLs so custom code references crawlable, fully-qualified URLs
- Support nested references via `{{Reference.Field}}` dot notation, traversing reference chains to arbitrary depth
- Replace the flat variable dropdown with a submenu-based field selector so nested reference fields can be picked directly
- Add `buildAbsoluteAssetUrl` helper alongside the existing site base URL utilities
- Thread an optional `tenantId`/`primaryDomainUrl` through the resolver and the repository reads it performs (settings, assets, items, fields), keeping the base function correct for multi-tenant deployments without an overlay and resolving asset URLs against the right per-tenant domain
- Fetch the site base URL lazily — only when an asset placeholder is actually present — so non-asset custom code makes no extra queries

## Test plan

- [ ] On a dynamic page, add `{{ImageField}}` to custom head code and verify it renders as an absolute asset URL on the published page
- [ ] Add `{{Reference.Name}}` and confirm it resolves the referenced item's field value
- [ ] Add a deeper `{{Reference.Reference.Field}}` chain and confirm it resolves
- [ ] Use the variable picker button and confirm reference fields expand into a submenu and insert the correct `{{...}}` token
- [ ] Confirm unknown/invalid placeholders are left untouched
- [ ] Verify static export produces the same resolved (absolute) URLs
- [ ] Confirm custom code without asset placeholders triggers no extra settings query