### PR TITLE
fix: prevent slider stretching the page in aspect-ratio containers

### DIFF
--- a/app/site.css
+++ b/app/site.css
@@ -71,13 +71,15 @@
 }
 
 /* Swiper needs a definite container width. When a slider ends up shrink-to-fit
-   (e.g. it lost its `w-full` at a breakpoint and sits in an `align-items:center`
-   flex parent), its `width:100%` slides create a circular layout that blows the
-   width up to the browser max — Swiper then measures that and sizes every slide
-   to it, leaving the slider effectively invisible. Capping to the container
-   width breaks the cycle without forcing a width, so explicit widths still win. */
+   (e.g. an `align-items:center` flex parent, or an `aspect-ratio` wrapper with
+   no definite width), its `width:100%` slides create a circular layout that
+   blows the width up to the browser max — Swiper then measures that and sizes
+   every slide to it, and any `aspect-ratio` ancestor amplifies it into a runaway
+   height. `contain: inline-size` decouples the slider's width from its contents
+   so it resolves from its containing block instead, breaking the cycle without
+   forcing a width — explicit widths still win. */
 [data-slider-id] {
-  max-width: 100%;
+  contain: inline-size;
 }
 
 /* Pre-init slider layout: size slides by the configured per-view before Swiper

--- a/public/swiper-minimal.css
+++ b/public/swiper-minimal.css
@@ -13,16 +13,18 @@
 .swiper-slide-invisible-blank { visibility: hidden; }
 
 /*
- * Slides default to Tailwind `w-full` (width:100%). When the slider has no
- * definite width (e.g. it lost `w-full` at a breakpoint and sits in an
- * `align-items:center` flex parent, making it shrink-to-fit), the percentage-
- * width chain becomes circular and the slider blows up to the browser max
- * width — Swiper then measures that and sizes every slide to it, leaving the
- * slider effectively invisible. Capping to the container width breaks the cycle
- * without forcing a width, so explicit widths still win. Mirrors the height fix
- * below and applies in both the canvas and published output.
+ * Slides default to Tailwind `w-full` (width:100%). When the slider sits in a
+ * shrink-to-fit context (e.g. an `align-items:center` flex parent, or an
+ * `aspect-ratio` wrapper with no definite width), the percentage-width chain
+ * becomes circular: the slider blows up to the browser max width, Swiper
+ * measures that and sizes every slide to it, and any `aspect-ratio` ancestor
+ * amplifies it into a runaway height too. `contain: inline-size` decouples the
+ * slider's own width from its (inflated) contents, so it resolves from its
+ * containing block or an aspect-ratio ancestor instead — breaking the cycle
+ * without forcing a width. Explicit widths still win. Applies in both the
+ * canvas and published output.
  */
-.swiper { max-width: 100%; }
+.swiper { contain: inline-size; }
 
 /*
  * Slides default to Tailwind `h-full` (height:100%). When the slider itself has


### PR DESCRIPTION
## Summary

Imported projects with a slider inside an `aspect-ratio` wrapper (e.g. `aspect-[4/6]`) could make the whole builder canvas absurdly tall. The slider's `width:100%` slides created a circular layout that blew the width up to the browser max, and the aspect-ratio ancestor amplified that into a runaway height (page ~16.7M px tall).

The previous `max-width: 100%` cap didn't help here because the containing block (the aspect-ratio wrapper) was itself unbounded, so `100%` resolved to the same runaway width.

## Changes

- Replace `max-width: 100%` on the slider with `contain: inline-size` (in `swiper-minimal.css` for `.swiper` and `site.css` for `[data-slider-id]`)
- This decouples the slider's own width from its (inflated) contents, so it resolves from its containing block or aspect-ratio ancestor instead — breaking the cycle without forcing a width. Explicit widths still win.

## Test plan

- [ ] Open a page with a slider inside an `aspect-[4/6]` / `aspect-[1/1]` wrapper in a shrink-to-fit (`items-center`) column
- [ ] Confirm the slider resolves to its aspect size (e.g. 400×600) instead of stretching the page
- [ ] Confirm normal sliders (`w-full` in a definite-width container) still render at full width
- [ ] Confirm canvas and published/preview output match