### PR TITLE
fix: hoist inline base64 rich-text images to assets

### DIFF
--- a/lib/repositories/collectionItemValueRepository.ts
+++ b/lib/repositories/collectionItemValueRepository.ts
@@ -56,6 +56,13 @@ export async function insertValuesBulk(
 
   if (values.length === 0) return;
 
+  // Hoist inline base64 rich-text images to the asset manager so importers never
+  // persist multi-MB data URIs inline (safe no-op for non-rich-text values).
+  // Dynamically imported to keep the upload deps (sharp/file-upload) out of the
+  // read/render module graph that also pulls in this repository.
+  const { uploadInlineRichTextImagesInRows } = await import('@/lib/rich-text-image-upload');
+  await uploadInlineRichTextImagesInRows(values);
+
   const now = new Date().toISOString();
   const valuesToInsert = values.map(v => ({
     id: randomUUID(),
@@ -85,6 +92,11 @@ export async function insertValuesDirectPg(
   values: Array<{ item_id: string; field_id: string; value: string | null; is_published?: boolean }>
 ): Promise<void> {
   if (values.length === 0) return;
+
+  // Hoist inline base64 rich-text images before the direct-PG insert (this path
+  // handles oversized values — exactly where multi-MB base64 blobs land).
+  const { uploadInlineRichTextImagesInRows } = await import('@/lib/rich-text-image-upload');
+  await uploadInlineRichTextImagesInRows(values);
 
   const knex = await getKnexClient();
   const tenantId = await getTenantIdFromHeaders();
@@ -601,6 +613,19 @@ export async function setValuesByFieldName(
   const autoBumpedUpdatedAt = updatedAtFieldId && !(updatedAtFieldId in valuesToSet);
   if (autoBumpedUpdatedAt) {
     valuesToSet[updatedAtFieldId!] = new Date().toISOString();
+  }
+
+  // Hoist any inline base64 images embedded in rich-text values out to the asset
+  // manager before they're stored. Callers that author rich text from markdown
+  // (AI/MCP tools, editor saves) can otherwise persist multi-MB data URIs inline,
+  // which blow past the serverless payload limit and block publishing.
+  const richTextFieldIds = Object.keys(valuesToSet).filter(
+    id => fieldMap[id] === 'rich_text' && typeof valuesToSet[id] === 'string');
+  if (richTextFieldIds.length > 0) {
+    const { uploadInlineRichTextImages } = await import('@/lib/rich-text-image-upload');
+    for (const fieldId of richTextFieldIds) {
+      valuesToSet[fieldId] = await uploadInlineRichTextImages(valuesToSet[fieldId]);
+    }
   }
 
   // Detect changes and removals for translation management (only for draft)

--- a/lib/rich-text-image-upload.ts
+++ b/lib/rich-text-image-upload.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared server-side handling for inline base64 images in rich-text content.
+ *
+ * Any ingestion path that authors rich-text (TipTap JSON) — the AI/MCP collection
+ * item tools, the Airtable/Webflow importers, direct editor saves — can end up
+ * with `data:image/...;base64,...` blobs embedded directly in the content. Those
+ * multi-MB values blow past the serverless payload limit and block publishing.
+ *
+ * These helpers decode each inline image, upload it to the asset manager (via the
+ * same `uploadFile` path used elsewhere, so tenant scoping and WebP conversion
+ * are inherited), and rewrite the node `src` to the hosted URL.
+ */
+
+import { extractRichTextImageUrls, isDataImageUrl, parseDataImageUri, replaceRichTextImageUrls } from '@/lib/csv-utils';
+import { uploadFile } from '@/lib/file-upload';
+
+/** Cheap gate so non-image values skip parsing entirely. */
+const DATA_IMAGE_MARKER = 'data:image';
+
+/** Build a File from a base64 data-image URI so it can go through uploadFile. */
+function dataUriToFile(dataUri: string): File | null {
+  const parsed = parseDataImageUri(dataUri);
+  if (!parsed) return null;
+  const buffer = Buffer.from(parsed.base64, 'base64');
+  if (buffer.length === 0) return null;
+  const filename = `inline-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${parsed.extension}`;
+  return new File([buffer], filename, { type: parsed.mimeType });
+}
+
+/** Upload one base64 data-image URI, returning its hosted asset (or null on failure). */
+async function uploadDataUri(dataUri: string): Promise<{ assetId: string; publicUrl: string } | null> {
+  const file = dataUriToFile(dataUri);
+  if (!file) return null;
+  const asset = await uploadFile(file, 'rich-text-inline');
+  if (!asset?.public_url) return null;
+  return { assetId: asset.id, publicUrl: asset.public_url };
+}
+
+/** Collect the unique inline base64 image srcs referenced by a rich-text value. */
+function collectDataImageSrcs(value: string): string[] {
+  return extractRichTextImageUrls(value)
+    .map((ref) => ref.src)
+    .filter(isDataImageUrl);
+}
+
+/**
+ * Replace inline base64 images in a single rich-text (TipTap JSON) value with
+ * hosted asset URLs. Returns the value untouched when it holds no base64 image
+ * or isn't rich-text JSON, so it's safe to call on any value.
+ */
+export async function uploadInlineRichTextImages(value: string | null): Promise<string | null> {
+  if (!value || !value.includes(DATA_IMAGE_MARKER)) return value;
+
+  const uniqueSrcs = Array.from(new Set(collectDataImageSrcs(value)));
+  if (uniqueSrcs.length === 0) return value;
+
+  const srcToAsset = new Map<string, { assetId: string; publicUrl: string }>();
+  for (const src of uniqueSrcs) {
+    const uploaded = await uploadDataUri(src);
+    if (uploaded) srcToAsset.set(src, uploaded);
+  }
+
+  return srcToAsset.size > 0 ? replaceRichTextImageUrls(value, srcToAsset) : value;
+}
+
+/**
+ * In-place variant for bulk value rows: uploads every unique inline base64 image
+ * across the batch once, then rewrites each affected row's `value`. No-op when
+ * the batch contains no base64 images.
+ */
+export async function uploadInlineRichTextImagesInRows<T extends { value: string | null }>(rows: T[]): Promise<void> {
+  const affected = rows.filter((row): row is T & { value: string } =>
+    !!row.value && row.value.includes(DATA_IMAGE_MARKER));
+  if (affected.length === 0) return;
+
+  const uniqueSrcs = new Set<string>();
+  for (const row of affected) {
+    for (const src of collectDataImageSrcs(row.value)) uniqueSrcs.add(src);
+  }
+
+  const srcToAsset = new Map<string, { assetId: string; publicUrl: string }>();
+  for (const src of uniqueSrcs) {
+    const uploaded = await uploadDataUri(src);
+    if (uploaded) srcToAsset.set(src, uploaded);
+  }
+  if (srcToAsset.size === 0) return;
+
+  for (const row of affected) {
+    row.value = replaceRichTextImageUrls(row.value, srcToAsset);
+  }
+}


### PR DESCRIPTION
## Summary

Rich-text content authored by the AI/MCP tools, the Airtable/Webflow importers, or direct editor saves could store `data:image` base64 blobs inline. These multi-MB values exceed the serverless payload limit and block publishing. Only the CSV importer handled this — every other path inlined the image verbatim.

This centralizes the fix at the collection item value write layer so all ingestion paths upload inline base64 images to the asset manager and rewrite the node `src` to the hosted URL.

## Changes

- Add `lib/rich-text-image-upload.ts` with `uploadInlineRichTextImages` (single value) and `uploadInlineRichTextImagesInRows` (batch, in-place), reusing the existing base64 helpers from `csv-utils` and the shared `uploadFile` (inherits WebP conversion + storage)
- Wire it into `setValuesByFieldName` (AI/MCP tools + editor saves) for rich-text fields
- Wire it into `insertValuesBulk` and `insertValuesDirectPg` (Airtable/Webflow imports, and the oversized-value path where base64 blobs land)
- Use dynamic imports at the write sites so the upload deps (sharp/file-upload) stay out of the read/render module graph
- Remote URLs and non-rich-text values are left untouched; duplicate blobs upload once; upload failures degrade gracefully (value unchanged)

## Test plan

- [ ] Create a CMS item via the AI/MCP tools with a rich-text field containing a base64 markdown image — verify it publishes and the stored value references a hosted asset URL, not `data:image`
- [ ] Save a rich-text field with an inline base64 image from the editor — verify same
- [ ] Import content via Airtable/Webflow containing base64 rich-text images — verify hoisting
- [ ] Confirm remote-URL images in rich text are unaffected
- [ ] Confirm existing CSV import still works (now backed by the same guard)
- [ ] Confirm non-rich-text values are unchanged