### PR TITLE
fix: play interactions targeting component instance root

### DIFF
--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -2412,10 +2412,17 @@ function tagLayerSubtreeWithComponentId(layer: Layer, componentId: string): Laye
  */
 function transformLayersForInstance(
   layers: Layer[],
-  instanceLayerId: string
+  instanceLayerId: string,
+  rootMasterId?: string,
 ): Layer[] {
   // Build ID map: original ID -> instance-specific ID
   const idMap = new Map<string, string>();
+
+  // The component root renders with the instance ID, so map its master ID
+  // to the instance ID for child tweens/interactions that target the root.
+  if (rootMasterId && rootMasterId !== instanceLayerId) {
+    idMap.set(rootMasterId, instanceLayerId);
+  }
 
   // First pass: collect all layer IDs and generate new ones
   const collectIds = (layerList: Layer[]) => {
@@ -2509,7 +2516,7 @@ function resolveComponentsInLayers(
         // Transform all component children with instance-specific IDs
         // This ensures unique layer IDs when multiple instances of the same component exist
         const transformedChildren = componentContent.children
-          ? transformLayersForInstance(componentContent.children, layer.id)
+          ? transformLayersForInstance(componentContent.children, layer.id, componentContent.id)
           : [];
 
         // Recursively resolve any nested components within the transformed children

--- a/lib/resolve-components.ts
+++ b/lib/resolve-components.ts
@@ -210,11 +210,23 @@ function remapVariableCollectionLayerIds(vars: LayerVariables, idMap: Map<string
  * This enables animations to target the correct elements when multiple instances exist.
  * @param layers - Layers to transform
  * @param instanceLayerId - The component instance's layer ID used as namespace
+ * @param rootMasterId - The component root's master ID, mapped to the instance ID so
+ *   child interactions targeting the root (which renders as the instance) resolve correctly
  * @returns Transformed layers with remapped IDs and interaction references
  */
-export function transformLayerIdsForInstance(layers: Layer[], instanceLayerId: string): Layer[] {
+export function transformLayerIdsForInstance(
+  layers: Layer[],
+  instanceLayerId: string,
+  rootMasterId?: string,
+): Layer[] {
   // Build ID map: original ID -> instance-specific ID
   const idMap = new Map<string, string>();
+
+  // The component root renders with the instance ID, so map its master ID
+  // to the instance ID for child tweens/interactions that target the root.
+  if (rootMasterId && rootMasterId !== instanceLayerId) {
+    idMap.set(rootMasterId, instanceLayerId);
+  }
 
   // First pass: collect all layer IDs and generate new ones
   const collectIds = (layerList: Layer[]) => {
@@ -656,7 +668,7 @@ export function resolveComponents(
         // Transform layer IDs to be instance-specific
         // This ensures each component instance has unique IDs for proper animation targeting
         const resolvedChildren = taggedChildren.length
-          ? transformLayerIdsForInstance(taggedChildren, layer.id)
+          ? transformLayerIdsForInstance(taggedChildren, layer.id, componentContent.id)
           : [];
 
         // Remap root layer interactions to reference transformed child IDs


### PR DESCRIPTION
## Summary

Height (and other) interactions that target a component instance's root element didn't play on published/preview pages — e.g. a hamburger click meant to tween the nav's height did nothing while the nav was a component instance, but worked once detached. This fixes the ID remapping so those interactions resolve correctly.

## Changes

- Seed the per-instance ID map with the component root's master ID → instance ID in `transformLayerIdsForInstance` (SSR) and `transformLayersForInstance` (canvas), via a new optional `rootMasterId` param
- Pass the root master ID from `resolveComponents` and `resolveComponentsInLayers` so child interactions whose tween/trigger targets the component root map to the instance's real DOM id instead of falling back to the (non-existent) master id

## Root cause

Component instance children are namespaced to `{instanceId}-{childId}`, but the id map used to rewrite interaction `tween.layer_id` was built only from child ids. A child interaction targeting the component **root** (which renders with the plain instance id) fell through the `|| tween.layer_id` fallback and kept the master root id, matching no DOM element — so the tween was silently skipped. Detaching worked because ids are regenerated together in one consistent pass.

## Test plan

- [ ] Build a component whose child (e.g. hamburger/button) has a click interaction tweening the component **root** (height, rotation, etc.)
- [ ] Place a single instance on a page, open the **published/preview** page, trigger it → animation plays
- [ ] Add a **second instance** on the same page → both animate independently
- [ ] Detach a component → still works
- [ ] Verify child → child tweens and root-level interactions still work (no regression)