### PR TITLE
fix: disable link setting on iframe-based layers

### DIFF
--- a/app/(builder)/ycode/components/LinkSettings.tsx
+++ b/app/(builder)/ycode/components/LinkSettings.tsx
@@ -266,9 +266,12 @@ export default function LinkSettings(props: LinkSettingsProps) {
     // Check if layer can have a layer-level link (includes rich text links check)
     const { canHaveLinks, issue } = canLayerHaveLink(layer, draft.layers);
 
-    // Only show issue if there's no existing link (allow editing existing links)
-    if (!canHaveLinks && issue && linkType === 'none') {
-      return issue;
+    if (!canHaveLinks && issue) {
+      // Unsupported layer types (iframe-based) can never have a link — always
+      // surface the message. Nesting issues only block when no link exists yet.
+      if (issue.type === 'unsupported' || linkType === 'none') {
+        return issue;
+      }
     }
 
     return null;
@@ -626,11 +629,13 @@ export default function LinkSettings(props: LinkSettingsProps) {
       >
         <Empty>
           <EmptyDescription>
-            {linkNestingIssue.type === 'richText'
-              ? 'Cannot add a link to a layer that contains rich text links. Remove the rich text links first.'
-              : linkNestingIssue.type === 'ancestor'
-                ? `Links cannot be nested. This layer is inside a "${linkNestingIssue.layerName}" layer that already has a link.`
-                : 'Links cannot be nested. This layer contains child layers with links.'}
+            {linkNestingIssue.type === 'unsupported'
+              ? 'Links aren\u2019t supported on this layer, as it renders in an isolated iframe.'
+              : linkNestingIssue.type === 'richText'
+                ? 'Cannot add a link to a layer that contains rich text links. Remove the rich text links first.'
+                : linkNestingIssue.type === 'ancestor'
+                  ? `Links cannot be nested. This layer is inside a "${linkNestingIssue.layerName}" layer that already has a link.`
+                  : 'Links cannot be nested. This layer contains child layers with links.'}
           </EmptyDescription>
         </Empty>
       </SettingsPanel>

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -1207,6 +1207,9 @@ function layerLabelFallback(layer: Layer): string {
   return layer.customName || layer.name;
 }
 
+/** Layer types rendered as iframes, where a wrapping link can't receive clicks. */
+export const LINK_UNSUPPORTED_LAYER_NAMES = new Set(['htmlEmbed', 'map']);
+
 /**
  * Check if a layer can have a link added
  * @param layer - The layer to check
@@ -1218,8 +1221,18 @@ export function canLayerHaveLink(
   layer: Layer,
   allLayers: Layer[],
   type: 'layer' | 'richText' = 'layer'
-): { canHaveLinks: boolean; issue?: { type: 'self' | 'ancestor' | 'child' | 'richText'; layerName?: string } } {
+): { canHaveLinks: boolean; issue?: { type: 'self' | 'ancestor' | 'child' | 'richText' | 'unsupported'; layerName?: string } } {
   if (type === 'layer') {
+    // Iframe-based layers (Code embed, Map) capture pointer events, so a
+    // wrapping <a> never receives the click — a layer-level link would
+    // silently do nothing. Block it rather than offer a broken affordance.
+    if (LINK_UNSUPPORTED_LAYER_NAMES.has(layer.name)) {
+      return {
+        canHaveLinks: false,
+        issue: { type: 'unsupported' }
+      };
+    }
+
     // Checking if a layer-level link can be added
     // Can't add layer link if the layer has rich text links
     if (hasRichTextLinks(layer)) {


### PR DESCRIPTION
## Summary

Code embed and Map layers render inside an isolated iframe. The iframe captures pointer events, so a wrapping `<a>` never receives the click — the Link setting looked functional but silently did nothing. This disables the setting for those layers and explains why.

## Changes

- Add `LINK_UNSUPPORTED_LAYER_NAMES` (Code embed, Map) and block layer-level links for them in `canLayerHaveLink`
- Show an explanatory message in the Link panel instead of the (non-working) controls
- Always surface the message for these layers, even if a link value was previously saved

## Test plan

- [ ] Select a Code embed layer and confirm the Link panel shows the explanatory message
- [ ] Select a Map layer and confirm the same
- [ ] Confirm normal layers (div, button, etc.) still show working Link controls
- [ ] Confirm rich-text link nesting messages are unchanged