### PR TITLE
fix: resolve dropped hrefs on inline rich-text links

### DIFF
--- a/lib/mcp/utils.ts
+++ b/lib/mcp/utils.ts
@@ -290,7 +290,17 @@ function parseInlineMarks(text: string): TiptapNode[] {
       nodes.push({
         type: 'text',
         text: match[3],
-        marks: [{ type: 'richTextLink', attrs: { href: match[4], linkType: 'url' } }],
+        // Match the canonical LinkSettings shape the renderer resolves via
+        // getLinkSettingsFromMark/generateLinkHref — a bare { href } is ignored.
+        marks: [{
+          type: 'richTextLink',
+          attrs: {
+            type: 'url',
+            url: { type: 'dynamic_text', data: { content: match[4] } },
+            target: '_blank',
+            rel: 'noopener noreferrer nofollow',
+          },
+        }],
       });
     }
     lastIndex = match.index + match[0].length;

--- a/lib/templates/content.ts
+++ b/lib/templates/content.ts
@@ -116,7 +116,7 @@ export const contentTemplates: Record<string, BlockTemplate> = {
                     { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Item C' }] }] },
                   ],
                 },
-                { type: 'paragraph', content: [{ type: 'text', marks: [{ type: 'richTextLink', attrs: { href: '#', linkType: 'url' } }], text: 'Text link' }] },
+                { type: 'paragraph', content: [{ type: 'text', marks: [{ type: 'richTextLink', attrs: { type: 'url', url: { type: 'dynamic_text', data: { content: '#' } } } }], text: 'Text link' }] },
                 { type: 'paragraph', content: [{ type: 'text', marks: [{ type: 'bold' }], text: 'Bold text' }] },
                 { type: 'paragraph', content: [{ type: 'text', marks: [{ type: 'italic' }], text: 'Italic text' }] },
               ],

--- a/lib/text-format-utils.ts
+++ b/lib/text-format-utils.ts
@@ -7,6 +7,7 @@ import { contentHasBlockElements, hasBlockElementsWithResolver } from '@/lib/tip
 import { applyComponentOverrides, resolveComponents } from '@/lib/resolve-components';
 import type { GlobalFieldMeta } from '@/lib/collection-field-utils';
 import { getDefaultFormatId, isFormatValidForFieldType } from '@/lib/variable-format-utils';
+import { getLinkSettingsFromMark } from '@/lib/tiptap-extensions/rich-text-link';
 import HtmlEmbedRenderer from '@/components/HtmlEmbedRenderer';
 
 /**
@@ -537,8 +538,9 @@ function renderTextNode(
                 collectionItemData,
                 pageCollectionItemData,
               };
-              // Use shared link generation utility
-              return generateLinkHref(mark.attrs as LinkSettings, fullContext) || '#';
+              // Normalise attrs to canonical LinkSettings (tolerates legacy
+              // { href, linkType } shape) before resolving the href.
+              return generateLinkHref(getLinkSettingsFromMark(mark.attrs || {}), fullContext) || '#';
             })();
 
           const linkProps: Record<string, any> = {

--- a/lib/tiptap-extensions/rich-text-link.ts
+++ b/lib/tiptap-extensions/rich-text-link.ts
@@ -326,12 +326,18 @@ export const RichTextLink = Mark.create<RichTextLinkOptions>({
 });
 
 /**
- * Extract LinkSettings from mark attributes
+ * Extract LinkSettings from mark attributes.
+ * Tolerates the legacy `{ href, linkType }` shape (older MCP-authored links) by
+ * mapping a bare `href` into the canonical url variable structure.
  */
 export function getLinkSettingsFromMark(attrs: Record<string, any>): LinkSettings {
+  const legacyUrl = !attrs.url && typeof attrs.href === 'string' && attrs.href
+    ? { type: 'dynamic_text' as const, data: { content: attrs.href } }
+    : undefined;
+
   return {
-    type: attrs.type || 'url',
-    url: attrs.url || undefined,
+    type: attrs.type || attrs.linkType || 'url',
+    url: attrs.url || legacyUrl || undefined,
     email: attrs.email || undefined,
     phone: attrs.phone || undefined,
     asset: attrs.asset || undefined,


### PR DESCRIPTION
## Summary

Inline rich-text links (e.g. authored via MCP as `[text](url)`) rendered without a working `href`, so clicks did nothing on published/previewed pages. Closes #493.

The root cause: the MCP inline parser stored the link mark with a non-canonical shape (`{ href, linkType }`), while the renderer resolves links through `LinkSettings` (`{ type: 'url', url: { type: 'dynamic_text', data: { content } } }`). With `type`/`url` missing, the href resolved to empty and was dropped. The editor's own markdown path already used the correct shape.

## Changes

- Emit canonical `url` variable attrs from the MCP inline parser (`lib/mcp/utils.ts`), matching the editor's markdown authoring
- Tolerate the legacy `{ href, linkType }` mark shape in `getLinkSettingsFromMark`, so already-authored links resolve at render time (both React and server-HTML paths)
- Normalise mark attrs via `getLinkSettingsFromMark` on the React render path (`lib/text-format-utils.ts`) instead of casting raw attrs
- Fix the sample template link to use the canonical shape (`lib/templates/content.ts`)

## Test plan

- [ ] Author a rich-text link via MCP `[text](url)` → published/preview HTML has a working `href`
- [ ] Existing MCP-authored links (legacy shape) now render with an href
- [ ] Editor-authored links (url/page/email/phone/asset/field) still resolve correctly
- [ ] Bold/italic and other inline formatting unaffected
- [ ] `target`/`rel`/`download` still applied