### PR TITLE
fix: require auth for templates API routes

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -142,8 +142,10 @@ export async function proxy(request: NextRequest) {
   const skipPreviewAuth = process.env.DISABLE_PREVIEW_AUTH === 'true'
     && pathname.startsWith('/ycode/preview');
 
-  // Protect API and preview routes with auth
-  if (!skipPreviewAuth && (pathname.startsWith('/ycode/api') || pathname.startsWith('/ycode/preview'))) {
+  // Protect API and preview routes with auth. `/api/templates` lives outside the
+  // `/ycode` tree (public site route group) but exposes destructive builder-only
+  // operations (apply/export), so it must be gated here too.
+  if (!skipPreviewAuth && (pathname.startsWith('/ycode/api') || pathname.startsWith('/ycode/preview') || pathname.startsWith('/api/templates'))) {
     const authResponse = await verifyApiAuth(request);
     if (authResponse) {
       if (authResponse.status === 401) {


### PR DESCRIPTION
## Summary

The `/api/templates` routes sit outside the `/ycode` tree, so the middleware auth gate never covered them. This left destructive, builder-only operations reachable without any authentication — most notably `POST /api/templates/:id/apply`, which clears the current site content and replaces it with a template. An unauthenticated attacker could repeatedly apply a template to keep a site in a reset state, an effective denial-of-service (and defacement) against published sites.

## Changes

- Gate the entire `/api/templates` prefix in the middleware auth check, alongside the existing `/ycode/api` and `/ycode/preview` protection.

## Test plan

- [ ] Unauthenticated `GET /api/templates` returns `401`
- [ ] Unauthenticated `POST /api/templates/:id/apply` returns `401` and does not modify content
- [ ] Unauthenticated `POST /api/templates/export` and `POST /api/templates/export-and-upload` return `401`
- [ ] Authenticated builder requests to list and apply templates still succeed