### PR TITLE
fix: prevent 404 on lightbox bound to multi-image field

### DIFF
--- a/lib/asset-utils.ts
+++ b/lib/asset-utils.ts
@@ -899,12 +899,11 @@ export function collectLayerAssetIds(
     const linkAssetId = layer.variables?.link?.asset?.id;
     addAssetId(linkAssetId);
 
-    // Lightbox file assets
-    if (layer.settings?.lightbox?.files) {
+    // Lightbox file assets (addAssetId guards non-string/non-UUID values,
+    // so nested arrays or external URLs are safely ignored)
+    if (Array.isArray(layer.settings?.lightbox?.files)) {
       for (const fileId of layer.settings.lightbox.files) {
-        if (fileId && !fileId.startsWith('http') && !fileId.startsWith('/')) {
-          addAssetId(fileId);
-        }
+        addAssetId(fileId);
       }
     }
 

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -1443,14 +1443,12 @@ async function injectCollectionData(
   // Lightbox CMS field binding — resolve filesField to concrete asset IDs/URLs
   const lightboxSettings = layer.settings?.lightbox;
   if (lightboxSettings?.filesSource === 'cms' && lightboxSettings.filesField && isFieldVariable(lightboxSettings.filesField)) {
-    const resolvedValue = resolveFieldValueWithRelationships(lightboxSettings.filesField, enhancedValues, layerDataMap);
+    // Multi-image fields resolve to an array (or JSON-encoded array); single-image
+    // fields resolve to a plain asset ID/URL, optionally comma-separated.
+    const resolvedValue = resolveFieldValueWithRelationships(lightboxSettings.filesField, enhancedValues, layerDataMap) as string | string[] | undefined;
     if (resolvedValue) {
-      // The value can be a single asset ID, a comma-separated list, or a JSON array
-      let resolvedFiles: string[];
-      try {
-        const parsed = JSON.parse(resolvedValue);
-        resolvedFiles = Array.isArray(parsed) ? parsed : [resolvedValue];
-      } catch {
+      let resolvedFiles = parseMultiAssetFieldValue(resolvedValue);
+      if (resolvedFiles.length === 0 && typeof resolvedValue === 'string') {
         resolvedFiles = resolvedValue.includes(',')
           ? resolvedValue.split(',').map(s => s.trim()).filter(Boolean)
           : [resolvedValue];


### PR DESCRIPTION
## Summary

A dynamic CMS page returned a 404 for the whole page when a Lightbox element with Image Source = CMS Field was bound to a multi-image field. Single-image fields and File Manager worked fine. This fixes the resolution so multi-image fields render correctly.

## Changes

- Resolve lightbox CMS bindings with the shared `parseMultiAssetFieldValue` helper so multi-image field values (arrays) are flattened instead of wrapped in a nested array
- Keep single-value and comma-separated string handling as a fallback
- Harden the lightbox asset-collection loop to rely on the existing non-string guard instead of calling `.startsWith()` on raw values, so unexpected shapes can no longer throw and 404 the page

## Test plan

- [ ] Bind a Lightbox (Image Source = CMS Field) to a multi-image field on a dynamic CMS page and confirm the item page loads (200) and the lightbox opens with all images
- [ ] Switch the binding to a single-image field — still works
- [ ] Switch the binding to File Manager — still works
- [ ] `curl -i` the item URL returns 200 and the HTML contains a populated `data-lightbox-files` attribute