### PR TITLE
fix: respect custom slide widths in sliders

### DIFF
--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -193,8 +193,10 @@ const SLIDER_BOOT_SCRIPT = `
   }
 
   function buildConfig(s) {
-    var perView = function (bp) { return resolveResp(s.groupSlide, bp, 1); };
-    var perGroup = function (bp) { return Math.min(resolveResp(s.slidesPerGroup, bp, 1), perView(bp)); };
+    // Per view 1 defers to each slide's own CSS width ('auto'); >1 forces a count.
+    var perViewCount = function (bp) { return resolveResp(s.groupSlide, bp, 1); };
+    var perView = function (bp) { var c = perViewCount(bp); return c > 1 ? c : 'auto'; };
+    var perGroup = function (bp) { return Math.min(resolveResp(s.slidesPerGroup, bp, 1), perViewCount(bp)); };
     var config = {
       slidesPerView: perView('mobile'),
       slidesPerGroup: perGroup('mobile'),

--- a/lib/slider-utils.ts
+++ b/lib/slider-utils.ts
@@ -134,9 +134,17 @@ export function buildBaseSwiperOptions(
 
   if (effectModule) modules.push(effectModule);
 
-  const perView = (bp: Breakpoint) => resolveResponsiveNumber(settings.groupSlide, bp, 1);
+  // When "Per view" is 1 (default), defer to each slide's own CSS width via
+  // `slidesPerView: 'auto'` so custom slide widths (e.g. a peek carousel with
+  // `w-[80%]`) are respected. Only force a numeric slidesPerView when the user
+  // explicitly wants more than one slide per view.
+  const perViewCount = (bp: Breakpoint) => resolveResponsiveNumber(settings.groupSlide, bp, 1);
+  const perView = (bp: Breakpoint): number | 'auto' => {
+    const count = perViewCount(bp);
+    return count > 1 ? count : 'auto';
+  };
   const perGroup = (bp: Breakpoint) =>
-    Math.min(resolveResponsiveNumber(settings.slidesPerGroup, bp, 1), perView(bp));
+    Math.min(resolveResponsiveNumber(settings.slidesPerGroup, bp, 1), perViewCount(bp));
 
   const config: SwiperOptions = {
     modules,


### PR DESCRIPTION
## Summary

Sliders with a custom slide width (for example a peek carousel using `w-[80%] max-w-[800px]`) rendered mis-sized and stopped looping back to the first slide. This restores their behavior while keeping the responsive multi-per-view feature intact.

The regression came from wiring "Per view" to a numeric `slidesPerView`: when Per view was 1 (the default) Swiper forced each slide to the full container width, overriding the slide's own CSS width and breaking the loop wrap.

## Changes

- Use `slidesPerView: 'auto'` when "Per view" is 1 so each slide's CSS width is respected; only force a numeric count when Per view > 1
- Mirror the same logic in the static-export slider boot script

## Test plan

- [ ] Slider with default full-width slides still fills the container and loops
- [ ] Slider with a custom slide width (e.g. `w-[80%]`) renders at its designed width and loops back to the first slide
- [ ] Slider with "Per view" > 1 still shows the configured number of slides
- [ ] Continuous autoplay (delay 0) loops without stopping on the last slide
- [ ] Static export produces a slider with the same behavior