### PR TITLE
feat: add search to page and item pickers

### DIFF
--- a/app/(builder)/ycode/components/CollectionItemSelector.tsx
+++ b/app/(builder)/ycode/components/CollectionItemSelector.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import Icon from '@/components/ui/icon';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { Icon } from '@/components/ui/icon';
+
+import { FilterCombobox } from './filter-combobox';
+
 import { useDebounce } from '@/hooks/use-debounce';
 import { useCollectionsStore } from '@/stores/useCollectionsStore';
+import { cn } from '@/lib/utils';
 
 interface CollectionItemSelectorProps {
   collectionId: string;
@@ -19,9 +23,10 @@ const SEARCH_DEBOUNCE_MS = 300;
 /**
  * Top-bar picker for the active collection item on dynamic pages.
  *
- * Items are sourced from the preloaded store cache; typing triggers a
- * debounced server search that merges results into the cache so the
- * canvas can resolve items beyond the initial preload window.
+ * The trigger is the filter field (same UX as PageSelector). Items come from
+ * the preloaded store cache; typing triggers a debounced server search that
+ * merges results into the cache so the canvas can resolve items beyond the
+ * initial preload window.
  */
 export default function CollectionItemSelector({
   collectionId,
@@ -34,7 +39,7 @@ export default function CollectionItemSelector({
 
   const [search, setSearch] = useState('');
   const debouncedSearch = useDebounce(search, SEARCH_DEBOUNCE_MS);
-  const [isSearching, setIsSearching] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const dropdownItems = useMemo(() => {
     const items = itemsByCollection[collectionId] || [];
@@ -56,85 +61,99 @@ export default function CollectionItemSelector({
 
   useEffect(() => {
     if (!trimmedSearch) {
-      setIsSearching(false);
+      setIsLoading(false);
       return;
     }
 
     let cancelled = false;
-    setIsSearching(true);
+    setIsLoading(true);
     searchAndMergeItems(collectionId, trimmedSearch, SEARCH_LIMIT)
       .finally(() => {
-        if (!cancelled) setIsSearching(false);
+        if (!cancelled) setIsLoading(false);
       });
 
     return () => { cancelled = true; };
   }, [collectionId, trimmedSearch, searchAndMergeItems]);
 
-  // Auto-select the first item when none is selected yet
   useEffect(() => {
     if (!value && dropdownItems.length > 0) {
       onValueChange(dropdownItems[0].id);
     }
   }, [value, dropdownItems, onValueChange]);
 
-  const filteredItems = useMemo(() => {
-    if (!search.trim()) return dropdownItems;
-    const needle = search.toLowerCase();
-    return dropdownItems.filter((item) => item.label.toLowerCase().includes(needle));
-  }, [dropdownItems, search]);
+  const selectedLabel = dropdownItems.find((item) => item.id === value)?.label || '';
 
-  const selectedLabel = dropdownItems.find((item) => item.id === value)?.label || 'Select item';
-  const hasNoItems = dropdownItems.length === 0 && !isSearching;
-
-  const handleOpenChange = (open: boolean) => {
-    if (!open) setSearch('');
-  };
+  const handleEnter = useCallback((query: string) => {
+    if (!query.trim()) return;
+    const needle = query.toLowerCase();
+    const first = dropdownItems.find((item) => item.label.toLowerCase().includes(needle));
+    if (first) onValueChange(first.id);
+  }, [dropdownItems, onValueChange]);
 
   return (
-    <Select
-      value={value || ''}
-      onValueChange={(next) => {
-        onValueChange(next);
-        setSearch('');
-      }}
-      onOpenChange={handleOpenChange}
-      disabled={hasNoItems}
+    <FilterCombobox
+      displayValue={selectedLabel}
+      placeholder="Select item"
+      searchPlaceholder="Search items..."
+      ariaLabel="Select collection item"
+      className="w-24"
+      align="start"
+      popoverClassName="min-w-72 max-w-96"
+      isLoading={isLoading}
+      leading={(
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="shrink-0">
+              <Icon name="database" className="size-3 opacity-50" />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>Collection item</TooltipContent>
+        </Tooltip>
+      )}
+      onSearchChange={setSearch}
+      onEnter={handleEnter}
     >
-      <SelectTrigger className="w-24 justify-between" size="sm">
-        <div className="flex items-center gap-1.5 min-w-0 flex-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="shrink-0">
-                <Icon name="database" className="size-3 opacity-50" />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>Collection item</TooltipContent>
-          </Tooltip>
-          <span className="truncate">{selectedLabel}</span>
-        </div>
-      </SelectTrigger>
+      {({ search: query, hasQuery, close }) => {
+        const needle = query.trim().toLowerCase();
+        const visibleItems = needle
+          ? dropdownItems.filter((item) => item.label.toLowerCase().includes(needle))
+          : dropdownItems;
 
-      <SelectContent
-        searchable
-        searchValue={search}
-        onSearchChange={setSearch}
-        searchPlaceholder="Search items..."
-        searchLoading={isSearching}
-        align="start"
-        className="min-w-72 max-w-96"
-      >
-        {filteredItems.length === 0 ? (
-          <div className="px-2 py-4 text-center text-xs text-muted-foreground">
-            {search ? (isSearching ? 'Searching...' : 'No items found') : 'No items available'}
-          </div>
-        ) : (
-          filteredItems.map((item) => (
-            <SelectItem key={item.id} value={item.id}>
-              <span className="truncate">{item.label}</span>
-            </SelectItem>
-          ))
-        )}
-      </SelectContent>
-    </Select>
+        if (visibleItems.length === 0) {
+          return (
+            <div className="px-2 py-4 text-center text-xs text-muted-foreground">
+              {hasQuery ? (isLoading ? 'Searching...' : 'No items found') : 'No items available'}
+            </div>
+          );
+        }
+
+        return visibleItems.map((item) => {
+          const isSelected = item.id === value;
+          return (
+            <div
+              key={item.id}
+              role="option"
+              aria-selected={isSelected}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => {
+                onValueChange(item.id);
+                close();
+              }}
+              className={cn(
+                'hover:bg-accent hover:text-accent-foreground text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-xs outline-hidden select-none',
+                isSelected && 'bg-secondary/50'
+              )}
+            >
+              <span className="min-w-0 truncate">{item.label}</span>
+              {isSelected && (
+                <span className="absolute right-2 flex size-3 items-center justify-center">
+                  <Icon name="check" className="size-3 opacity-50" />
+                </span>
+              )}
+            </div>
+          );
+        });
+      }}
+    </FilterCombobox>
   );
 }

--- a/app/(builder)/ycode/components/PageSelector.tsx
+++ b/app/(builder)/ycode/components/PageSelector.tsx
@@ -3,9 +3,9 @@
 /**
  * PageSelector - Reusable page selector with folder tree
  *
- * Renders a Popover dropdown showing pages organized in a folder tree.
- * Used in link settings, rich text link settings, collection link fields,
- * and the center canvas page navigation.
+ * Renders a combobox: the trigger is the filter input, and the popover
+ * lists pages in a folder tree. Used in link settings, rich text link
+ * settings, collection link fields, and the center canvas page navigation.
  */
 
 // 1. React
@@ -13,19 +13,16 @@ import React, { memo, useCallback, useContext, useEffect, useMemo, useRef, useSt
 
 // 3. ShadCN UI
 import Icon from '@/components/ui/icon';
-import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
+
+// 4. Internal components
+import { FilterCombobox } from './filter-combobox';
 
 // 5. Stores
 import { usePagesStore } from '@/stores/usePagesStore';
 
 // 6. Utils
-import { buildPageTree, getNodeIcon, getPageIcon } from '@/lib/page-utils';
+import { buildPageTree, filterPageTree, getNodeIcon, getPageIcon } from '@/lib/page-utils';
 import { cn } from '@/lib/utils';
 
 // 7. Types
@@ -39,7 +36,7 @@ interface PageSelectorProps {
   disabled?: boolean;
   /** Show error pages in a separate "Error pages" folder. Default: false */
   includeErrorPages?: boolean;
-  /** Custom class for the trigger button */
+  /** Custom class for the trigger */
   className?: string;
   /** Popover alignment relative to trigger. Default: "end" (right-aligned) */
   align?: 'start' | 'center' | 'end';
@@ -55,6 +52,7 @@ interface PageSelectorProps {
 interface TreeContextValue {
   collapsedFolderIds: Set<string>;
   selectedValue: string | null;
+  isSearching: boolean;
   onToggleFolder: (folderId: string) => void;
   onPageSelect: (pageId: string) => void;
 }
@@ -80,6 +78,7 @@ const TreeRow = memo(function TreeRow({ node, depth, isCollapsed, isSelected }: 
   const handleRowClick = useCallback(() => {
     if (!ctx) return;
     if (isFolder) {
+      if (ctx.isSearching) return;
       ctx.onToggleFolder(node.id);
     } else {
       ctx.onPageSelect(node.id);
@@ -88,7 +87,7 @@ const TreeRow = memo(function TreeRow({ node, depth, isCollapsed, isSelected }: 
 
   const handleChevronClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    if (isFolder && ctx) {
+    if (isFolder && ctx && !ctx.isSearching) {
       ctx.onToggleFolder(node.id);
     }
   }, [ctx, isFolder, node.id]);
@@ -96,6 +95,7 @@ const TreeRow = memo(function TreeRow({ node, depth, isCollapsed, isSelected }: 
   return (
     <div>
       <div
+        onMouseDown={(e) => e.preventDefault()}
         onClick={handleRowClick}
         className={cn(
           "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-1.25 rounded-sm py-1.5 pr-8 pl-2 text-xs outline-hidden select-none data-disabled:opacity-50 data-disabled:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
@@ -105,6 +105,8 @@ const TreeRow = memo(function TreeRow({ node, depth, isCollapsed, isSelected }: 
       >
         {hasChildren ? (
           <button
+            type="button"
+            tabIndex={-1}
             onClick={handleChevronClick}
             className={cn(
               'size-3 flex items-center justify-center shrink-0',
@@ -158,15 +160,15 @@ const TreeRow = memo(function TreeRow({ node, depth, isCollapsed, isSelected }: 
 });
 
 /**
- * Thin wrapper that reads `collapsedFolderIds` and `selectedValue` from
- * context and forwards only primitive props to the memoized `TreeRow`. This
- * keeps `TreeRow` insulated from Set/object identity changes higher up the
- * tree — a toggle on folder A only re-renders A's row (and its child connectors
+ * Thin wrapper that reads collapse/selection/search state from context and
+ * forwards only primitive props to the memoized `TreeRow`. This keeps
+ * `TreeRow` insulated from Set/object identity changes higher up the tree —
+ * a toggle on folder A only re-renders A's row (and its child connectors
  * for unmount), not unrelated rows.
  */
 function TreeRowConnector({ node, depth }: { node: PageTreeNode; depth: number }) {
   const ctx = useContext(TreeContext);
-  const isCollapsed = !!ctx && node.type === 'folder' && ctx.collapsedFolderIds.has(node.id);
+  const isCollapsed = !!ctx && !ctx.isSearching && node.type === 'folder' && ctx.collapsedFolderIds.has(node.id);
   const isSelected = !!ctx && node.type === 'page' && node.id === ctx.selectedValue;
   return <TreeRow
     node={node} depth={depth}
@@ -186,6 +188,17 @@ function getFolderIdKey(folders: PageFolder[]): string {
   return ids.join('|');
 }
 
+function findFirstPageId(nodes: PageTreeNode[]): string | null {
+  for (const node of nodes) {
+    if (node.type === 'page') return node.id;
+    if (node.children) {
+      const childId = findFirstPageId(node.children);
+      if (childId) return childId;
+    }
+  }
+  return null;
+}
+
 /**
  * Reusable page selector with folder tree dropdown
  */
@@ -199,7 +212,6 @@ function PageSelectorImpl({
   align = 'end',
   popoverClassName,
 }: PageSelectorProps) {
-  const [isOpen, setIsOpen] = useState(false);
 
   const pages = usePagesStore((state) => state.pages);
   const folders = usePagesStore((state) => state.folders);
@@ -325,21 +337,18 @@ function PageSelectorImpl({
     return ancestors;
   }, [pagesById, foldersById]);
 
-  const handleOpenChange = useCallback((open: boolean) => {
-    setIsOpen(open);
-    if (open && value) {
-      const ancestorIds = getAncestorFolderIds(value);
-      if (ancestorIds.length > 0) {
-        setCollapsedFolderIds(prev => {
-          let changed = false;
-          const next = new Set(prev);
-          for (const id of ancestorIds) {
-            if (next.delete(id)) changed = true;
-          }
-          return changed ? next : prev;
-        });
+  const expandSelectedAncestors = useCallback(() => {
+    if (!value) return;
+    const ancestorIds = getAncestorFolderIds(value);
+    if (ancestorIds.length === 0) return;
+    setCollapsedFolderIds((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const id of ancestorIds) {
+        if (next.delete(id)) changed = true;
       }
-    }
+      return changed ? next : prev;
+    });
   }, [value, getAncestorFolderIds]);
 
   const toggleFolder = useCallback((folderId: string) => {
@@ -354,82 +363,88 @@ function PageSelectorImpl({
     });
   }, []);
 
-  const handlePageSelect = useCallback((pageId: string) => {
-    onValueChange(pageId);
-    setIsOpen(false);
-  }, [onValueChange]);
-
   const selectedPage = useMemo(() => {
     if (!value) return null;
     return pagesById.get(value) ?? null;
   }, [value, pagesById]);
 
-  const treeContext = useMemo<TreeContextValue>(() => ({
-    collapsedFolderIds,
-    selectedValue: value,
-    onToggleFolder: toggleFolder,
-    onPageSelect: handlePageSelect,
-  }), [collapsedFolderIds, value, toggleFolder, handlePageSelect]);
+  const handleEnter = useCallback((query: string) => {
+    const filtered = filterPageTree(pageTree, query);
+    const errorFiltered = errorPagesNode
+      ? filterPageTree([errorPagesNode], query)[0] ?? null
+      : null;
+    const firstPageId = findFirstPageId(filtered)
+      ?? (errorFiltered ? findFirstPageId([errorFiltered]) : null);
+    if (firstPageId) onValueChange(firstPageId);
+  }, [pageTree, errorPagesNode, onValueChange]);
 
   return (
-    <Popover open={isOpen} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="input"
-          size="sm"
-          role="combobox"
-          aria-expanded={isOpen}
-          disabled={disabled}
-          className={cn('w-full justify-between', selectedPage && 'text-foreground', className)}
-        >
-          <div className="flex items-center gap-1.5 min-w-0 flex-1">
-            {selectedPage ? (
-              <>
-                <Icon
-                  name={getPageIcon(selectedPage)}
-                  className="size-3 opacity-50 shrink-0"
-                />
-                <span className="truncate">{selectedPage.name}</span>
-                {selectedPage.is_publishable === false && (
-                  <Icon name="eye-off" className="size-3.5 shrink-0 opacity-70" />
-                )}
-              </>
-            ) : (
-              <span className="truncate">{placeholder}</span>
-            )}
-          </div>
-          <div className="shrink-0">
-            <Icon name="chevronDown" className="size-2.5! shrink-0 opacity-50" />
-          </div>
-        </Button>
-      </PopoverTrigger>
+    <FilterCombobox
+      displayValue={selectedPage?.name ?? ''}
+      placeholder={placeholder}
+      searchPlaceholder="Search pages..."
+      ariaLabel="Select page"
+      disabled={disabled}
+      className={cn(selectedPage && 'text-foreground', className)}
+      align={align}
+      popoverClassName={popoverClassName}
+      leading={selectedPage ? (
+        <Icon
+          name={getPageIcon(selectedPage)}
+          className="size-3 opacity-50 shrink-0"
+        />
+      ) : null}
+      trailing={selectedPage?.is_publishable === false ? (
+        <Icon name="eye-off" className="size-3.5 shrink-0 opacity-70" />
+      ) : null}
+      onOpen={expandSelectedAncestors}
+      onEnter={handleEnter}
+    >
+      {({ search, hasQuery, close }) => {
+        const filteredPageTree = filterPageTree(pageTree, search);
+        const filteredErrorPagesNode = !errorPagesNode
+          ? null
+          : hasQuery
+            ? filterPageTree([errorPagesNode], search)[0] ?? null
+            : errorPagesNode;
+        const hasResults = filteredPageTree.length > 0 || !!filteredErrorPagesNode;
 
-      <PopoverContent className={cn('w-auto min-w-56 max-w-96 p-1', popoverClassName)} align={align}>
-        <div className="max-h-100 overflow-y-auto">
-          <TreeContext.Provider value={treeContext}>
-            {pageTree.length > 0 && pageTree.map((node) => (
+        return (
+          <TreeContext.Provider
+            value={{
+              collapsedFolderIds,
+              selectedValue: value,
+              isSearching: hasQuery,
+              onToggleFolder: toggleFolder,
+              onPageSelect: (pageId) => {
+                onValueChange(pageId);
+                close();
+              },
+            }}
+          >
+            {filteredPageTree.length > 0 && filteredPageTree.map((node) => (
               <TreeRowConnector
                 key={node.id} node={node}
                 depth={0}
               />
             ))}
 
-            {errorPagesNode && (
+            {filteredErrorPagesNode && (
               <>
-                <Separator className="my-1" />
-                <TreeRowConnector node={errorPagesNode} depth={0} />
+                {filteredPageTree.length > 0 && <Separator className="my-1" />}
+                <TreeRowConnector node={filteredErrorPagesNode} depth={0} />
               </>
             )}
-          </TreeContext.Provider>
 
-          {pageTree.length === 0 && !errorPagesNode && (
-            <div className="text-sm text-muted-foreground text-center py-4">
-              No pages found
-            </div>
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
+            {!hasResults && (
+              <div className="text-xs text-muted-foreground text-center py-4">
+                No pages found
+              </div>
+            )}
+          </TreeContext.Provider>
+        );
+      }}
+    </FilterCombobox>
   );
 }
 

--- a/app/(builder)/ycode/components/filter-combobox.tsx
+++ b/app/(builder)/ycode/components/filter-combobox.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import React, { useCallback, useId, useRef, useState } from 'react';
+
+import { buttonVariants } from '@/components/ui/button';
+import Icon from '@/components/ui/icon';
+import { Input } from '@/components/ui/input';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from '@/components/ui/popover';
+import { Spinner } from '@/components/ui/spinner';
+
+import { cn } from '@/lib/utils';
+
+export interface FilterComboboxRenderProps {
+  search: string;
+  hasQuery: boolean;
+  close: () => void;
+}
+
+export interface FilterComboboxProps {
+  displayValue: string;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  ariaLabel: string;
+  disabled?: boolean;
+  isLoading?: boolean;
+  className?: string;
+  align?: 'start' | 'center' | 'end';
+  popoverClassName?: string;
+  leading?: React.ReactNode;
+  trailing?: React.ReactNode;
+  onOpen?: () => void;
+  onEnter?: (search: string) => void;
+  onSearchChange?: (search: string) => void;
+  children: (ctx: FilterComboboxRenderProps) => React.ReactNode;
+}
+
+function placeCaretAtEnd(input: HTMLInputElement | null) {
+  if (!input) return;
+  const length = input.value.length;
+  input.setSelectionRange(length, length);
+}
+
+/**
+ * Combobox whose trigger is the filter field. Typing filters the popover
+ * list; opening places a caret at the end of the current value.
+ */
+export function FilterCombobox({
+  displayValue,
+  placeholder = 'Select...',
+  searchPlaceholder = 'Search...',
+  ariaLabel,
+  disabled = false,
+  isLoading = false,
+  className,
+  align = 'end',
+  popoverClassName,
+  leading,
+  trailing,
+  onOpen,
+  onEnter,
+  onSearchChange,
+  children,
+}: FilterComboboxProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [isEditing, setIsEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const listboxId = useId();
+  const hasQuery = search.trim().length > 0;
+
+  const updateSearch = useCallback((next: string) => {
+    setSearch(next);
+    onSearchChange?.(next);
+  }, [onSearchChange]);
+
+  const openDropdown = useCallback(() => {
+    setIsOpen(true);
+    onOpen?.();
+  }, [onOpen]);
+
+  const closeDropdown = useCallback((options?: { blur?: boolean }) => {
+    setIsOpen(false);
+    setIsEditing(false);
+    updateSearch('');
+    if (options?.blur) inputRef.current?.blur();
+  }, [updateSearch]);
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    if (open) {
+      openDropdown();
+      return;
+    }
+    closeDropdown();
+  }, [openDropdown, closeDropdown]);
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setIsEditing(true);
+    updateSearch(e.target.value);
+    if (!isOpen) openDropdown();
+  }, [isOpen, openDropdown, updateSearch]);
+
+  const handleInputFocus = useCallback(() => {
+    if (disabled) return;
+    if (!isOpen) {
+      openDropdown();
+      requestAnimationFrame(() => placeCaretAtEnd(inputRef.current));
+    }
+  }, [disabled, isOpen, openDropdown]);
+
+  const handleInputClick = useCallback(() => {
+    if (disabled || isOpen) return;
+    openDropdown();
+    requestAnimationFrame(() => placeCaretAtEnd(inputRef.current));
+  }, [disabled, isOpen, openDropdown]);
+
+  const handleChevronMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (disabled) return;
+    if (isOpen) {
+      closeDropdown({ blur: true });
+      return;
+    }
+    openDropdown();
+    inputRef.current?.focus();
+    requestAnimationFrame(() => placeCaretAtEnd(inputRef.current));
+  }, [disabled, isOpen, openDropdown, closeDropdown]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown' && !isOpen) {
+      e.preventDefault();
+      openDropdown();
+      return;
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (hasQuery) {
+        onEnter?.(search);
+        closeDropdown({ blur: true });
+      }
+      return;
+    }
+    if (e.key !== 'Escape') {
+      e.stopPropagation();
+    }
+  }, [isOpen, hasQuery, search, onEnter, openDropdown, closeDropdown]);
+
+  const inputValue = isEditing ? search : displayValue;
+
+  return (
+    <Popover
+      open={isOpen}
+      onOpenChange={handleOpenChange}
+      modal={false}
+    >
+      <PopoverAnchor asChild>
+        <div
+          ref={triggerRef}
+          className={cn(
+            buttonVariants({ variant: 'input', size: 'sm' }),
+            'w-full justify-between',
+            (displayValue || isEditing) && 'text-foreground',
+            disabled && 'pointer-events-none opacity-50',
+            className
+          )}
+          onMouseDown={(e) => {
+            if (disabled) return;
+            if (e.target === inputRef.current) return;
+            if ((e.target as HTMLElement).closest('button')) return;
+            e.preventDefault();
+            inputRef.current?.focus();
+          }}
+        >
+          {leading}
+          <Input
+            ref={inputRef}
+            size="xs"
+            disableKeyboardStep
+            disabled={disabled}
+            value={inputValue}
+            placeholder={isEditing ? searchPlaceholder : placeholder}
+            autoComplete="off"
+            spellCheck={false}
+            role="combobox"
+            aria-expanded={isOpen}
+            aria-autocomplete="list"
+            aria-controls={listboxId}
+            aria-label={ariaLabel}
+            onChange={handleInputChange}
+            onFocus={handleInputFocus}
+            onClick={handleInputClick}
+            onKeyDown={handleKeyDown}
+            className="h-auto w-auto! min-w-0 flex-1 border-0 bg-transparent p-0 shadow-none rounded-none focus-visible:border-transparent focus-visible:ring-0"
+          />
+          {!isEditing && trailing}
+          {isLoading && <Spinner className="size-3.5 shrink-0" />}
+          <button
+            type="button"
+            tabIndex={-1}
+            disabled={disabled}
+            aria-label={isOpen ? 'Close list' : 'Open list'}
+            onMouseDown={handleChevronMouseDown}
+            className="shrink-0 inline-flex items-center justify-center"
+          >
+            <Icon name="chevronDown" className="size-2.5! shrink-0 opacity-50" />
+          </button>
+        </div>
+      </PopoverAnchor>
+
+      <PopoverContent
+        id={listboxId}
+        role="listbox"
+        className={cn('w-auto min-w-56 max-w-96 p-1', popoverClassName)}
+        align={align}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+        onInteractOutside={(e) => {
+          if (triggerRef.current?.contains(e.target as Node)) {
+            e.preventDefault();
+          }
+        }}
+      >
+        <div className="max-h-100 overflow-y-auto">
+          {children({ search, hasQuery, close: () => closeDropdown({ blur: true }) })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/lib/page-utils.ts
+++ b/lib/page-utils.ts
@@ -729,6 +729,43 @@ export function buildPageTree(
 }
 
 /**
+ * Filter a page tree by a case-insensitive name query.
+ * Matching pages keep their ancestor folders so hierarchy stays visible.
+ * A folder whose name matches is kept with all of its children.
+ */
+export function filterPageTree(nodes: PageTreeNode[], query: string): PageTreeNode[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return nodes;
+
+  const filterNodes = (list: PageTreeNode[]): PageTreeNode[] => {
+    const result: PageTreeNode[] = [];
+
+    for (const node of list) {
+      const name = node.type === 'folder'
+        ? (node.data as PageFolder).name
+        : (node.data as Page).name;
+      const nameMatches = name.toLowerCase().includes(needle);
+
+      if (nameMatches) {
+        result.push(node);
+        continue;
+      }
+
+      if (node.children && node.children.length > 0) {
+        const filteredChildren = filterNodes(node.children);
+        if (filteredChildren.length > 0) {
+          result.push({ ...node, children: filteredChildren });
+        }
+      }
+    }
+
+    return result;
+  };
+
+  return filterNodes(nodes);
+}
+
+/**
  * Flatten a page tree structure into a linear array with depth information
  */
 export function flattenPageTree(


### PR DESCRIPTION
## Summary

Add in-trigger search to the page picker and the dynamic-page collection item picker so users can type to filter long lists without an extra search field.

## Changes

- Add a shared `FilterCombobox` that uses the trigger as the filter input
- Filter the pages tree by name while keeping folder hierarchy
- Apply the same trigger-to-filter UX to dynamic page collection items
- Keep the caret at the end of the current value instead of selecting it

## Test plan

- [ ] Open the Pages dropdown in the canvas and type a page name — the list filters as you type
- [ ] Confirm the caret sits at the end of the current page name (no blue selection highlight)
- [ ] Press Enter to select the first matching page
- [ ] Search for a page inside a folder — the folder stays visible and expanded
- [ ] Search for something with no matches — empty state uses the smaller font
- [ ] On a dynamic page, type in the collection item picker and confirm the list filters
- [ ] Confirm item search still finds items beyond the initial preload
- [ ] Open a page picker in link settings and confirm search works there too
- [ ] Escape or click away restores the selected name


Made with [Cursor](https://cursor.com)