### PR TITLE
fix: preserve animated gifs in image elements

### DIFF
--- a/app/a/[hash]/[...name]/route.ts
+++ b/app/a/[hash]/[...name]/route.ts
@@ -96,7 +96,10 @@ export async function GET(
     }
 
     const transform = parseTransformParams(url.searchParams);
-    const canResize = transform && isImage;
+    // Never run Sharp on GIFs — it flattens animated frames into a single
+    // static image, killing the animation. Serve the raw bytes instead.
+    const isGif = asset.mime_type === 'image/gif';
+    const canResize = transform && isImage && !isGif;
 
     if (canResize) {
       const buffer = Buffer.from(await response.arrayBuffer());

--- a/lib/asset-utils.ts
+++ b/lib/asset-utils.ts
@@ -392,12 +392,14 @@ const EDITOR_DEFAULT_IMAGE_QUALITY = 80;
 /**
  * Bitmap MIME types we want to size-cap through the proxy in the editor.
  * SVGs are skipped (vector, no decode cost) and videos/audio aren't bitmap
- * decoded at all.
+ * decoded at all. GIFs are skipped too — Sharp collapses animated GIFs to a
+ * single static frame, so downscaling would kill the animation.
  */
 function isBitmapImageMime(mimeType?: string | null): boolean {
   if (!mimeType) return false;
   if (!mimeType.startsWith('image/')) return false;
   if (mimeType === 'image/svg+xml') return false;
+  if (mimeType === 'image/gif') return false;
   return true;
 }
 
@@ -441,10 +443,19 @@ function isProxyUrl(url: string): boolean {
   return url.startsWith('/a/');
 }
 
+/** Cheap extension sniff: does the URL path end in `.gif`? */
+function isGifUrl(url: string): boolean {
+  const path = url.split('?')[0].split('#')[0].toLowerCase();
+  return path.endsWith('.gif');
+}
+
 /**
- * Check if a URL supports image transformation params
+ * Check if a URL supports image transformation params.
+ * GIFs are excluded — Sharp flattens animated GIFs to a single frame, so
+ * appending `width`/`quality` would break the animation.
  */
 function isTransformableUrl(url: string): boolean {
+  if (isGifUrl(url)) return false;
   if (isProxyUrl(url)) return true;
   try {
     const urlObj = new URL(url);


### PR DESCRIPTION
## Summary

Animated GIFs rendered as image elements lost their animation because the asset proxy resized them with Sharp, which flattens a GIF to its first frame. Removing the `?width=&quality=` params from the URL made the GIF animate again. This skips optimization for GIFs so they always serve the raw, animated bytes.

## Changes

- Guard the `/a/{hash}` proxy route so Sharp never processes `image/gif` — animated bytes are streamed as-is (fixes already-published/imported URLs that still carry the params, no re-upload needed)
- Exclude GIFs from `isBitmapImageMime()` so the editor stops appending `width`/`quality`
- Exclude `.gif` URLs from `isTransformableUrl()` so published pages emit no optimized `src` or `srcset` for GIFs (mirrors existing SVG handling)

## Test plan

- [ ] Add an animated GIF to an image element and publish — verify it animates
- [ ] Confirm a GIF inside a component animates
- [ ] Existing GIF URLs with `?width=&quality=` animate without re-uploading
- [ ] Non-GIF images still get resized/optimized (srcset + width/quality intact)
- [ ] SVGs still render unchanged