### PR TITLE
fix: make slider responsive and fix rendering issues

### DIFF
--- a/app/(builder)/ycode/components/SliderSettings.tsx
+++ b/app/(builder)/ycode/components/SliderSettings.tsx
@@ -7,7 +7,7 @@
  * Walks up the tree to find the root slider layer and reads/writes settings there.
  */
 
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -26,7 +26,8 @@ import ToggleGroup from './ToggleGroup';
 
 import { addChildToLayerTree, findAncestorByName, getCollectionVariable } from '@/lib/layer-utils';
 import { isSliderLayerName, DEFAULT_SLIDER_SETTINGS, createSlideLayer } from '@/lib/templates/utilities';
-import { EFFECTS_WITH_PER_VIEW } from '@/lib/slider-utils';
+import { EFFECTS_WITH_PER_VIEW, resolveResponsiveNumber, writeResponsiveNumber } from '@/lib/slider-utils';
+import { BREAKPOINTS } from '@/lib/breakpoint-utils';
 import { slidePrev, slideNext } from '@/hooks/use-canvas-slider';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { usePagesStore } from '@/stores/usePagesStore';
@@ -103,6 +104,7 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldG
   const addLayerWithId = usePagesStore((state) => state.addLayerWithId);
   const updateComponentDraft = useComponentsStore((state) => state.updateComponentDraft);
   const setSelectedLayerId = useEditorStore((state) => state.setSelectedLayerId);
+  const activeBreakpoint = useEditorStore((state) => state.activeBreakpoint);
   const clearLayerData = useCollectionLayerStore((state) => state.clearLayerData);
 
   // Inner slides wrapper and the first slide inside it (the loop template when CMS-bound)
@@ -111,6 +113,21 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldG
   const templateSlideCollection = templateSlide ? getCollectionVariable(templateSlide) : null;
   const isMultiAssetSource = templateSlideCollection?.source_field_type === 'multi_asset';
   const isCmsSource = !!templateSlideCollection;
+
+  // Slider settings, resolved for the active breakpoint. Per view / per group are
+  // responsive, so their inputs reflect (and write to) the breakpoint currently
+  // selected in the builder's viewport switcher.
+  const settings: SliderSettingsType = { ...DEFAULT_SLIDER_SETTINGS, ...sliderLayer?.settings?.slider };
+  const perViewValue = resolveResponsiveNumber(settings.groupSlide, activeBreakpoint, 1);
+  const perGroupValue = Math.min(resolveResponsiveNumber(settings.slidesPerGroup, activeBreakpoint, 1), perViewValue);
+  const breakpointLabel = BREAKPOINTS.find(bp => bp.value === activeBreakpoint)?.label ?? '';
+
+  // Local draft state lets users freely type/clear the number inputs without the
+  // controlled value snapping back; valid values commit on change, blur clamps.
+  const [perViewInput, setPerViewInput] = useState(String(perViewValue));
+  const [perGroupInput, setPerGroupInput] = useState(String(perGroupValue));
+  useEffect(() => { setPerViewInput(String(perViewValue)); }, [perViewValue]);
+  useEffect(() => { setPerGroupInput(String(perGroupValue)); }, [perGroupValue]);
 
   // The multi-image field option is only enabled if at least one such field
   // is reachable from this slider's context (page or ancestor collections).
@@ -269,11 +286,6 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldG
     ? 'static'
     : isMultiAssetSource ? 'multi_asset' : 'collection';
 
