### PR TITLE
feat: convert text layers to headings and back

### DIFF
--- a/app/(builder)/ycode/components/LayerContextMenu.tsx
+++ b/app/(builder)/ycode/components/LayerContextMenu.tsx
@@ -23,7 +23,7 @@ import { useClipboardStore } from '@/stores/useClipboardStore';
 import { useExternalPasteStore } from '@/stores/useExternalPasteStore';
 import { isClipboardReadGranted, readExternalDesignClipboard } from '@/lib/import/clipboard-detect';
 import { useComponentsStore } from '@/stores/useComponentsStore';
-import { canHaveChildren, canPasteIntoParent, LINK_NESTING_ERROR, findLayerById, getClassesString, regenerateInteractionIds, canCopyLayer, canDeleteLayer, regenerateIdsWithInteractionRemapping, removeLayerById, findParentAndIndex, insertLayerAfter, updateLayerProps, canConvertToCollection, isExcludedFromCollection, getCollectionVariable, resetBindingsOnCollectionSourceChange } from '@/lib/layer-utils';
+import { canHaveChildren, canPasteIntoParent, LINK_NESTING_ERROR, findLayerById, getClassesString, regenerateInteractionIds, canCopyLayer, canDeleteLayer, regenerateIdsWithInteractionRemapping, removeLayerById, findParentAndIndex, insertLayerAfter, updateLayerProps, canConvertToCollection, isExcludedFromCollection, getCollectionVariable, getTextHeadingConversion, resetBindingsOnCollectionSourceChange } from '@/lib/layer-utils';
 import { getStyleIds } from '@/lib/layer-style-resolve';
 import { getLayerIcon, getLayerName } from '@/lib/layer-display-utils';
 import { cloneDeep } from 'lodash';
@@ -773,6 +773,25 @@ function LayerContextMenuInner({
     }
   };
 
+  const handleConvertTextHeading = () => {
+    if (!layer) return;
+
+    const conversion = getTextHeadingConversion(layer);
+    if (!conversion) return;
+
+    if (isComponentContext && editingComponentId) {
+      updateComponentAndBroadcast(updateLayerProps(getComponentLayers(), layerId, conversion));
+    } else {
+      updateLayer(pageId, layerId, conversion);
+      if (liveLayerUpdates) {
+        liveLayerUpdates.broadcastLayerUpdate(layerId, conversion);
+      }
+    }
+  };
+
+  const textHeadingConversion = layer ? getTextHeadingConversion(layer) : null;
+  const showConvertTextHeading = !!textHeadingConversion && !isComponentInstance;
+
   const isCollection = !!(layer && getCollectionVariable(layer));
   const canConvert = !!(layer && canConvertToCollection(layer));
   const showConvertOption = !!(layer && !isCollection && canHaveChildren(layer) && !layer.componentId);
