### PR TITLE
feat: preload custom fonts to reduce swap flash

### DIFF
--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -12,7 +12,8 @@ import { unstable_cache } from 'next/cache';
 import { resolveCustomCodePlaceholders } from '@/lib/resolve-cms-variables';
 import { renderRootLayoutHeadCode } from '@/lib/parse-head-html';
 import { generateInitialAnimationCSS, type HiddenLayerInfo } from '@/lib/animation-utils';
-import { buildCustomFontsCss, buildFontClassesCss, fetchGoogleFontsCss, getGoogleFontLinks } from '@/lib/font-utils';
+import { buildCustomFontsCss, buildFontClassesCss, fetchGoogleFontsCss, getCustomFontPreloads, getGoogleFontLinks } from '@/lib/font-utils';
+import type { FontPreload } from '@/lib/font-utils';
 import { buildImageSizes, collectLayerAssetIds, findLcpCandidate, generateImageSrcset, getAssetProxyUrl, getOptimizedImageUrl } from '@/lib/asset-utils';
 import { getAllPages } from '@/lib/repositories/pageRepository';
 import { getAllPageFolders } from '@/lib/repositories/pageFolderRepository';
@@ -593,12 +594,14 @@ export default async function PageRenderer({
   let fontsCss = '';
   let googleFontsInlinedCss = '';
   let googleFontLinkUrls: string[] = [];
+  let fontPreloads: FontPreload[] = [];
   try {
     const { getAllFonts: getAllDraftFonts } = await import('@/lib/repositories/fontRepository');
     const { getPublishedFonts } = await import('@/lib/repositories/fontRepository');
     const fonts = isPreview ? await getAllDraftFonts() : await getPublishedFonts();
     fontsCss = buildCustomFontsCss(fonts) + buildFontClassesCss(fonts);
     googleFontLinkUrls = getGoogleFontLinks(fonts);
+    fontPreloads = getCustomFontPreloads(fonts);
 
     // Inline the resolved @font-face CSS so the browser skips the blocking
     // round-trip to fonts.googleapis.com and goes straight to gstatic for
@@ -841,6 +844,20 @@ export default async function PageRenderer({
           />
         ))
       )}
+
+      {/* Preload uploaded custom font binaries so the browser fetches them from
+          <head> instead of after CSS parsing, shrinking the font swap window.
+          `crossOrigin` is required — fonts are always fetched in CORS mode. */}
+      {fontPreloads.map((font) => (
+        <link
+          key={`font-preload-${font.href}`}
+          rel="preload"
+          as="font"
+          href={font.href}
+          type={font.type}
+          crossOrigin="anonymous"
+        />
+      ))}
 
       {/* Inject custom font @font-face rules and font class CSS */}
       {fontsCss && (

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -10,6 +10,7 @@
 
 import { layerToHtml, buildAnchorMap } from '@/lib/page-fetcher'
 import type { PageData } from '@/lib/page-fetcher'
+import type { FontPreload } from '@/lib/font-utils'
 import { getClassesString } from '@/lib/layer-utils'
 import { getEffectiveApplyStyle } from '@/lib/animation-utils'
 
@@ -642,6 +643,8 @@ export interface BuildHtmlInput {
   colorVariablesCss: string | null
   /** Inlined @font-face + font class CSS for Google and custom fonts. */
   fontsCss?: string | null
+  /** Custom font binaries to hint via `<link rel="preload" as="font">`. */
+  fontPreloads?: FontPreload[]
   includeSwiper: boolean
   interactions: ExportedInteraction[]
   /** Site-wide custom code from Settings → General (head + body slots). */
@@ -664,6 +667,7 @@ export function buildDocument({
   publishedCss,
   colorVariablesCss,
   fontsCss,
+  fontPreloads,
   includeSwiper,
   interactions,
   globalCustomCodeHead,
@@ -693,6 +697,15 @@ export function buildDocument({
     head.push(`<meta name="twitter:image" content="${escapeHtml(ogImage)}" />`)
   }
   if (noindex) head.push('<meta name="robots" content="noindex" />')
+
+  // Preload uploaded custom font binaries so the browser fetches them from
+  // <head> instead of after CSS parsing. `crossorigin` is required — fonts are
+  // always fetched in CORS mode.
+  for (const font of fontPreloads ?? []) {
+    head.push(
+      `<link rel="preload" as="font" href="${escapeHtml(font.href)}" type="${escapeHtml(font.type)}" crossorigin="anonymous" />`,
+    )
+  }
 
   const css = [fontsCss, colorVariablesCss, publishedCss].filter(Boolean).join('\n')
   if (css) head.push(`<style>${css}</style>`)

--- a/lib/apps/static-export/engine.ts
+++ b/lib/apps/static-export/engine.ts
@@ -13,8 +13,10 @@ import {
   buildCustomFontsCss,
   buildFontClassesCss,
   fetchGoogleFontsCss,
+  getCustomFontPreloads,
   getGoogleFontLinks,
 } from '@/lib/font-utils'
+import type { FontPreload } from '@/lib/font-utils'
 import { generateColorVariablesCss } from '@/lib/repositories/colorVariableRepository'
 import { getAssetById } from '@/lib/repositories/assetRepository'
 import { getPublishedFonts } from '@/lib/repositories/fontRepository'
@@ -183,6 +185,7 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
 
     // ---- Font CSS (Google inlined @font-face + custom @font-face + class rules)
     let fontsCss = ''
+    let fontPreloads: FontPreload[] = []
     if (fonts.length > 0) {
       const googleLinks = getGoogleFontLinks(fonts)
       const [googleCss] = await Promise.all([
@@ -193,6 +196,7 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
       fontsCss = [googleCss, buildCustomFontsCss(fonts), buildFontClassesCss(fonts)]
         .filter(Boolean)
         .join('\n')
+      fontPreloads = getCustomFontPreloads(fonts)
     }
 
     // ---- Render every page (default locale + per non-default locale) ----
@@ -214,6 +218,7 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
             publishedCss: publishedCss ?? null,
             colorVariablesCss: colorVariablesCss ?? null,
             fontsCss: fontsCss || null,
+            fontPreloads,
             includeSwiper: resolved.hasSlider,
             interactions: resolved.interactions,
             globalCustomCodeHead: globalCustomCodeHead ?? null,

--- a/lib/font-utils.ts
+++ b/lib/font-utils.ts
@@ -240,6 +240,43 @@ export function mapExtensionToFontFormat(extension: string): string | null {
   }
 }
 
+/** Map a CSS @font-face format string to the MIME type used on `<link>` preloads */
+export function mapFontFormatToMimeType(format: string | null | undefined): string {
+  switch ((format || 'woff2').toLowerCase()) {
+    case 'woff2': return 'font/woff2';
+    case 'woff': return 'font/woff';
+    case 'truetype': return 'font/ttf';
+    case 'opentype': return 'font/otf';
+    case 'embedded-opentype': return 'application/vnd.ms-fontobject';
+    default: return 'font/woff2';
+  }
+}
+
+/** A font file to hint the browser to fetch early via `<link rel="preload" as="font">` */
+export interface FontPreload {
+  href: string;
+  type: string;
+}
+
+/**
+ * Build preload descriptors for uploaded custom fonts so the browser starts
+ * fetching the binaries from <head> instead of after CSS parsing — reducing the
+ * font swap window (CLS/LCP). Google fonts are excluded: they ship many
+ * unicode-range subsets, and preloading all of them wastes bandwidth.
+ */
+export function getCustomFontPreloads(fonts: Font[]): FontPreload[] {
+  const seen = new Set<string>();
+  const preloads: FontPreload[] = [];
+
+  for (const font of fonts) {
+    if (font.type !== 'custom' || !font.url || seen.has(font.url)) continue;
+    seen.add(font.url);
+    preloads.push({ href: font.url, type: mapFontFormatToMimeType(font.kind) });
+  }
+
+  return preloads;
+}
+
 /**
  * Build CSS for loading all installed fonts.
  * Generates @import rules for Google fonts and @font-face for custom fonts.


### PR DESCRIPTION
## Summary

Custom (uploaded) fonts now get a `<link rel="preload" as="font">` hint in the page `<head>`, so the browser starts fetching the font binary during initial HTML parsing instead of waiting until it parses the `@font-face` CSS. This shrinks the font-swap window that causes the CLS/LCP flash on sites using a custom heading/body font.

## Changes

- Add `getCustomFontPreloads()` and `mapFontFormatToMimeType()` helpers to `lib/font-utils.ts` (deduped by URL, correct preload MIME per format)
- Emit font preload links in `PageRenderer` for live and preview pages, alongside the existing font `<style>` blocks
- Mirror the preloads into the static export `<head>` (`static-export/engine.ts` + `document.ts`)
- Always set `crossorigin="anonymous"` (fonts are fetched in CORS mode) and dedupe by URL

## Notes

- **Custom fonts only.** Google fonts are intentionally excluded — they ship many `unicode-range` subsets, so preloading all of them would waste bandwidth and compete with LCP.
- Purely additive to `<head>`; no other rendering behavior changes.

## Test plan

- [ ] Open a page/preview that uses an uploaded custom font → `<head>` contains one `<link rel="preload" as="font" ... crossorigin="anonymous">` per custom font
- [ ] `type` matches the font format (e.g. `.ttf` → `font/ttf`, `.woff2` → `font/woff2`)
- [ ] A page with only Google fonts emits no font preloads
- [ ] Multiple layers using the same custom font produce a single preload (deduped)
- [ ] Static export HTML `<head>` includes the same preload links