### PR TITLE
fix: improve OpenAI and Google Gemini support in the AI builder

### DIFF
--- a/app/(builder)/ycode/api/ai/chat/route.ts
+++ b/app/(builder)/ycode/api/ai/chat/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { getAgentProvider, AgentConfigurationError } from '@/lib/agent/providers';
+import { humanizeProviderError } from '@/lib/agent/providers/errors';
 import { runAgent } from '@/lib/agent/runtime';
 import { getAuthUser } from '@/lib/supabase-auth';
 import { getTenantIdFromHeaders } from '@/lib/supabase-server';
@@ -144,7 +145,8 @@ export async function POST(request: Request): Promise<Response> {
           send(event);
         }
       } catch (error) {
-        send({ type: 'error', message: error instanceof Error ? error.message : 'Agent run failed' });
+        console.error('[AI chat] Agent run failed:', error);
+        send({ type: 'error', message: humanizeProviderError(error) });
       } finally {
         controller.enqueue(encoder.encode('data: [DONE]\n\n'));
         controller.close();

--- a/app/(builder)/ycode/components/ai/AiChatPanel.tsx
+++ b/app/(builder)/ycode/components/ai/AiChatPanel.tsx
@@ -455,7 +455,7 @@ export default function AiChatPanel({ embedded = false }: AiChatPanelProps) {
     <div className="flex-1 min-h-0 flex flex-col justify-start gap-4 p-3">
       {composer}
       {error && (
-        <div className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+        <div className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2 break-words">
           {error}
         </div>
       )}
@@ -585,7 +585,7 @@ export default function AiChatPanel({ embedded = false }: AiChatPanelProps) {
               ))}
 
               {error && (
-                <div className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+                <div className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2 break-words">
                   {error}
                 </div>
               )}

--- a/app/(builder)/ycode/components/ai/AiChatPanel.tsx
+++ b/app/(builder)/ycode/components/ai/AiChatPanel.tsx
@@ -54,6 +54,47 @@ function parseUrls(text: string): string[] {
   return Array.from(new Set(text.match(URL_REGEX) ?? [])).map((url) => url.replace(/[.,)]+$/, ''));
 }
 
+/** Split text on bare URLs and render each as a link opening in a new tab. */
+function linkifyText(text: string): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(URL_REGEX)) {
+    // Trailing punctuation belongs to the sentence, not the URL.
+    const url = match[0].replace(/[.,)]+$/, '');
+    if (match.index > lastIndex) {
+      nodes.push(text.slice(lastIndex, match.index));
+    }
+    nodes.push(
+      <a
+        key={`${url}-${match.index}`}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline underline-offset-2 break-all hover:opacity-80"
+      >
+        {url}
+      </a>,
+    );
+    lastIndex = match.index + url.length;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+  return nodes;
+}
+
+/** Error banner shown in the chat transcript; provider errors often contain
+ * docs/billing URLs, so bare links render clickable. */
+function ErrorNotice({ message }: { message: string }) {
+  return (
+    <div className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2 break-words">
+      {linkifyText(message)}
+    </div>
+  );
+}
+
 // Configure markdown parsing once rather than passing options on every parse.
 marked.setOptions({ gfm: true, breaks: true });
 
@@ -454,11 +495,7 @@ export default function AiChatPanel({ embedded = false }: AiChatPanelProps) {
   ) : (
     <div className="flex-1 min-h-0 flex flex-col justify-start gap-4 p-3">
       {composer}
-      {error && (
-        <div className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2 break-words">
-          {error}
-        </div>
-      )}
+      {error && <ErrorNotice message={error} />}
     </div>
   );
 
@@ -584,11 +621,7 @@ export default function AiChatPanel({ embedded = false }: AiChatPanelProps) {
                 />
               ))}
 
