### PR TITLE
fix: auto-set slug on import and fix heading selector

### DIFF
--- a/app/(builder)/ycode/api/collections/import/process/route.ts
+++ b/app/(builder)/ycode/api/collections/import/process/route.ts
@@ -6,8 +6,9 @@ import {
   completeImport,
 } from '@/lib/repositories/collectionImportRepository';
 import { createItemsBulk, deleteItem, getMaxIdValue, getMaxManualOrder } from '@/lib/repositories/collectionItemRepository';
-import { insertValuesBulk, insertValuesDirectPg } from '@/lib/repositories/collectionItemValueRepository';
+import { insertValuesBulk, insertValuesDirectPg, getValuesByFieldId } from '@/lib/repositories/collectionItemValueRepository';
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
+import { generateUniqueSlug } from '@/lib/collection-utils';
 import {
   convertValueForFieldType,
   SKIP_COLUMN,
@@ -129,6 +130,7 @@ function prepareRow(
   columnMapping: Record<string, string>,
   fieldMap: Map<string, CollectionField>,
   autoFields: { idField?: CollectionField; createdAtField?: CollectionField; updatedAtField?: CollectionField },
+  slugContext: { slugField?: CollectionField; nameField?: CollectionField; usedSlugs: Set<string> },
   currentMaxId: number,
   manualOrder: number,
   now: string,
@@ -185,6 +187,30 @@ function prepareRow(
       warnings.push(
         `Row ${rowNumber}, column "${csvColumn}": value "${truncateValue(rawValue)}" is not a valid ${field.type} for field "${field.name}", skipped`
       );
+    }
+  }
+
+  // Ensure the slug is always populated. When the slug column isn't mapped (or
+  // its cell is empty) derive a unique slug from the name field so items remain
+  // routable instead of ending up with an empty slug.
+  if (slugContext.slugField) {
+    const slugFieldId = slugContext.slugField.id;
+    const slugValue = values.find(v => v.field_id === slugFieldId);
+    const hasSlug = !!slugValue?.value && slugValue.value.trim() !== '';
+
+    if (hasSlug) {
+      slugContext.usedSlugs.add(slugValue!.value!.trim());
+    } else {
+      const nameValue = slugContext.nameField
+        ? values.find(v => v.field_id === slugContext.nameField!.id)?.value ?? ''
+        : '';
+      const generatedSlug = generateUniqueSlug(nameValue, slugContext.usedSlugs);
+
+      if (slugValue) {
+        slugValue.value = generatedSlug;
+      } else {
+        values.push({ item_id: itemId, field_id: slugFieldId, value: generatedSlug, is_published: false });
+      }
     }
   }
 
@@ -341,6 +367,20 @@ export async function POST(request: NextRequest) {
       updatedAtField: fields.find(f => f.key === AUTO_FIELD_KEYS[2]),
     };
 
+    // Slug fallback: seed already-used slugs so auto-generated ones stay unique
+    // across batches (each collection has its own slug field, so filtering by
+    // field_id effectively scopes to this collection).
+    const slugField = fields.find(f => f.key === 'slug');
+    const nameField = fields.find(f => f.key === 'name');
+    const usedSlugs = new Set<string>();
+    if (slugField) {
+      const existingSlugValues = await getValuesByFieldId(slugField.id, false);
+      for (const v of existingSlugValues) {
+        if (v.value) usedSlugs.add(v.value.trim());
+      }
+    }
+    const slugContext = { slugField, nameField, usedSlugs };
+
     // Get max ID and max manual_order in parallel (2 queries)
     const [currentMaxIdResult, currentMaxOrderResult] = await Promise.all([
       getMaxIdValue(importJob.collection_id, false),
@@ -364,7 +404,7 @@ export async function POST(request: NextRequest) {
       try {
         const { prepared, newMaxId } = prepareRow(
           row, rowNumber, importJob.collection_id,
-          importJob.column_mapping, fieldMap, autoFields,
+          importJob.column_mapping, fieldMap, autoFields, slugContext,
           currentMaxId, manualOrderOffset + i, now, errors
         );
         currentMaxId = newMaxId;

--- a/app/(builder)/ycode/components/RichTextEditor.tsx
+++ b/app/(builder)/ycode/components/RichTextEditor.tsx
@@ -8,7 +8,7 @@
  * Data is stored in data-variable attribute as JSON-encoded string
  */
 
-import React, { useEffect, useState, useImperativeHandle, forwardRef, useCallback, useMemo, useRef } from 'react';
+import React, { useEffect, useState, useImperativeHandle, forwardRef, useCallback, useMemo, useReducer, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { useEditor, EditorContent } from '@tiptap/react';
 import { Mark, mergeAttributes } from '@tiptap/core';
@@ -652,6 +652,16 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(({
     if (!editor) return;
     editor.setEditable(!disabled);
   }, [editor, disabled]);
+
+  // Tiptap v3's useEditor no longer re-renders on every transaction, so toolbar
+  // state read via editor.isActive(...) (e.g. the heading Select) goes stale when
+  // the selection moves. Force a re-render on each transaction to keep it in sync.
+  const [, forceToolbarUpdate] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => {
+    if (!editor) return;
+    editor.on('transaction', forceToolbarUpdate);
+    return () => { editor.off('transaction', forceToolbarUpdate); };
+  }, [editor]);
 
   // Sync CMS context into editor storage so node views can access it, then
   // force every dynamic-variable badge to re-render. Badges resolve their label

--- a/lib/apps/airtable/sync-service.ts
+++ b/lib/apps/airtable/sync-service.ts
@@ -13,7 +13,7 @@ import { randomUUID } from 'crypto';
 
 import { getSupabaseAdmin, runWithTenantId } from '@/lib/supabase-server';
 import { getAppSettingValue, setAppSetting } from '@/lib/repositories/appSettingsRepository';
-import { slugify } from '@/lib/collection-utils';
+import { generateUniqueSlug as generateUniqueSlugFromSet } from '@/lib/collection-utils';
 import { isAssetFieldType, isMultipleAssetField, getAssetCategoryForField } from '@/lib/collection-field-utils';
 import { ALLOWED_MIME_TYPES } from '@/lib/asset-constants';
 import { uploadFile } from '@/lib/file-upload';
@@ -476,17 +476,7 @@ interface SlugContext {
 }
 
 function generateUniqueSlug(value: string | null, ctx: SlugContext): string {
-  const base = slugify(value || 'item');
-  if (!ctx.existingSlugs.has(base)) {
-    ctx.existingSlugs.add(base);
-    return base;
-  }
-
-  let n = 1;
-  while (ctx.existingSlugs.has(`${base}-${n}`)) n++;
-  const unique = `${base}-${n}`;
-  ctx.existingSlugs.add(unique);
-  return unique;
+  return generateUniqueSlugFromSet(value, ctx.existingSlugs);
 }
 
 /**

--- a/lib/collection-utils.ts
+++ b/lib/collection-utils.ts
@@ -211,6 +211,27 @@ export function slugify(name: string): string {
 }
 
 /**
+ * Generate a URL-safe slug that is unique within a set of existing slugs.
+ * Appends an incrementing suffix (`-1`, `-2`, ...) on collision and records
+ * the result in `existingSlugs` so subsequent calls stay unique.
+ * @param value - Source text to slugify (falls back to "item" when empty)
+ * @param existingSlugs - Mutable set of slugs already taken
+ */
+export function generateUniqueSlug(value: string | null | undefined, existingSlugs: Set<string>): string {
+  const base = slugify(value || 'item');
+  if (!existingSlugs.has(base)) {
+    existingSlugs.add(base);
+    return base;
+  }
+
+  let n = 1;
+  while (existingSlugs.has(`${base}-${n}`)) n++;
+  const unique = `${base}-${n}`;
+  existingSlugs.add(unique);
+  return unique;
+}
+
+/**
  * Validate field name format (lowercase, alphanumeric, underscores)
  * @param fieldName - The field name to validate
  * @returns True if valid


### PR DESCRIPTION
## Summary

Fixes two CMS bugs: collection items imported from CSV without a mapped slug column ended up with an empty slug (unroutable), and the rich-text field's heading dropdown didn't reflect the block under the cursor.

## Changes

- Auto-generate a unique slug from the item's name field during CSV import when the slug column is unmapped or its cell is empty, seeding existing slugs so generated ones stay unique across batches
- Extract a shared `generateUniqueSlug` util in `collection-utils.ts` and reuse it in the Airtable sync service (removes duplicated logic)
- Force the rich-text toolbar to re-render on editor transactions so the heading `Select` (and other `isActive`-based states) stays in sync with the current selection — Tiptap v3's `useEditor` no longer re-renders per transaction

## Test plan

- [ ] Import a CSV without mapping the Slug column — every item gets a unique slug derived from its Name
- [ ] Import a CSV where some slug cells are empty — those rows still get a generated slug, mapped ones are preserved
- [ ] Import two rows with the same Name — slugs are de-duplicated (`name`, `name-1`)
- [ ] Open a collection item's rich-text field, click into an H2 — the dropdown immediately reads "Heading 2"
- [ ] Switch Paragraph/H2/H3 on the first try; bold/italic and undo/redo states also update correctly
- [ ] Verify Airtable sync still generates slugs correctly