### PR TITLE
fix: prevent grid span from silently breaking

### DIFF
--- a/lib/tailwind-class-mapper.ts
+++ b/lib/tailwind-class-mapper.ts
@@ -240,6 +240,14 @@ function ensureLengthUnit(value: string): string {
 }
 
 /**
+ * Normalizes a grid span value to a bare Tailwind suffix.
+ * Accepts CSS-native shorthand ("span 3") as well as bare values ("3", "full", "auto").
+ */
+function normalizeGridSpanValue(value: string): string {
+  return value.replace(/^span\s+/i, '').trim();
+}
+
+/**
  * Map of Tailwind class prefixes to their property names
  * Used for conflict detection and removal
  */
@@ -911,12 +919,14 @@ export function propertyToClass(
 
     // Grid Column Span
     if (property === 'gridColumnSpan') {
-      return value === 'full' ? 'col-span-full' : `col-span-${value}`;
+      const span = normalizeGridSpanValue(value);
+      return span === 'full' ? 'col-span-full' : `col-span-${span}`;
     }
 
     // Grid Row Span
     if (property === 'gridRowSpan') {
-      return value === 'full' ? 'row-span-full' : `row-span-${value}`;
+      const span = normalizeGridSpanValue(value);
+      return span === 'full' ? 'row-span-full' : `row-span-${span}`;
     }
   }
 


### PR DESCRIPTION
## Summary

Grid column/row span values provided as CSS-native shorthand (e.g. `span 3`) were turned into invalid Tailwind classes like `col-span-span 3`, so the span was silently dropped and had no effect on the layout. Closes #430.

## Changes

- Add a `normalizeGridSpanValue()` helper that strips a leading `span ` prefix (case-insensitive) before generating the class
- Apply it in the `gridColumnSpan` and `gridRowSpan` forward mappings so `span 3` → `col-span-3`

## Notes

The designer UI already stores bare values (`3`, `full`), so it was unaffected. The invalid values originate from programmatic input — the MCP tool schema advertises `span 3` as an accepted value. The fix keeps bare values (`3`, `full`, `auto`) working while also tolerating the CSS-native form, and the result round-trips consistently with the UI select.

## Test plan

- [ ] Set a grid column span of `3` in the designer — element spans 3 columns
- [ ] Set `full` — element spans all columns
- [ ] Via MCP, set `gridColumnSpan` to `span 3` — produces valid `col-span-3` and the span applies
- [ ] Re-open the layer in the designer — span select shows the correct value