### PR TITLE
perf: reduce published page size by not shipping unused components

### DIFF
--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -882,7 +882,11 @@ export default async function PageRenderer({
           isPreview={isPreview}
           translations={translations}
           resolvedAssets={resolvedAssets}
-          components={components}
+          // Rich-text embedded components are already pre-resolved into the layer
+          // tree (_resolvedLayers), so the client renderer never needs the full
+          // component library. Passing [] avoids serializing every component
+          // definition into the RSC payload (see issue #447).
+          components={[]}
           serverSettings={serverSettings}
           globalsData={Object.keys(globalsData).length > 0 ? globalsData : undefined}
           globalsMeta={Object.keys(globalsMeta).length > 0 ? globalsMeta : undefined}

--- a/lib/text-format-utils.ts
+++ b/lib/text-format-utils.ts
@@ -785,6 +785,28 @@ function renderRichTextComponentBlock(
   }
 
   const component = components?.find(c => c.id === componentId);
+
+  // Build updated ancestor set including the current component
+  const updatedAncestors = new Set(ancestorComponentIds);
+  updatedAncestors.add(componentId);
+
+  // Published/SSR path: layers are pre-resolved server-side by
+  // resolveRichTextCollections (nested components and collections at any depth),
+  // so the full `components` library is not needed on the client — only the
+  // resolved layers. This lets published pages serialize an empty `components`
+  // array, keeping the RSC payload small without curating which definitions survive.
+  if (block.attrs._resolvedLayers) {
+    // Component metadata is unused when rendering pre-resolved layers; fall back
+    // to a lightweight stub so an empty `components` array still renders.
+    const resolvedComponent = component ?? ({ id: componentId, name: '' } as Component);
+    if (!renderComponentBlock) {
+      return React.createElement('span', { key, 'data-component-id': componentId }, `[${resolvedComponent.name}]`);
+    }
+    return renderComponentBlock(resolvedComponent, block.attrs._resolvedLayers, overrides, key, updatedAncestors);
+  }
+
+  // Fallback (edit mode): resolve from the component definition, which requires
+  // the full component metadata and library to be present.
   if (!component) {
     return React.createElement('span', { key, className: 'text-xs text-muted-foreground' }, '[missing component]');
   }
@@ -793,16 +815,6 @@ function renderRichTextComponentBlock(
     return React.createElement('span', { key, 'data-component-id': componentId }, `[${component.name}]`);
   }
 
-  // Build updated ancestor set including the current component
-  const updatedAncestors = new Set(ancestorComponentIds);
-  updatedAncestors.add(componentId);
-
-  // Use pre-resolved layers (from server-side resolveRichTextCollections) when available
-  if (block.attrs._resolvedLayers) {
-    return renderComponentBlock(component, block.attrs._resolvedLayers, overrides, key, updatedAncestors);
-  }
-
-  // Fallback: resolve from component definition (edit mode)
   if (!component.layers?.length) {
     return React.createElement('span', { key, className: 'text-xs text-muted-foreground' }, '[missing component]');
   }


### PR DESCRIPTION
## Summary

Published pages serialized the entire component library into the Next.js RSC/Flight payload even when the visible page didn't need it, inflating document size well beyond the rendered HTML (Googlebot's 2 MB crawl limit was exceeded on content-heavy pages). Since rich-text embedded components are already fully pre-resolved into the layer tree server-side, the client renderer no longer needs the component library and published pages now serialize an empty array.

Closes #447

## Changes

- Render pre-resolved rich-text embedded components (`_resolvedLayers`) without requiring the component to exist in the passed-in `components` array; the array is now only needed for the edit-mode fallback
- Pass `components={[]}` from `PageRenderer` to the public renderer, keeping the real array for server-side asset pre-resolution
- No detection heuristics: nested `collection → rich text → component → nested component → collection` chains work automatically because the server bakes `_resolvedLayers` at every depth

## Test plan

- [ ] Load a published page with a normal component instance — renders unchanged
- [ ] Load a published page that embeds a component inside rich text — renders correctly (no `[missing component]`)
- [ ] Verify a component embedded via a deep chain (collection → rich text → component → nested component) still renders
- [ ] Compare document size before/after — component definitions no longer appear in the payload
- [ ] Editor canvas still renders rich-text embedded components (edit-mode fallback path)