### PR TITLE
fix: use lowercase hreflang attribute on alternate links

### DIFF
--- a/components/HreflangAlternateLinks.tsx
+++ b/components/HreflangAlternateLinks.tsx
@@ -1,0 +1,28 @@
+import type { HreflangAlternate } from '@/lib/hreflang-utils';
+
+interface HreflangAlternateLinksProps {
+  alternates: HreflangAlternate[];
+}
+
+/**
+ * Renders the `<link rel="alternate" hreflang="...">` cluster into the document
+ * head. Uses the lowercase `hreflang` attribute (HTML standard / Google's
+ * convention) instead of React's `hrefLang` prop, which React 19 emits verbatim
+ * as camelCase. React 19 hoists these link tags to <head> during SSR.
+ */
+export default function HreflangAlternateLinks({ alternates }: HreflangAlternateLinksProps) {
+  if (alternates.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {alternates.map((alt) => (
+        <link
+          key={alt.hreflang}
+          {...({ rel: 'alternate', hreflang: alt.hreflang, href: alt.href } as Record<string, string>)}
+        />
+      ))}
+    </>
+  );
+}

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -2,6 +2,7 @@ import AnimationInitializer from '@/components/AnimationInitializer';
 import BodyClassApplier from '@/components/BodyClassApplier';
 import ContentHeightReporter from '@/components/ContentHeightReporter';
 import CustomCodeInjector from '@/components/CustomCodeInjector';
+import HreflangAlternateLinks from '@/components/HreflangAlternateLinks';
 import LayerRendererPublic from '@/components/LayerRendererPublic';
 import SliderInitializer from '@/components/SliderInitializer';
 import LightboxInitializer from '@/components/LightboxInitializer';
@@ -28,6 +29,9 @@ import { buildGlobalsMetaMap, buildGlobalsValueMap } from '@/lib/collection-fiel
 import { buildLocalizedPageUrls, type LocalizedDynamicSlug } from '@/lib/page-utils';
 import { getTranslatableKey } from '@/lib/locale-runtime';
 import { getSlugTranslationsByLocale } from '@/lib/repositories/translationRepository';
+import { buildPageHreflangAlternatesForPage } from '@/lib/generate-page-metadata';
+import { getSiteBaseUrl } from '@/lib/url-utils';
+import type { HreflangAlternate } from '@/lib/hreflang-utils';
 import type { Layer, BackgroundsDesign, Component, Page, CollectionItemWithValues, CollectionField, Locale, PageFolder, PasswordProtectionContext, Translation } from '@/types';
 
 interface PageLinkRef { collection_item_id: string; page_id: string }