-              {error && (
-                <div className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2 break-words">
-                  {error}
-                </div>
-              )}
+              {error && <ErrorNotice message={error} />}
             </div>
 
             {showJumpToLatest && (

--- a/app/(builder)/ycode/components/ai/AiChatPanel.tsx
+++ b/app/(builder)/ycode/components/ai/AiChatPanel.tsx
@@ -1002,14 +1002,32 @@ function groupParts(parts: ChatMessagePart[]): PartGroup[] {
   return groups;
 }
 
+/**
+ * Cheap markdown-syntax stripper for live-streamed narration. Re-parsing real
+ * markdown (marked + DOMPurify) on every streamed token is expensive and
+ * flickers on half-written syntax, but raw markers like **Publish** must never
+ * reach the user either — so streaming text drops the syntax and renders the
+ * words plain. Tolerates unterminated markers mid-stream.
+ */
+function stripMarkdownSyntax(text: string): string {
+  return text
+    .replace(/^```[^\n]*$/gm, '')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/^\s*[-*+]\s+/gm, '• ')
+    .replace(/^>\s?/gm, '')
+    .replace(/\*\*|__/g, '')
+    .replace(/`/g, '')
+    .replace(/\*([^*\n]+)\*/g, '$1')
+    // Links: keep the label; a partially streamed "[label](htt" keeps the label.
+    .replace(/!?\[([^\]]*)\]\(([^)]*)\)?/g, '$1');
+}
+
 /** The intermediate narration + tool steps, shown inside the collapsed trail.
  * Narration text is dimmed so the closing summary below stays the focus.
  *
- * While streaming, narration is rendered as plain text rather than markdown:
- * the text grows a token at a time and re-parsing markdown (marked + DOMPurify)
- * on every token is expensive and flickers on half-written syntax. The trail
- * collapses once the turn finishes, so the full markdown render only runs when
- * the user re-expands it. */
+ * While streaming, narration is rendered as markdown-stripped plain text (see
+ * stripMarkdownSyntax). The trail collapses once the turn finishes, so the
+ * full markdown render only runs when the user re-expands it. */
 function ThinkingTrail({ parts, streaming }: { parts: ChatMessagePart[]; streaming: boolean }) {
   // Failed tool calls are hidden: the agent retries after errors, so showing
   // red X rows only alarms the user about steps that were already recovered.
@@ -1029,7 +1047,7 @@ function ThinkingTrail({ parts, streaming }: { parts: ChatMessagePart[]; streami
         ) : (
           <div key={index} className="opacity-60">
             {streaming ? (
-              <div className="text-xs leading-relaxed break-words whitespace-pre-wrap">{group.text}</div>
+              <div className="text-xs leading-relaxed break-words whitespace-pre-wrap">{stripMarkdownSyntax(group.text)}</div>
             ) : (
               <MarkdownText text={group.text} />
             )}

--- a/lib/agent/providers/errors.ts
+++ b/lib/agent/providers/errors.ts
@@ -1,0 +1,34 @@
+/**
+ * Provider SDK errors often carry a raw API response body as their message.
+ * The Google SDK is the worst offender: its message is a JSON envelope
+ * ({"error":{"message":"...","code":429,...}}) whose inner message is itself
+ * another JSON blob, followed by per-quota bullet lines. Unwrap all of that to
+ * the human-readable sentence so the chat panel never shows raw JSON.
+ */
+export function humanizeProviderError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  let message = raw.trim();
+
+  // Unwrap nested {"error":{"message":...}} envelopes (Google nests two deep).
+  for (let depth = 0; depth < 3; depth += 1) {
+    if (!message.startsWith('{')) break;
+    const inner = parseErrorEnvelope(message);
+    if (!inner) break;
+    message = inner;
+  }
+
+  // Keep only the leading prose: Gemini appends "* Quota exceeded for
+  // metric ..." bullet lines and retry hints on separate lines.
+  const firstLine = message.split('\n')[0]?.trim() ?? '';
+  return firstLine || 'Agent run failed';
+}
+
+function parseErrorEnvelope(json: string): string | null {
+  try {
+    const parsed = JSON.parse(json) as { error?: { message?: unknown }; message?: unknown };
+    const inner = parsed.error?.message ?? parsed.message;
+    return typeof inner === 'string' && inner.trim() ? inner.trim() : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/agent/providers/google.ts
+++ b/lib/agent/providers/google.ts
@@ -90,6 +90,9 @@ export function createGoogleProvider(apiKey: string): AgentProvider {
               id: part.functionCall.id ?? `gemini_call_${Date.now()}_${toolCallCounter}`,
               name: part.functionCall.name,
               input: (part.functionCall.args ?? {}) as Record<string, unknown>,
+              // Opaque reasoning signature that must be echoed back on this
+              // functionCall part in history (see toGeminiContents).
+              thoughtSignature: part.thoughtSignature,
             };
           }
         }
@@ -138,7 +141,12 @@ function toGeminiContents(messages: AgentMessage[]): Content[] {
         parts.push({ inlineData: { mimeType: block.mediaType, data: block.data } });
       } else if (block.type === 'tool_use') {
         toolNameById.set(block.id, block.name);
-        parts.push({ functionCall: { name: block.name, args: block.input } });
+        parts.push({
+          functionCall: { name: block.name, args: block.input },
+          // Echo Gemini's thought signature back verbatim — omitting it makes
+          // the API warn and degrades multi-turn tool calling.
+          ...(block.thoughtSignature ? { thoughtSignature: block.thoughtSignature } : {}),
+        });
       } else if (block.type === 'tool_result') {
         parts.push({
           functionResponse: {

--- a/lib/agent/providers/openai.ts
+++ b/lib/agent/providers/openai.ts
@@ -51,14 +51,12 @@ export function createOpenAiProvider(apiKey: string): AgentProvider {
     id: 'openai-byok',
 
     async *streamMessage(options: ProviderStreamOptions): AsyncIterable<ProviderStreamEvent> {
+      const reasoningEffort = reasoningEffortFor(options.model);
       const stream = await client.chat.completions.create(
         {
           model: options.model,
           max_completion_tokens: options.maxTokens,
-          // Design/building work doesn't benefit from deep reasoning the way
-          // code does (Framer measured no eval difference), so default OpenAI
-          // reasoning models to low effort — faster and cheaper per turn.
-          ...(isReasoningModel(options.model) ? { reasoning_effort: 'low' as const } : {}),
+          ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
           messages: [
             { role: 'system', content: options.system },
             ...toOpenAiMessages(options.messages),
@@ -184,9 +182,18 @@ function toOpenAiMessages(messages: AgentMessage[]): OpenAI.Chat.Completions.Cha
   return out;
 }
 
-/** Models that accept the `reasoning_effort` parameter (GPT-5 family and o-series). */
-function isReasoningModel(model: string): boolean {
-  return /^(gpt-5|o\d)/.test(model);
+/**
+ * Reasoning effort per model, or null for models that don't accept the
+ * parameter. Design/building work doesn't benefit from deep reasoning the way
+ * code does (Framer measured no eval difference), so reasoning models default
+ * to low effort. gpt-5.5 rejects function tools combined with reasoning on
+ * /v1/chat/completions ("use /v1/responses or set reasoning_effort to 'none'"),
+ * so it runs with reasoning off — switching this provider to the Responses API
+ * is the path if we ever want reasoning + tools on that model.
+ */
+function reasoningEffortFor(model: string): 'none' | 'low' | null {
+  if (/^gpt-5\.5/.test(model)) return 'none';
+  return /^(gpt-5|o\d)/.test(model) ? 'low' : null;
 }
 
 /** Tool input arrives as streamed partial JSON; empty means a no-arg tool. */

--- a/lib/agent/providers/types.ts
+++ b/lib/agent/providers/types.ts
@@ -28,6 +28,10 @@ export interface AgentToolUseBlock {
   id: string;
   name: string;
   input: Record<string, unknown>;
+  /** Gemini attaches an opaque signature to functionCall parts that must be
+   * echoed back verbatim in history, or tool calling degrades (the API warns
+   * about missing thought_signature). Other providers ignore it. */
+  thoughtSignature?: string;
 }
 
 export interface AgentToolResultBlock {
@@ -64,7 +68,7 @@ export interface AgentUsage {
  */
 export type ProviderStreamEvent =
   | { type: 'text_delta'; text: string }
-  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown>; thoughtSignature?: string }
   | { type: 'message_stop'; stopReason: string | null; usage?: AgentUsage };
 
 export interface ProviderStreamOptions {

--- a/lib/agent/runtime.ts
+++ b/lib/agent/runtime.ts
@@ -236,6 +236,7 @@ export async function* runAgent(options: RunAgentOptions): AsyncIterable<Runtime
             id: event.id,
             name: event.name,
             input: event.input,
+            thoughtSignature: event.thoughtSignature,
           };
           toolUses.push(block);
           yield { type: 'tool_call', id: event.id, name: event.name, input: event.input };

--- a/stores/useAiChatStore.ts
+++ b/stores/useAiChatStore.ts
@@ -58,6 +58,9 @@ export interface ChatMessage {
   mentions?: Mention[];
   /** Wall-clock duration of the turn, shown as "Thought for Ns". */
   thinkingMs?: number;
+  /** Model id that produced this assistant turn (e.g. "claude-sonnet-5").
+   * Absent on user messages and on turns run before this was recorded. */
+  model?: string;
   /** Pages this turn edited, with per-page affected layer counts (Changes card). */
   changes?: TurnChange[];
   /** True for the auto-generated visual self-review turn (rendered compactly). */
@@ -429,6 +432,7 @@ function stripMessageForStorage(message: ChatMessage): ChatMessage {
     thinkingMs: message.thinkingMs,
     changes: message.changes,
     review: message.review,
+    model: message.model,
     // Keep the reference metadata so @page/component/layer badges re-render
     // when a chat is reloaded from history (the raw "@label" text alone can't
     // reconstruct the pill's type/icon).
@@ -504,6 +508,12 @@ export const useAiChatStore = create<AiChatStore>()(
         const isReview = reviewDepth > 0;
         const promptText = trimmed || 'Use the attached image(s) as a reference for what to build.';
 
+        // Review passes run on the cheaper review model of the same provider;
+        // the user's pick only applies to the main turn. Recorded on the
+        // assistant message so history (and the admin transcript view) shows
+        // which model produced each turn.
+        const turnModel = isReview ? reviewModelFor(get().model) : get().model ?? undefined;
+
         const userMessage: ChatMessage = {
           id: newId(),
           role: 'user',
@@ -513,7 +523,14 @@ export const useAiChatStore = create<AiChatStore>()(
           mentions: attachment?.mentions && attachment.mentions.length > 0 ? attachment.mentions : undefined,
           review: isReview || undefined,
         };
-        const assistantMessage: ChatMessage = { id: newId(), role: 'assistant', text: '', toolCalls: [], parts: [] };
+        const assistantMessage: ChatMessage = {
+          id: newId(),
+          role: 'assistant',
+          text: '',
+          toolCalls: [],
+          parts: [],
+          model: turnModel,
+        };
 
         // Fallback Undo baseline: snapshot the active page before the turn in case
         // the server can't supply authoritative before-layers (page_changed
@@ -573,9 +590,7 @@ export const useAiChatStore = create<AiChatStore>()(
               selectedLayers: attachment?.selectedLayers ?? [],
               mentions: attachment?.mentions ?? [],
               referenceUrls: attachment?.referenceUrls ?? [],
-              // Review passes run on the cheaper review model of the same
-              // provider; the user's pick only applies to the main turn.
-              model: isReview ? reviewModelFor(get().model) : get().model ?? undefined,
+              model: turnModel,
             }),
             signal,
           });


### PR DESCRIPTION
## Summary

Fix a set of issues found while testing the AI builder with OpenAI and
Google Gemini providers: broken tool calls on gpt-5.5, degraded Gemini
tool calling, and raw JSON / markdown leaking into the chat UI.

## Changes

- Disable reasoning effort for gpt-5.5 tool calls — the model rejects
  function tools combined with `reasoning_effort` on `/v1/chat/completions`,
  which made every request fail with a 400
- Echo Gemini `thought_signature` back on functionCall parts in tool-call
  history, fixing API warnings and degraded multi-turn tool calling
- Unwrap nested JSON provider error bodies (Gemini 429s especially) into a
  short human-readable message instead of showing the raw blob
- Render URLs in chat error messages as clickable links and wrap long
  unbroken URLs so they no longer overflow the error block
- Strip markdown syntax from live-streamed AI narration so users never see
  raw markers like `**bold**` mid-stream
- Persist the model id on assistant chat turns so history shows which model
  produced each turn

## Test plan

- [ ] Run a build prompt with GPT-5.5 — tool calls succeed (no 400 error)
- [ ] Run a build prompt with GPT-5 Mini — still works with low reasoning effort
- [ ] Run a multi-tool prompt with Gemini — no thought_signature warning
- [ ] Trigger a provider error (e.g. exhausted quota key) — message is readable prose, links are clickable, text stays inside the block
- [ ] Watch the "Working…" trail while streaming — no raw markdown markers appear

Made with [Cursor](https://cursor.com)