### PR TITLE
fix: AI chat killed after 60 seconds on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,11 +6,11 @@
   "installCommand": "npm install",
   "framework": "nextjs",
   "functions": {
-    "app/(builder)/ycode/api/**/*.ts": {
-      "maxDuration": 60
-    },
     "app/(builder)/ycode/api/ai/chat/route.ts": {
       "maxDuration": 300
+    },
+    "app/(builder)/ycode/api/**/*.ts": {
+      "maxDuration": 60
     },
     "app/(builder)/ycode/mcp/*/route.ts": {
       "maxDuration": 60


### PR DESCRIPTION
## Summary

The 1.28.9 fix that moved the AI chat route's `maxDuration` into `vercel.json` doesn't take effect: Vercel resolves `functions` patterns first-match-wins in definition order, and the 60s catch-all `app/(builder)/ycode/api/**/*.ts` is listed above the chat route entry. Every agent run gets hard-killed at 60 seconds, so turns end silently truncated ("Thought for 1m" with no result).

Refs: [Vercel duration docs](https://vercel.com/docs/functions/configuring-functions/duration) (ordering note), [vercel/vercel#15315](https://github.com/vercel/vercel/issues/15315) (`getLambdaOptionsFromFunction` is first-match-wins).

## Changes

- Move the `app/(builder)/ycode/api/ai/chat/route.ts` entry above the builder API catch-all in `vercel.json` so its 300s budget actually applies

## Test plan

- [ ] Deploy to Vercel and run an agent prompt that takes over a minute — the turn completes instead of stopping at "Thought for 1m"
- [ ] Confirm other builder API routes still show a 60s max duration in the Vercel functions dashboard

Made with [Cursor](https://cursor.com)