@@ -722,6 +726,25 @@ export default async function PageRenderer({
       )
       : undefined;
 
+  // Build hreflang alternates for multilingual sites. Rendered as lowercase
+  // <link rel="alternate" hreflang> tags below (not via Next metadata, which
+  // emits camelCase hrefLang). Skipped for previews, error pages, and noindex
+  // pages, mirroring the sitemap's language cluster.
+  let hreflangAlternates: HreflangAlternate[] = [];
+  if (!isPreview && availableLocales.length > 1 && page.error_page === null && !page.settings?.seo?.noindex) {
+    try {
+      const globalCanonicalUrl = await getSettingByKey('global_canonical_url').catch(() => null);
+      const baseUrl = getSiteBaseUrl({
+        globalCanonicalUrl: typeof globalCanonicalUrl === 'string' ? globalCanonicalUrl : null,
+      });
+      if (baseUrl) {
+        hreflangAlternates = await buildPageHreflangAlternatesForPage(page, baseUrl, collectionItem);
+      }
+    } catch (error) {
+      console.error('[PageRenderer] Error building hreflang alternates:', error);
+    }
+  }
+
   return (
     <>
       {/* Global head code fallback when layout skips it (SKIP_SETUP mode) */}
@@ -731,6 +754,9 @@ export default async function PageRenderer({
 
       {/* Page-specific custom head code — React 19 hoists meta/link/style/title to <head> */}
       {pageCustomCodeHead && renderRootLayoutHeadCode(pageCustomCodeHead, 'page-head')}
+
+      {/* hreflang alternates for multilingual sites (lowercase attribute) */}
+      <HreflangAlternateLinks alternates={hreflangAlternates} />
 
       {/* Preload the LCP image so the browser starts the fetch from <head>
           rather than waiting until the parser reaches the <img> tag. Pairs

--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -18,12 +18,9 @@ import { getAllPublishedPageFolders } from '@/lib/repositories/pageFolderReposit
 import { getSlugTranslationsByLocale } from '@/lib/repositories/translationRepository';
 import { buildSvgDataUrl, getAssetProxyUrl } from '@/lib/asset-utils';
 import { generateColorVariablesCss } from '@/lib/repositories/colorVariableRepository';
-import { buildPageHreflangAlternates } from '@/lib/hreflang-utils';
+import { buildPageHreflangAlternates, type HreflangAlternate } from '@/lib/hreflang-utils';
 import { getTranslatableKey } from '@/lib/locale-runtime';
 import { buildAbsolutePageUrl, getSiteBaseUrl } from '@/lib/url-utils';
-
-/** Languages map shape Next.js expects under `metadata.alternates.languages`. */
-type MetadataLanguages = NonNullable<NonNullable<Metadata['alternates']>['languages']>;
 
 /**
  * Global page render settings fetched once per page render
@@ -207,19 +204,23 @@ const fetchHreflangDataset = cache(async (): Promise<HreflangDataset> => {
 });
 
 /**
- * Build the `metadata.alternates.languages` map for a page on a multilingual
- * site. Returns null when hreflang shouldn't be emitted (single locale, no
- * absolute base URL, or no resolvable alternates).
+ * Build the hreflang alternates for a page on a multilingual site. Returns an
+ * empty array when hreflang shouldn't be emitted (single locale or no
+ * resolvable alternates). Rendered as lowercase `<link rel="alternate"
+ * hreflang>` tags (see HreflangAlternateLinks) rather than via Next's
+ * `metadata.alternates.languages`, which React 19 emits as camelCase `hrefLang`.
  */
-async function buildHreflangLanguages(
+export async function buildPageHreflangAlternatesForPage(
   page: Page,
   baseUrl: string,
-  collectionItem?: CollectionItemWithValues
-): Promise<MetadataLanguages | null> {
+  collectionItem?: CollectionItemWithValues,
+   
+  tenantId?: string
+): Promise<HreflangAlternate[]> {
   const { locales, folders, translationsByLocale } = await fetchHreflangDataset();
 
   if (locales.length <= 1) {
-    return null;
+    return [];
   }
 
   // Dynamic pages need the collection item's slug to resolve per-locale URLs.
@@ -232,7 +233,7 @@ async function buildHreflangLanguages(
     }
     : null;
 
-  const alternates = buildPageHreflangAlternates({
+  return buildPageHreflangAlternates({
     page,
     folders,
     baseUrl,
@@ -240,16 +241,6 @@ async function buildHreflangLanguages(
     translationsByLocale,
     dynamicSlug,
   });
-
-  if (alternates.length === 0) {
-    return null;
-  }
-
-  const languages: MetadataLanguages = {};
-  for (const alt of alternates) {
-    languages[alt.hreflang as keyof MetadataLanguages] = alt.href;
-  }
-  return languages;
 }
 
 /**
@@ -334,23 +325,10 @@ export async function generatePageMetadata(
       };
     }
 
-    // Add hreflang alternates for multilingual sites. Skipped for error pages
-    // and noindex pages (excluded from the language cluster, mirroring the
-    // sitemap), and requires an absolute base URL to emit valid links.
-    if (siteBaseUrl && !isErrorPage && !seo?.noindex) {
-      try {
-        const languages = await buildHreflangLanguages(page, siteBaseUrl, collectionItem);
-        if (languages) {
-          metadata.alternates = {
-            ...metadata.alternates,
-            languages,
-          };
-        }
-      } catch (error) {
-        // Non-fatal: a page should still render without hreflang links.
-        console.error('Failed to generate hreflang alternates:', error);
-      }
-    }
+    // hreflang alternates are rendered as lowercase <link> tags in the page
+    // head (see HreflangAlternateLinks / PageRenderer), not via
+    // metadata.alternates.languages — React 19 emits that map's `hrefLang`
+    // prop verbatim, but the HTML/Google standard is lowercase `hreflang`.
   }
 
   // Add custom favicon and web clip (apple-touch-icon) — applies to preview too.


### PR DESCRIPTION
## Summary

Localized sites emitted alternate language links as `<link rel="alternate" hrefLang="de" ...>` (camelCase). Google's documentation and the HTML standard expect the lowercase `hreflang` attribute. This switches the output to `hreflang` for better SEO consistency.

The camelCase came from Next.js's `metadata.alternates.languages`, which renders the React `hrefLang` prop — React 19 now emits that prop verbatim instead of lowercasing it. The fix stops routing hreflang through Next metadata and renders the link cluster directly with the lowercase attribute.

## Changes

- Add `HreflangAlternateLinks` component that renders `<link rel="alternate" hreflang="...">` with the lowercase attribute (hoisted to `<head>` by React 19)
- Export `buildPageHreflangAlternatesForPage` from `generate-page-metadata` and render the alternates in `PageRenderer`
- Remove the `metadata.alternates.languages` map so Next no longer emits the camelCase tags
- Keep the same guards as before: multilingual sites only, skipping previews, error pages, and noindex pages
- Canonical URL handling is unchanged; the sitemap already used lowercase `hreflang`

## Test plan

- [ ] On a multi-locale site, view source of a page and confirm `<link rel="alternate" hreflang="...">` is lowercase
- [ ] Confirm one entry per locale plus `x-default`, with correct localized URLs
- [ ] Confirm single-locale sites emit no hreflang links
- [ ] Confirm preview, 404/401, and noindex pages emit no hreflang links
- [ ] Confirm the canonical link is still present and correct