### PR TITLE
fix: prevent preview mode from rapidly oscillating in size

### DIFF
--- a/app/(builder)/ycode/components/CenterCanvas.tsx
+++ b/app/(builder)/ycode/components/CenterCanvas.tsx
@@ -2985,7 +2985,7 @@ const CenterCanvas = React.memo(function CenterCanvas({
         {/* Preview iframe area */}
         <div
           ref={previewContainerRef}
-          className="flex-1 relative flex items-start overflow-auto"
+          className="flex-1 relative flex items-start overflow-x-auto overflow-y-hidden"
           style={{ padding: `${CANVAS_BORDER}px` }}
         >
           {isPreviewLoading && (


### PR DESCRIPTION
## Summary

Fixes preview mode rapidly oscillating (zooming in/out) on screen for users on Windows/Linux. Closes #387.

The preview container was sized to fill its client box exactly, so a sub-pixel-rounded vertical scrollbar could appear. On platforms with classic (non-overlay) scrollbars — like Windows — that scrollbar consumes `clientWidth`, which retriggers the autofit zoom calculation, shrinks the content, hides the scrollbar, restores the width, and loops. macOS uses overlay scrollbars (zero layout width), which is why the issue couldn't be reproduced there.

## Changes

- Set the preview container to `overflow-x-auto overflow-y-hidden`. The iframe is always sized to the visible area and scrolls its content internally, so the outer container never needs to scroll vertically — removing the spurious vertical scrollbar breaks the feedback loop without reserving any gutter space.

## Test plan

- [ ] On Windows/Linux, open a page preview and confirm the view no longer oscillates
- [ ] On macOS, confirm preview still renders and fits as before
- [ ] Zoom in past fit (custom zoom) and confirm horizontal scrolling still works
- [ ] Verify tall pages still scroll inside the preview iframe
- [ ] Verify mobile/tablet viewport modes render centered and fit correctly