### PR TITLE
fix: prevent large image uploads from failing on Vercel

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -891,8 +891,10 @@ export const cacheApi = {
 
 // File Upload API
 
-// Files above this threshold use presigned URLs to bypass serverless body limits
-const DIRECT_UPLOAD_THRESHOLD = 4.5 * 1024 * 1024; // 4.5MB
+// Files above this threshold use presigned URLs to bypass serverless body limits.
+// Vercel caps the serverless request body at ~4.5MB, and multipart/form-data adds
+// encoding overhead on top of the raw file, so we keep headroom below the hard limit.
+const DIRECT_UPLOAD_THRESHOLD = 4 * 1024 * 1024; // 4MB
 
 /**
  * Upload a file via presigned URL (direct browser-to-storage).
@@ -961,7 +963,7 @@ async function uploadViaPresignedUrl(
 
 /**
  * Upload a file and create Asset record.
- * Small files (<4.5MB) go through the server for WebP conversion.
+ * Small files (<4MB) go through the server for WebP conversion.
  * Large files use presigned URLs to upload directly to storage.
  *
  * @param file - File to upload


### PR DESCRIPTION
## Summary

Uploading images just under 4.5MB failed on Vercel with a 413 error. The client picked the upload path based on a threshold set exactly at Vercel's ~4.5MB serverless request body limit, leaving no headroom for `multipart/form-data` encoding overhead. Lowering the threshold to 4MB routes near-limit files through the presigned direct-to-storage path.

## Changes

- Lower `DIRECT_UPLOAD_THRESHOLD` from 4.5MB to 4MB in `lib/api.ts`
- Update comment and JSDoc to reflect the new threshold and explain the Vercel body limit reasoning

## Test plan

- [ ] On a Vercel deployment, upload an image between 4MB and 4.5MB — should succeed via the presigned URL path
- [ ] Upload a small image (<4MB) — should still go through the server and be converted to WebP
- [ ] Upload a large image (>10MB, under 50MB cap) — should still succeed