### PR TITLE
fix: prevent broken breadcrumb links when a reference is empty

### DIFF
--- a/lib/link-utils.ts
+++ b/lib/link-utils.ts
@@ -460,7 +460,10 @@ export function resolveCollectionLinkValue(
     // Handle dynamic pages with specific collection item
     if (page.is_dynamic && linkValue.page.collection_item_id && collectionItemSlugs) {
       const itemSlug = collectionItemSlugs[linkValue.page.collection_item_id];
-      href = buildLocalizedDynamicPageUrl(page, folders, itemSlug || null, locale, translations || undefined);
+      // Unresolved item slug (empty/missing reference, deleted target) → emit no
+      // link rather than the literal `{slug}` placeholder from the URL pattern.
+      if (!itemSlug) return null;
+      href = buildLocalizedDynamicPageUrl(page, folders, itemSlug, locale, translations || undefined);
     } else {
       // Static page or dynamic page without specific item
       href = buildLocalizedSlugPath(page, folders, 'page', locale, translations || undefined);
@@ -582,7 +585,13 @@ export function generateLinkHref(
                 break;
             }
 
-            href = buildLocalizedDynamicPageUrl(page, folders, itemSlug || null, locale, translations || undefined);
+            // A specific collection item was requested but its slug could not be
+            // resolved (empty/missing reference, deleted target, or out-of-bounds
+            // next/previous). Emit no href instead of the literal `{slug}` pattern
+            // so the element renders without a broken link.
+            href = itemSlug
+              ? buildLocalizedDynamicPageUrl(page, folders, itemSlug, locale, translations || undefined)
+              : '';
           } else {
             // Static page or dynamic page without specific item
             href = buildLocalizedSlugPath(page, folders, 'page', locale, translations || undefined);


### PR DESCRIPTION
## Summary

Dynamic-page links that point to a specific collection item (e.g. a breadcrumb linking to a parent category via a reference field) fell back to the literal `{slug}` URL pattern whenever the target item's slug couldn't be resolved. This produced clickable links pointing to `/{slug}`, which 404. Now we emit no link in that case, so the element renders as plain text instead of a broken link.

## Changes

- In `generateLinkHref` and `resolveCollectionLinkValue`, only build a dynamic-page URL when a concrete item slug is resolved; otherwise emit no href
- Covers empty/missing reference values, deleted targets, and out-of-bounds next/previous navigation (which previously also leaked `/{slug}`)

## Test plan

- [ ] Subcategory page with a valid parent reference → breadcrumb links to the correct parent URL
- [ ] Subcategory page whose reference field is empty → breadcrumb crumb renders as text with no href (no `/{slug}`, no 404)
- [ ] next/previous navigation at the first/last item → no `/{slug}` href emitted
- [ ] Verify on both default and secondary (prefixed) locales