### PR TITLE
fix: prevent CMS crash when switching collections

### DIFF
--- a/app/(builder)/ycode/components/CMS.tsx
+++ b/app/(builder)/ycode/components/CMS.tsx
@@ -2023,6 +2023,13 @@ const CMS = React.memo(function CMS() {
                         );
                       }
 
+                      // Guard against non-primitive values (e.g. rich-text objects
+                      // paired with a text field during a collection switch) that
+                      // would crash React if rendered directly.
+                      const displayValue = typeof value === 'object' && value !== null
+                        ? extractPlainTextFromTiptap(value)
+                        : value;
+
                       return (
                         <td
                           key={field.id}
@@ -2030,7 +2037,7 @@ const CMS = React.memo(function CMS() {
                           onClick={() => handleEditItem(item)}
                         >
                           <span className="line-clamp-1 truncate">
-                            {value || '-'}
+                            {displayValue || '-'}
                           </span>
                         </td>
                       );


### PR DESCRIPTION
## Summary

Switching collections on the CMS page could crash with "Objects are not valid as a React child (found: object with keys {type, content})". The fallback table cell rendered raw field values, and during a collection switch the new collection's field definitions are briefly paired with the previous collection's item values — so a text field can receive a rich-text object.

## Changes

- Coerce non-primitive cell values through `extractPlainTextFromTiptap` before rendering in the CMS table fallback cell

## Test plan

- [ ] Open the CMS page and switch between collections that have rich-text and text fields
- [ ] Confirm no React child error appears in the console
- [ ] Confirm text/rich-text/other field values still display correctly