@@ -902,6 +921,22 @@ function LayerContextMenuInner({
           Export as HTML
           <ContextMenuShortcut><Icon name="code" className="size-3" /></ContextMenuShortcut>
         </ContextMenuItem>
+
+        {showConvertTextHeading && textHeadingConversion && (
+          <>
+            <ContextMenuSeparator />
+
+            <ContextMenuItem onClick={handleConvertTextHeading} disabled={isLocked}>
+              {textHeadingConversion.name === 'heading' ? 'Convert to heading' : 'Convert to text'}
+              <ContextMenuShortcut>
+                <Icon
+                  name={textHeadingConversion.name === 'heading' ? 'heading' : 'text'}
+                  className="size-3"
+                />
+              </ContextMenuShortcut>
+            </ContextMenuItem>
+          </>
+        )}
 
         {(showConvertOption || isCollection) && (
           <>

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -900,9 +900,19 @@ const RightSidebar = React.memo(function RightSidebar({
 
   // Update local state when selected layer changes (for settings fields)
   const [prevSelectedLayerId, setPrevSelectedLayerId] = useState<string | null>(null);
+  // Track element name + tag so the tag selectors resync when the layer's type
+  // changes in place (e.g. converting a heading to text via the context menu),
+  // where the selection id stays the same.
+  const layerTagSignature = `${selectedLayer?.name ?? ''}:${selectedLayer?.settings?.tag ?? ''}`;
+  const [prevLayerTagSignature, setPrevLayerTagSignature] = useState<string>('');
   if (selectedLayerId !== prevSelectedLayerId) {
     setPrevSelectedLayerId(selectedLayerId);
+    setPrevLayerTagSignature(layerTagSignature);
     setCustomId(sanitizeHtmlId(selectedLayer?.settings?.id || selectedLayer?.attributes?.id || ''));
+    setContainerTag(selectedLayer?.settings?.tag || getDefaultContainerTag(selectedLayer));
+    setTextTag(selectedLayer?.settings?.tag || getDefaultTextTag(selectedLayer));
+  } else if (layerTagSignature !== prevLayerTagSignature) {
+    setPrevLayerTagSignature(layerTagSignature);
     setContainerTag(selectedLayer?.settings?.tag || getDefaultContainerTag(selectedLayer));
     setTextTag(selectedLayer?.settings?.tag || getDefaultTextTag(selectedLayer));
   }

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -666,6 +666,36 @@ export function isTextContentLayer(layer: Layer | null | undefined): boolean {
 }
 
 /**
+ * Build the props to convert a text layer into a heading (or the reverse).
+ * Switches the element `name` and its default HTML tag while preserving
+ * content, classes, and design.
+ *
+ * Only genuine block-level text and headings qualify: inline text used as
+ * button captions, alert messages, or labels (tag `span`/`label`) is excluded
+ * so conversion never emits an `<h2>` inside a `<button>` or `<p>`.
+ */
+export function getTextHeadingConversion(
+  layer: Layer | null | undefined
+): Pick<Layer, 'name' | 'settings'> | null {
+  if (!layer) return null;
+
+  // Heading (incl. legacy text with an h1-h6 tag) → paragraph text.
+  if (isHeadingLayer(layer)) {
+    return { name: 'text', settings: { ...layer.settings, tag: 'p' } };
+  }
+
+  // Block-level paragraph text → heading (skip inline span/label variants).
+  if (layer.name === 'text') {
+    const tag = layer.settings?.tag;
+    if (!tag || tag === 'p') {
+      return { name: 'heading', settings: { ...layer.settings, tag: 'h2' } };
+    }
+  }
+
+  return null;
+}
+
+/**
  * Check if a layer is a rich text element (block-level text with full formatting).
  */
 export function isRichTextLayer(layer: Layer | null | undefined): boolean {


### PR DESCRIPTION
## Summary

Adds a context-menu action to convert a text layer into a heading and vice versa, available from both the layers tree and the canvas. Content, styles, and CMS/component-variable bindings are preserved through the swap.

## Changes

- Add `getTextHeadingConversion` utility that returns the `name`/`settings` to flip a block-level text layer to a heading (tag `h2`) or a heading back to text (tag `p`)
- Add "Convert to heading" / "Convert to text" item to the shared layer context menu (tree + canvas), wired for both page and component-editing contexts with live-update broadcast
- Restrict the action to genuine block-level text and headings — inline text used as button captions, alert messages, and labels (tag `span`/`label`) is excluded so it never emits an `<h2>` inside a `<button>`/`<p>`
- Resync the right sidebar Tag selector when a layer's type changes in place, so the dropdown reflects the new tag immediately after conversion

## Test plan

- [ ] Right-click a Text element in the layers tree → "Convert to heading" → renders as `<h2>`, keeps text/classes/design
- [ ] Right-click a Heading → "Convert to text" → renders as `<p>`, sidebar Tag dropdown updates to `P`
- [ ] Repeat both from the canvas right-click menu
- [ ] Convert a text layer bound to a CMS field / component variable → binding is preserved
- [ ] Verify the action does NOT appear on button captions, alert messages, form labels, or rich text layers
- [ ] Verify the action is hidden/disabled for component instances and locked layers