### PR TITLE
refactor: slim MCP tool schemas and improve AI reliability

### DIFF
--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -811,16 +811,17 @@ This is the ONLY correct way to structure page sections. The container constrain
 batch_operations({
   page_id: "...",
   operations: [
-    // 1. Section wrapper
-    { type: "add_layer", parent_layer_id: "body", template: "section", ref_id: "hero",
+    // 1. Section wrapper — add the layer, then style it via update_design (ref_id)
+    { type: "add_layer", parent_layer_id: "body", template: "section", ref_id: "hero" },
+    { type: "update_design", layer_id: "hero",
       design: {
         layout: { isActive: true, display: "Flex", flexDirection: "column", alignItems: "center" },
         spacing: { isActive: true, paddingTop: "120px", paddingBottom: "80px" }
       }
     },
     // 2. Container (MANDATORY — constrains content width)
-    { type: "add_layer", parent_layer_id: "hero", template: "div", ref_id: "container",
-      custom_name: "Container",
+    { type: "add_layer", parent_layer_id: "hero", template: "div", ref_id: "container", custom_name: "Container" },
+    { type: "update_design", layer_id: "container",
       design: {
         layout: { isActive: true, display: "Flex", flexDirection: "column", alignItems: "center" },
         sizing: { isActive: true, width: "100%", maxWidth: "1280px" },
@@ -828,8 +829,8 @@ batch_operations({
       }
     },
     // 3. Content wrapper (centers and constrains text)
-    { type: "add_layer", parent_layer_id: "container", template: "div", ref_id: "content",
-      custom_name: "Content",
+    { type: "add_layer", parent_layer_id: "container", template: "div", ref_id: "content", custom_name: "Content" },
+    { type: "update_design", layer_id: "content",
       design: {
         layout: { isActive: true, display: "Flex", flexDirection: "column", alignItems: "center", gap: "24px" },
         sizing: { isActive: true, maxWidth: "720px" }
@@ -853,8 +854,8 @@ batch_operations({
       }
     },
     // 6. Button row
-    { type: "add_layer", parent_layer_id: "content", template: "div", ref_id: "buttons",
-      custom_name: "Buttons",
+    { type: "add_layer", parent_layer_id: "content", template: "div", ref_id: "buttons", custom_name: "Buttons" },
+    { type: "update_design", layer_id: "buttons",
       design: {
         layout: { isActive: true, display: "Flex", flexDirection: "row", gap: "12px" }
       }
@@ -873,6 +874,9 @@ batch_operations({
   ]
 })
 \`\`\`
+
+Style layers with an \`update_design\` operation that references the \`ref_id\` (or layer ID)
+from a prior \`add_layer\` — \`add_layer\` itself only creates the layer.
 
 ### Verify After Building
 
@@ -942,9 +946,8 @@ Use \`batch_operations\` whenever building more than 2-3 layers. It fetches
 the layer tree once, applies all operations, then saves once — much faster.
 
 Key feature: use \`ref_id\` in add_layer operations, then reference that ID
-in later operations within the same batch.
-
-You can also set design inline with add_layer (via the design field) to reduce the number of operations.
+in later operations within the same batch — including an \`update_design\`
+operation to style a layer right after creating it.
 
 ### Responsive Strategy
 

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -42,7 +42,7 @@ const EXAMPLE_PROMPTS = {
     'Use batch_operations whenever building more than 2-3 layers',
     'Create styles (create_style) before building repeating elements',
     'Use ref_id in batch_operations to reference layers created in the same batch',
-    'Set design inline with add_layer to reduce the number of operations',
+    'Style a layer with an update_design operation referencing the ref_id from its add_layer',
     'Use add_font + search_google_fonts to add custom fonts before using them',
     'Always publish after completing changes',
     'For repeating UI primitives, build a component and use create_component_variant for visual flavors',

--- a/lib/mcp/tools/batch.ts
+++ b/lib/mcp/tools/batch.ts
@@ -25,8 +25,7 @@ const addLayerOp = z.object({
   text_content: z.string().optional(),
   rich_content: z.array(richTextBlockSchema).optional().describe('For richText: structured content blocks'),
   custom_name: z.string().optional(),
-  ref_id: z.string().optional().describe('A reference ID so later operations can target this layer'),
-  design: designSchema.optional().describe('Design properties to apply immediately on creation'),
+  ref_id: z.string().optional().describe('A reference ID so later operations can target this layer. Style it with a follow-up update_design op referencing this ref_id.'),
   image_asset_id: z.string().optional().describe('For image layers: asset ID to display'),
 });
 
@@ -120,16 +119,12 @@ EXAMPLE:
               if (!parent) { results.push({ op: i, status: 'error', detail: `Parent "${op.parent_layer_id}" not found` }); continue; }
               if (!canHaveChildren(parent)) { results.push({ op: i, status: 'error', detail: `"${parent.customName || parent.name}" cannot have children` }); continue; }
 
-              let newLayer = createLayerFromTemplate(op.template, {
+              const newLayer = createLayerFromTemplate(op.template, {
                 customName: op.custom_name,
                 textContent: op.text_content,
                 richContent: op.rich_content as RichTextBlock[] | undefined,
               });
               if (!newLayer) { results.push({ op: i, status: 'error', detail: `Unknown template "${op.template}"` }); continue; }
-
-              if (op.design) {
-                newLayer = applyDesignToLayer(newLayer, op.design as Record<string, Record<string, unknown>>);
-              }
 
               if (op.image_asset_id && newLayer.variables?.image) {
                 newLayer.variables = {

--- a/lib/mcp/tools/components.ts
+++ b/lib/mcp/tools/components.ts
@@ -344,8 +344,11 @@ EXAMPLE: A "Card" component with a title variable:
 
   server.tool(
     'update_component_layers',
-    `Modify a component's layer tree. Works like batch_operations but for component layers.
-Use ref_id in add_layer to name layers, then reference them in later operations.
+    `Edit the inside of a component: add, remove, move, restyle, or set content on the
+layers within a component's tree (the master definition, not a page instance). This is
+the batch_operations equivalent for components — use it to build or change a component's
+internal structure. Use ref_id in add_layer to name layers, then reference them in
+later operations (e.g. a follow-up update_design op to style a just-added layer).
 
 Pass variant_id to target a specific named variant; omit it to update the primary variant
 (variants[0]), which is what most components have.`,
@@ -363,8 +366,7 @@ Pass variant_id to target a specific named variant; omit it to update the primar
           rich_content: z.array(richTextBlockSchema).optional()
             .describe('For richText: structured content blocks. Overrides text_content.'),
           custom_name: z.string().optional(),
-          ref_id: z.string().optional().describe('Reference ID for later operations'),
-          design: designSchema.optional(),
+          ref_id: z.string().optional().describe('Reference ID for later operations. Style it with a follow-up update_design op referencing this ref_id.'),
           image_asset_id: z.string().optional().describe('For image layers: asset ID to display'),
           variable_id: z.string().optional()
             .describe('Component variable ID to link to this layer\'s primary content (text/image/link)'),
@@ -458,10 +460,6 @@ Pass variant_id to target a specific named variant; omit it to update the primar
                 richContent: op.rich_content as RichTextBlock[] | undefined,
               });
               if (!newLayer) { results.push({ op: i, status: 'error', detail: `Unknown template "${op.template}"` }); continue; }
-
-              if (op.design) {
-                newLayer = applyDesignToLayer(newLayer, op.design as Record<string, Record<string, unknown>>);
-              }
 
               if (op.image_asset_id && newLayer.variables?.image) {
                 newLayer.variables = {

--- a/lib/tailwind-class-mapper.ts
+++ b/lib/tailwind-class-mapper.ts
@@ -247,6 +247,11 @@ function normalizeGridSpanValue(value: string): string {
   return value.replace(/^span\s+/i, '').trim();
 }
 
+/** Tailwind `display` utility values the editor supports as bare classes. */
+const DISPLAY_VALUES = new Set([
+  'block', 'inline-block', 'inline', 'flex', 'inline-flex', 'grid', 'inline-grid', 'hidden',
+]);
+
 /**
  * Map of Tailwind class prefixes to their property names
  * Used for conflict detection and removal
@@ -695,8 +700,12 @@ export function propertyToClass(
   // Layout conversions
   if (category === 'layout') {
     switch (property) {
-      case 'display':
-        return value.toLowerCase();
+      case 'display': {
+        // Map CSS synonyms (e.g. "none") to Tailwind's canonical value and
+        // ignore unsupported values so we never emit an invalid class like "none".
+        const normalized = value.toLowerCase() === 'none' ? 'hidden' : value.toLowerCase();
+        return DISPLAY_VALUES.has(normalized) ? normalized : null;
+      }
       case 'flexDirection':
         if (value === 'row') return 'flex-row';
         if (value === 'column') return 'flex-col';


### PR DESCRIPTION
## Summary

Reduces the size of the MCP tool surface that AI clients (Claude, etc.) must load and search, and fixes a couple of design edge cases. This makes the largest tools smaller and more discoverable, and prevents an invalid CSS class from being generated.

Context: Claude's tool-search defers MCP tool definitions and searches them on demand. The two largest tools (`update_component_layers` and `batch_operations`, ~18.7KB each) dominated the surface, and `update_component_layers` was failing to surface in search — it collided with `update_component`.

## Changes

- Remove the inline `design` param from the `add_layer` operation in `batch_operations` and `update_component_layers`. Styling is now done with a follow-up `update_design` operation referencing the layer's `ref_id`. This drops one ~6KB design-schema embedding from each tool, shrinking the two largest tools ~34% (~13KB off the total surface).
- Rewrite the `update_component_layers` description with distinct, keyword-rich wording so tool search reliably surfaces it instead of returning `update_component`.
- Normalize `display` values in the Tailwind class mapper: `"none"` maps to `"hidden"`, and unsupported values are dropped — no more invalid classes like `max-md:none`.
- Update MCP instructions and the reference resource to the two-step `add_layer` + `update_design` styling pattern.

Design property descriptions were intentionally kept (agents rely on those format hints), so this is a capability-preserving reduction.

## Test plan

- [ ] Build a section via `batch_operations` using `add_layer` + follow-up `update_design` and verify layers are created and styled correctly
- [ ] Edit a component's internals via `update_component_layers` (add + style a layer) and verify it persists on the master
- [ ] Set `display: "none"` through a design update and confirm it renders `hidden` (not an invalid class)
- [ ] Confirm an unsupported display value is dropped rather than emitting an invalid class
- [ ] Verify AI tool search surfaces `update_component_layers` for component-editing queries