### PR TITLE
feat: make page social preview image translatable

### DIFF
--- a/app/(site)/[...slug]/page.tsx
+++ b/app/(site)/[...slug]/page.tsx
@@ -422,6 +422,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
         collectionItem: data.collectionItem,
         pagePath: '/' + slugPath,
         globalSeoSettings: globalSettings,
+        translations: data.translations,
       }),
       baseUrl: getSiteBaseUrl({ globalCanonicalUrl: globalSettings.globalCanonicalUrl }),
     }),

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -274,6 +274,7 @@ export async function generateMetadata(): Promise<Metadata> {
         fallbackTitle: 'Home',
         pagePath: '/',
         globalSeoSettings: globalSettings,
+        translations: data.translations,
       }),
       baseUrl: getSiteBaseUrl({ globalCanonicalUrl: globalSettings.globalCanonicalUrl }),
     }),

--- a/app/(site)/ycode/preview/[...slug]/page.tsx
+++ b/app/(site)/ycode/preview/[...slug]/page.tsx
@@ -159,5 +159,6 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   return generatePageMetadata(data.page, {
     isPreview: true,
     collectionItem: data.collectionItem,
+    translations: data.translations,
   });
 }

--- a/app/(site)/ycode/preview/page.tsx
+++ b/app/(site)/ycode/preview/page.tsx
@@ -137,5 +137,6 @@ export async function generateMetadata(): Promise<Metadata> {
   return generatePageMetadata(data.page, {
     isPreview: true,
     fallbackTitle: 'Homepage',
+    translations: data.translations,
   });
 }

--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -19,7 +19,7 @@ import { getSlugTranslationsByLocale } from '@/lib/repositories/translationRepos
 import { buildSvgDataUrl, getAssetProxyUrl } from '@/lib/asset-utils';
 import { generateColorVariablesCss } from '@/lib/repositories/colorVariableRepository';
 import { buildPageHreflangAlternates, type HreflangAlternate } from '@/lib/hreflang-utils';
-import { getTranslatableKey } from '@/lib/locale-runtime';
+import { getTranslatableKey, getTranslatedAssetId, getTranslatedText } from '@/lib/locale-runtime';
 import { buildAbsolutePageUrl, getSiteBaseUrl } from '@/lib/url-utils';
 
 /**
@@ -63,6 +63,8 @@ export interface GenerateMetadataOptions {
   tenantId?: string;
   /** Primary domain URL (e.g. https://example.com) for metadataBase */
   primaryDomainUrl?: string;
