### PR TITLE
fix: render page body wrapper as div instead of main

### DIFF
--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -898,7 +898,7 @@ export default async function PageRenderer({
         />
       )}
 
-      <main
+      <div
         id="ybody"
         className="contents"
         data-layer-id="body"
@@ -945,7 +945,7 @@ export default async function PageRenderer({
             isPublished={passwordProtection.isPublished}
           />
         )}
-      </main>
+      </div>
 
       {/* Initialize GSAP animations based on layer interactions.
           Skipped entirely when no layer has interactions so we don't ship


### PR DESCRIPTION
## Summary

The published/preview page body wrapper (`#ybody`) was emitted as a `<main>` element, creating a `main` ARIA landmark that wrapped the entire document — including nav, header, and footer. That is semantically incorrect and makes the landmark meaningless for assistive tech. This renders the wrapper as a plain `<div>` instead.

## Changes

- Render the body layer wrapper as `<div id="ybody">` instead of `<main id="ybody">` in `PageRenderer`

## Notes

- The wrapper keeps `className="contents"` (`display: contents`), so layout/visual output is unchanged.
- `data-layer-type` was already `div`, so the tag now matches the layer type.
- Only ID-based CSS (`#ybody select`) targets this element; unaffected by the tag change.
- Users can add their own semantic `<main>` around their content region if desired.

## Test plan

- [ ] Load a published page — layout and styling unchanged
- [ ] Inspect DOM: `#ybody` is a `<div>`, no `main` landmark wrapping nav/header/footer
- [ ] Verify `#ybody select` styling (native select arrow) still applies
- [ ] Load a 401 password-protected page — form still renders correctly