### PR TITLE
fix: stop slider transitions from resetting animations

### DIFF
--- a/components/AnimationInitializer.tsx
+++ b/components/AnimationInitializer.tsx
@@ -68,6 +68,17 @@ function getElement(layerId: string): HTMLElement | null {
 }
 
 /**
+ * Whether a mutated node lives inside a Swiper slider. Swiper reshuffles
+ * existing slide nodes on transition/loop (childList mutations), which must
+ * not trigger an animation rebind — real new content arrives via the
+ * ITEMS_INJECTED_EVENT path instead.
+ */
+function isInsideSlider(node: Node | null): boolean {
+  const el = node instanceof Element ? node : node?.parentElement ?? null;
+  return !!el?.closest('[data-slider-id], .swiper-wrapper');
+}
+
+/**
  * Pre-paint each tween's `from` state so the element rests in its intended
  * initial appearance before the trigger fires. CSS via generateInitialAnimationCSS()
  * only covers intro triggers (load, scroll-into-view); for hover/click we apply
@@ -712,6 +723,10 @@ export default function AnimationInitializer({ layers, injectInitialCSS }: Anima
     const remountObserver = new MutationObserver(mutations => {
       for (const m of mutations) {
         if (m.type !== 'childList') continue;
+        // Skip Swiper's internal slide reshuffling (loop/transition) so a
+        // slide change doesn't rebind animations and reset user-toggled
+        // click/hover states (e.g. an open nav menu) elsewhere on the page.
+        if (isInsideSlider(m.target)) continue;
         for (const n of m.addedNodes) {
           if (containsTrackedId(n)) {
             scheduleRebind();


### PR DESCRIPTION
## Summary

A slider advancing to the next slide could reset unrelated GSAP animations on the page — for example, closing an open navigation menu. This fixes that interference so animations keep their state while a slider transitions.

## Changes

- Ignore `childList` mutations that originate inside a slider (`[data-slider-id]` / `.swiper-wrapper`) in the animation remount observer
- Swiper moves/reshuffles real slide nodes on loop and transition; those moves were mistaken for newly mounted content, triggering a full animation rebind that re-applied every interaction's initial state
- Genuine dynamically-injected content (filter / load-more) is unaffected — it flows through the separate `ITEMS_INJECTED_EVENT` path, which still triggers rebinds as before

## Test plan

- [ ] Add a slider (loop enabled) and a separate element with a click-toggle animation (e.g. a nav menu that opens on click)
- [ ] Open the toggle, then let the slider advance / click next — the toggle stays open
- [ ] Confirm load / scroll-into-view / hover animations on other elements still play normally
- [ ] Toggle a filter or load-more on a collection and confirm injected items still animate (rebind still works)