### PR TITLE
fix: avoid noisy geocoding error when map token missing

### DIFF
--- a/app/(builder)/ycode/api/maps/geocode/route.ts
+++ b/app/(builder)/ycode/api/maps/geocode/route.ts
@@ -105,11 +105,17 @@ export async function GET(request: NextRequest) {
       headers: { 'Cache-Control': 'public, max-age=432000, s-maxage=432000' },
     });
   } catch (error) {
-    console.error('Geocoding error:', error);
     const message = error instanceof Error ? error.message : 'Failed to geocode address';
+
+    // A missing provider token is an expected config state, not a server error
+    const isNotConfigured = message.includes('not configured');
+    if (!isNotConfigured) {
+      console.error('Geocoding error:', error);
+    }
+
     return NextResponse.json(
       { error: message },
-      { status: message.includes('not configured') ? 400 : 500 }
+      { status: isNotConfigured ? 400 : 500 }
     );
   }
 }

--- a/app/(builder)/ycode/components/MapSettings.tsx
+++ b/app/(builder)/ycode/components/MapSettings.tsx
@@ -176,7 +176,7 @@ export default function MapSettings({ layer, onLayerUpdate }: MapSettingsProps) 
 
   // Geocoding search via API route
   useEffect(() => {
-    if (!debouncedQuery || debouncedQuery.length < 3) {
+    if (!hasToken || !debouncedQuery || debouncedQuery.length < 3) {
       setSearchResults([]);
       return;
     }
@@ -201,7 +201,7 @@ export default function MapSettings({ layer, onLayerUpdate }: MapSettingsProps) 
         }
       })
       .finally(() => setIsSearching(false));
-  }, [debouncedQuery, provider]);
+  }, [debouncedQuery, provider, hasToken]);
 
   const handleSelectResult = useCallback(
     (result: SearchResult) => {


### PR DESCRIPTION
## Summary

Prevent a noisy geocoding error from appearing when a map layer's provider token isn't configured. The map settings panel was firing address-search requests even when it already knew no token existed, and the geocode API route logged a full error stack trace for what is really an expected configuration state.

## Changes

- Skip the geocode search request in `MapSettings` when no provider token is configured (`hasToken` guard)
- Treat a missing provider token as an expected `400` response in the geocode API route instead of logging a server error

## Test plan

- [ ] Add a map layer without configuring a Mapbox/Google token and type in the address search — no console error appears and no request is sent
- [ ] Configure a valid token and confirm address search still returns results