+  /** Per-locale translations, keyed `{source}:{id}:{content_key}`, for localized SEO */
+  translations?: Record<string, Translation> | null;
 }
 
 /**
@@ -256,24 +258,29 @@ export async function generatePageMetadata(
   page: Page,
   options: GenerateMetadataOptions = {}
 ): Promise<Metadata> {
-  const { isPreview = false, fallbackTitle, fallbackDescription, collectionItem, pagePath, primaryDomainUrl } = options;
+  const { isPreview = false, fallbackTitle, fallbackDescription, collectionItem, pagePath, primaryDomainUrl, translations } = options;
 
   const seo = page.settings?.seo;
   const isErrorPage = page.error_page !== null;
 
+  // Resolve locale-translated SEO values (falls back to originals when no
+  // completed translation exists for the current locale).
+  const seoTitle = getTranslatedText(seo?.title, 'seo:title', translations, page.id);
+  const seoDescription = getTranslatedText(seo?.description, 'seo:description', translations, page.id);
+
   // Build title - resolve field variables if collection item is available
-  let title = seo?.title || page.name || fallbackTitle || 'Page';
-  if (collectionItem && seo?.title) {
-    title = resolveInlineVariables(seo.title, collectionItem) || page.name || fallbackTitle || 'Page';
+  let title = seoTitle || page.name || fallbackTitle || 'Page';
+  if (collectionItem && seoTitle) {
+    title = resolveInlineVariables(seoTitle, collectionItem) || page.name || fallbackTitle || 'Page';
   }
   if (isPreview) {
     title = `[Preview] ${title}`;
   }
 
   // Build description - resolve field variables if collection item is available
-  let description = seo?.description || fallbackDescription || page.name;
-  if (collectionItem && seo?.description) {
-    description = resolveInlineVariables(seo.description, collectionItem) || fallbackDescription || page.name;
+  let description = seoDescription || fallbackDescription || page.name;
+  if (collectionItem && seoDescription) {
+    description = resolveInlineVariables(seoDescription, collectionItem) || fallbackDescription || page.name;
   }
 
   // Base metadata
@@ -349,8 +356,14 @@ export async function generatePageMetadata(
 
   // Add Open Graph and Twitter Card metadata (not for error pages)
   if (!isErrorPage) {
+    // A fixed asset (string ID) can be translated per locale; CMS field
+    // variables resolve from the collection item instead.
+    const seoImage = typeof seo?.image === 'string'
+      ? getTranslatedAssetId(seo.image, 'seo:image', translations, page.id)
+      : seo?.image;
+
     // Resolve image URL (handles both Asset ID string and FieldVariable)
-    let imageUrl = seo?.image ? await resolveImageUrl(seo.image, collectionItem) : null;
+    let imageUrl = seoImage ? await resolveImageUrl(seoImage, collectionItem) : null;
 
     // Make relative URLs absolute — social crawlers require absolute og:image URLs
     if (imageUrl && imageUrl.startsWith('/') && siteBaseUrl) {

--- a/lib/localisation-utils.ts
+++ b/lib/localisation-utils.ts
@@ -1,4 +1,4 @@
-import type { Layer, Page, Translation, Locale, LocaleOption, CollectionField, Component, ComponentVariable, DynamicTextVariable, DynamicRichTextVariable } from '@/types';
+import type { Layer, Page, Translation, Locale, LocaleOption, CollectionField, Component, ComponentVariable, DynamicTextVariable, DynamicRichTextVariable, StringAssetId, FieldVariable } from '@/types';
 import { getLayerIcon, getLayerName } from '@/lib/layer-display-utils';
 import {
   buildLayerTranslationKey,
@@ -651,7 +651,7 @@ function classifySeoValue(value: string): { contentType: 'text' | 'richtext'; op
 
 function extractSeoItems(
   pageId: string,
-  seo: { title?: string; description?: string } | undefined,
+  seo: { title?: string; description?: string; image?: StringAssetId | FieldVariable | null } | undefined,
   items: TranslatableItem[]
 ): void {
   if (!seo) return;
@@ -686,6 +686,22 @@ function extractSeoItems(
       info: {
         icon: 'search',
         label: 'SEO Description',
+      },
+    });
+  }
+
+  // Only a fixed asset (not a CMS field variable) is translatable per locale.
+  if (typeof seo.image === 'string' && seo.image.trim()) {
+    items.push({
+      key: `page:${pageId}:seo:image`,
+      source_type: 'page',
+      source_id: pageId,
+      content_key: 'seo:image',
+      content_type: 'asset_id',
+      content_value: seo.image,
+      info: {
+        icon: 'image',
+        label: 'Social preview',
       },
     });
   }


### PR DESCRIPTION
## Summary

The page SEO social preview image was shared across all locales. This makes a fixed (static) social preview image translatable per locale, and wires up the existing SEO title/description translations so they actually apply when generating page metadata.

## Changes

- Register the page SEO social preview as a per-locale translatable item (`seo:image`, asset type) — surfaces in the localization panel using the existing asset picker
- Apply locale-specific SEO title, description, and social preview image when generating page metadata (`generatePageMetadata`), falling back to the original when no completed translation exists
- Thread `translations` into all page/preview metadata routes
- Exclude CMS-bound previews from translation — a `FieldVariable` preview continues to resolve from the collection item's image field

## Test plan

- [ ] Add a locale, set a static social preview image on a page, add a translated image for the locale, publish, and confirm the localized URL emits the translated `og:image` / `twitter:image`
- [ ] Confirm translated SEO title/description now render on localized URLs
- [ ] Confirm a CMS-bound (field variable) preview does NOT appear as translatable and still resolves from the collection item's image field
- [ ] Confirm default-locale pages are unchanged (original image/title/description)