### PR TITLE
fix: apply the correct max duration to the AI chat route

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,11 +6,11 @@
   "installCommand": "npm install",
   "framework": "nextjs",
   "functions": {
-    "app/(builder)/ycode/api/**/*.ts": {
-      "maxDuration": 60
-    },
     "app/(builder)/ycode/api/ai/chat/route.ts": {
       "maxDuration": 300
+    },
+    "app/(builder)/ycode/api/**/*.ts": {
+      "maxDuration": 60
     },
     "app/(builder)/ycode/mcp/*/route.ts": {
       "maxDuration": 60


### PR DESCRIPTION
## Summary

The AI chat route's 300-second `maxDuration` in `vercel.json` was listed after the catch-all `app/(builder)/ycode/api/**/*.ts` pattern, so the catch-all's 60-second limit won and long AI chat runs were killed after a minute. Reorder the entries so the specific AI chat rule comes first and its 300-second limit actually applies.

## Changes

- Move the AI chat route's `maxDuration` entry above the catch-all API pattern in `vercel.json`

## Test plan

- [ ] Deploy and run an AI chat session longer than 60 seconds — it should not be cut off
- [ ] Confirm other builder API routes still use the 60-second limit

Made with [Cursor](https://cursor.com)