### PR TITLE
fix: prevent trigger events from becoming undeletable

### DIFF
--- a/app/(builder)/ycode/components/InteractionsPanel.tsx
+++ b/app/(builder)/ycode/components/InteractionsPanel.tsx
@@ -903,21 +903,26 @@ export default function InteractionsPanel({
     (interactionId: string) => {
       // Clear inline preview styles (e.g. backgroundColor) that were applied via
       // gsap.set on every tween in this interaction, otherwise they persist on
-      // the canvas after the trigger is removed.
-      const removedInteraction = interactions.find((i) => i.id === interactionId);
-      if (removedInteraction) {
-        const keysByLayer = new Map<string, Set<string>>();
-        (removedInteraction.tweens || []).forEach((tween) => {
-          const set = keysByLayer.get(tween.layer_id) || new Set<string>();
-          Object.keys(tween.from || {}).forEach((k) => set.add(k));
-          Object.keys(tween.to || {}).forEach((k) => set.add(k));
-          keysByLayer.set(tween.layer_id, set);
-        });
-        keysByLayer.forEach((keys, layerId) => {
-          clearLiveStyleForKeys(layerId, Array.from(keys));
-        });
+      // the canvas after the trigger is removed. Wrapped in try/catch: preview
+      // cleanup is cosmetic and must never block the actual removal below.
+      try {
+        const removedInteraction = interactions.find((i) => i.id === interactionId);
+        if (removedInteraction) {
+          const keysByLayer = new Map<string, Set<string>>();
+          (removedInteraction.tweens || []).forEach((tween) => {
+            const set = keysByLayer.get(tween.layer_id) || new Set<string>();
+            Object.keys(tween.from || {}).forEach((k) => set.add(k));
+            Object.keys(tween.to || {}).forEach((k) => set.add(k));
+            keysByLayer.set(tween.layer_id, set);
+          });
+          keysByLayer.forEach((keys, layerId) => {
+            clearLiveStyleForKeys(layerId, Array.from(keys));
+          });
+        }
+        clearAllPreviewStyles();
+      } catch (error) {
+        console.warn('Failed to clear interaction preview styles:', error);
       }
-      clearAllPreviewStyles();
 
       const updatedInteractions = interactions.filter((i) => i.id !== interactionId);
       onLayerUpdate(triggerLayer.id, { interactions: updatedInteractions });
@@ -985,16 +990,21 @@ export default function InteractionsPanel({
 
       // Clear any inline preview styles (e.g. backgroundColor) that were applied
       // via gsap.set during editing — otherwise they persist on the canvas after
-      // the tween is removed.
-      const removedTween = (selectedInteraction.tweens || []).find((t) => t.id === tweenId);
-      if (removedTween) {
-        const keys = Array.from(new Set([
-          ...Object.keys(removedTween.from || {}),
-          ...Object.keys(removedTween.to || {}),
-        ]));
-        clearLiveStyleForKeys(removedTween.layer_id, keys);
+      // the tween is removed. Wrapped in try/catch: preview cleanup is cosmetic
+      // and must never block the actual removal below.
+      try {
+        const removedTween = (selectedInteraction.tweens || []).find((t) => t.id === tweenId);
+        if (removedTween) {
+          const keys = Array.from(new Set([
+            ...Object.keys(removedTween.from || {}),
+            ...Object.keys(removedTween.to || {}),
+          ]));
+          clearLiveStyleForKeys(removedTween.layer_id, keys);
+        }
+        clearAllPreviewStyles();
+      } catch (error) {
+        console.warn('Failed to clear tween preview styles:', error);
       }
-      clearAllPreviewStyles();
 
       const updatedInteractions = updateInteractionById(
         interactions,
@@ -1094,15 +1104,20 @@ export default function InteractionsPanel({
 
       // Clear any inline preview styles (e.g. backgroundColor) that were applied
       // via gsap.set during editing — otherwise they persist on the canvas after
-      // the property is removed.
-      const targetTween = (selectedInteraction.tweens || []).find((t) => t.id === tweenId);
-      if (targetTween) {
-        clearLiveStyleForKeys(
-          targetTween.layer_id,
-          propertyOption.properties.map((p) => p.key as string)
-        );
+      // the property is removed. Wrapped in try/catch: preview cleanup is
+      // cosmetic and must never block the actual removal below.
+      try {
+        const targetTween = (selectedInteraction.tweens || []).find((t) => t.id === tweenId);
+        if (targetTween) {
+          clearLiveStyleForKeys(
+            targetTween.layer_id,
+            propertyOption.properties.map((p) => p.key as string)
+          );
+        }
+        clearAllPreviewStyles();
+      } catch (error) {
+        console.warn('Failed to clear property preview styles:', error);
       }
-      clearAllPreviewStyles();
 
       const updatedInteractions = updateInteractionById(
         interactions,


### PR DESCRIPTION
## Summary

Fixes a bug where a trigger event could not be deleted once it had an animated property. Deleting worked fine until a property was added, then the delete did nothing while the rest of the editor stayed responsive.

The event remove handler ran GSAP/iframe preview cleanup **synchronously before** the actual removal, and that cleanup block only executes when the event has animated properties. If any cleanup call threw in a given environment, the exception aborted the handler before the delete ran, so the event was never removed. This regression was introduced with the background-color animation feature.

## Changes

- Wrap preview cleanup in `try/catch` in the interaction, tween, and property remove handlers so cosmetic cleanup can never block the actual removal
- Log a warning instead of throwing when cleanup fails

## Test plan

- [ ] Add a trigger event with an animation and an animated property, then delete the event via the X — it should be removed
- [ ] Delete an animation and an animated property individually — still works
- [ ] Delete an event with no animated properties — still works
- [ ] Confirm no leftover inline styles remain on the canvas after deletion in the normal (non-error) path