### PR TITLE
fix: allow creating a component inside a component

### DIFF
--- a/app/(builder)/ycode/components/LayerContextMenu.tsx
+++ b/app/(builder)/ycode/components/LayerContextMenu.tsx
@@ -106,7 +106,7 @@ function LayerContextMenuInner({
   onLayerSelect,
   liveLayerUpdates,
   liveComponentUpdates,
-  editingComponentId = null,
+  editingComponentId: editingComponentIdProp = null,
   isComponentDialogOpen,
   setIsComponentDialogOpen,
   isLayoutDialogOpen,
@@ -138,6 +138,12 @@ function LayerContextMenuInner({
   const components = useComponentsStore((state) => state.components);
   const componentDrafts = useComponentsStore((state) => state.componentDrafts);
   const editingComponentVariantId = useEditorStore((state) => state.editingComponentVariantId);
+  // Prefer the prop (passed by the layers tree) but fall back to the editor
+  // store so the canvas context menu also knows when a component is being
+  // edited — otherwise "Create component" on the canvas resolves against the
+  // page draft and silently fails for layers inside a component.
+  const storeEditingComponentId = useEditorStore((state) => state.editingComponentId);
+  const editingComponentId = editingComponentIdProp ?? storeEditingComponentId;
   // Resolve the active variant id for the component being edited. When
   // unspecified (or pointing at a missing variant) we fall back to the first
   // variant so the editor never shows an empty tree.

--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -1999,9 +1999,9 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
           }
         }
 
-        // Create Component: Option + Cmd + K
+        // Create Component: Option + Cmd + K (works on pages and inside a component)
         if (e.altKey && e.metaKey && e.code === 'KeyK' && !isContentOnlyRole) {
-          if (!isInputFocused && currentPageId && selectedLayerId && !editingComponentId) {
+          if (!isInputFocused && currentPageId && selectedLayerId) {
             e.preventDefault();
             const layers = getCurrentLayers();
             const layer = findLayerById(layers, selectedLayerId);
@@ -2351,11 +2351,19 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
             if (!open) closeCreateComponentDialog();
           }}
           onConfirm={async (componentName: string) => {
-            const componentId = await createComponentFromLayer(
-              currentPageId,
-              createComponentDialog.layerId!,
-              componentName
-            );
+            // When editing a component master, extract into a nested component
+            // via the components store; otherwise create from the page draft.
+            const componentId = editingComponentId
+              ? await useComponentsStore.getState().createComponentFromLayer(
+                editingComponentId,
+                createComponentDialog.layerId!,
+                componentName
+              )
+              : await createComponentFromLayer(
+                currentPageId,
+                createComponentDialog.layerId!,
+                componentName
+              );
             if (componentId && liveComponentUpdates) {
               const { getComponentById } = useComponentsStore.getState();
               const component = getComponentById(componentId);


### PR DESCRIPTION
## Summary

Creating a new component from a layer while editing an existing component master silently did nothing. This restores nested component creation from both the right-click context menu and the keyboard shortcut.

## Changes

- Source `editingComponentId` from the editor store in the layer context menu, falling back to the prop. The canvas never passed this prop, so "Create component" on the canvas resolved against the page draft and silently failed for layers inside a component.
- Enable the ⌥⌘K "Create component" shortcut while editing a component master (previously blocked), and route its dialog to the components store so it extracts into a nested component.

## Test plan

- [ ] On a page, right-click a layer → "Create component" — still works
- [ ] Enter "Edit master component", right-click a child layer in the canvas → "Create component" — creates a nested component
- [ ] Same via the left layers-tree context menu — creates a nested component
- [ ] Select a layer inside a component master and press ⌥⌘K — opens the dialog and creates a nested component
- [ ] Nested component instances inside the extracted subtree are preserved and render correctly
- [ ] Pressing ⌥⌘K on an existing component instance does nothing (can't re-wrap an instance)