### PR TITLE
fix: support capture groups in redirect destinations

### DIFF
--- a/app/(builder)/ycode/settings/redirects/page.tsx
+++ b/app/(builder)/ycode/settings/redirects/page.tsx
@@ -287,9 +287,9 @@ export default function RedirectsSettingsPage() {
             <Field>
               <FieldLabel htmlFor="add-old-url">Old URL</FieldLabel>
               <FieldDescription>
-                The URL path to redirect from (e.g. /old-page). Use a wildcard
-                pattern to match many URLs at once: /blog/.* matches everything
-                under /blog.
+                The URL path to redirect from (e.g. {'"/old-page"'}). Use a wildcard
+                pattern to match many URLs at once: {'"/blog/(.*)"'} matches everything
+                under /blog and captures the matched part for reuse.
               </FieldDescription>
               <Input
                 id="add-old-url"
@@ -303,8 +303,9 @@ export default function RedirectsSettingsPage() {
             <Field>
               <FieldLabel htmlFor="add-new-url">New URL</FieldLabel>
               <FieldDescription>
-                Internal path (e.g. /new-page) or external URL. When the old URL is a
-                wildcard pattern, use $0 to insert the matched path (e.g. /posts/$0).
+                Internal path (e.g. {'"/new-page"'}) or external URL. To reuse a captured
+                part of a wildcard pattern, reference it with $1
+                (e.g. {'"/old-path/(.*)"'} → {'"/new-path/$1"'}).
               </FieldDescription>
               <Input
                 id="add-new-url"
@@ -353,9 +354,9 @@ export default function RedirectsSettingsPage() {
             <Field>
               <FieldLabel htmlFor="edit-old-url">Old URL</FieldLabel>
               <FieldDescription>
-                The URL path to redirect from (e.g. /old-page). Use a wildcard
-                pattern to match many URLs at once: /blog/.* matches everything
-                under /blog.
+                The URL path to redirect from (e.g. {'"/old-page"'}). Use a wildcard
+                pattern to match many URLs at once: {'"/blog/(.*)"'} matches everything
+                under /blog and captures the matched part for reuse.
               </FieldDescription>
               <Input
                 id="edit-old-url"
@@ -369,9 +370,10 @@ export default function RedirectsSettingsPage() {
             <Field>
               <FieldLabel htmlFor="edit-new-url">New URL</FieldLabel>
               <FieldDescription>
-                Internal path (e.g. /new-page) or external URL (e.g.
-                https://example.com). When the old URL is a wildcard pattern,
-                use $0 to insert the matched path (e.g. /posts/$0).
+                Internal path (e.g. {'"/new-page"'}) or external URL (e.g.
+                {' '}{'"https://example.com"'}). To reuse a captured part of a wildcard
+                pattern, reference it with $1 (e.g. {'"/old-path/(.*)"'} →
+                {' '}{'"/new-path/$1"'}).
               </FieldDescription>
               <Input
                 id="edit-new-url"

--- a/lib/mcp/tools/pages.ts
+++ b/lib/mcp/tools/pages.ts
@@ -251,7 +251,7 @@ or external URL), with optional 301 (permanent) or 302 (temporary) semantics. Pa
 
 Examples:
 - { old_url: "/about-us", new_url: "/about", type: "301" }
-- { old_url: "/blog/.+", new_url: "/posts/$0" } (regex — entire match is $0)
+- { old_url: "/blog/(.*)", new_url: "/posts/$1" } (regex — $1 is the captured group)
 - { old_url: "/", new_url: "/welcome" } (root / homepage redirect)`,
     {
       old_url: z.string().describe('The old internal path (must start with /). Use ".+" or ".*" for regex patterns.'),

--- a/lib/redirect-utils.ts
+++ b/lib/redirect-utils.ts
@@ -1,6 +1,15 @@
 import type { Redirect } from '@/types';
 
 /**
+ * Convert legacy PCRE-style substitution tokens to JS `String.replace` tokens.
+ * The UI documents `$0` as the full matched path (PHP `preg_replace` behavior),
+ * but JS uses `$&` for the full match. `$1`+ capture groups are left untouched.
+ */
+function normalizeReplacementTokens(replacement: string): string {
+  return replacement.replace(/\$0/g, '$$&');
+}
+
+/**
  * Match a request path against configured redirects.
  * Exact string matches take priority, then regex patterns (`.+`, `.*`).
  * Ported from legacy CustomDomain::getRedirectedUrl behavior.
@@ -40,7 +49,7 @@ export function matchRedirect(
       const regex = new RegExp(`^${escapedPattern}$`);
 
       if (regex.test(currentPath)) {
-        const newUrl = currentPath.replace(regex, r.newUrl);
+        const newUrl = currentPath.replace(regex, normalizeReplacementTokens(r.newUrl));
         return { ...r, newUrl };
       }
     } catch {


### PR DESCRIPTION
## Summary

Wildcard redirects never substituted the matched path into the destination — users following the docs (`/blog/.*` → `/post/$0`) ended up with a literal `$0` in the URL. The destination is computed with JavaScript `String.replace`, which does not recognize the legacy PCRE `$0` token.

## Changes

- Map the legacy `$0` token to JavaScript's full-match token (`$&`) so existing redirects that used `$0` keep working instead of leaking a literal `$0`
- Update the redirects settings UI (Add + Edit dialogs) to document capture groups as the recommended approach: `"/old-path/(.*)"` → `"/new-path/$1"`
- Update the `add_redirect` MCP tool example to use a capture group

## Test plan

- [ ] Add a redirect `"/old-path/(.*)"` → `"/new-path/$1"` and confirm `/old-path/foo` redirects to `/new-path/foo`
- [ ] Confirm an exact (non-wildcard) redirect still works
- [ ] Confirm a legacy rule using `$0` inserts the full matched path (backward compat)
- [ ] Verify 301 (default) vs 302 status codes