### PR TITLE
fix: prevent slider from disappearing when shrink-to-fit

### DIFF
--- a/app/site.css
+++ b/app/site.css
@@ -70,6 +70,16 @@
   stroke: currentColor;
 }
 
+/* Swiper needs a definite container width. When a slider ends up shrink-to-fit
+   (e.g. it lost its `w-full` at a breakpoint and sits in an `align-items:center`
+   flex parent), its `width:100%` slides create a circular layout that blows the
+   width up to the browser max — Swiper then measures that and sizes every slide
+   to it, leaving the slider effectively invisible. Capping to the container
+   width breaks the cycle without forcing a width, so explicit widths still win. */
+[data-slider-id] {
+  max-width: 100%;
+}
+
 /* Pre-init slider layout: size slides by the configured per-view before Swiper
    JS initializes, preventing a flash where every slide is full-width (1 per
    view) on load. Swiper sets exact inline widths on init which override these.

--- a/public/swiper-minimal.css
+++ b/public/swiper-minimal.css
@@ -13,6 +13,18 @@
 .swiper-slide-invisible-blank { visibility: hidden; }
 
 /*
+ * Slides default to Tailwind `w-full` (width:100%). When the slider has no
+ * definite width (e.g. it lost `w-full` at a breakpoint and sits in an
+ * `align-items:center` flex parent, making it shrink-to-fit), the percentage-
+ * width chain becomes circular and the slider blows up to the browser max
+ * width — Swiper then measures that and sizes every slide to it, leaving the
+ * slider effectively invisible. Capping to the container width breaks the cycle
+ * without forcing a width, so explicit widths still win. Mirrors the height fix
+ * below and applies in both the canvas and published output.
+ */
+.swiper { max-width: 100%; }
+
+/*
  * Slides default to Tailwind `h-full` (height:100%). When the slider itself has
  * no definite height (e.g. `h-[100%]` on tablet/mobile), the percentage-height
  * chain becomes circular and slides collapse to 0 — the first slide appears


### PR DESCRIPTION
## Summary

A slider whose container ends up shrink-to-fit renders as invisible on both the builder canvas and published/preview pages. This adds a defensive width cap that keeps the slider constrained to its container.

## Root cause

When a slider loses its `w-full` at a breakpoint (e.g. only `max-md`/`max-lg` width variants remain) and sits inside an `align-items:center` flex parent, it becomes shrink-to-fit on the cross axis. Its slides use `width:100%`, which creates a circular layout that blows the width up to the browser max (`16777216px`). Swiper then measures that runaway width on init and sizes every slide to it, so the slide content is centered far off-screen and the slider looks empty.

## Changes

- Cap `.swiper` to `max-width: 100%` in `public/swiper-minimal.css` (loaded by both the canvas and published output), mirroring the existing circular-height fix in that file
- Cap `[data-slider-id]` to `max-width: 100%` in `app/site.css` as a first-paint safeguard for published/preview pages, where `swiper-minimal.css` is injected asynchronously

The cap is a no-op for correctly-sized sliders and, being a cap rather than a forced width, does not override explicit widths.

## Test plan

- [ ] Open a slider that has no desktop `w-full` inside a centered flex parent — it renders at container width instead of collapsing
- [ ] Confirm canvas and published/preview render identically
- [ ] Confirm normal full-width sliders are unaffected
- [ ] Confirm a slider with an explicit width keeps that width