### PR TITLE
fix: respect custom slider widths without multi-view flash

### DIFF
--- a/app/site.css
+++ b/app/site.css
@@ -82,24 +82,32 @@
   contain: inline-size;
 }
 
-/* Pre-init slider layout: size slides by the configured per-view before Swiper
-   JS initializes, preventing a flash where every slide is full-width (1 per
-   view) on load. Swiper sets exact inline widths on init which override these.
-   Values are resolved per breakpoint (desktop-first) into CSS vars on the
-   slider root by LayerRenderer. */
+/* Slides never shrink in the slider flex row. */
 [data-slider-id] > .swiper-wrapper > .swiper-slide {
   flex-shrink: 0;
+}
+
+/* Pre-init slide sizing for numeric multi-view sliders (per-view > 1): size
+   slides by the configured per-view before Swiper JS initializes, preventing a
+   flash where every full-width (`w-full`) slide shows one-per-view on load.
+   Only sliders with per-view > 1 carry `data-slider-presize` (see LayerRenderer)
+   so these rules intentionally override the slide's own width utility. Per-view
+   1 sliders are NOT marked, so their own slide width wins — e.g. a custom-width
+   peek carousel `w-[80%]` with slidesPerView 'auto'. Swiper sets exact inline
+   widths on init which override these. Values resolved per breakpoint
+   (desktop-first) into CSS vars on the slider root by LayerRenderer. */
+[data-slider-presize] > .swiper-wrapper > .swiper-slide {
   width: calc(100% / var(--ycode-spv-mobile, 1));
 }
 
 @media (min-width: 768px) {
-  [data-slider-id] > .swiper-wrapper > .swiper-slide {
+  [data-slider-presize] > .swiper-wrapper > .swiper-slide {
     width: calc(100% / var(--ycode-spv-tablet, var(--ycode-spv-mobile, 1)));
   }
 }
 
 @media (min-width: 1024px) {
-  [data-slider-id] > .swiper-wrapper > .swiper-slide {
+  [data-slider-presize] > .swiper-wrapper > .swiper-slide {
     width: calc(100% / var(--ycode-spv-desktop, var(--ycode-spv-tablet, var(--ycode-spv-mobile, 1))));
   }
 }

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -14,7 +14,7 @@ import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEd
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
-import { resolveResponsiveNumber } from '@/lib/slider-utils';
+import { getSliderPresizeVars } from '@/lib/slider-utils';
 import { useCanvasSlider } from '@/hooks/use-canvas-slider';
 import { resolveFieldFromSources } from '@/lib/cms-variables-utils';
 import { getDynamicTextContent, getImageUrlFromVariable, getVideoUrlFromVariable, getIframeUrlFromVariable, isFieldVariable, isAssetVariable, isStaticTextVariable, isDynamicTextVariable, getAssetId, getStaticTextContent, createAssetVariable, createDynamicTextVariable, resolveDesignStyles } from '@/lib/variable-utils';
@@ -2246,17 +2246,14 @@ const LayerItemImpl: React.FC<{
       if (layer.name === 'slider' && layer.settings?.slider) {
         elementProps['data-slider-id'] = layer.id;
         elementProps['data-slider-settings'] = JSON.stringify(layer.settings.slider);
-        // Expose per-view per breakpoint as CSS vars so slides are sized before
-        // Swiper JS runs (prevents a 1-slide flash on load). site.css consumes
-        // these; Swiper overrides with exact inline widths on init.
-        const spv = layer.settings.slider.groupSlide;
-        const existingStyle = (typeof elementProps.style === 'object' && elementProps.style) || {};
-        elementProps.style = {
-          ...existingStyle,
-          '--ycode-spv-mobile': resolveResponsiveNumber(spv, 'mobile', 1),
-          '--ycode-spv-tablet': resolveResponsiveNumber(spv, 'tablet', 1),
-          '--ycode-spv-desktop': resolveResponsiveNumber(spv, 'desktop', 1),
-        };
+        // Pre-size slides before Swiper JS runs (prevents a 1-slide flash) only
+        // for numeric multi-view sliders; per-view 1 keeps its own slide widths.
+        const presizeVars = getSliderPresizeVars(layer.settings.slider);
+        if (presizeVars) {
+          elementProps['data-slider-presize'] = '';
+          const existingStyle = (typeof elementProps.style === 'object' && elementProps.style) || {};
+          elementProps.style = { ...existingStyle, ...presizeVars };
+        }
       }
       if (SWIPER_DATA_ATTR_MAP[layer.name]) {
         elementProps[SWIPER_DATA_ATTR_MAP[layer.name]] = '';

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -20,7 +20,7 @@ import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextCo
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
 import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
-import { resolveResponsiveNumber } from '@/lib/slider-utils';
+import { getSliderPresizeVars } from '@/lib/slider-utils';
 import { getDynamicTextContent, getImageUrlFromVariable, getVideoUrlFromVariable, getIframeUrlFromVariable, isFieldVariable, isAssetVariable, isStaticTextVariable, isDynamicTextVariable, getStaticTextContent, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
 import { getTranslatedAssetId, getTranslatedText } from '@/lib/locale-runtime';
 import { isValidLinkSettings, generateLinkHref, resolveLinkAttrs, isLinkAtCollectionBoundary, isLinkToCurrentPage, type LinkResolutionContext } from '@/lib/link-utils';
@@ -973,17 +973,14 @@ const LayerItem: React.FC<{
       if (layer.name === 'slider' && layer.settings?.slider) {
         elementProps['data-slider-id'] = layer.id;
         elementProps['data-slider-settings'] = JSON.stringify(layer.settings.slider);
-        // Expose per-view per breakpoint as CSS vars so slides are sized before
-        // Swiper JS runs (prevents a 1-slide flash on load). site.css consumes
-        // these; Swiper overrides with exact inline widths on init.
-        const spv = layer.settings.slider.groupSlide;
-        const existingStyle = (typeof elementProps.style === 'object' && elementProps.style) || {};
-        elementProps.style = {
-          ...existingStyle,
-          '--ycode-spv-mobile': resolveResponsiveNumber(spv, 'mobile', 1),
-          '--ycode-spv-tablet': resolveResponsiveNumber(spv, 'tablet', 1),
-          '--ycode-spv-desktop': resolveResponsiveNumber(spv, 'desktop', 1),
-        };
+        // Pre-size slides before Swiper JS runs (prevents a 1-slide flash) only
+        // for numeric multi-view sliders; per-view 1 keeps its own slide widths.
+        const presizeVars = getSliderPresizeVars(layer.settings.slider);
+        if (presizeVars) {
+          elementProps['data-slider-presize'] = '';
+          const existingStyle = (typeof elementProps.style === 'object' && elementProps.style) || {};
+          elementProps.style = { ...existingStyle, ...presizeVars };
+        }
       }
       if (SWIPER_DATA_ATTR_MAP[layer.name]) {
         elementProps[SWIPER_DATA_ATTR_MAP[layer.name]] = '';

--- a/lib/slider-utils.ts
+++ b/lib/slider-utils.ts
@@ -70,6 +70,23 @@ export function maxResponsiveNumber(value: ResponsiveNumber | undefined, fallbac
 }
 
 /**
+ * Per-breakpoint per-view CSS vars used to pre-size slides before Swiper inits
+ * (prevents a 1-slide flash), or null when not needed. Only numeric multi-view
+ * sliders (per-view > 1 on some breakpoint) are pre-sized; per-view 1 sliders
+ * keep their own slide widths (e.g. custom-width peek carousels using 'auto').
+ * The presence of this object also gates the `data-slider-presize` marker.
+ */
+export function getSliderPresizeVars(settings: SliderSettings): Record<string, number> | null {
+  const spv = settings.groupSlide;
+  if (maxResponsiveNumber(spv, 1) <= 1) return null;
+  return {
+    '--ycode-spv-mobile': resolveResponsiveNumber(spv, 'mobile', 1),
+    '--ycode-spv-tablet': resolveResponsiveNumber(spv, 'tablet', 1),
+    '--ycode-spv-desktop': resolveResponsiveNumber(spv, 'desktop', 1),
+  };
+}
+
+/**
  * Snapshot React-applied inline CSS custom properties (e.g. --bg-img) on a
  * slider's slide elements and return a restore function. Swiper's
  * destroy(cleanStyles=true) wipes each slide's entire style attribute, which


### PR DESCRIPTION
## Summary

Sliders with a custom slide width and "Per view" 1 (e.g. a testimonials or peek carousel using `w-[33.3%]`) rendered as a single full-width slide on published/preview pages, even though the builder showed them correctly. The pre-init sizing CSS that prevents a load flash for multi-view sliders was overriding those custom widths.

## Changes

- Only mark sliders with "Per view" > 1 with `data-slider-presize`, so the pre-size rule (`width: 100%/per-view`) applies only to numeric multi-view sliders — keeping their no-flash behaviour
- Per-view-1 sliders are no longer pre-sized, so their own slide widths win (`slidesPerView: 'auto'`)
- Scope the pre-size CSS in `app/site.css` to `[data-slider-presize]`
- Extract per-view CSS vars into a shared `getSliderPresizeVars` helper used by both renderers

## Test plan

- [ ] Per-view-1 slider with custom slide widths (`w-[33.3%]`) shows all slides across the row in preview and published pages
- [ ] Per-view > 1 slider (`w-full` slides) shows the configured count with no 1→N flash on load
- [ ] Responsive per-view (e.g. 1 on mobile, 3 on desktop) renders correctly at each breakpoint
- [ ] Builder canvas rendering is unchanged