### PR TITLE
fix: keep legacy headings a heading when changing tag

### DIFF
--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -1056,9 +1056,16 @@ const RightSidebar = React.memo(function RightSidebar({
     setTextTag(tag);
     if (selectedLayerId) {
       const currentSettings = selectedLayer?.settings || {};
-      handleLayerUpdate(selectedLayerId, {
-        settings: { ...currentSettings, tag }
-      });
+      // Normalize the element name to match the tag family so legacy headings
+      // (stored as text with an h1-h6 tag) migrate to a proper heading.
+      const name = headingTagOptions.some(opt => opt.value === tag) ? 'heading' : 'text';
+      const updates: Partial<Layer> = { name, settings: { ...currentSettings, tag } };
+      // Drop an auto-assigned "Text"/"Heading" label so the layer shows its
+      // content again (a user's custom layer name is left untouched).
+      if (selectedLayer?.customName === 'Text' || selectedLayer?.customName === 'Heading') {
+        updates.customName = undefined;
+      }
+      handleLayerUpdate(selectedLayerId, updates);
     }
   };
 
@@ -2356,7 +2363,11 @@ const RightSidebar = React.memo(function RightSidebar({
 
               {/* Tag Selector - For heading and text layers */}
               {(selectedLayer?.name === 'heading' || (selectedLayer?.name === 'text' && !isContainerLayer(selectedLayer))) && (() => {
-                const tagOptions = selectedLayer?.name === 'heading' ? headingTagOptions : textTagOptions;
+                // Use isHeadingLayer (not name === 'heading') so legacy headings
+                // stored as text with an h1-h6 tag still get heading tag options
+                // instead of p/span/label — otherwise changing the tag demotes
+                // them to a paragraph.
+                const tagOptions = isHeadingLayer(selectedLayer) ? headingTagOptions : textTagOptions;
                 return (
                   <div className="grid grid-cols-3">
                     <Label variant="muted">Tag</Label>

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -665,6 +665,9 @@ export function isTextContentLayer(layer: Layer | null | undefined): boolean {
   return layer.name === 'heading' || layer.name === 'text';
 }
 
+/** Auto-assigned layer labels that should track the text/heading element type. */
+const AUTO_TEXT_HEADING_LABELS = new Set(['Text', 'Heading']);
+
 /**
  * Build the props to convert a text layer into a heading (or the reverse).
  * Switches the element `name` and its default HTML tag while preserving
@@ -673,22 +676,37 @@ export function isTextContentLayer(layer: Layer | null | undefined): boolean {
  * Only genuine block-level text and headings qualify: inline text used as
  * button captions, alert messages, or labels (tag `span`/`label`) is excluded
  * so conversion never emits an `<h2>` inside a `<button>` or `<p>`.
+ *
+ * An auto-assigned "Text"/"Heading" label is dropped so the layer shows its
+ * text content in the Layers panel; a user's custom layer name is preserved.
  */
 export function getTextHeadingConversion(
   layer: Layer | null | undefined
-): Pick<Layer, 'name' | 'settings'> | null {
+): Pick<Layer, 'name' | 'settings' | 'customName'> | null {
   if (!layer) return null;
+
+  // Drop an auto-assigned "Text"/"Heading" label so the converted layer shows
+  // its content again; keep a user-defined custom name.
+  const clearLabel = !!layer.customName && AUTO_TEXT_HEADING_LABELS.has(layer.customName);
 
   // Heading (incl. legacy text with an h1-h6 tag) → paragraph text.
   if (isHeadingLayer(layer)) {
-    return { name: 'text', settings: { ...layer.settings, tag: 'p' } };
+    return {
+      name: 'text',
+      settings: { ...layer.settings, tag: 'p' },
+      ...(clearLabel ? { customName: undefined } : {}),
+    };
   }
 
   // Block-level paragraph text → heading (skip inline span/label variants).
   if (layer.name === 'text') {
     const tag = layer.settings?.tag;
     if (!tag || tag === 'p') {
-      return { name: 'heading', settings: { ...layer.settings, tag: 'h2' } };
+      return {
+        name: 'heading',
+        settings: { ...layer.settings, tag: 'h2' },
+        ...(clearLabel ? { customName: undefined } : {}),
+      };
     }
   }
 


### PR DESCRIPTION
## Summary

Headings created before the heading/text element split are stored as a text layer with an `h1`-`h6` tag. Because the Tag dropdown decided its options from `name === 'heading'`, these legacy headings were offered `p`/`span`/`label` instead of `h1`-`h6`, and picking an option demoted them to a paragraph (icon flipped from H to T).

## Changes

- Gate the Tag dropdown options on `isHeadingLayer()` so legacy text-with-heading-tag layers get `h1`-`h6` options
- On tag change, normalize `name` to match the tag family (`h1`-`h6` → `heading`, otherwise `text`), migrating legacy layers to the modern shape
- Drop an auto-assigned `Text`/`Heading` `customName` on tag change and on context-menu conversion so the layer shows its content in the Layers panel (genuine custom names are preserved)

## Test plan

- [ ] Select a legacy heading (text layer with `tag: h1`); Tag dropdown shows h1-h6, not p/span/label
- [ ] Change its tag to h2 — stays a heading, renders `<h2>`, keeps H icon
- [ ] Layers panel shows the heading's text content, not "Heading"
- [ ] Add a fresh Heading/Text element and confirm the Tag dropdown still behaves correctly
- [ ] Context menu "Convert to text"/"Convert to heading" still works and shows content as label
- [ ] A layer with a user-defined custom name keeps that name after conversion