### PR TITLE
fix: remove built with ycode from page meta description

### DIFF
--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -271,9 +271,9 @@ export async function generatePageMetadata(
   }
 
   // Build description - resolve field variables if collection item is available
-  let description = seo?.description || fallbackDescription || `${page.name} - Built with Ycode`;
+  let description = seo?.description || fallbackDescription || page.name;
   if (collectionItem && seo?.description) {
-    description = resolveInlineVariables(seo.description, collectionItem) || fallbackDescription || `${page.name} - Built with Ycode`;
+    description = resolveInlineVariables(seo.description, collectionItem) || fallbackDescription || page.name;
   }
 
   // Base metadata


### PR DESCRIPTION
## Summary

Pages without a custom SEO description were getting "- Built with Ycode" automatically appended to their meta description, which users have been complaining about. This falls back to the page name instead.

## Changes

- Remove the `- Built with Ycode` suffix from the fallback meta description in `generatePageMetadata`
- Fall back to the page name when no SEO description (or field-resolved description) is set

## Test plan

- [ ] Publish a page with no SEO description set and confirm the meta description no longer contains "- Built with Ycode"
- [ ] Confirm pages with a custom SEO description are unaffected
- [ ] Confirm dynamic (collection) pages resolve their description correctly