### PR TITLE
fix: prevent sanitizeHtmlId crash on non-string ids

### DIFF
--- a/lib/html-utils.ts
+++ b/lib/html-utils.ts
@@ -25,10 +25,10 @@
  * sanitizeHtmlId('Section:1.2') // 'Section:1.2'
  * sanitizeHtmlId('-123-') // '-123-'
  */
-export function sanitizeHtmlId(value: string): string {
-  if (!value) return '';
+export function sanitizeHtmlId(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '';
 
-  return value
+  return String(value)
     // Replace spaces with hyphens
     .replace(/\s+/g, '-')
     // Replace invalid characters with hyphens (keep only letters, numbers, hyphens, underscores, colons, periods)


### PR DESCRIPTION
## Summary

Fixes a `TypeError: value.replace is not a function` that crashed the `RightSidebar` when a selected layer's `id` was a number instead of a string.

## Changes

- Coerce the `sanitizeHtmlId` input to a string with `String(value)` before running regex replacements
- Widen the parameter type to `unknown` and handle `null`/`undefined`/empty explicitly

## Test plan

- [ ] Select a layer whose settings/attributes `id` is a number and confirm the RightSidebar no longer crashes
- [ ] Verify string ids still sanitize correctly (spaces/invalid chars become hyphens)
- [ ] Verify empty/null/undefined ids return an empty string