### PR TITLE
fix: guard string component variable values

### DIFF
--- a/lib/mcp/tools/components.ts
+++ b/lib/mcp/tools/components.ts
@@ -29,6 +29,7 @@ import {
   replaceLayerWithComponentInstance,
 } from '@/lib/layer-utils';
 import { EMPTY_OVERRIDES, createTextComponentVariableValue } from '@/lib/variable-utils';
+import { stringToTiptapContent } from '@/lib/text-format-utils';
 import { collectFontFamiliesFromDesign, ensureFontsInstalled, fontWarnings } from '@/lib/mcp/font-install';
 import { getCachedLayers as getPageLayers, saveCachedLayers } from '@/lib/mcp/page-layers';
 import { getAllPages } from '@/lib/repositories/pageRepository';
@@ -60,13 +61,30 @@ const variableUpdateSchema = z.object({
   default_value: z.unknown().optional(),
 });
 
+/**
+ * Coerce a `default_value` into the object shape the renderer expects.
+ *
+ * `default_value` is intentionally untyped in the tool schema (its shape
+ * depends on the variable type), so callers routinely pass a bare string for
+ * text variables. Storing that verbatim breaks rendering for every page using
+ * the component, so wrap it in the matching variable value here.
+ */
+function normalizeDefaultValue(value: unknown, type: z.infer<typeof variableTypeEnum>): ComponentVariableValue {
+  if (typeof value === 'string') {
+    return type === 'rich_text'
+      ? createTextComponentVariableValue(stringToTiptapContent(value))
+      : { type: 'dynamic_text', data: { content: value } };
+  }
+  return value as ComponentVariableValue;
+}
+
 function normalizeVariables(input: Array<z.infer<typeof variableUpdateSchema>>): ComponentVariable[] {
   return input.map((v) => ({
     id: v.id || generateId(),
     name: v.name,
     type: v.type,
     ...(v.placeholder !== undefined && { placeholder: v.placeholder }),
-    ...(v.default_value !== undefined && { default_value: v.default_value as ComponentVariableValue }),
+    ...(v.default_value !== undefined && { default_value: normalizeDefaultValue(v.default_value, v.type) }),
   }));
 }
 

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -4228,9 +4228,10 @@ function resolveLayerAssets(
     }
   }
 
-  // Resolve richTextImage src URLs inside Tiptap content
+  // Resolve richTextImage src URLs inside Tiptap content. The value is read
+  // from persisted layer JSON, so guard against a primitive before probing it.
   const textVar = layer.variables?.text;
