### PR TITLE
fix: correct linear easing for sliders

### DIFF
--- a/lib/slider-utils.ts
+++ b/lib/slider-utils.ts
@@ -257,11 +257,28 @@ export function buildCanvasSwiperOptions(
   return config;
 }
 
+/**
+ * Map stored easing values (Tailwind-style class names) to valid CSS
+ * transition-timing-function values. `ease-linear` is not valid CSS — the
+ * correct value is `linear` — while the others coincide with valid CSS.
+ */
+const EASING_TO_CSS: Record<string, string> = {
+  'ease-linear': 'linear',
+  'ease-in': 'ease-in',
+  'ease-in-out': 'ease-in-out',
+  'ease-out': 'ease-out',
+};
+
+/** Convert a stored slider/lightbox easing value to a valid CSS timing function */
+export function easingToCss(easing: string): string {
+  return EASING_TO_CSS[easing] || easing || 'ease-in-out';
+}
+
 /** Apply easing to the Swiper wrapper's CSS transition-timing-function */
 export function applySwiperEasing(swiperEl: HTMLElement, easing: string) {
   const wrapper = swiperEl.querySelector('.swiper-wrapper') as HTMLElement | null;
   if (wrapper) {
-    wrapper.style.transitionTimingFunction = easing || 'ease-in-out';
+    wrapper.style.transitionTimingFunction = easingToCss(easing);
   }
 }
 


### PR DESCRIPTION
## Summary

Slider easing didn't apply the Linear option. The slider stored easing as Tailwind-style class names (`ease-linear`, `ease-in`, `ease-in-out`, `ease-out`) and set them directly as the inline `transition-timing-function`. Three of those coincide with valid CSS values, but `ease-linear` is not valid CSS (the correct value is `linear`), so the browser ignored it and fell back to the default easing.

## Changes

- Add `easingToCss` mapper in `lib/slider-utils.ts` to translate stored easing values to valid CSS timing functions
- Route `applySwiperEasing` through the mapper (single choke point used by both canvas preview and production initializer)

## Test plan

- [ ] Set a slider's easing to Linear and confirm the transition is linear (not eased)
- [ ] Verify Ease in, Ease out, and Ease in out still behave correctly
- [ ] Confirm both the canvas preview and the published page reflect the easing