### PR TITLE
fix: support rich text CMS field default values

### DIFF
--- a/app/(builder)/ycode/components/FieldFormDialog.tsx
+++ b/app/(builder)/ycode/components/FieldFormDialog.tsx
@@ -34,7 +34,7 @@ import { clampDateInputValue } from '@/lib/date-format-utils';
 import { useCollectionsStore } from '@/stores/useCollectionsStore';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { useAssetsStore } from '@/stores/useAssetsStore';
-import RichTextEditor from './RichTextEditor';
+import ExpandableRichTextEditor from './ExpandableRichTextEditor';
 import CollectionLinkFieldInput from './CollectionLinkFieldInput';
 import ColorFieldInput from './ColorFieldInput';
 import AssetFieldCard from './AssetFieldCard';
@@ -553,10 +553,11 @@ export default function FieldFormDialog({
                     />
                   )
                 ) : fieldType === 'rich_text' ? (
-                  <RichTextEditor
+                  <ExpandableRichTextEditor
                     value={fieldDefault}
                     onChange={setFieldDefault}
                     placeholder="Default value"
+                    sheetDescription="Field default value"
                   />
                 ) : fieldType === 'link' ? (
                   <CollectionLinkFieldInput

--- a/database/migrations/20260713000001_widen_collection_fields_default.ts
+++ b/database/migrations/20260713000001_widen_collection_fields_default.ts
@@ -1,0 +1,50 @@
+import { Knex } from 'knex';
+
+/**
+ * Migration: Widen collection_fields.default from varchar(255) to text
+ *
+ * Rich text field defaults are stored as serialized TipTap JSON, which easily
+ * exceeds 255 characters. The column must accept free-form text of any length.
+ *
+ * Idempotent: only alters the column when it is still length-limited.
+ */
+export async function up(knex: Knex): Promise<void> {
+  const result = await knex.raw(`
+    SELECT character_maximum_length
+    FROM information_schema.columns
+    WHERE table_name = 'collection_fields' AND column_name = 'default'
+  `);
+
+  const maxLength: number | null = result?.rows?.[0]?.character_maximum_length ?? null;
+
+  if (maxLength !== null) {
+    await knex.raw(`
+      ALTER TABLE collection_fields
+      ALTER COLUMN "default" TYPE text;
+    `);
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const result = await knex.raw(`
+    SELECT character_maximum_length
+    FROM information_schema.columns
+    WHERE table_name = 'collection_fields' AND column_name = 'default'
+  `);
+
+  const maxLength: number | null = result?.rows?.[0]?.character_maximum_length ?? null;
+
+  if (maxLength === null) {
+    // Truncate any values longer than 255 chars so the column can shrink back.
+    await knex.raw(`
+      UPDATE collection_fields
+      SET "default" = LEFT("default", 255)
+      WHERE "default" IS NOT NULL AND LENGTH("default") > 255;
+    `);
+
+    await knex.raw(`
+      ALTER TABLE collection_fields
+      ALTER COLUMN "default" TYPE varchar(255);
+    `);
+  }
+}


### PR DESCRIPTION
## Summary

Setting a default value on a CMS Rich text field was broken: the input rendered as a plain text field (no formatting), and saving longer/formatted values failed with a 500. This adds a proper rich text editor for the default and widens the storage column.

## Changes

- Render the `rich_text` default value with `ExpandableRichTextEditor` — a compact button that opens the full editor sheet, matching the item-editing experience (the field dialog is too small for an inline editor)
- Widen `collection_fields.default` from `varchar(255)` to `text` so serialized TipTap JSON defaults are no longer truncated
- Add an idempotent migration that only alters the column when still length-limited

## Test plan

- [ ] Add/edit a CMS field of type Rich text → the Default row shows an Expand button, not a plain input
- [ ] Set a formatted default (bold, list, link) and save — no 500 error
- [ ] Reopen the field — the formatted default loads back into the editor
- [ ] Create a new item in that collection — the rich text field is pre-filled with the default
- [ ] Existing plain-string defaults still load without breaking