-  if (textVar && 'type' in textVar && textVar.type === 'dynamic_rich_text') {
+  if (textVar && typeof textVar === 'object' && 'type' in textVar && textVar.type === 'dynamic_rich_text') {
     const resolvedContent = resolveRichTextImageAssets((textVar as any).data?.content, assetMap);
     if (resolvedContent !== (textVar as any).data?.content) {
       variableUpdates.text = {

--- a/lib/resolve-components.ts
+++ b/lib/resolve-components.ts
@@ -6,6 +6,7 @@
 
 import type { Layer, Component, ComponentVariable, ComponentVariableValue, LayerVariables, VariantSettingsValue } from '@/types';
 import { getComponentVariantLayers } from './component-variant-utils';
+import { normalizeComponentVariableValue } from './variable-utils';
 
 /**
  * Remap collection_layer_id in a FieldVariable using the ID map.
@@ -386,7 +387,7 @@ export function applyComponentOverrides(
       const variableDef = componentVariables?.find(v => v.id === linkedTextVariableId);
       const overrideCategory = (variableDef?.type === 'rich_text' ? 'rich_text' : 'text') as OverrideCategory;
       const overrideValue = overrides?.[overrideCategory]?.[linkedTextVariableId];
-      const valueToApply = overrideValue ?? variableDef?.default_value;
+      const valueToApply = normalizeComponentVariableValue(overrideValue ?? variableDef?.default_value);
 
       // Only apply if it's a text variable (has 'type' property, not ImageSettingsValue)
       if (valueToApply && 'type' in valueToApply) {

--- a/lib/variable-utils.ts
+++ b/lib/variable-utils.ts
@@ -116,6 +116,25 @@ export function createTextComponentVariableValue(tiptapContent: object): Compone
 }
 
 /**
+ * Coerce a persisted component variable value into its object form.
+ *
+ * Text values are expected to be `{ type, data }` objects, but a bare string
+ * can reach the database — the MCP component tools accept an unvalidated
+ * `default_value`, so an agent can store `"Accessories"` instead of
+ * `{ type: 'dynamic_text', data: { content: 'Accessories' } }`. Callers probe
+ * these values with the `in` operator, which throws on a primitive, so
+ * normalize before inspecting. Returns undefined for values that can never
+ * be a variable value.
+ */
+export function normalizeComponentVariableValue(value: unknown): ComponentVariableValue | undefined {
+  if (typeof value === 'string') {
+    return { type: 'dynamic_text', data: { content: value } };
+  }
+  if (typeof value !== 'object' || value === null) return undefined;
+  return value as ComponentVariableValue;
+}
+
+/**
  * Extract Tiptap JSON content from text ComponentVariableValue
  * Returns the Tiptap content object or a default empty document
  * Handles both DynamicRichTextVariable (with formatting) and DynamicTextVariable (plain text)
@@ -123,16 +142,17 @@ export function createTextComponentVariableValue(tiptapContent: object): Compone
 export function extractTiptapFromComponentVariable(value?: ComponentVariableValue): object {
   const emptyDoc = { type: 'doc', content: [{ type: 'paragraph' }] };
 
-  if (!value) return emptyDoc;
+  const normalized = normalizeComponentVariableValue(value);
+  if (!normalized) return emptyDoc;
 
   // Check if value is a text variable (has 'type' property) vs ImageSettingsValue (has 'src' property)
-  if ('type' in value && value.type === 'dynamic_rich_text') {
-    return (value as DynamicRichTextVariable).data.content;
+  if ('type' in normalized && normalized.type === 'dynamic_rich_text') {
+    return (normalized as DynamicRichTextVariable).data.content;
   }
 
-  if ('type' in value && value.type === 'dynamic_text') {
+  if ('type' in normalized && normalized.type === 'dynamic_text') {
     // Convert plain text to Tiptap format
-    return stringToTiptapContent((value as DynamicTextVariable).data.content);
+    return stringToTiptapContent((normalized as DynamicTextVariable).data.content);
   }
 
   return emptyDoc;


### PR DESCRIPTION
## Summary

A component variable's `default_value` is untyped in the MCP tool schema, so an agent can store a bare string (`"Accessories"`) where the renderer expects `{ type: 'dynamic_text', data: { content: 'Accessories' } }`. Probing that primitive with the `in` operator throws `TypeError: Cannot use 'in' operator to search for 'type' in Accessories`, `fetchPageByPath` swallows the error and returns null, so **every page using the component falls back to the starter template** — in the builder preview and on the published site.

Found on a live site whose header component held two such values: all 74 pages served the default "Welcome to Ycode" screen instead of their content.

This hardens the render path so existing bad data recovers without a migration, and closes the write path so new values are stored in the correct shape.

## Changes

- Add `normalizeComponentVariableValue` in `lib/variable-utils.ts`, coercing a bare string to `dynamic_text` and rejecting other primitives
- Normalize before the `in` probe in `applyComponentOverrides` (`lib/resolve-components.ts`) — the crash site
- Normalize in `extractTiptapFromComponentVariable`, which had the same unguarded probe
- Guard the layer-variable read in `resolveLayerAssets` (`lib/page-fetcher.ts`) against a primitive
- Wrap bare-string `default_value`s at the MCP boundary in `normalizeVariables` (`lib/mcp/tools/components.ts`) — Tiptap for `rich_text` variables, `dynamic_text` otherwise

`set_component_instance` already takes a typed `text: z.string()` and builds the value itself, so `default_value` was the only unvalidated path.

## Test plan

- [ ] Create a component via MCP `create_component` with `default_value: "Some label"` on a text variable, add an instance to a page, and confirm the page renders the label instead of falling back to the starter template
- [ ] Repeat with a `rich_text` variable and confirm the string is stored as Tiptap content
- [ ] Set a variable's `default_value` to a bare string directly in the database, then load a page using that component — should render the string, not 500
- [ ] Regression: components with well-formed `{ type, data }` defaults, per-instance overrides, and variant switching all render unchanged
- [ ] Regression: image, link, icon, and variant variables (object values without a `type` key) are unaffected
- [ ] `npm run lint` and `npm run type-check` pass

Made with [Cursor](https://cursor.com)