### PR TITLE
fix: dropdown and animated menus stay hidden on published pages

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -2280,8 +2280,12 @@ const LayerItemImpl: React.FC<{
       }
     }
 
-    // Hide elements with hiddenGenerated: true by default (in all modes)
-    if (layer.hiddenGenerated) {
+    // Hide elements with hiddenGenerated: true by default (in all modes).
+    // Scoped to alerts only: the flag is meant for form success/error alerts
+    // (toggled here for the builder preview). Non-alert layers (e.g. animated
+    // dropdowns) manage visibility via data-gsap-hidden and must not be pinned
+    // to display:none here.
+    if (layer.hiddenGenerated && layer.alertType) {
       const existingStyle = typeof elementProps.style === 'object' ? elementProps.style : {};
       elementProps.style = { ...existingStyle, display: 'none' };
     }

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -1007,8 +1007,12 @@ const LayerItem: React.FC<{
       }
     }
 
-    // Hide elements with hiddenGenerated: true by default (in all modes)
-    if (layer.hiddenGenerated) {
+    // Hide elements with hiddenGenerated: true by default (in all modes).
+    // Scoped to alerts only: the flag is meant for form success/error alerts,
+    // whose reveal path clears inline display. Non-alert layers (e.g. animated
+    // dropdowns) manage visibility via data-gsap-hidden and must not be pinned
+    // to display:none here.
+    if (layer.hiddenGenerated && layer.alertType) {
       const existingStyle = typeof elementProps.style === 'object' ? elementProps.style : {};
       elementProps.style = { ...existingStyle, display: 'none' };
     }

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -4788,8 +4788,11 @@ export function layerToHtml(
     attrs.push(`id="${escapeHtml(layer.attributes.id)}"`);
   }
 
-  // Hide elements marked as hiddenGenerated (e.g. alerts, slider fraction placeholder)
-  if (layer.hiddenGenerated) {
+  // Hide elements marked as hiddenGenerated. Scoped to alerts only: the flag is
+  // meant for form success/error alerts, whose reveal path clears inline display.
+  // Non-alert layers (e.g. animated dropdowns) manage visibility via
+  // data-gsap-hidden and must not be pinned to display:none here.
+  if (layer.hiddenGenerated && layer.alertType) {
     const existingDynamic = layer._dynamicStyles || {};
     layer = { ...layer, _dynamicStyles: { ...existingDynamic, display: 'none' } };
   }


### PR DESCRIPTION
## Summary

Layers flagged `hiddenGenerated` were always forced to `display: none`, but only form alerts have a reveal mechanism that clears that inline style. Non-alert layers that carried the flag (e.g. animated dropdown/accordion menus in a nav bar) stayed permanently hidden, so their hover/click reveal animations ran on an invisible element and appeared broken. This scopes the hiding to alert layers only.

## Changes

- Gate the `hiddenGenerated` → `display: none` hiding on `layer.alertType` in all three render paths: `LayerRendererPublic.tsx` (published/preview), `LayerRenderer.tsx` (builder canvas), and `lib/page-fetcher.ts` (static HTML export)
- Non-alert layers now manage their own visibility via the animation system's `data-gsap-hidden` attribute, which the reveal animation can clear

## Why it's safe

- Every legitimate `hiddenGenerated` producer is an alert and also sets `alertType` (form success/error alerts, password-form error alert); there is no non-alert producer
- Alerts are unchanged: published mode still hides them via the separate `alertType` branch and reveals on submit; the builder alert preview toggle still works since alerts have `alertType`

## Test plan

- [ ] On a published page, a nav dropdown/accordion with a hover/click reveal animation shows on trigger
- [ ] Submit a form with an error → error alert appears; with success → success alert appears
- [ ] In the builder, toggling an alert's preview visibility still shows/hides it
- [ ] Static export output keeps form alerts hidden by default