### PR TITLE
feat: preserve AVIF images instead of converting to WebP

### DIFF
--- a/app/a/[hash]/[...name]/route.ts
+++ b/app/a/[hash]/[...name]/route.ts
@@ -99,30 +99,49 @@ export async function GET(
     // Never run Sharp on GIFs — it flattens animated frames into a single
     // static image, killing the animation. Serve the raw bytes instead.
     const isGif = asset.mime_type === 'image/gif';
+    const isAvif = asset.mime_type === 'image/avif';
     const canResize = transform && isImage && !isGif;
 
     if (canResize) {
       const buffer = Buffer.from(await response.arrayBuffer());
-      let pipeline = sharp(buffer);
 
-      if (transform.width || transform.height) {
-        pipeline = pipeline.resize(transform.width, transform.height, {
-          fit: 'cover',
-          withoutEnlargement: true,
+      try {
+        let pipeline = sharp(buffer);
+
+        if (transform.width || transform.height) {
+          pipeline = pipeline.resize(transform.width, transform.height, {
+            fit: 'cover',
+            withoutEnlargement: true,
+          });
+        }
+
+        // Preserve AVIF on output (already highly compressed); normalize every
+        // other raster format to WebP.
+        pipeline = isAvif
+          ? pipeline.avif({ quality: transform.quality })
+          : pipeline.webp({ quality: transform.quality });
+
+        const resized = await pipeline.toBuffer();
+
+        return new Response(new Uint8Array(resized), {
+          status: 200,
+          headers: {
+            'Content-Type': isAvif ? 'image/avif' : 'image/webp',
+            'Content-Length': resized.length.toString(),
+          },
+        });
+      } catch {
+        // Sharp's bundled decoder can't decode some bitstreams (e.g. 10/12-bit
+        // AVIF, which browsers still render). Since the decode failure blocks
+        // any re-encode, serve the original bytes untouched rather than failing.
+        return new Response(new Uint8Array(buffer), {
+          status: 200,
+          headers: {
+            'Content-Type': asset.mime_type || 'application/octet-stream',
+            'Content-Length': buffer.length.toString(),
+          },
         });
       }
-
-      pipeline = pipeline.webp({ quality: transform.quality });
-
-      const resized = await pipeline.toBuffer();
-
-      return new Response(new Uint8Array(resized), {
-        status: 200,
-        headers: {
-          'Content-Type': 'image/webp',
-          'Content-Length': resized.length.toString(),
-        },
-      });
     }
 
     // Mirror the upstream status (206 for partial content) and range headers so

--- a/lib/file-upload.ts
+++ b/lib/file-upload.ts
@@ -130,10 +130,13 @@ async function convertImageToWebP(file: File): Promise<{
   height: number | null;
 } | null> {
   try {
-    // Only convert raster images (skip SVG, GIF with animations, etc.)
+    // Only convert raster images. Skip SVG, animated GIFs, and AVIF — AVIF is
+    // already a highly-compressed modern format, so re-encoding to WebP would
+    // typically inflate size and lose quality for no benefit.
     if (!isAssetOfType(file.type, ASSET_CATEGORIES.IMAGES) ||
         file.type === 'image/svg+xml' ||
-        file.type === 'image/gif') {
+        file.type === 'image/gif' ||
+        file.type === 'image/avif') {
       return null;
     }
 


### PR DESCRIPTION
## Summary

AVIF is already a highly-compressed modern format. Re-encoding it to WebP — both on upload and during on-the-fly resizing — typically inflates file size and loses quality for no benefit. This keeps AVIF as AVIF end-to-end while staying robust for bitstreams Sharp can't decode.

## Changes

- Skip AVIF in the upload-time WebP converter (`lib/file-upload.ts`), alongside SVG and animated GIF
- Keep AVIF as AVIF through the asset proxy (`/a/...`): resized AVIFs are re-encoded to AVIF, all other raster formats still normalize to WebP
- Fall back to serving the original bytes when Sharp's bundled decoder can't handle a bitstream (e.g. 10/12-bit AVIF, which browsers still render), so the request returns 200 instead of 500

## Test plan

- [ ] Upload an AVIF and confirm it is stored as AVIF (not converted to WebP)
- [ ] Request an 8-bit AVIF via `/a/{hash}/{name}.avif?width=320&quality=85` and confirm it returns resized `image/avif`
- [ ] Request a 10/12-bit AVIF with resize params and confirm it returns 200 with the original bytes (viewable, not a 500)
- [ ] Confirm non-AVIF images (JPG/PNG) still resize to WebP as before
- [ ] Confirm animated GIFs still serve raw (unchanged)