### PR TITLE
fix: prevent media from playing on the canvas

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -2966,8 +2966,9 @@ const LayerItemImpl: React.FC<{
           const domain = privacyMode ? 'youtube-nocookie.com' : 'youtube.com';
 
           // Build YouTube embed URL with parameters
+          // Never autoplay on the canvas to avoid distracting playback while editing
           const params: string[] = [];
-          if (normalizedAttributes?.autoplay === true) params.push('autoplay=1');
+          if (!isEditMode && normalizedAttributes?.autoplay === true) params.push('autoplay=1');
           if (normalizedAttributes?.muted === true) params.push('mute=1');
           if (normalizedAttributes?.loop === true) params.push(`loop=1&playlist=${videoId}`);
           if (normalizedAttributes?.controls !== true) params.push('controls=0');
@@ -2997,26 +2998,36 @@ const LayerItemImpl: React.FC<{
             applyCustomAttributes(iframeProps, layer.settings.customAttributes);
           }
 
-          // Only add editor event handlers in edit mode (client-side only)
+          // On the canvas, the cross-origin iframe swallows clicks (so the layer
+          // can't be selected) and lets the user start playback. Wrap it in a
+          // selectable container and disable iframe interaction, mirroring the
+          // native media and map handling.
           if (isEditMode && !isEditing) {
-            const originalOnClick = elementProps.onClick as ((e: React.MouseEvent) => void) | undefined;
-            iframeProps.onClick = (e: React.MouseEvent) => {
-              if (isLockedByOther) {
-                e.stopPropagation();
-                e.preventDefault();
-                return;
-              }
-              if (e.button !== 2) {
-                e.stopPropagation();
-                onLayerClick?.(layer.id, e);
-              }
-              if (originalOnClick) {
-                originalOnClick(e);
-              }
-            };
-            iframeProps.onContextMenu = (e: React.MouseEvent) => {
-              e.stopPropagation();
-            };
+            const mediaOnlyKeys = [
+              'controls', 'loop', 'muted', 'preload', 'autoplay', 'volume',
+              'playsInline', 'poster', 'src', 'youtubePrivacyMode',
+              'controlsList', 'crossOrigin', 'disablePictureInPicture', 'disableRemotePlayback',
+            ];
+            const wrapperProps: Record<string, any> = { ...elementProps };
+            mediaOnlyKeys.forEach((key) => delete wrapperProps[key]);
+            // Positioning context so the absolutely-positioned iframe fills the
+            // wrapper's (aspect-ratio) box exactly, with no gaps.
+            wrapperProps.className = `${wrapperProps.className || ''} relative`.trim();
+
+            return (
+              <div {...wrapperProps}>
+                <iframe
+                  key={`youtube-${layer.id}-${videoId}`}
+                  src={embedUrl}
+                  title="YouTube video"
+                  className="absolute inset-0 block h-full w-full pointer-events-none"
+                  style={{ border: 'none' }}
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                  suppressHydrationWarning
+                />
+              </div>
+            );
           }
 
           return (
@@ -3125,7 +3136,8 @@ const LayerItemImpl: React.FC<{
       // React treats autoPlay as a DOM property, not an HTML attribute,
       // so it won't survive SSR or hydration. Remove from props and
       // apply via ref to avoid both the warning and the rendering issue.
-      const shouldAutoPlay = mediaProps.autoplay === true;
+      // Never autoplay on the canvas to avoid distracting playback while editing.
+      const shouldAutoPlay = !isEditMode && mediaProps.autoplay === true;
       delete mediaProps.autoplay;
 
       // React doesn't reliably reflect `muted` to the DOM during SSR/hydration,
@@ -3147,45 +3159,8 @@ const LayerItemImpl: React.FC<{
         mediaProps.poster = posterUrl;
       }
 
-      // Handle special attributes that need to be set on the DOM element
-      // (autoplay, muted, and volume must be set via JavaScript on the DOM element)
-      if (htmlTag === 'audio' || htmlTag === 'video') {
-        const originalRef = mediaProps.ref;
-        const volumeValue = normalizedAttributes?.volume
-          ? parseInt(normalizedAttributes.volume) / 100
-          : undefined;
-
-        if (shouldAutoPlay || shouldMute || volumeValue !== undefined) {
-          mediaProps.ref = (element: HTMLAudioElement | HTMLVideoElement | null) => {
-            if (originalRef) {
-              if (typeof originalRef === 'function') {
-                originalRef(element);
-              } else {
-                (originalRef as React.MutableRefObject<HTMLAudioElement | HTMLVideoElement | null>).current = element;
-              }
-            }
-
-            if (element) {
-              // Mute before play() so mobile browsers allow autoplay.
-              if (shouldMute) {
-                element.muted = true;
-                element.setAttribute('muted', '');
-              }
-              if (shouldAutoPlay) {
-                element.autoplay = true;
-                element.setAttribute('autoplay', '');
-                element.play().catch(() => {});
-              }
-              if (volumeValue !== undefined) {
-                element.volume = volumeValue;
-              }
-            }
-          };
-        }
-      }
-
-      return (
-        <Tag {...mediaProps}>
+      const mediaChildren = (
+        <>
           {textContent && textContent}
           {effectiveChildren && effectiveChildren.length > 0 && (
             <LayerRenderer
@@ -3231,6 +3206,96 @@ const LayerItemImpl: React.FC<{
               lcpCandidateLayerId={lcpCandidateLayerId}
             />
           )}
+        </>
+      );
+
+      // On the canvas, <audio> is entirely native controls that swallow clicks,
+      // so the layer can't be selected and clicking starts playback. Wrap it in
+      // a selectable container and make the element non-interactive. <video> is
+      // handled below without a wrapper so it keeps its exact published sizing.
+      if (isEditMode && htmlTag === 'audio') {
+        // Media-only attributes belong on the element, not the wrapper div.
+        const mediaOnlyKeys = [
+          'controls', 'loop', 'muted', 'preload', 'autoplay', 'volume',
+          'playsInline', 'poster', 'src', 'youtubePrivacyMode',
+          'controlsList', 'crossOrigin', 'disablePictureInPicture', 'disableRemotePlayback',
+        ];
+        const wrapperProps: Record<string, any> = { ...mediaProps };
+        mediaOnlyKeys.forEach((key) => delete wrapperProps[key]);
+        // <audio> has no intrinsic height/width classes. Keep the wrapper
+        // block-level (so stacked players don't sit side by side) but shrink it
+        // to the player's natural width instead of stretching full width.
+        wrapperProps.className = `${wrapperProps.className || ''} w-fit max-w-full`.trim();
+
+        const mediaElementProps: Record<string, any> = { ...normalizedAttributes };
+        delete mediaElementProps.autoplay;
+        delete mediaElementProps.volume;
+        delete mediaElementProps.youtubePrivacyMode;
+        if (mediaSrc) mediaElementProps.src = mediaSrc;
+        mediaElementProps.className = 'pointer-events-none';
+        mediaElementProps.tabIndex = -1;
+        mediaElementProps.suppressHydrationWarning = true;
+
+        return (
+          <div {...wrapperProps}>
+            <Tag {...mediaElementProps}>
+              {mediaChildren}
+            </Tag>
+          </div>
+        );
+      }
+
+      // Block manual playback of <video> on the canvas without altering its
+      // layout: it renders exactly like the published page, but any attempt to
+      // play (clicking to select, native controls) is immediately paused.
+      if (isEditMode && htmlTag === 'video') {
+        const originalOnPlay = mediaProps.onPlay as ((e: React.SyntheticEvent<HTMLVideoElement>) => void) | undefined;
+        mediaProps.onPlay = (e: React.SyntheticEvent<HTMLVideoElement>) => {
+          e.currentTarget.pause();
+          originalOnPlay?.(e);
+        };
+      }
+
+      // Handle special attributes that need to be set on the DOM element
+      // (autoplay, muted, and volume must be set via JavaScript on the DOM element)
+      if (htmlTag === 'audio' || htmlTag === 'video') {
+        const originalRef = mediaProps.ref;
+        const volumeValue = normalizedAttributes?.volume
+          ? parseInt(normalizedAttributes.volume) / 100
+          : undefined;
+
+        if (shouldAutoPlay || shouldMute || volumeValue !== undefined) {
+          mediaProps.ref = (element: HTMLAudioElement | HTMLVideoElement | null) => {
+            if (originalRef) {
+              if (typeof originalRef === 'function') {
+                originalRef(element);
+              } else {
+                (originalRef as React.MutableRefObject<HTMLAudioElement | HTMLVideoElement | null>).current = element;
+              }
+            }
+
+            if (element) {
+              // Mute before play() so mobile browsers allow autoplay.
+              if (shouldMute) {
+                element.muted = true;
+                element.setAttribute('muted', '');
+              }
+              if (shouldAutoPlay) {
+                element.autoplay = true;
+                element.setAttribute('autoplay', '');
+                element.play().catch(() => {});
+              }
+              if (volumeValue !== undefined) {
+                element.volume = volumeValue;
+              }
+            }
+          };
+        }
+      }
+
+      return (
+        <Tag {...mediaProps}>
+          {mediaChildren}
         </Tag>
       );
     }


### PR DESCRIPTION
## Summary

Videos, audio, and YouTube embeds could autoplay or be played while editing on the canvas, which was distracting. They now stay paused in the editor while the published site is unaffected.

## Changes

- Disable autoplay on the canvas for native `<video>`/`<audio>` and YouTube embeds
- Wrap `<audio>` and YouTube iframes in a selectable, non-interactive container so clicking selects the layer instead of triggering playback (their native/cross-origin controls otherwise swallow clicks)
- Pause native `<video>` on any manual play attempt, keeping its exact published sizing (no wrapper, so object-fit and aspect-ratio are preserved)
- Leave published/preview rendering unchanged (autoplay and controls still work on live pages)

## Test plan

- [ ] On the canvas, a video with autoplay does not play; clicking it selects the layer without playing
- [ ] Clicking an audio player on the canvas selects the layer and does not start playback
- [ ] Two stacked audio players remain stacked (not side by side)
- [ ] A YouTube embed on the canvas is selectable and does not autoplay/play
- [ ] Video sizing/aspect-ratio/object-fit on the canvas matches the preview
- [ ] Published page: video/audio/YouTube autoplay and controls still work as before