### PR TITLE
docs: clarify MCP component editing for AI clients

### DIFF
--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -76,7 +76,10 @@ Each layer has:
 - Leaf elements (text, image, input, video, icon, hr, htmlEmbed) CANNOT have children
 - Sections cannot contain other sections
 - Links cannot nest inside links
-- Component instances are read-only (edit the master component instead)
+- Component instances are read-only IN PLACE: a page layer with a \`componentId\` is an instance of a
+  master component, so you cannot add/move/delete/style its inner layers through page/layer tools. This
+  does NOT mean component internals are unreachable — you edit them on the master via \`get_component\` +
+  \`update_component_layers\` (see Components below). Per-instance differences use variables/overrides.
 
 ### Design Properties
 
@@ -433,6 +436,18 @@ delete_redirect({ redirect_id: "..." })
 
 Components are reusable layer trees that can be instanced across pages.
 Each instance shares the same structure but can override specific content via **variables**.
+
+**Editing a component's internals (IMPORTANT — a common point of confusion):**
+A component's structure and design live on the **master component**, not on the instances placed on pages.
+When \`get_layers\` returns a layer with a \`componentId\`, that layer is an *instance* — its inner layers are
+read-only in place and won't appear as editable children in the page tree. Component internals are fully
+reachable and editable; you just target the master instead of the instance:
+\`\`\`
+get_component({ component_id: "<the layer's componentId>" })          // full internal layer tree + variables
+update_component_layers({ component_id: "...", operations: [...] })   // add / move / delete / style / link internals
+\`\`\`
+Edits to the master propagate to every instance. Use **variables** only for content that should differ per
+instance, and **variants** for whole alternate layer trees.
 
 **Creating a component:**
 1. Use \`create_component\` with a name and optional variables

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -69,6 +69,7 @@ const ELEMENTS_REFERENCE_JSON = JSON.stringify({
     section_cannot_contain_section: true,
     links_cannot_nest: true,
     component_instances_are_readonly: true,
+    component_instances_note: 'A page layer with a componentId is a component instance. Its inner layers are read-only in place. To edit a component\'s structure/design, target the master with get_component + update_component_layers; per-instance content uses variables/overrides.',
   },
   element_types: {
     structure: {


### PR DESCRIPTION
## Summary

AI clients (Claude) connected over MCP were interpreting "component instances are read-only" to mean a component's internals aren't reachable at all. In reality internals are fully editable — just via the master component tools, not by drilling into an on-page instance. This clarifies the MCP documentation so AIs target the right tools.

## Changes

- Rewrite the Nesting Rules note in `instructions.ts` to explain instances are read-only *in place*, and point to `get_component` + `update_component_layers` for editing internals
- Add an "Editing a component's internals" note in the Components section with the exact tool calls and the instance-vs-master distinction
- Add a `component_instances_note` to the machine-readable `reference.ts` nesting rules alongside the existing boolean flag

## Test plan

- [ ] Read `ycode://reference` and confirm `component_instances_note` is present
- [ ] Confirm the MCP server instructions include the new component-internals guidance
- [ ] Ask an MCP client to modify a component placed on a page and confirm it targets `get_component` / `update_component_layers` instead of reporting it can't