-  const settings: SliderSettingsType = {
-    ...DEFAULT_SLIDER_SETTINGS,
-    ...sliderLayer.settings?.slider,
-  };
-
   const updateSetting = (key: keyof SliderSettingsType, value: SliderSettingsType[keyof SliderSettingsType]) => {
     onLayerUpdate(sliderLayer.id, {
       settings: {
@@ -395,10 +407,10 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldG
           </div>
         </div>
 
-        {/* Slides per view - only for effects that support multiple slides */}
+        {/* Slides per view - responsive, only for effects that support multiple slides */}
         {EFFECTS_WITH_PER_VIEW.has(settings.animationEffect) && (
           <div className="grid grid-cols-3 items-center">
-            <Label variant="muted">Per view</Label>
+            <Label variant="muted" title={`Slides visible per view on ${breakpointLabel}`}>Per view</Label>
             <div className="col-span-2 *:w-full">
               <InputGroup>
                 <InputGroupInput
@@ -406,19 +418,32 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldG
                   step="1"
                   min="1"
                   max="10"
-                  value={String(settings.groupSlide)}
+                  value={perViewInput}
                   onChange={(e) => {
-                    const n = parseInt(e.target.value, 10);
+                    const raw = e.target.value.replace(/[^0-9]/g, '');
+                    setPerViewInput(raw);
+                    const n = parseInt(raw, 10);
                     if (!Number.isNaN(n) && n >= 1 && n <= 10) {
-                      const patch: Partial<typeof settings> = { groupSlide: n };
-                      if (settings.slidesPerGroup > n) patch.slidesPerGroup = n;
+                      const patch: Partial<SliderSettingsType> = {
+                        groupSlide: writeResponsiveNumber(settings.groupSlide, activeBreakpoint, n),
+                      };
+                      if (perGroupValue > n) {
+                        patch.slidesPerGroup = writeResponsiveNumber(settings.slidesPerGroup, activeBreakpoint, n);
+                      }
                       updateSettings(patch);
                     }
                   }}
                   onBlur={() => {
-                    const n = settings.groupSlide;
-                    if (n < 1) updateSettings({ groupSlide: 1, slidesPerGroup: 1 });
-                    else if (n > 10) updateSettings({ groupSlide: 10, slidesPerGroup: Math.min(settings.slidesPerGroup, 10) });
+                    const parsed = parseInt(perViewInput, 10);
+                    const clamped = Number.isNaN(parsed) ? 1 : Math.min(Math.max(parsed, 1), 10);
+                    setPerViewInput(String(clamped));
+                    const patch: Partial<SliderSettingsType> = {
+                      groupSlide: writeResponsiveNumber(settings.groupSlide, activeBreakpoint, clamped),
+                    };
+                    if (perGroupValue > clamped) {
+                      patch.slidesPerGroup = writeResponsiveNumber(settings.slidesPerGroup, activeBreakpoint, clamped);
+                    }
+                    updateSettings(patch);
                   }}
                 />
                 <InputGroupAddon align="inline-end" className="text-xs text-muted-foreground">
@@ -429,28 +454,31 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldG
           </div>
         )}
 
-        {/* Slides per group - only when slidesPerView > 1 */}
-        {EFFECTS_WITH_PER_VIEW.has(settings.animationEffect) && settings.groupSlide > 1 && (
+        {/* Slides per group - responsive, only when slidesPerView > 1 */}
+        {EFFECTS_WITH_PER_VIEW.has(settings.animationEffect) && perViewValue > 1 && (
           <div className="grid grid-cols-3 items-center">
-            <Label variant="muted">Per group</Label>
+            <Label variant="muted" title={`Slides advanced per step on ${breakpointLabel}`}>Per group</Label>
             <div className="col-span-2 *:w-full">
               <InputGroup>
                 <InputGroupInput
                   stepper
                   step="1"
                   min="1"
-                  max={settings.groupSlide}
-                  value={String(settings.slidesPerGroup)}
+                  max={perViewValue}
+                  value={perGroupInput}
                   onChange={(e) => {
-                    const n = parseInt(e.target.value, 10);
-                    if (!Number.isNaN(n) && n >= 1 && n <= settings.groupSlide) {
-                      updateSetting('slidesPerGroup', n);
+                    const raw = e.target.value.replace(/[^0-9]/g, '');
+                    setPerGroupInput(raw);
+                    const n = parseInt(raw, 10);
+                    if (!Number.isNaN(n) && n >= 1 && n <= perViewValue) {
+                      updateSetting('slidesPerGroup', writeResponsiveNumber(settings.slidesPerGroup, activeBreakpoint, n));
                     }
                   }}
                   onBlur={() => {
-                    const n = settings.slidesPerGroup;
-                    if (n < 1) updateSetting('slidesPerGroup', 1);
-                    else if (n > settings.groupSlide) updateSetting('slidesPerGroup', settings.groupSlide);
+                    const parsed = parseInt(perGroupInput, 10);
+                    const clamped = Number.isNaN(parsed) ? 1 : Math.min(Math.max(parsed, 1), perViewValue);
+                    setPerGroupInput(String(clamped));
+                    updateSetting('slidesPerGroup', writeResponsiveNumber(settings.slidesPerGroup, activeBreakpoint, clamped));
                   }}
                 />
                 <InputGroupAddon align="inline-end" className="text-xs text-muted-foreground">
@@ -671,7 +699,7 @@ export default function SliderSettings({ layer, onLayerUpdate, allLayers, fieldG
                 </Label>
               </div>
             )}
-            {EFFECTS_WITH_PER_VIEW.has(settings.animationEffect) && settings.groupSlide > 1 && (
+            {EFFECTS_WITH_PER_VIEW.has(settings.animationEffect) && perViewValue > 1 && (
               <div className="flex items-center gap-2">
                 <Checkbox
                   id="slider-centered"

--- a/app/site.css
+++ b/app/site.css
@@ -70,6 +70,52 @@
   stroke: currentColor;
 }
 
+/* Pre-init slider layout: size slides by the configured per-view before Swiper
+   JS initializes, preventing a flash where every slide is full-width (1 per
+   view) on load. Swiper sets exact inline widths on init which override these.
+   Values are resolved per breakpoint (desktop-first) into CSS vars on the
+   slider root by LayerRenderer. */
+[data-slider-id] > .swiper-wrapper > .swiper-slide {
+  flex-shrink: 0;
+  width: calc(100% / var(--ycode-spv-mobile, 1));
+}
+
+@media (min-width: 768px) {
+  [data-slider-id] > .swiper-wrapper > .swiper-slide {
+    width: calc(100% / var(--ycode-spv-tablet, var(--ycode-spv-mobile, 1)));
+  }
+}
+
+@media (min-width: 1024px) {
+  [data-slider-id] > .swiper-wrapper > .swiper-slide {
+    width: calc(100% / var(--ycode-spv-desktop, var(--ycode-spv-tablet, var(--ycode-spv-mobile, 1))));
+  }
+}
+
+/* Hide slider nav buttons and pagination until Swiper initializes so they don't
+   flash in a pre-init state (enabled buttons that become locked/disabled, or a
+   single bullet template that expands to N bullets). SliderInitializer sets
+   data-slider-initialized on the root after mounting. Slides are pre-sized above
+   so they render correctly without waiting; only these controls are deferred.
+   visibility (not display) keeps layout stable — no shift when they appear. */
+[data-slider-id]:not([data-slider-initialized]) [data-slider-prev],
+[data-slider-id]:not([data-slider-initialized]) [data-slider-next],
+[data-slider-id]:not([data-slider-initialized]) [data-slider-pagination] {
+  visibility: hidden;
+}
+
+/* Hide locked nav buttons and pagination synchronously. Swiper adds
+   `swiper-button-lock` / `swiper-pagination-lock` during init when there's only
+   one page (all slides fit), but the rules that hide them live in
+   swiper-minimal.css which is injected by JS afterwards — that async gap let a
+   locked control blink into view once the initialized gate above released.
+   Duplicating the rules here (loaded at first paint) closes that gap and hides
+   the pagination when there's nothing to paginate. */
+[data-slider-id] .swiper-button-lock,
+[data-slider-id] .swiper-pagination-lock {
+  display: none !important;
+}
+
 /* Custom dropdown chevron for native <select> elements on published pages.
    The native arrow is removed by the inline `ycode-form-reset` styles in
    PageRenderer.tsx; this rule restores a consistent chevron. */

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -14,6 +14,7 @@ import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEd
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
+import { resolveResponsiveNumber } from '@/lib/slider-utils';
 import { useCanvasSlider } from '@/hooks/use-canvas-slider';
 import { resolveFieldFromSources } from '@/lib/cms-variables-utils';
 import { getDynamicTextContent, getImageUrlFromVariable, getVideoUrlFromVariable, getIframeUrlFromVariable, isFieldVariable, isAssetVariable, isStaticTextVariable, isDynamicTextVariable, getAssetId, getStaticTextContent, createAssetVariable, createDynamicTextVariable, resolveDesignStyles } from '@/lib/variable-utils';
@@ -2245,6 +2246,17 @@ const LayerItemImpl: React.FC<{
       if (layer.name === 'slider' && layer.settings?.slider) {
         elementProps['data-slider-id'] = layer.id;
         elementProps['data-slider-settings'] = JSON.stringify(layer.settings.slider);
+        // Expose per-view per breakpoint as CSS vars so slides are sized before
+        // Swiper JS runs (prevents a 1-slide flash on load). site.css consumes
+        // these; Swiper overrides with exact inline widths on init.
+        const spv = layer.settings.slider.groupSlide;
+        const existingStyle = (typeof elementProps.style === 'object' && elementProps.style) || {};
+        elementProps.style = {
+          ...existingStyle,
+          '--ycode-spv-mobile': resolveResponsiveNumber(spv, 'mobile', 1),
+          '--ycode-spv-tablet': resolveResponsiveNumber(spv, 'tablet', 1),
+          '--ycode-spv-desktop': resolveResponsiveNumber(spv, 'desktop', 1),
+        };
       }
       if (SWIPER_DATA_ATTR_MAP[layer.name]) {
         elementProps[SWIPER_DATA_ATTR_MAP[layer.name]] = '';

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -20,6 +20,7 @@ import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextCo
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
+import { resolveResponsiveNumber } from '@/lib/slider-utils';
 import { getDynamicTextContent, getImageUrlFromVariable, getVideoUrlFromVariable, getIframeUrlFromVariable, isFieldVariable, isAssetVariable, isStaticTextVariable, isDynamicTextVariable, getStaticTextContent, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
 import { getTranslatedAssetId, getTranslatedText } from '@/lib/locale-runtime';
 import { isValidLinkSettings, generateLinkHref, resolveLinkAttrs, isLinkAtCollectionBoundary, isLinkToCurrentPage, type LinkResolutionContext } from '@/lib/link-utils';
@@ -972,6 +973,17 @@ const LayerItem: React.FC<{
       if (layer.name === 'slider' && layer.settings?.slider) {
         elementProps['data-slider-id'] = layer.id;
         elementProps['data-slider-settings'] = JSON.stringify(layer.settings.slider);
+        // Expose per-view per breakpoint as CSS vars so slides are sized before
+        // Swiper JS runs (prevents a 1-slide flash on load). site.css consumes
+        // these; Swiper overrides with exact inline widths on init.
+        const spv = layer.settings.slider.groupSlide;
+        const existingStyle = (typeof elementProps.style === 'object' && elementProps.style) || {};
+        elementProps.style = {
+          ...existingStyle,
+          '--ycode-spv-mobile': resolveResponsiveNumber(spv, 'mobile', 1),
+          '--ycode-spv-tablet': resolveResponsiveNumber(spv, 'tablet', 1),
+          '--ycode-spv-desktop': resolveResponsiveNumber(spv, 'desktop', 1),
+        };
       }
       if (SWIPER_DATA_ATTR_MAP[layer.name]) {
         elementProps[SWIPER_DATA_ATTR_MAP[layer.name]] = '';

--- a/hooks/use-canvas-slider.ts
+++ b/hooks/use-canvas-slider.ts
@@ -13,7 +13,7 @@ import Swiper from 'swiper';
 import type { Layer, SliderSettings } from '@/types';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { DEFAULT_SLIDER_SETTINGS } from '@/lib/slider-constants';
-import { buildCanvasSwiperOptions, applySwiperEasing } from '@/lib/slider-utils';
+import { buildCanvasSwiperOptions, applySwiperEasing, maxResponsiveNumber, preserveSlideCssVars } from '@/lib/slider-utils';
 
 /**
  * Count the real (non-duplicate) swiper-slide DOM children inside the
@@ -106,10 +106,18 @@ export function useCanvasSlider(
 
   const isSlider = isEditMode && layer.name === 'slider';
 
+  // The canvas resolves per-view/per-group for the builder's active breakpoint
+  // (Swiper's window-based breakpoints can't be used from the builder frame).
+  const activeBreakpoint = useEditorStore((state) => state.activeBreakpoint);
+
   const settings: SliderSettings = { ...DEFAULT_SLIDER_SETTINGS, ...layer.settings?.slider };
+  // groupSlide / slidesPerGroup can be per-breakpoint objects, so serialize them
+  // to detect changes to any breakpoint's value.
+  const groupSlideKey = JSON.stringify(settings.groupSlide);
+  const slidesPerGroupKey = JSON.stringify(settings.slidesPerGroup);
   const settingsKey = useMemo(
-    () => `${settings.animationEffect}-${settings.duration}-${settings.easing}-${settings.groupSlide}-${settings.slidesPerGroup}-${settings.centered}-${settings.paginationType}-${settings.navigation}-${settings.loop}`,
-    [settings.animationEffect, settings.duration, settings.easing, settings.groupSlide, settings.slidesPerGroup, settings.centered, settings.paginationType, settings.navigation, settings.loop],
+    () => `${settings.animationEffect}-${settings.duration}-${settings.easing}-${groupSlideKey}-${slidesPerGroupKey}-${settings.centered}-${settings.paginationType}-${settings.navigation}-${settings.loop}-${activeBreakpoint}`,
+    [settings.animationEffect, settings.duration, settings.easing, groupSlideKey, slidesPerGroupKey, settings.centered, settings.paginationType, settings.navigation, settings.loop, activeBreakpoint],
   );
 
   const settingsRef = useRef(settings);
@@ -153,7 +161,7 @@ export function useCanvasSlider(
   // Loop requires at least `slidesPerView + slidesPerGroup` slides; with
   // slidesPerView='auto' the safest conservative threshold is 2.
   const needsLoop = settings.loop === 'loop';
-  const minSlidesForLoop = Math.max(2, (settings.slidesPerGroup || 1) + 1);
+  const minSlidesForLoop = Math.max(2, maxResponsiveNumber(settings.slidesPerGroup, 1) + 1);
   const initBucket = slideCount === 0
     ? 'empty'
     : needsLoop && slideCount < minSlidesForLoop
@@ -177,7 +185,7 @@ export function useCanvasSlider(
     ghostEl.style.cssText = 'position:absolute!important;color:transparent!important;z-index:-1!important;pointer-events:none!important';
     el.appendChild(ghostEl);
 
-    const options = buildCanvasSwiperOptions(settingsRef.current, ghostEl);
+    const options = buildCanvasSwiperOptions(settingsRef.current, ghostEl, activeBreakpoint);
     const swiper = new Swiper(el, options);
     applySwiperEasing(el, settingsRef.current.easing);
 
@@ -309,12 +317,16 @@ export function useCanvasSlider(
     return () => {
       wrapperObserver?.disconnect();
       swiperRegistry.delete(layer.id);
+      // Swiper.destroy wipes each slide's style attribute, stripping
+      // React-applied CSS vars (e.g. --bg-img). Restore them after destroy.
+      const restoreSlideVars = preserveSlideCssVars(el);
       swiper.destroy(true, true);
+      restoreSlideVars();
       ghostEl.remove();
       swiperRef.current = null;
       setSliderAnimating(false);
     };
-  }, [isSlider, elementRef, settingsKey, layer.id, initBucket]);
+  }, [isSlider, elementRef, settingsKey, layer.id, initBucket, activeBreakpoint]);
 
   // Navigate to the slide containing the selected layer
   useEffect(() => {

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -179,12 +179,31 @@ const SLIDER_BOOT_SCRIPT = `
     requestAnimationFrame(syncAll);
   }
 
+  // Resolve a responsive number (number or per-breakpoint object) using the
+  // desktop-first fallback chain, mirroring lib/slider-utils.ts.
+  var BP_FALLBACKS = { desktop: ['desktop'], tablet: ['tablet', 'desktop'], mobile: ['mobile', 'tablet', 'desktop'] };
+  function resolveResp(value, bp, fallback) {
+    if (value == null) return fallback;
+    if (typeof value === 'number') return value;
+    var chain = BP_FALLBACKS[bp];
+    for (var i = 0; i < chain.length; i++) {
+      if (typeof value[chain[i]] === 'number') return value[chain[i]];
+    }
+    return fallback;
+  }
+
   function buildConfig(s) {
+    var perView = function (bp) { return resolveResp(s.groupSlide, bp, 1); };
+    var perGroup = function (bp) { return Math.min(resolveResp(s.slidesPerGroup, bp, 1), perView(bp)); };
     var config = {
-      slidesPerView: 'auto',
-      slidesPerGroup: s.slidesPerGroup || 1,
+      slidesPerView: perView('mobile'),
+      slidesPerGroup: perGroup('mobile'),
       centeredSlides: !!s.centered,
       speed: Math.round((parseFloat(s.duration) || 0.5) * 1000),
+      breakpoints: {
+        768: { slidesPerView: perView('tablet'), slidesPerGroup: perGroup('tablet') },
+        1024: { slidesPerView: perView('desktop'), slidesPerGroup: perGroup('desktop') },
+      },
     };
     if (SPECIAL_EFFECTS[s.animationEffect]) config.effect = s.animationEffect;
     if (s.loop === 'loop') config.loop = true;

--- a/lib/slider-utils.ts
+++ b/lib/slider-utils.ts
@@ -15,7 +15,88 @@ import {
   EffectCards,
 } from 'swiper/modules';
 import type { SwiperOptions } from 'swiper/types';
-import type { SliderSettings, SwiperAnimationEffect } from '@/types';
+import type { Breakpoint, ResponsiveNumber, SliderSettings, SwiperAnimationEffect } from '@/types';
+
+/** Desktop-first fallback chain: a breakpoint inherits from larger ones when unset */
+const BREAKPOINT_FALLBACKS: Record<Breakpoint, Breakpoint[]> = {
+  desktop: ['desktop'],
+  tablet: ['tablet', 'desktop'],
+  mobile: ['mobile', 'tablet', 'desktop'],
+};
+
+/**
+ * Resolve a responsive value for a breakpoint, following the desktop-first
+ * fallback chain. Plain numbers apply to every breakpoint.
+ */
+export function resolveResponsiveNumber(
+  value: ResponsiveNumber | undefined,
+  breakpoint: Breakpoint,
+  fallback: number,
+): number {
+  if (value == null) return fallback;
+  if (typeof value === 'number') return value;
+  for (const bp of BREAKPOINT_FALLBACKS[breakpoint]) {
+    const resolved = value[bp];
+    if (typeof resolved === 'number') return resolved;
+  }
+  return fallback;
+}
+
+/**
+ * Write a per-breakpoint value into a responsive value, collapsing to a plain
+ * number when only the desktop base is set (keeps stored settings clean).
+ */
+export function writeResponsiveNumber(
+  current: ResponsiveNumber | undefined,
+  breakpoint: Breakpoint,
+  next: number,
+): ResponsiveNumber {
+  const obj: Partial<Record<Breakpoint, number>> =
+    typeof current === 'object' && current !== null ? { ...current } : {};
+  if (typeof current === 'number') obj.desktop = current;
+  obj[breakpoint] = next;
+
+  const keys = Object.keys(obj) as Breakpoint[];
+  if (keys.length === 1 && typeof obj.desktop === 'number') return obj.desktop;
+  return obj;
+}
+
+/** Highest value a responsive number takes across all breakpoints */
+export function maxResponsiveNumber(value: ResponsiveNumber | undefined, fallback: number): number {
+  if (value == null) return fallback;
+  if (typeof value === 'number') return value;
+  const values = Object.values(value).filter((v): v is number => typeof v === 'number');
+  return values.length ? Math.max(...values) : fallback;
+}
+
+/**
+ * Snapshot React-applied inline CSS custom properties (e.g. --bg-img) on a
+ * slider's slide elements and return a restore function. Swiper's
+ * destroy(cleanStyles=true) wipes each slide's entire style attribute, which
+ * strips these vars; React won't re-render to reapply them, so we restore
+ * them manually after destroy.
+ */
+export function preserveSlideCssVars(sliderEl: HTMLElement): () => void {
+  const slides = Array.from(
+    sliderEl.querySelectorAll<HTMLElement>('.swiper-wrapper > .swiper-slide'),
+  );
+  const snapshots = slides.map((slide) => {
+    const vars: Record<string, string> = {};
+    for (let i = 0; i < slide.style.length; i++) {
+      const prop = slide.style[i];
+      if (prop.startsWith('--')) vars[prop] = slide.style.getPropertyValue(prop);
+    }
+    return { slide, vars };
+  });
+
+  return () => {
+    for (const { slide, vars } of snapshots) {
+      for (const [prop, value] of Object.entries(vars)) {
+        slide.style.setProperty(prop, value);
+      }
+    }
+  };
+}
 
 /** Effect name → Swiper module mapping */
 export const EFFECT_MODULES: Partial<Record<SwiperAnimationEffect, typeof EffectFade>> = {
@@ -35,21 +116,42 @@ export const ALL_SWIPER_MODULES = [Navigation, Pagination, Autoplay, Mousewheel]
 /**
  * Build the shared base Swiper config from slider settings.
  * Covers options common to both canvas and production.
+ *
+ * When `fixedBreakpoint` is set (canvas editor), per-view/per-group are resolved
+ * for that single breakpoint and no responsive `breakpoints` map is emitted —
+ * Swiper's window-based breakpoints can't be used there because the instance is
+ * created from the builder frame (whose window width never matches the canvas
+ * iframe viewport). Otherwise (production) the mobile values seed the base and
+ * min-width breakpoints override at 768px (tablet) and 1024px (desktop).
  */
-export function buildBaseSwiperOptions(settings: SliderSettings): SwiperOptions {
+export function buildBaseSwiperOptions(
+  settings: SliderSettings,
+  fixedBreakpoint?: Breakpoint,
+): SwiperOptions {
   const modules = [...ALL_SWIPER_MODULES];
   const effectKey = settings.animationEffect;
   const effectModule = EFFECT_MODULES[effectKey];
 
   if (effectModule) modules.push(effectModule);
 
+  const perView = (bp: Breakpoint) => resolveResponsiveNumber(settings.groupSlide, bp, 1);
+  const perGroup = (bp: Breakpoint) =>
+    Math.min(resolveResponsiveNumber(settings.slidesPerGroup, bp, 1), perView(bp));
+
   const config: SwiperOptions = {
     modules,
-    slidesPerView: 'auto',
-    slidesPerGroup: settings.slidesPerGroup || 1,
+    slidesPerView: perView(fixedBreakpoint ?? 'mobile'),
+    slidesPerGroup: perGroup(fixedBreakpoint ?? 'mobile'),
     centeredSlides: settings.centered,
     speed: Math.round(parseFloat(settings.duration || '0.5') * 1000),
   };
+
+  if (!fixedBreakpoint) {
+    config.breakpoints = {
+      768: { slidesPerView: perView('tablet'), slidesPerGroup: perGroup('tablet') },
+      1024: { slidesPerView: perView('desktop'), slidesPerGroup: perGroup('desktop') },
+    };
+  }
 
   if (effectModule) {
     config.effect = effectKey as SwiperOptions['effect'];
@@ -107,8 +209,12 @@ export function buildProductionSwiperOptions(settings: SliderSettings): SwiperOp
 /**
  * Build canvas-only Swiper config (all interactions disabled).
  */
-export function buildCanvasSwiperOptions(settings: SliderSettings, ghostPaginationEl: HTMLElement): SwiperOptions {
-  const config = buildBaseSwiperOptions(settings);
+export function buildCanvasSwiperOptions(
+  settings: SliderSettings,
+  ghostPaginationEl: HTMLElement,
+  activeBreakpoint: Breakpoint,
+): SwiperOptions {
+  const config = buildBaseSwiperOptions(settings, activeBreakpoint);
 
   config.simulateTouch = false;
   config.allowTouchMove = false;
@@ -196,6 +302,17 @@ export function syncSliderStateAttributes(swiper: InstanceType<typeof import('sw
   swiper.on('paginationUpdate', syncBullets);
   swiper.on('navigationNext', syncNavButtons);
   swiper.on('navigationPrev', syncNavButtons);
+  // Re-sync nav aria-disabled when the layout changes (e.g. a responsive
+  // breakpoint switches slidesPerView). Swiper updates its own disabled classes
+  // on these events but not our aria bridge, so next/prev could stay visually
+  // disabled after resizing from desktop to mobile.
+  swiper.on('update', syncNavButtons);
+  swiper.on('breakpoint', syncNavButtons);
+  swiper.on('resize', syncNavButtons);
+  swiper.on('toEdge', syncNavButtons);
+  swiper.on('fromEdge', syncNavButtons);
+  swiper.on('lock', syncNavButtons);
+  swiper.on('unlock', syncNavButtons);
 
   // Initial sync after mount
   requestAnimationFrame(syncAll);

--- a/types/index.ts
+++ b/types/index.ts
@@ -217,10 +217,17 @@ export interface LightboxSettings {
   duration: string; // Transition duration in seconds
 }
 
+/**
+ * A value that can either be a single number (applies to every breakpoint) or
+ * an object of per-breakpoint overrides. Desktop is the base; tablet/mobile
+ * fall back to larger breakpoints when unset (desktop-first).
+ */
+export type ResponsiveNumber = number | Partial<Record<Breakpoint, number>>;
+
 export interface SliderSettings {
   navigation: boolean;
-  groupSlide: number;
-  slidesPerGroup: number;
+  groupSlide: ResponsiveNumber; // Slides visible per view (responsive)
+  slidesPerGroup: ResponsiveNumber; // Slides advanced per navigation step (responsive)
   loop: SliderLoopMode;
   centered: boolean;
   touchEvents: boolean;


### PR DESCRIPTION
## Summary

Fixes multiple functionality and display issues with the Slider module (GitHub #449). Per view / Per group are now responsive per breakpoint, the configured slide count actually renders, and the builder canvas now matches the live preview and published output — including on page load and across breakpoint switches.

Closes #449

## Changes

- Make Per view / Per group responsive per breakpoint via a new `ResponsiveNumber` type (backward-compatible with existing plain-number configs)
- Wire Per view to Swiper `slidesPerView` so the slider shows the configured number of items, with breakpoint overrides for production
- Allow typing numbers directly into the Per view / Per group inputs (local draft state, commit on change, clamp on blur)
- Make the canvas evaluate the active builder breakpoint so mobile/tablet settings render in the editor, matching preview
- Preserve slide background CSS variables across Swiper reinitialization (setting changes no longer wipe the background)
- Pre-size slides via CSS variables and hide locked/uninitialized nav + pagination to eliminate the load-time flash (single slide, blinking arrows)
- Hide pagination and nav when there is only one page
- Mirror the responsive Swiper config in the static HTML export

## Test plan

- [ ] Set Per view to 3 on desktop — canvas and preview both show 3 slides
- [ ] Type a value directly into Per view / Per group — no snap-back, clamps to 1–10 on blur
- [ ] Set different Per view per breakpoint — canvas updates when switching viewport, matches preview
- [ ] Change item count — slide background images stay intact on canvas (no reload needed)
- [ ] Reload a published/preview page — no single-slide flash, no blinking nav arrows
- [ ] Slider with one page — pagination and nav hidden
- [ ] Open an existing (pre-change) slider — renders unchanged, no migration needed