### PR TITLE
fix: use neutral placeholder email in default template

### DIFF
--- a/lib/templates/layouts.ts
+++ b/lib/templates/layouts.ts
@@ -36600,7 +36600,7 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
                                           'content': [
                                             {
                                               'type': 'text',
-                                              'text': 'info@ycode.com'
+                                              'text': 'hello@example.com'
                                             }
                                           ]
                                         }


### PR DESCRIPTION
## Summary

The default page template shipped a real Ycode inbox (`info@ycode.com`) as the footer contact address. Sites published without editing the footer invited visitors to email it, resulting in misdirected mail. Swap it for a neutral example address so new projects never expose a real inbox.

## Changes

- Replace `info@ycode.com` with `hello@example.com` in the default template footer (`lib/templates/layouts.ts`)

## Test plan

- [ ] Create a new project from the default template
- [ ] Confirm the footer contact text reads `hello@example.com`
- [ ] Confirm no other `@ycode.com` address remains in the shipped template