### PR TITLE
fix: allow Code Embed popups to escape sandbox

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -2880,7 +2880,7 @@ const LayerItemImpl: React.FC<{
           data-layer-id={layer.id}
           data-layer-type="htmlEmbed"
           data-html-embed="true"
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals"
           className={fullClassName}
           style={{
             width: '100%',

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -1444,7 +1444,7 @@ const LayerItem: React.FC<{
           data-layer-id={layer.id}
           data-layer-type="htmlEmbed"
           data-html-embed="true"
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals"
           className={fullClassName}
           style={{
             width: '100%',

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -5074,7 +5074,7 @@ export function layerToHtml(
 
     attrs.push('data-html-embed="true"');
     attrs.push(`srcdoc="${escapedIframeContent}"`);
-    attrs.push('sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"');
+    attrs.push('sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals"');
     attrs.push('style="width: 100%; border: none; display: block;"');
     attrs.push(`title="Code Embed ${layer.id}"`);
 


### PR DESCRIPTION
## Summary

Popups triggered from inside a Code Embed (e.g. Google Maps' "View larger map" / "Directions" buttons) were blocked on published sites. The Code Embed iframe sandbox allowed opening popups but not letting them escape the sandbox, so `window.open` from a nested embed was dropped by the browser.

## Changes

- Add `allow-popups-to-escape-sandbox` to the Code Embed iframe sandbox in the public renderer, editor canvas, and SSR/static HTML output

## Test plan

- [ ] Add a Google Maps embed to a Code element and publish
- [ ] Click "View larger map" / "Directions" on the live site and confirm the popup opens
- [ ] Verify the embed still renders isolated in the editor canvas