### PR TITLE
perf: default non-LCP images to lazy loading

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -2522,10 +2522,11 @@ const LayerItemImpl: React.FC<{
 
       const isLcpCandidate = !!lcpCandidateLayerId && layer.id === lcpCandidateLayerId;
       const imgLoadingAttr = layer.attributes?.loading as string | undefined;
-      // LCP candidate always loads eagerly with high fetchpriority — overrides
-      // the image template's default `loading="lazy"`. Other images keep
-      // whatever the user/template set (defaults to lazy).
-      const effectiveLoading = isLcpCandidate ? 'eager' : imgLoadingAttr;
+      // LCP candidate always loads eagerly with high fetchpriority. Every other
+      // image falls back to `lazy` when no explicit value is set: React 19
+      // auto-emits `<link rel="preload" as="image">` for any non-lazy <img>, so
+      // an unset attribute would wastefully preload below-the-fold images.
+      const effectiveLoading = isLcpCandidate ? 'eager' : (imgLoadingAttr ?? 'lazy');
 
       const optimizedSrc = getOptimizedImageUrl(finalImageUrl, 1920, 85);
 

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -1082,10 +1082,11 @@ const LayerItem: React.FC<{
 
       const isLcpCandidate = !!lcpCandidateLayerId && layer.id === lcpCandidateLayerId;
       const imgLoadingAttr = layer.attributes?.loading as string | undefined;
-      // LCP candidate always loads eagerly with high fetchpriority — overrides
-      // the image template's default `loading="lazy"`. Other images keep
-      // whatever the user/template set.
-      const effectiveLoading = isLcpCandidate ? 'eager' : imgLoadingAttr;
+      // LCP candidate always loads eagerly with high fetchpriority. Every other
+      // image falls back to `lazy` when no explicit value is set: React 19
+      // auto-emits `<link rel="preload" as="image">` for any non-lazy <img>, so
+      // an unset attribute would wastefully preload below-the-fold images.
+      const effectiveLoading = isLcpCandidate ? 'eager' : (imgLoadingAttr ?? 'lazy');
 
       const optimizedSrc = getOptimizedImageUrl(finalImageUrl, 1920, 85);
 


### PR DESCRIPTION
## Summary

React 19 automatically emits `<link rel="preload" as="image">` for every non-lazy `<img>` it renders. Images without an explicit `loading` attribute were shipping with none, so the browser preloaded below-the-fold images and diluted the intended hero image's priority. This defaults non-LCP images to `loading="lazy"` so only the LCP image is preloaded.

Observed on a live site: the homepage preloaded 5 images (including an 8192px and a 4300px image) when only the single hero should have been. The 4 extra preloads all traced back to images that had no `loading` attribute, triggering React's auto-preload heuristic.

## Changes

- Default non-LCP images to `loading="lazy"` when no explicit value is set, in both `LayerRendererPublic` (published output) and `LayerRenderer` (builder canvas)
- LCP candidate still renders `eager` + `fetchPriority="high"` and remains preloaded
- Images with an explicit `loading` value are unchanged

## Test plan

- [ ] Publish a page with one large hero image and several below-the-fold images that have no `loading` attribute
- [ ] View source and confirm only the hero emits `<link rel="preload" as="image">`
- [ ] Confirm the hero `<img>` still has `loading="eager"` and `fetchPriority="high"`
- [ ] Confirm below-the-fold images now render `loading="lazy"`
- [ ] Confirm images with an explicitly set `loading="eager"` still preload as before