### PR TITLE
fix: remove buttons broken by browser extensions

### DIFF
--- a/app/(builder)/ycode/components/BorderControls.tsx
+++ b/app/(builder)/ycode/components/BorderControls.tsx
@@ -466,7 +466,7 @@ const BorderControls = memo(function BorderControls({ layer, onLayerUpdate, acti
                     className="justify-start w-full"
                     onClick={handleAddBorder}
                   >
-                      <div className="size-5 rounded-[6px] shrink-0 -ml-1 relative overflow-hidden outline outline-current/10 outline-offset-[-1px]">
+                      <div className="size-5 rounded-[6px] shrink-0 -ml-1 relative overflow-hidden outline outline-current/10 -outline-offset-1">
                         <div className="absolute inset-0 opacity-15 bg-checkerboard bg-background z-10" />
                       </div>
                       <span className="dark:opacity-50">Add...</span>
@@ -478,7 +478,7 @@ const BorderControls = memo(function BorderControls({ layer, onLayerUpdate, acti
                     className="justify-start w-full"
                   >
                       <div className="flex items-center gap-2">
-                        <div className="size-5 rounded-[6px] shrink-0 -ml-1 relative overflow-hidden outline dark:outline-white/10 outline-offset-[-1px]">
+                        <div className="size-5 rounded-[6px] shrink-0 -ml-1 relative overflow-hidden outline dark:outline-white/10 -outline-offset-1">
                           <div className="absolute inset-0 z-20" style={{ background: parseBorderColorToCss(borderColor, colorVariables) }} />
                           <div className="absolute inset-0 opacity-15 bg-checkerboard bg-background z-10" />
                         </div>
@@ -721,14 +721,13 @@ const BorderControls = memo(function BorderControls({ layer, onLayerUpdate, acti
                   </div>
                 </PopoverContent>
               </Popover>
-              <span
-                role="button"
-                tabIndex={0}
+              <button
+                type="button"
                 className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                 onClick={handleRemoveDivider}
               >
                 <Icon name="x" className="size-2.5" />
-              </span>
+              </button>
             </div>
           </div>
         )}
@@ -745,7 +744,7 @@ const BorderControls = memo(function BorderControls({ layer, onLayerUpdate, acti
                     className="justify-start flex-1"
                   >
                     <div className="flex items-center gap-2">
-                      <div className="size-5 rounded-[6px] shrink-0 -ml-1 relative overflow-hidden outline dark:outline-white/10 outline-offset-[-1px]">
+                      <div className="size-5 rounded-[6px] shrink-0 -ml-1 relative overflow-hidden outline dark:outline-white/10 -outline-offset-1">
                         <div className="absolute inset-0 z-20" style={{ background: parseBorderColorToCss(outlineColor, colorVariables) }} />
                         <div className="absolute inset-0 opacity-15 bg-checkerboard bg-background z-10" />
                       </div>
@@ -800,14 +799,13 @@ const BorderControls = memo(function BorderControls({ layer, onLayerUpdate, acti
                   </div>
                 </PopoverContent>
               </Popover>
-              <span
-                role="button"
-                tabIndex={0}
+              <button
+                type="button"
                 className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                 onClick={handleRemoveOutline}
               >
                 <Icon name="x" className="size-2.5" />
-              </span>
+              </button>
             </div>
           </div>
         )}

--- a/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
+++ b/app/(builder)/ycode/components/CollectionFiltersSettings.tsx
@@ -671,14 +671,13 @@ export default function CollectionFiltersSettings({
             <Icon name="database" className="size-2.5 opacity-60" />
           </div>
           <Label variant="muted" className="truncate">Item ID</Label>
-          <span
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
             className="ml-auto -my-1 -mr-0.5 shrink-0 p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
             onClick={() => handleRemoveCondition(group.id, condition.id)}
           >
             <Icon name="x" className="size-2.5" />
-          </span>
+          </button>
         </header>
 
         <Select
@@ -761,14 +760,13 @@ export default function CollectionFiltersSettings({
             </div>
             <Label variant="muted" className="truncate">{displayName}</Label>
 
-            <span
-              role="button"
-              tabIndex={0}
+            <button
+              type="button"
               className="ml-auto -my-1 -mr-0.5 shrink-0 p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
               onClick={() => handleRemoveCondition(group.id, condition.id)}
             >
               <Icon name="x" className="size-2.5" />
-            </span>
+            </button>
           </header>
 
           {/* Operator Select */}

--- a/app/(builder)/ycode/components/ColorPicker.tsx
+++ b/app/(builder)/ycode/components/ColorPicker.tsx
@@ -1983,14 +1983,13 @@ export default function ColorPicker({
           <Label variant="muted" className="truncate max-w-30 cursor-pointer">
             {imagePreviewUrl ? (imageLabel || 'Image') : getDisplayText(displayValue, rgbaColor.a)}
           </Label>
-          <span
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
             className="ml-auto -mr-0.5 p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
             onClick={handleClear}
           >
             <Icon name="x" className="size-2.5" />
-          </span>
+          </button>
         </div>
       ) : (
           <Button
@@ -2121,14 +2120,13 @@ export default function ColorPicker({
                     <Label variant="muted" className="truncate text-xs flex-1">
                       {solidBinding.fieldName || 'Color field'}
                     </Label>
-                    <span
-                      role="button"
-                      tabIndex={0}
+                    <button
+                      type="button"
                       className="ml-auto -mr-0.5 p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                       onClick={() => binding?.onUnbind(null)}
                     >
                       <Icon name="x" className="size-2.5" />
-                    </span>
+                    </button>
                   </div>
                 ) : (
                   <div className="flex items-center gap-2">
@@ -2259,14 +2257,13 @@ export default function ColorPicker({
                           <Label variant="muted" className="truncate text-xs flex-1">
                             {stopBinding.fieldName || 'Color field'}
                           </Label>
-                          <span
-                            role="button"
-                            tabIndex={0}
+                          <button
+                            type="button"
                             className="ml-auto -mr-0.5 p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                             onClick={() => binding?.onUnbind(selectedStopId)}
                           >
                             <Icon name="x" className="size-2.5" />
-                          </span>
+                          </button>
                         </div>
                       ) : (
                         <div className="flex items-center gap-2">
@@ -2388,14 +2385,13 @@ export default function ColorPicker({
                           <Label variant="muted" className="truncate text-xs flex-1">
                             {stopBinding.fieldName || 'Color field'}
                           </Label>
-                          <span
-                            role="button"
-                            tabIndex={0}
+                          <button
+                            type="button"
                             className="ml-auto -mr-0.5 p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                             onClick={() => binding?.onUnbind(selectedStopId)}
                           >
                             <Icon name="x" className="size-2.5" />
-                          </span>
+                          </button>
                         </div>
                       ) : (
                         <div className="flex items-center gap-2">

--- a/app/(builder)/ycode/components/ConditionalVisibilitySettings.tsx
+++ b/app/(builder)/ycode/components/ConditionalVisibilitySettings.tsx
@@ -645,14 +645,13 @@ export default function ConditionalVisibilitySettings({
               <Icon name="database" className="size-2.5 opacity-60" />
             </div>
             <Label variant="muted" className="truncate">Item ID</Label>
-            <span
-              role="button"
-              tabIndex={0}
+            <button
+              type="button"
               className="ml-auto -my-1 -mr-0.5 shrink-0 p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
               onClick={() => handleRemoveCondition(group.id, condition.id)}
             >
               <Icon name="x" className="size-2.5" />
-            </span>
+            </button>
           </header>
 
           <Select
@@ -717,14 +716,13 @@ export default function ConditionalVisibilitySettings({
             </div>
             <Label variant="muted" className="truncate">{displayName}</Label>
 
-            <span
-              role="button"
-              tabIndex={0}
+            <button
+              type="button"
               className="ml-auto -my-1 -mr-0.5 shrink-0 p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
               onClick={() => handleRemoveCondition(group.id, condition.id)}
             >
               <Icon name="x" className="size-2.5" />
-            </span>
+            </button>
           </header>
 
           {/* Operator Select */}

--- a/app/(builder)/ycode/components/EffectControls.tsx
+++ b/app/(builder)/ycode/components/EffectControls.tsx
@@ -512,7 +512,7 @@ const EffectControls = memo(function EffectControls({ layer, onLayerUpdate, acti
                         variant="input" size="sm"
                         className="justify-start"
                       >
-                        <div className="size-5 rounded-[6px] shrink-0 -ml-1 relative overflow-hidden outline outline-current/10 outline-offset-[-1px]">
+                        <div className="size-5 rounded-[6px] shrink-0 -ml-1 relative overflow-hidden outline outline-current/10 -outline-offset-1">
                           <div className="absolute inset-0 opacity-15 bg-checkerboard bg-background z-10" />
                         </div>
                         <span className="dark:opacity-50">Add...</span>
@@ -720,14 +720,13 @@ const EffectControls = memo(function EffectControls({ layer, onLayerUpdate, acti
                     step={1}
                   />
                 </div>
-                <span
-                  role="button"
-                  tabIndex={0}
+                <button
+                  type="button"
                   className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                   onClick={handleRemoveBlur}
                 >
                   <Icon name="x" className="size-2.5" />
-                </span>
+                </button>
               </div>
             </div>
           )}
@@ -757,14 +756,13 @@ const EffectControls = memo(function EffectControls({ layer, onLayerUpdate, acti
                     step={1}
                   />
                 </div>
-                <span
-                  role="button"
-                  tabIndex={0}
+                <button
+                  type="button"
                   className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                   onClick={handleRemoveBackdropBlur}
                 >
                   <Icon name="x" className="size-2.5" />
-                </span>
+                </button>
               </div>
             </div>
           )}

--- a/app/(builder)/ycode/components/InteractionsPanel.tsx
+++ b/app/(builder)/ycode/components/InteractionsPanel.tsx
@@ -187,9 +187,8 @@ function SortableAnimationItem({
         })()}
       </Badge>
 
-      <span
-        role="button"
-        tabIndex={0}
+      <button
+        type="button"
         className="-mr-0.5 p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
         onClick={(e) => {
           e.stopPropagation();
@@ -197,7 +196,7 @@ function SortableAnimationItem({
         }}
       >
         <Icon name="x" className="size-2.5" />
-      </span>
+      </button>
     </div>
   );
 }
@@ -1245,9 +1244,8 @@ export default function InteractionsPanel({
                 {TRIGGER_LABELS[interaction.trigger]}
               </Label>
 
-              <span
-                role="button"
-                tabIndex={0}
+              <button
+                type="button"
                 className="ml-auto -my-1 -mr-0.5 p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                 onClick={(e) => {
                   e.stopPropagation();
@@ -1255,7 +1253,7 @@ export default function InteractionsPanel({
                 }}
               >
                 <Icon name="x" className="size-2.5" />
-              </span>
+              </button>
             </div>
           ))}
         </div>
@@ -2126,14 +2124,13 @@ export default function InteractionsPanel({
                       <span className="text-xs text-muted-foreground">
                         {propertyOption.label}
                       </span>
-                      <span
-                        role="button"
-                        tabIndex={0}
+                      <button
+                        type="button"
                         className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                         onClick={() => handleRemovePropertyFromTween(selectedTween.id, propertyOption.type)}
                       >
                         <Icon name="x" className="size-2.5" />
-                      </span>
+                      </button>
                     </div>
 
                     {propertyOption.properties.map((prop) => {

--- a/app/(builder)/ycode/components/LayerStylesPanel.tsx
+++ b/app/(builder)/ycode/components/LayerStylesPanel.tsx
@@ -136,15 +136,15 @@ function SortableStyleChip({
           <span className="text-yellow-400 text-[10px]">Customized</span>
         )}
       </span>
-      <span
-        role="button"
+      <button
+        type="button"
         tabIndex={-1}
         onPointerDown={(e) => e.stopPropagation()}
         onClick={(e) => { e.stopPropagation(); onRemove(); }}
         className="shrink-0 cursor-pointer opacity-60 hover:opacity-100"
       >
         <Icon name="x" className="size-2.5" />
-      </span>
+      </button>
     </div>
   );
 }

--- a/app/(builder)/ycode/components/SizingControls.tsx
+++ b/app/(builder)/ycode/components/SizingControls.tsx
@@ -730,14 +730,13 @@ const SizingControls = memo(function SizingControls({ layer, onLayerUpdate }: Si
                 </SelectContent>
               </Select>
             </ButtonGroup>
-            <span
-              role="button"
-              tabIndex={0}
+            <button
+              type="button"
               className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
               onClick={handleRemoveAspectRatio}
             >
               <Icon name="x" className="size-2.5" />
-            </span>
+            </button>
           </div>
         </div>
       )}

--- a/app/(builder)/ycode/components/TransformControls.tsx
+++ b/app/(builder)/ycode/components/TransformControls.tsx
@@ -167,16 +167,14 @@ const TransformControls = memo(function TransformControls({ layer, onLayerUpdate
   };
 
   const renderRemoveButton = (id: string) => (
-    <span
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
       aria-label={`Remove ${id}`}
       className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer shrink-0"
       onClick={removeHandlers[id]}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); removeHandlers[id](); } }}
     >
       <Icon name="x" className="size-2.5" />
-    </span>
+    </button>
   );
 
   const scaleSliderValue = parseFloat(inputs.scale[0]) || 1;

--- a/app/(builder)/ycode/components/TransitionControls.tsx
+++ b/app/(builder)/ycode/components/TransitionControls.tsx
@@ -118,16 +118,14 @@ const TransitionControls = memo(function TransitionControls({ layer, onLayerUpda
   }, [deactivate, inputs.delay, updateDesignProperty]);
 
   const renderRemoveButton = (id: string, onRemove: () => void) => (
-    <span
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
       aria-label={`Remove ${id}`}
       className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer shrink-0"
       onClick={onRemove}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onRemove(); } }}
     >
       <Icon name="x" className="size-2.5" />
-    </span>
+    </button>
   );
 
   return (

--- a/app/(builder)/ycode/components/TypographyControls.tsx
+++ b/app/(builder)/ycode/components/TypographyControls.tsx
@@ -622,14 +622,13 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
                   </div>
                 </PopoverContent>
               </Popover>
-              <span
-                role="button"
-                tabIndex={0}
+              <button
+                type="button"
                 className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                 onClick={handleRemoveUnderline}
               >
                 <Icon name="x" className="size-2.5" />
-              </span>
+              </button>
             </div>
           </div>
         )}
@@ -654,14 +653,13 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
                   </SelectGroup>
                 </SelectContent>
               </Select>
-              <span
-                role="button"
-                tabIndex={0}
+              <button
+                type="button"
                 className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                 onClick={handleRemoveTransform}
               >
                 <Icon name="x" className="size-2.5" />
-              </span>
+              </button>
             </div>
           </div>
         )}
@@ -679,14 +677,13 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
                 placeholder="2"
                 className="flex-1"
               />
-              <span
-                role="button"
-                tabIndex={0}
+              <button
+                type="button"
                 className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
                 onClick={handleRemoveLineClamp}
               >
                 <Icon name="x" className="size-2.5" />
-              </span>
+              </button>
             </div>
           </div>
         )}

--- a/app/(builder)/ycode/settings/agent/page.tsx
+++ b/app/(builder)/ycode/settings/agent/page.tsx
@@ -349,16 +349,9 @@ function ProviderCard({ provider, isConnected, scope, onOpenSettings }: Provider
   const models = AGENT_MODELS.filter((option) => option.provider === provider.id);
 
   return (
-    <div
+    <button
+      type="button"
       onClick={onOpenSettings}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onOpenSettings();
-        }
-      }}
       className="flex items-center gap-3 w-full p-4 bg-secondary/20 rounded-lg transition-colors text-left hover:bg-secondary/40 cursor-pointer"
     >
       <div className="flex items-center justify-center size-10 rounded-lg bg-secondary shrink-0">
@@ -374,7 +367,7 @@ function ProviderCard({ provider, isConnected, scope, onOpenSettings }: Provider
 
       {isConnected && <ProviderScopeBadge scope={scope} className="shrink-0" />}
       <ProviderStatusBadge isConnected={isConnected} className="shrink-0" />
-    </div>
+    </button>
   );
 }
 

--- a/components/ui/input-group.tsx
+++ b/components/ui/input-group.tsx
@@ -37,7 +37,7 @@ function InputGroup({ className, size = 'xs', ...props }: InputGroupProps) {
           'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
 
           // Focus state.
-          'has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-[0px]',
+          'has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-0',
 
           // Error state.
           'has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40',
@@ -209,22 +209,22 @@ function InputGroupInput({
       {stepper && !props.disabled && (
         <InputGroupAddon align="inline-end" className="p-0 px-1.5 hidden group-hover:flex absolute right-0 top-0 h-full items-center rounded-r-[10px]">
           <div className="flex flex-col -gap-px">
-            <span
-              role="button"
+            <button
+              type="button"
               tabIndex={-1}
               className="p-0 opacity-50 hover:opacity-100 transition-opacity cursor-pointer"
               onClick={handleIncrement}
             >
               <Icon name="chevronUp" className="size-2.5" />
-            </span>
-            <span
-              role="button"
+            </button>
+            <button
+              type="button"
               tabIndex={-1}
               className="p-0 opacity-50 hover:opacity-100 transition-opacity cursor-pointer -mt-0.5"
               onClick={handleDecrement}
             >
               <Icon name="chevronDown" className="size-2.5" />
-            </span>
+            </button>
           </div>
         </InputGroupAddon>
       )}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -141,7 +141,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(function Input({
           step={step}
           className={cn(
             'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground bg-input border-transparent w-full min-w-0 border transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:font-medium disabled:cursor-not-allowed disabled:opacity-50',
-            'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[0px]',
+            'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-0',
             '',
             'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
             sizeClasses[size],
@@ -156,22 +156,22 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(function Input({
         {!props.disabled && (
           <div className="absolute right-px top-px bottom-px items-center rounded-r-[10px] hidden group-hover:flex px-1.5">
             <div className="flex flex-col -gap-px">
-              <span
-                role="button"
+              <button
+                type="button"
                 tabIndex={-1}
                 className="p-0 opacity-50 hover:opacity-100 transition-opacity cursor-pointer"
                 onClick={handleIncrement}
               >
                 <Icon name="chevronUp" className="size-2.5" />
-              </span>
-              <span
-                role="button"
+              </button>
+              <button
+                type="button"
                 tabIndex={-1}
                 className="p-0 opacity-50 hover:opacity-100 transition-opacity cursor-pointer -mt-0.5"
                 onClick={handleDecrement}
               >
                 <Icon name="chevronDown" className="size-2.5" />
-              </span>
+              </button>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

Some remove (X) icons and other controls in the builder panels stopped working when certain browser extensions (e.g. the Flylighter web clipper) were active. Those extensions inject document-level click listeners that swallow clicks on non-interactive elements. The affected controls were built as `<span role="button">` / `<div role="button">` rather than real buttons, so their clicks were intercepted.

## Changes

- Convert remove/clear and stepper controls from `<span/div role="button">` to native `<button type="button">` across the interactions, typography, border, effects, sizing, color, layer-styles, filters, and conditional-visibility panels, plus the shared input number-steppers and the agent provider card
- Drop now-redundant `role`, `tabIndex`, and duplicated `onKeyDown` handlers (native buttons handle focus and Enter/Space automatically); preserve `tabIndex={-1}` and `onPointerDown` where needed
- Leave controls that live inside an existing `<button>` as spans to avoid generating invalid nested buttons
- Tidy a few Tailwind class shorthands (`ring-0`, `-outline-offset-1`)

## Test plan

- [ ] With the Flylighter extension enabled, remove an animation property, tween, and interaction in the Interactions panel
- [ ] Remove typography (underline/transform/line-clamp), border divider/outline, blur/backdrop-blur, and aspect ratio
- [ ] Clear a color and unbind a CMS color field (solid + gradient stops)
- [ ] Remove a layer style and confirm drag-reorder still works
- [ ] Use number steppers (up/down) and confirm they don't steal tab focus
- [ ] Remove a collection filter / conditional-visibility condition
- [ ] Open a provider settings sheet from the Agent settings card
- [ ] Re-verify all of the above with the extension disabled (no regressions)