### PR TITLE
fix: use proxy URL for multi-asset field images

### DIFF
--- a/lib/multi-asset-utils.ts
+++ b/lib/multi-asset-utils.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Asset } from '@/types';
-import { formatFileSize } from './asset-utils';
+import { formatFileSize, getAssetProxyUrl } from './asset-utils';
 import { MULTI_ASSET_VIRTUAL_FIELDS } from './collection-field-utils';
 
 /**
@@ -16,7 +16,10 @@ import { MULTI_ASSET_VIRTUAL_FIELDS } from './collection-field-utils';
 export function buildAssetVirtualValues(asset: Asset): Record<string, string> {
   return {
     [MULTI_ASSET_VIRTUAL_FIELDS.FILENAME]: asset.filename || '',
-    [MULTI_ASSET_VIRTUAL_FIELDS.URL]: asset.public_url || '',
+    // Prefer the cached `/a/` proxy URL over the raw Supabase Storage URL so
+    // these multi-asset values (backgrounds/video/audio bound to __asset_url)
+    // are served through the CDN-cached proxy instead of direct Storage egress.
+    [MULTI_ASSET_VIRTUAL_FIELDS.URL]: getAssetProxyUrl(asset) || asset.public_url || '',
     [MULTI_ASSET_VIRTUAL_FIELDS.FILE_SIZE]: formatFileSize(asset.file_size || 0),
     [MULTI_ASSET_VIRTUAL_FIELDS.MIME_TYPE]: asset.mime_type || '',
     [MULTI_ASSET_VIRTUAL_FIELDS.WIDTH]: asset.width?.toString() || '',


### PR DESCRIPTION
## Summary

Multi-asset (gallery) field images rendered on published pages pointed directly at the raw Supabase Storage URL instead of the CDN-cached `/a/` proxy that single-asset fields already use. This causes unnecessary Storage egress and inconsistent URLs on published sites.

## Changes

- Build multi-asset `__asset_url` virtual values through `getAssetProxyUrl(asset)`, falling back to `public_url` only when there is no `storage_path` (e.g. inline SVGs)

## Test plan

- [ ] Add a multi-asset field to a collection and bind an image layer inside a gallery loop to it
- [ ] Publish and confirm the rendered `<img src>` uses `/a/{hash}/{slug}.ext` instead of a `*.supabase.co` URL
- [ ] Confirm single-asset field images still resolve to `/a/...`
- [ ] Confirm inline SVG assets (no storage path) still fall back to their public URL