### PR TITLE
feat: add configurable security headers

### DIFF
--- a/app/(builder)/ycode/settings/security/page.tsx
+++ b/app/(builder)/ycode/settings/security/page.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+} from '@/components/ui/field';
+import { Button } from '@/components/ui/button';
+import { CodeEditor } from '@/components/ui/code-editor';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { cn, isCloudVersion } from '@/lib/utils';
+import { useSettingsStore } from '@/stores/useSettingsStore';
+import {
+  REFERRER_POLICY_OPTIONS,
+  SECURITY_HEADERS_SETTING_KEY,
+  getDefaultSecurityHeadersSettings,
+} from '@/lib/security-headers';
+import type { SecurityHeadersSettings } from '@/lib/security-headers';
+
+// Radix Select forbids empty-string values, so "off" is a sentinel that maps
+// to an empty Referrer-Policy (header omitted).
+const REFERRER_POLICY_OFF = 'off';
+
+export default function SecuritySettingsPage() {
+  const { getSettingByKey, saveSettings } = useSettingsStore();
+
+  const stored = getSettingByKey(SECURITY_HEADERS_SETTING_KEY) as Partial<SecurityHeadersSettings> | null;
+  const [settings, setSettings] = useState<SecurityHeadersSettings>({
+    ...getDefaultSecurityHeadersSettings(),
+    ...(stored || {}),
+  });
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Individual header controls are gated on the master toggle.
+  const disabled = !settings.enabled;
+
+  // HSTS is a host/TLS concern already handled by the platform on cloud, so the
+  // control is only useful for self-hosted installs.
+  const showHsts = !isCloudVersion();
+
+  const updateSetting = useCallback(<K extends keyof SecurityHeadersSettings>(
+    key: K,
+    value: SecurityHeadersSettings[K],
+  ) => {
+    setSettings((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true);
+    try {
+      const success = await saveSettings({
+        [SECURITY_HEADERS_SETTING_KEY]: settings,
+      });
+
+      if (!success) {
+        toast.error(useSettingsStore.getState().error || 'Settings could not be saved. Please try again.');
+        return;
+      }
+
+      toast.success('Security headers have been successfully saved');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [saveSettings, settings]);
+
+  return (
+    <div className="p-8">
+      <div className="max-w-3xl mx-auto">
+        <header className="pt-8 pb-3">
+          <span className="text-base font-medium">Security settings</span>
+        </header>
+
+        <div className="grid grid-cols-3 gap-10 bg-secondary/20 p-8 rounded-lg">
+          <div>
+            <FieldLegend>Security headers</FieldLegend>
+            <FieldDescription>
+              HTTP response headers added to every published page to defend against clickjacking, MIME-sniffing, and referrer leakage. Nothing is applied until you save — recommended values are pre-filled below.
+            </FieldDescription>
+          </div>
+
+          <div className="col-span-2 grid grid-cols-2 gap-8">
+            <Field orientation="horizontal" className="flex-row-reverse col-span-2">
+              <FieldContent>
+                <FieldLabel htmlFor="security-enabled">Enable security headers</FieldLabel>
+                <FieldDescription>
+                  Turn off to send no security headers on published pages.
+                </FieldDescription>
+              </FieldContent>
+              <Switch
+                id="security-enabled"
+                checked={settings.enabled}
+                onCheckedChange={(checked) => updateSetting('enabled', checked)}
+              />
+            </Field>
+
+            <FieldSeparator className="col-span-2" />
+
+            <Field className="col-span-2">
+              <FieldLabel htmlFor="frame-options">X-Frame-Options</FieldLabel>
+              <FieldDescription>
+                Controls whether your pages can be embedded in an iframe. Prevents clickjacking.
+              </FieldDescription>
+              <Select
+                value={settings.frameOptions}
+                onValueChange={(value) => updateSetting('frameOptions', value as SecurityHeadersSettings['frameOptions'])}
+                disabled={disabled}
+              >
+                <SelectTrigger id="frame-options">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="SAMEORIGIN">SAMEORIGIN — allow embedding on the same origin</SelectItem>
+                  <SelectItem value="DENY">DENY — never allow embedding</SelectItem>
+                  <SelectItem value="OFF">Off — do not send this header</SelectItem>
+                </SelectContent>
+              </Select>
+            </Field>
+
+            <Field orientation="horizontal" className="flex-row-reverse col-span-2">
+              <FieldContent>
+                <FieldLabel htmlFor="content-type-options">X-Content-Type-Options: nosniff</FieldLabel>
+                <FieldDescription>
+                  Stops browsers from MIME-sniffing responses away from the declared content type.
+                </FieldDescription>
+              </FieldContent>
+              <Switch
+                id="content-type-options"
+                checked={settings.contentTypeOptions}
+                onCheckedChange={(checked) => updateSetting('contentTypeOptions', checked)}
+                disabled={disabled}
+              />
+            </Field>
+
+            <FieldSeparator className="col-span-2" />
+
+            <Field className="col-span-2">
+              <FieldLabel htmlFor="referrer-policy">Referrer-Policy</FieldLabel>
+              <FieldDescription>
+                Controls how much referrer information is sent with requests to other sites.
+              </FieldDescription>
+              <Select
+                value={settings.referrerPolicy || REFERRER_POLICY_OFF}
+                onValueChange={(value) => updateSetting('referrerPolicy', value === REFERRER_POLICY_OFF ? '' : value)}
+                disabled={disabled}
+              >
+                <SelectTrigger id="referrer-policy">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={REFERRER_POLICY_OFF}>Off — do not send this header</SelectItem>
+                  {REFERRER_POLICY_OPTIONS.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+
+            <Field className="col-span-2">
+              <FieldLabel htmlFor="permissions-policy">Permissions-Policy</FieldLabel>
+              <FieldDescription>
+                Restricts which browser features the page may use. Leave empty to omit the header.
+              </FieldDescription>
+              <Input
+                id="permissions-policy"
+                value={settings.permissionsPolicy}
+                onChange={(e) => updateSetting('permissionsPolicy', e.target.value)}
+                placeholder="camera=(), microphone=(), geolocation=()"
+                disabled={disabled}
+              />
+            </Field>
+
+            <FieldSeparator className="col-span-2" />
+
+            <Field className="col-span-2">
+              <FieldLabel htmlFor="content-security-policy">Content-Security-Policy</FieldLabel>
+              <FieldDescription>
+                Powerful but easy to misconfigure — a strict policy can break inline styles, fonts, or scripts on your site. Leave empty to omit the header.
+              </FieldDescription>
+              <CodeEditor
+                value={settings.contentSecurityPolicy}
+                onValueChange={(value) => updateSetting('contentSecurityPolicy', value)}
+                placeholder="default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline';"
+                readOnly={disabled}
+                className={cn('min-h-24', disabled && 'opacity-50')}
+              />
+            </Field>
+
+            {showHsts && (
+              <>
+                <Field className="col-span-2">
+                  <FieldLabel htmlFor="strict-transport-security">Strict-Transport-Security (HSTS)</FieldLabel>
+                  <FieldDescription>
+                    Forces browsers to use HTTPS. Leave empty if your host already sets this (e.g. Vercel). Only enable once HTTPS is fully working.
+                  </FieldDescription>
+                  <Input
+                    id="strict-transport-security"
+                    value={settings.strictTransportSecurity}
+                    onChange={(e) => updateSetting('strictTransportSecurity', e.target.value)}
+                    placeholder="max-age=63072000; includeSubDomains; preload"
+                    disabled={disabled}
+                  />
+                </Field>
+
+                <FieldSeparator className="col-span-2" />
+              </>
+            )}
+
+            <div className="col-span-2 flex justify-end">
+              <Button
+                size="sm" onClick={handleSave}
+                disabled={isSaving}
+              >
+                {isSaving ? 'Saving...' : 'Save changes'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/security-headers-server.ts
+++ b/lib/security-headers-server.ts
@@ -1,0 +1,85 @@
+/**
+ * Server-side application of configurable security headers.
+ *
+ * Kept separate from `security-headers.ts` (pure/client-safe) because it reads
+ * the database. Both the base middleware (`proxy.ts`) and the cloud middleware
+ * import `applySecurityHeaders` so the two stay in sync after an upstream merge.
+ *
+ * Caching uses stale-while-revalidate keyed by tenant: a fresh value is served
+ * from memory, a stale value is served immediately while refreshing in the
+ * background, and only a cold cache awaits the DB (bounded) — so the header
+ * lookup never blocks a hot request path.
+ */
+
+import type { NextResponse } from 'next/server';
+import { getSettingByKey } from '@/lib/repositories/settingsRepository';
+import { SECURITY_HEADERS_SETTING_KEY, resolveSecurityHeaders } from '@/lib/security-headers';
+
+const CACHE_TTL_MS = 30_000;
+const COLD_READ_TIMEOUT_MS = 1_000;
+
+interface CacheEntry {
+  at: number;
+  headers: Record<string, string>;
+}
+
+const cache = new Map<string, CacheEntry>();
+const inFlight = new Map<string, Promise<void>>();
+
+/** Refresh a tenant's cached headers from the DB, keeping the last value on error. */
+async function refresh(cacheKey: string, tenantId?: string): Promise<void> {
+  try {
+    const stored = await getSettingByKey(SECURITY_HEADERS_SETTING_KEY, tenantId);
+    cache.set(cacheKey, { at: Date.now(), headers: resolveSecurityHeaders(stored) });
+  } catch {
+    // Pre-setup or DB unavailable — keep any prior value; otherwise cache empty
+    // so we don't hammer a failing DB on every request.
+    if (!cache.has(cacheKey)) {
+      cache.set(cacheKey, { at: Date.now(), headers: {} });
+    }
+  } finally {
+    inFlight.delete(cacheKey);
+  }
+}
+
+/**
+ * Resolve the security headers to send, scoped to a tenant when provided.
+ * Never throws and never blocks beyond a short cold-start timeout.
+ */
+export async function getSecurityHeaders(tenantId?: string): Promise<Record<string, string>> {
+  const cacheKey = tenantId || 'default';
+  const entry = cache.get(cacheKey);
+  const isFresh = entry && Date.now() - entry.at < CACHE_TTL_MS;
+
+  if (isFresh) {
+    return entry.headers;
+  }
+
+  if (!inFlight.has(cacheKey)) {
+    inFlight.set(cacheKey, refresh(cacheKey, tenantId));
+  }
+
+  // Stale value available: serve it now, let the refresh finish in the background.
+  if (entry) {
+    return entry.headers;
+  }
+
+  // Cold cache: wait briefly for the first read, then fall back to no headers.
+  await Promise.race([
+    inFlight.get(cacheKey),
+    new Promise((resolve) => setTimeout(resolve, COLD_READ_TIMEOUT_MS)),
+  ]);
+
+  return cache.get(cacheKey)?.headers ?? {};
+}
+
+/** Apply the resolved security headers to a public page response. */
+export async function applySecurityHeaders(
+  response: NextResponse,
+  tenantId?: string,
+): Promise<void> {
+  const headers = await getSecurityHeaders(tenantId);
+  for (const [key, value] of Object.entries(headers)) {
+    response.headers.set(key, value);
+  }
+}

--- a/lib/security-headers.ts
+++ b/lib/security-headers.ts
@@ -1,0 +1,99 @@
+/**
+ * Security headers configuration for published/public pages.
+ *
+ * Opt-in: headers are applied to public page responses only after a site saves
+ * a configuration via Settings → Security. Sites with no saved configuration
+ * are left untouched, so existing sites and their custom code/features are never
+ * affected without the owner's action.
+ */
+
+export interface SecurityHeadersSettings {
+  /** Master toggle. When false, no security headers are sent. */
+  enabled: boolean;
+  /** X-Frame-Options value; 'OFF' omits the header. */
+  frameOptions: 'SAMEORIGIN' | 'DENY' | 'OFF';
+  /** Send `X-Content-Type-Options: nosniff` when true. */
+  contentTypeOptions: boolean;
+  /** Referrer-Policy value; empty string omits the header. */
+  referrerPolicy: string;
+  /** Permissions-Policy value; empty string omits the header. */
+  permissionsPolicy: string;
+  /** Content-Security-Policy value; empty string omits the header. */
+  contentSecurityPolicy: string;
+  /** Strict-Transport-Security value; empty string omits the header. */
+  strictTransportSecurity: string;
+}
+
+/** The settings key under which the configuration is stored. */
+export const SECURITY_HEADERS_SETTING_KEY = 'security_headers';
+
+/** Allowed Referrer-Policy values for the settings UI. */
+export const REFERRER_POLICY_OPTIONS = [
+  'no-referrer',
+  'no-referrer-when-downgrade',
+  'origin',
+  'origin-when-cross-origin',
+  'same-origin',
+  'strict-origin',
+  'strict-origin-when-cross-origin',
+  'unsafe-url',
+] as const;
+
+/** Recommended values pre-filled in the settings UI (not auto-applied). */
+export function getDefaultSecurityHeadersSettings(): SecurityHeadersSettings {
+  return {
+    enabled: true,
+    // Only `nosniff` is on by default — it has essentially no breakage risk.
+    // Everything else is left off so enabling the feature never changes a
+    // site's behavior (framing, referrer, device APIs, CSP, HTTPS) unless the
+    // owner explicitly opts in:
+    //   - X-Frame-Options can break sites intentionally embedded cross-origin.
+    //   - A restrictive Permissions-Policy can disable geolocation/camera/mic.
+    //   - CSP can block custom code; HSTS is often set by the host (e.g. Vercel).
+    frameOptions: 'OFF',
+    contentTypeOptions: true,
+    referrerPolicy: '',
+    permissionsPolicy: '',
+    contentSecurityPolicy: '',
+    strictTransportSecurity: '',
+  };
+}
+
+/**
+ * Build the HTTP header map from a site's saved configuration.
+ * Returns an empty object when nothing is saved (opt-in) or the feature is off.
+ */
+export function resolveSecurityHeaders(
+  stored: Partial<SecurityHeadersSettings> | null,
+): Record<string, string> {
+  // Opt-in: never send headers for a site that hasn't saved a configuration,
+  // so existing sites are never changed without the owner's action.
+  if (!stored || Object.keys(stored).length === 0) return {};
+
+  const settings = { ...getDefaultSecurityHeadersSettings(), ...stored };
+
+  if (!settings.enabled) return {};
+
+  const headers: Record<string, string> = {};
+
+  if (settings.frameOptions && settings.frameOptions !== 'OFF') {
+    headers['X-Frame-Options'] = settings.frameOptions;
+  }
+  if (settings.contentTypeOptions) {
+    headers['X-Content-Type-Options'] = 'nosniff';
+  }
+  if (settings.referrerPolicy) {
+    headers['Referrer-Policy'] = settings.referrerPolicy;
+  }
+  if (settings.permissionsPolicy) {
+    headers['Permissions-Policy'] = settings.permissionsPolicy;
+  }
+  if (settings.contentSecurityPolicy) {
+    headers['Content-Security-Policy'] = settings.contentSecurityPolicy;
+  }
+  if (settings.strictTransportSecurity) {
+    headers['Strict-Transport-Security'] = settings.strictTransportSecurity;
+  }
+
+  return headers;
+}

--- a/lib/settings-nav-items.ts
+++ b/lib/settings-nav-items.ts
@@ -14,6 +14,7 @@ export const SETTINGS_NAV_ITEMS: SettingsNavItem[] = [
   { id: 'agent', label: 'Agent', path: '/ycode/settings/agent' },
   { id: 'users', label: 'Users', path: '/ycode/settings/users' },
   { id: 'redirects', label: 'Redirects', path: '/ycode/settings/redirects' },
+  { id: 'security', label: 'Security', path: '/ycode/settings/security' },
   { id: 'email', label: 'Email', path: '/ycode/settings/email' },
   { id: 'templates', label: 'Templates', path: '/ycode/settings/templates' },
   { id: 'updates', label: 'Updates', path: '/ycode/settings/updates' },

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { applySecurityHeaders } from '@/lib/security-headers-server';
 
 /**
  * Public API routes that skip authentication.
@@ -173,6 +174,7 @@ export async function proxy(request: NextRequest) {
 
     const rewriteResponse = NextResponse.rewrite(rewriteUrl);
     rewriteResponse.headers.set('x-pathname', pathname);
+    await applySecurityHeaders(rewriteResponse);
     return rewriteResponse;
   }
 
@@ -183,6 +185,11 @@ export async function proxy(request: NextRequest) {
   response.headers.set('x-pathname', pathname);
 
   // Cache-Control for public pages is configured centrally via next.config.ts headers().
+
+  // Apply configurable security headers to public pages only (not builder/API).
+  if (isPublicPage) {
+    await applySecurityHeaders(response);
+  }
 
   return response;
 }


### PR DESCRIPTION
## Summary

Adds a Settings → Security page where site owners can configure HTTP security headers for their published pages (CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, HSTS). The feature is fully opt-in — no headers are sent until a configuration is saved, so existing sites are never changed without the owner's action.

## Changes

- Add `lib/security-headers.ts` — pure, client-safe types, defaults, and resolver that maps a saved config to an HTTP header map (empty when unsaved or disabled)
- Add `lib/security-headers-server.ts` — server helper that reads the setting and applies headers to responses, backed by a per-tenant stale-while-revalidate cache so the request hot path never blocks on the DB
- Apply headers on public page responses in `proxy.ts`
- Add a "Security" item to the settings navigation
- Add the Settings → Security UI with a master toggle, per-header controls (disabled when the master toggle is off), and recommended values pre-filled but not auto-applied

## Notes

- Safe defaults: only `X-Content-Type-Options: nosniff` is pre-enabled; X-Frame-Options and Referrer-Policy default to off so enabling the feature never changes framing/referrer behavior unless the owner opts in
- The HSTS control is hidden on cloud (via `isCloudVersion()`) since the platform already manages it; it remains available for self-hosted installs

## Test plan

- [ ] With no saved config, verify a published page returns no security headers
- [ ] Save a config and confirm the selected headers appear on published pages
- [ ] Confirm the builder (`/ycode`) never receives security headers
- [ ] Toggle the master switch off and verify all headers are omitted
- [ ] Leave a field empty (e.g. CSP) and confirm that header is omitted
- [ ] Confirm individual controls are disabled when the master toggle is off