### PR TITLE
fix: reliably create and edit nested components

### DIFF
--- a/app/(builder)/ycode/components/YCodeBuilderMain.tsx
+++ b/app/(builder)/ycode/components/YCodeBuilderMain.tsx
@@ -199,6 +199,7 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
   const lastLayersByPageRef = useRef<Map<string, Layer[]>>(new Map());
   const previousPageIdRef = useRef<string | null>(null);
   const previousResourceIdRef = useRef<string | null>(null); // Track URL resourceId changes
+  const previousComponentResourceIdRef = useRef<string | null>(null); // Track URL component id changes
   const hasInitializedLayerFromUrlRef = useRef(false);
   const previousIsEditingRef = useRef<boolean | undefined>(undefined);
 
@@ -839,6 +840,12 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
     if (isComponentRoute && components.length === 0) return;
     if (isCollectionRoute && collections.length === 0 && !builderDataPreloaded) return;
 
+    // Reset the component-id tracker when leaving component routes so
+    // re-entering the same component later is still detected as a change.
+    if (!isComponentRoute) {
+      previousComponentResourceIdRef.current = null;
+    }
+
     // Handle route types: layers, page, collection, collections-base, component
     if ((routeType === 'layers' || routeType === 'page') && resourceId) {
       const page = pages.find(p => p.id === resourceId);
@@ -900,9 +907,16 @@ export default function YCodeBuilder({ children }: YCodeBuilderProps = {} as YCo
     }
 
     if (routeType === 'component' && resourceId && !isExitingComponentModeRef.current) {
+      // Only sync state from the URL when the URL's component id actually
+      // changed. Otherwise this effect re-runs when editingComponentId is set
+      // programmatically (e.g. entering a nested component) before the URL
+      // updates, and reverts it back to the stale parent component id.
+      const componentResourceChanged = resourceId !== previousComponentResourceIdRef.current;
+      previousComponentResourceIdRef.current = resourceId;
+
       const { getComponentById, loadComponentDraft } = useComponentsStore.getState();
       const component = getComponentById(resourceId);
-      if (component && editingComponentId !== resourceId) {
+      if (component && editingComponentId !== resourceId && componentResourceChanged) {
         const { setEditingComponentId, setEditingComponentVariantId } = useEditorStore.getState();
         // Use currentPageId if available, otherwise find homepage as fallback
         const returnPageId = currentPageId || (pages.length > 0 ? (findHomepage(pages)?.id || pages[0]?.id) : null);

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -2791,8 +2791,11 @@ export function replaceLayerWithComponentInstance(
 ): Layer[] {
   return layers.map((layer) => {
     if (layer.id === layerId) {
+      // Drop the original customName so the instance shows the component's
+      // name instead of the layer's previous rename.
+      const { customName: _customName, ...rest } = layer;
       return {
-        ...layer,
+        ...rest,
         componentId,
         children: [],
       };

--- a/stores/useComponentsStore.ts
+++ b/stores/useComponentsStore.ts
@@ -855,8 +855,11 @@ export const useComponentsStore = create<ComponentsStore>((set, get) => {
       const layerToCopy = findLayerById(layers, layerId);
       if (!layerToCopy) return null;
 
+      // Regenerate IDs so the component's internal layers don't collide with
+      // the instance layer that keeps the original id in the parent tree.
+      const regeneratedLayer = regenerateIdsWithInteractionRemapping(layerToCopy);
       // Strip CMS bindings that won't be valid inside a standalone component
-      const cleanedLayers = cleanLayersForComponentCreation([layerToCopy]);
+      const cleanedLayers = cleanLayersForComponentCreation([regeneratedLayer]);
       const newComponent = await createComponentViaApi(componentName, cleanedLayers);
       if (!newComponent) return null;
 

--- a/stores/usePagesStore.ts
+++ b/stores/usePagesStore.ts
@@ -2963,8 +2963,11 @@ export const usePagesStore = create<PagesStore>((set, get) => ({
     const layerToCopy = copyLayer(pageId, layerId);
     if (!layerToCopy) return null;
 
+    // Regenerate IDs so the component's internal layers don't collide with the
+    // instance layer that keeps the original id in the page tree.
+    const regeneratedLayer = regenerateIdsWithInteractionRemapping(layerToCopy);
     // Strip CMS bindings that won't be valid inside a standalone component
-    const cleanedLayers = cleanLayersForComponentCreation([layerToCopy]);
+    const cleanedLayers = cleanLayersForComponentCreation([regeneratedLayer]);
     const newComponent = await createComponentViaApi(componentName, cleanedLayers);
     if (!newComponent) return null;
 


### PR DESCRIPTION
## Summary

Fixes two bugs that broke creating a component from layers inside another component and then entering the new component's edit mode.

## Changes

- Regenerate layer ids when extracting layers into a new component, so the component's internal layers no longer collide with the instance layer left behind in the parent tree (the collision broke selection and navigation).
- Guard the URL-sync effect so a programmatically set `editingComponentId` (e.g. when entering a nested component) is no longer reverted to the stale parent component id before the URL updates.

## Test plan

- [ ] Create a component from a layer inside another component, then open the new component's edit mode — it opens the correct component
- [ ] Return to the parent component and confirm the canvas shows the parent, not the nested component
- [ ] Confirm extracted component layers get fresh ids (no id collision with the parent instance)
- [ ] Regular (page-level) component creation still works