### PR TITLE
fix: set html lang attribute on published pages

### DIFF
--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -576,6 +576,10 @@ export default async function PageRenderer({
   const { bodyClasses, childLayers: rawChildLayers } = extractBodyLayer(resolvedLayers);
   const hasLayers = rawChildLayers.length > 0;
 
+  // Language for <html lang> and the content wrapper. Falls back to the site's
+  // default locale so the document always advertises a language for a11y/SEO.
+  const resolvedLang = locale?.code || availableLocales.find((l) => l.is_default)?.code || undefined;
+
   // Generate CSS for initial animation states to prevent flickering
   const { css: initialAnimationCSS, hiddenLayerInfo } = generateInitialAnimationCSS(resolvedLayers);
 
@@ -883,13 +887,24 @@ export default async function PageRenderer({
       />
       <BodyClassApplier classes={bodyClasses || 'bg-white'} />
 
+      {/* Set <html lang> from the page locale. The root element is rendered by
+          the shared layout (which can't know the per-page locale), so apply it
+          here where the locale is resolved. */}
+      {resolvedLang && (
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `document.documentElement.lang=${JSON.stringify(resolvedLang)}`,
+          }}
+        />
+      )}
+
       <main
         id="ybody"
         className="contents"
         data-layer-id="body"
         data-layer-type="div"
         data-is-empty={hasLayers ? 'false' : 'true'}
-        lang={(locale?.code || availableLocales.find((l) => l.is_default)?.code) || undefined}
+        lang={resolvedLang}
       >
         <LayerRendererPublic
           layers={childLayers}


### PR DESCRIPTION
## Summary

Published pages were rendering the root `<html>` element without a `lang` attribute, failing accessibility audits ("`<html>` element does not have a `[lang]` attribute"). The root element is rendered by the shared site layout, which can't resolve the per-page locale, so the language is now applied where the locale is known.

## Changes

- Resolve the page language once (`resolvedLang`) from the current locale, falling back to the site's default locale
- Set `document.documentElement.lang` via an inline script (same pattern as the existing FOUC body-class script) so `<html>` advertises the correct language
- Reuse `resolvedLang` for the existing `<main id="ybody">` lang attribute

## Notes

- Applied in `PageRenderer` rather than the layout because the shared layout can't resolve the per-page locale (and in the cloud fork doing so would force dynamic rendering and break ISR). The change is identical in both repos.
- The static export path already renders `<html lang>` server-side, so it's unaffected.
- Non-English default locales are respected (no hardcoded `en`).

## Test plan

- [ ] Load a published page and confirm `<html>` has the correct `lang` (e.g. `en`)
- [ ] Set a non-English default locale and confirm `<html lang>` matches it
- [ ] Load a localized page (e.g. French) and confirm `<html lang="fr"`
- [ ] Run a Lighthouse/axe accessibility audit — the `[lang]` warning is gone