### PR TITLE
feat: show which pages changed before publish

### DIFF
--- a/app/(builder)/ycode/api/publish/preview/route.ts
+++ b/app/(builder)/ycode/api/publish/preview/route.ts
@@ -1,18 +1,24 @@
 import { NextRequest } from 'next/server';
-import { getUnpublishedPagesCount } from '@/lib/repositories/pageRepository';
+import { getUnpublishedAssetsCount } from '@/lib/repositories/assetRepository';
 import { getTotalPublishableItemsCount } from '@/lib/repositories/collectionItemRepository';
-import { getUnpublishedCollections } from '@/lib/repositories/collectionRepository';
-import { getUnpublishedComponents } from '@/lib/repositories/componentRepository';
-import { getUnpublishedLayerStyles } from '@/lib/repositories/layerStyleRepository';
-import { getUnpublishedAssets } from '@/lib/repositories/assetRepository';
+import { getUnpublishedCollectionsCount } from '@/lib/repositories/collectionRepository';
+import { getUnpublishedComponentChanges } from '@/lib/repositories/componentRepository';
+import { getUnpublishedLayerStylesCount } from '@/lib/repositories/layerStyleRepository';
+import { getUnpublishedPageChanges } from '@/lib/repositories/pageRepository';
 import { getUnpublishedTranslationsCount } from '@/lib/repositories/translationRepository';
 import { getUnpublishedGlobalVariablesCount } from '@/lib/repositories/globalVariableRepository';
 import { getDeletedDraftCount } from '@/lib/sync-utils';
 import { noCache } from '@/lib/api-response';
+import type { UnpublishedChange } from '@/lib/publish-changes';
 
 // Disable caching for this route
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
+
+export interface PublishPreviewChanges {
+  pages: UnpublishedChange[];
+  components: UnpublishedChange[];
+}
 
 export interface PublishPreviewCounts {
   pages: number;
@@ -23,6 +29,7 @@ export interface PublishPreviewCounts {
   assets: number;
   translations: number;
   globalVariables: number;
+  changes: PublishPreviewChanges;
   total: number;
 }
 
@@ -32,37 +39,34 @@ export interface PublishPreviewCounts {
  */
 export async function GET(_request: NextRequest) {
   try {
-    // Count changed + deleted in parallel for each entity type
     const [
-      pagesChanged, pagesDeleted,
+      pageChanges,
       collectionsChanged, collectionsDeleted,
       itemsChanged, itemsDeleted,
-      componentsChanged, componentsDeleted,
+      componentChanges,
       layerStylesChanged, layerStylesDeleted,
       assetsChanged, assetsDeleted,
       translationsChanged,
       globalVariablesChanged,
     ] = await Promise.all([
-      getUnpublishedPagesCount(),
-      getDeletedDraftCount('pages'),
-      getUnpublishedCollections().then(c => c.length),
+      getUnpublishedPageChanges(),
+      getUnpublishedCollectionsCount(),
       getDeletedDraftCount('collections'),
       getTotalPublishableItemsCount(),
       getDeletedDraftCount('collection_items'),
-      getUnpublishedComponents().then(c => c.length),
-      getDeletedDraftCount('components'),
-      getUnpublishedLayerStyles().then(s => s.length),
+      getUnpublishedComponentChanges(),
+      getUnpublishedLayerStylesCount(),
       getDeletedDraftCount('layer_styles'),
-      getUnpublishedAssets().then(a => a.length),
+      getUnpublishedAssetsCount(),
       getDeletedDraftCount('assets'),
       getUnpublishedTranslationsCount(),
       getUnpublishedGlobalVariablesCount(),
     ]);
 
-    const pages = pagesChanged + pagesDeleted;
+    const pages = pageChanges.length;
     const collections = collectionsChanged + collectionsDeleted;
     const collectionItems = itemsChanged + itemsDeleted;
-    const components = componentsChanged + componentsDeleted;
+    const components = componentChanges.length;
     const layerStyles = layerStylesChanged + layerStylesDeleted;
     const assets = assetsChanged + assetsDeleted;
     const translations = translationsChanged;
@@ -70,7 +74,21 @@ export async function GET(_request: NextRequest) {
     const total = pages + collections + collectionItems + components + layerStyles + assets + translations + globalVariables;
 
     return noCache({
-      data: { pages, collections, collectionItems, components, layerStyles, assets, translations, globalVariables, total } satisfies PublishPreviewCounts,
+      data: {
+        pages,
+        collections,
+        collectionItems,
+        components,
+        layerStyles,
+        assets,
+        translations,
+        globalVariables,
+        changes: {
+          pages: pageChanges,
+          components: componentChanges,
+        },
+        total,
+      } satisfies PublishPreviewCounts,
     });
   } catch (error) {
     console.error('Error fetching publish preview:', error);

--- a/app/(builder)/ycode/components/PublishPopover.tsx
+++ b/app/(builder)/ycode/components/PublishPopover.tsx
@@ -11,8 +11,14 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import Icon from '@/components/ui/icon';
 import { useSettingsStore } from '@/stores/useSettingsStore';
 import { cacheApi, publishApi } from '@/lib/api';
-import { formatRelativeTime } from '@/lib/utils';
+import { cn, formatRelativeTime } from '@/lib/utils';
 import { toast } from 'sonner';
+
+interface PublishPreviewChange {
+  id: string;
+  name: string;
+  status: 'new' | 'modified' | 'deleted' | 'unpublishing';
+}
 
 interface PublishPreviewCounts {
   pages: number;
@@ -23,11 +29,63 @@ interface PublishPreviewCounts {
   assets: number;
   translations: number;
   globalVariables: number;
+  changes: {
+    pages: PublishPreviewChange[];
+    components: PublishPreviewChange[];
+  };
   total: number;
 }
 
+type ExpandableCategory = keyof PublishPreviewCounts['changes'];
+
+function isExpandableCategory(key: string): key is ExpandableCategory {
+  return key === 'pages' || key === 'components';
+}
+
+function getChangeTitle(change: PublishPreviewChange): string {
+  if (change.status === 'deleted') return `${change.name} (deleted)`;
+  if (change.status === 'unpublishing') return `${change.name} (will unpublish)`;
+  if (change.status === 'new') return `${change.name} (new)`;
+  return change.name;
+}
+
+function ChangeCategoryRow({
+  icon,
+  label,
+  count,
+  showExpandIcon = false,
+}: {
+  icon: Parameters<typeof Icon>[0]['name'];
+  label: string;
+  count: number;
+  showExpandIcon?: boolean;
+}) {
+  return (
+    <>
+      <div className="flex items-center gap-1.5">
+        <div className="size-5.5 flex items-center justify-center bg-input rounded-md">
+          <Icon name={icon} className="size-2.5" />
+        </div>
+        {label}
+      </div>
+      <div className="flex items-center gap-1">
+        <div className="tabular-nums">{count}</div>
+        <Icon
+          name="chevronRight"
+          className={cn(
+            'size-2',
+            showExpandIcon
+              ? 'opacity-40 transition-transform group-data-[state=open]:rotate-90'
+              : 'invisible'
+          )}
+        />
+      </div>
+    </>
+  );
+}
+
 /** Breakdown row config for rendering */
-const BREAKDOWN_ITEMS: { key: keyof Omit<PublishPreviewCounts, 'total'>; label: string; icon: Parameters<typeof Icon>[0]['name'] }[] = [
+const BREAKDOWN_ITEMS: { key: keyof Omit<PublishPreviewCounts, 'total' | 'changes'>; label: string; icon: Parameters<typeof Icon>[0]['name'] }[] = [
   { key: 'pages', label: 'Pages', icon: 'page' },
   { key: 'components', label: 'Components', icon: 'component' },
   { key: 'collections', label: 'Collections', icon: 'database' },
@@ -242,17 +300,11 @@ export default function PublishPopover({
           </div>
         ) : changeCounts ? (
           changeCounts.total > 0 ? (
-            <Collapsible>
+            <div className="flex flex-col gap-1.5">
               <div className="flex items-center justify-between w-full">
-                <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors group">
-                  <div className="size-5.5 flex items-center justify-center bg-input rounded-md">
-                    <Icon
-                      name="chevronRight"
-                      className="size-2.5 transition-transform group-data-[state=open]:rotate-90"
-                    />
-                  </div>
+                <div className="text-xs text-muted-foreground">
                   {changeCounts.total} {changeCounts.total === 1 ? 'Change' : 'Changes'}
-                </CollapsibleTrigger>
+                </div>
                 {publishedAt && (
                   <Button
                     size="xs"
@@ -264,24 +316,61 @@ export default function PublishPopover({
                   </Button>
                 )}
               </div>
-              <CollapsibleContent>
-                <div className="flex flex-col gap-1.5 pt-1.5">
-                  {BREAKDOWN_ITEMS.map(({ key, label, icon }) =>
-                    changeCounts[key] > 0 ? (
-                      <div key={key} className="flex items-center justify-between text-xs text-muted-foreground">
-                        <span className="flex items-center gap-1.5">
-                          <div className="size-5.5 flex items-center justify-center bg-input rounded-md">
-                            <Icon name={icon} className="size-2.5" />
-                          </div>
-                          {label}
-                        </span>
-                        <span>{changeCounts[key]}</span>
-                      </div>
-                    ) : null
-                  )}
-                </div>
-              </CollapsibleContent>
-            </Collapsible>
+              {BREAKDOWN_ITEMS.map(({ key, label, icon }) => {
+                if (changeCounts[key] <= 0) return null;
+
+                const details = isExpandableCategory(key)
+                  ? changeCounts.changes?.[key] ?? []
+                  : [];
+
+                if (details.length === 0) {
+                  return (
+                    <div
+                      key={key}
+                      className="flex items-center justify-between text-xs text-muted-foreground"
+                    >
+                      <ChangeCategoryRow
+                        icon={icon}
+                        label={label}
+                        count={changeCounts[key]}
+                      />
+                    </div>
+                  );
+                }
+
+                return (
+                  <Collapsible key={key}>
+                    <CollapsibleTrigger className="flex items-center justify-between w-full text-xs text-muted-foreground hover:text-foreground transition-colors group">
+                      <ChangeCategoryRow
+                        icon={icon}
+                        label={label}
+                        count={changeCounts[key]}
+                        showExpandIcon
+                      />
+                    </CollapsibleTrigger>
+                    <CollapsibleContent>
+                      <ul
+                        role="list"
+                        className="max-h-32 overflow-y-auto pt-1 pl-7 text-xs text-muted-foreground"
+                      >
+                        {details.map((change) => (
+                          <li
+                            key={change.id}
+                            title={getChangeTitle(change)}
+                            className={cn(
+                              'truncate py-1 leading-4',
+                              change.status === 'deleted' && 'line-through'
+                            )}
+                          >
+                            {change.name}
+                          </li>
+                        ))}
+                      </ul>
+                    </CollapsibleContent>
+                  </Collapsible>
+                );
+              })}
+            </div>
           ) : (
             <span className="text-xs text-muted-foreground">Everything is up to date</span>
           )

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -209,6 +209,10 @@ export const publishApi = {
     assets: number;
     translations: number;
     globalVariables: number;
+    changes: {
+      pages: { id: string; name: string; status: 'new' | 'modified' | 'deleted' | 'unpublishing' }[];
+      components: { id: string; name: string; status: 'new' | 'modified' | 'deleted' | 'unpublishing' }[];
+    };
     total: number;
   }>> {
     return apiRequest('/ycode/api/publish/preview');

--- a/lib/publish-changes.ts
+++ b/lib/publish-changes.ts
@@ -1,0 +1,17 @@
+export type UnpublishedChangeStatus = 'new' | 'modified' | 'deleted' | 'unpublishing';
+
+export interface UnpublishedChange {
+  id: string;
+  name: string;
+  status: UnpublishedChangeStatus;
+}
+
+export function displayChangeName(name: string | null | undefined): string {
+  return name?.trim() || 'Untitled';
+}
+
+export function sortUnpublishedChanges(changes: UnpublishedChange[]): UnpublishedChange[] {
+  return [...changes].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  );
+}

--- a/lib/repositories/assetRepository.ts
+++ b/lib/repositories/assetRepository.ts
@@ -766,6 +766,72 @@ export async function getUnpublishedAssets(): Promise<Asset[]> {
 }
 
 /**
+ * Count unpublished assets from id/hash only — not file payloads or SVG content.
+ */
+export async function getUnpublishedAssetsCount(): Promise<number> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    throw new Error('Supabase not configured');
+  }
+
+  const draftAssets: Array<{ id: string; content_hash: string | null }> = [];
+  let offset = 0;
+
+  while (true) {
+    const { data, error } = await client
+      .from('assets')
+      .select('id, content_hash')
+      .eq('is_published', false)
+      .is('deleted_at', null)
+      .order('id', { ascending: true })
+      .range(offset, offset + SUPABASE_QUERY_LIMIT - 1);
+
+    if (error) {
+      throw new Error(`Failed to fetch draft assets: ${error.message}`);
+    }
+
+    const batch = data || [];
+    draftAssets.push(...batch);
+
+    if (batch.length < SUPABASE_QUERY_LIMIT) break;
+    offset += SUPABASE_QUERY_LIMIT;
+  }
+
+  if (draftAssets.length === 0) {
+    return 0;
+  }
+
+  const publishedHashById = new Map<string, string | null>();
+  const draftIds = draftAssets.map((asset) => asset.id);
+  const PUBLISHED_ASSET_HASH_BATCH_SIZE = 200;
+
+  for (let i = 0; i < draftIds.length; i += PUBLISHED_ASSET_HASH_BATCH_SIZE) {
+    const batchIds = draftIds.slice(i, i + PUBLISHED_ASSET_HASH_BATCH_SIZE);
+    const { data: publishedAssets, error: publishedError } = await client
+      .from('assets')
+      .select('id, content_hash')
+      .in('id', batchIds)
+      .eq('is_published', true);
+
+    if (publishedError) {
+      throw new Error(`Failed to fetch published assets: ${publishedError.message}`);
+    }
+
+    publishedAssets?.forEach((asset) => publishedHashById.set(asset.id, asset.content_hash));
+  }
+
+  let count = 0;
+  for (const draft of draftAssets) {
+    if (!publishedHashById.has(draft.id) || draft.content_hash !== publishedHashById.get(draft.id)) {
+      count++;
+    }
+  }
+
+  return count;
+}
+
+/**
  * Get soft-deleted draft assets that need their published versions and files removed
  */
 export async function getDeletedDraftAssets(): Promise<Asset[]> {

--- a/lib/repositories/collectionItemRepository.ts
+++ b/lib/repositories/collectionItemRepository.ts
@@ -1368,11 +1368,53 @@ export async function publishItem(id: string): Promise<CollectionItem> {
 
 }
 
-/**
- * Get total count of collection items needing publishing across all collections.
- * Checks both metadata (manual_order) and value changes.
- */
-export async function getTotalPublishableItemsCount(): Promise<number> {
+interface PublishableItemRef {
+  id: string;
+  collection_id: string;
+  status: 'new' | 'modified';
+}
+
+async function fetchCollectionItemsForPublish(
+  collectionIds: string[],
+  isPublished: boolean
+): Promise<Array<{ id: string; collection_id: string; manual_order: number }>> {
+  const client = await getSupabaseAdmin();
+  if (!client) {
+    throw new Error('Supabase client not configured');
+  }
+
+  const rows: Array<{ id: string; collection_id: string; manual_order: number }> = [];
+  let offset = 0;
+
+  while (true) {
+    let query = client
+      .from('collection_items')
+      .select('id, collection_id, manual_order')
+      .in('collection_id', collectionIds)
+      .eq('is_published', isPublished)
+      .order('id', { ascending: true })
+      .range(offset, offset + SUPABASE_QUERY_LIMIT - 1);
+
+    if (!isPublished) {
+      query = query.eq('is_publishable', true).is('deleted_at', null);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      throw new Error(`Failed to fetch ${isPublished ? 'published' : 'draft'} items: ${error.message}`);
+    }
+
+    const batch = data || [];
+    rows.push(...batch);
+
+    if (batch.length < SUPABASE_QUERY_LIMIT) break;
+    offset += SUPABASE_QUERY_LIMIT;
+  }
+
+  return rows;
+}
+
+async function getPublishableItemRefs(): Promise<PublishableItemRef[]> {
   const client = await getSupabaseAdmin();
 
   if (!client) {
@@ -1390,83 +1432,66 @@ export async function getTotalPublishableItemsCount(): Promise<number> {
   }
 
   if (!collections || collections.length === 0) {
-    return 0;
+    return [];
   }
 
-  const collectionIds = collections.map(c => c.id);
-
-  // Paginate both queries to avoid PostgREST's default 1000-row limit
-  const fetchAllItems = async (isPublished: boolean): Promise<Array<{ id: string; manual_order: number }>> => {
-    const rows: Array<{ id: string; manual_order: number }> = [];
-    let offset = 0;
-
-    while (true) {
-      let query = client
-        .from('collection_items')
-        .select('id, manual_order')
-        .in('collection_id', collectionIds)
-        .eq('is_published', isPublished)
-        .order('id', { ascending: true })
-        .range(offset, offset + SUPABASE_QUERY_LIMIT - 1);
-
-      if (!isPublished) {
-        query = query.eq('is_publishable', true).is('deleted_at', null);
-      }
-
-      const { data, error } = await query;
-      if (error) {
-        throw new Error(`Failed to fetch ${isPublished ? 'published' : 'draft'} items: ${error.message}`);
-      }
-
-      const batch = data || [];
-      rows.push(...batch);
-
-      if (batch.length < SUPABASE_QUERY_LIMIT) break;
-      offset += SUPABASE_QUERY_LIMIT;
-    }
-
-    return rows;
-  };
-
+  const collectionIds = collections.map((collection) => collection.id);
   const [draftItems, publishedItems] = await Promise.all([
-    fetchAllItems(false),
-    fetchAllItems(true),
+    fetchCollectionItemsForPublish(collectionIds, false),
+    fetchCollectionItemsForPublish(collectionIds, true),
   ]);
 
   const publishedMap = new Map<string, number>();
-  for (const pub of publishedItems) {
-    publishedMap.set(pub.id, pub.manual_order);
+  for (const published of publishedItems) {
+    publishedMap.set(published.id, published.manual_order);
   }
 
-  // Count items with metadata changes (new or order changed)
-  let count = 0;
-  const matchingOrderItemIds: string[] = [];
+  const refs: PublishableItemRef[] = [];
+  const matchingOrderItems: PublishableItemRef[] = [];
 
   for (const draft of draftItems) {
-    const pubOrder = publishedMap.get(draft.id);
-    if (pubOrder === undefined || draft.manual_order !== pubOrder) {
-      count++;
-    } else {
-      matchingOrderItemIds.push(draft.id);
+    const publishedOrder = publishedMap.get(draft.id);
+    if (publishedOrder === undefined) {
+      refs.push({ id: draft.id, collection_id: draft.collection_id, status: 'new' });
+      continue;
+    }
+
+    if (draft.manual_order !== publishedOrder) {
+      refs.push({ id: draft.id, collection_id: draft.collection_id, status: 'modified' });
+      continue;
+    }
+
+    matchingOrderItems.push({ id: draft.id, collection_id: draft.collection_id, status: 'modified' });
+  }
+
+  if (matchingOrderItems.length > 0) {
+    const valueChangedIds = await getItemIdsWithValueChanges(matchingOrderItems.map((item) => item.id));
+    const matchingById = new Map(matchingOrderItems.map((item) => [item.id, item]));
+    for (const itemId of valueChangedIds) {
+      const match = matchingById.get(itemId);
+      if (match) refs.push(match);
     }
   }
 
-  // For items with matching metadata, check value changes
-  if (matchingOrderItemIds.length > 0) {
-    const valueChanges = await countItemsWithValueChanges(matchingOrderItemIds);
-    count += valueChanges;
-  }
-
-  return count;
+  return refs;
 }
 
 /**
- * Count items whose draft values differ from published. Reads all values via
+ * Get total count of collection items needing publishing across all collections.
+ * Checks both metadata (manual_order) and value changes.
+ */
+export async function getTotalPublishableItemsCount(): Promise<number> {
+  const refs = await getPublishableItemRefs();
+  return refs.length;
+}
+
+/**
+ * Item IDs whose draft values differ from published. Reads all values via
  * the direct-DB (Knex) path in two queries rather than paginated PostgREST
  * batches of 50 items.
  */
-async function countItemsWithValueChanges(itemIds: string[]): Promise<number> {
-  if (itemIds.length === 0) return 0;
+async function getItemIdsWithValueChanges(itemIds: string[]): Promise<string[]> {
+  if (itemIds.length === 0) return [];
 
   let draftValueRows: Awaited<ReturnType<typeof getValueRowsForItems>> = [];
   let publishedValueRows: Awaited<ReturnType<typeof getValueRowsForItems>> = [];
@@ -1477,7 +1502,7 @@ async function countItemsWithValueChanges(itemIds: string[]): Promise<number> {
       getValueRowsForItems(itemIds, true),
     ]);
   } catch {
-    return 0; // Treat read failure as "no detectable changes" for the count
+    return [];
   }
 
   const groupByItem = (
@@ -1493,14 +1518,14 @@ async function countItemsWithValueChanges(itemIds: string[]): Promise<number> {
 
   const draftValsByItem = groupByItem(draftValueRows);
   const pubValsByItem = groupByItem(publishedValueRows);
+  const changedIds: string[] = [];
 
-  let changedCount = 0;
   for (const itemId of itemIds) {
     const draftVals = draftValsByItem.get(itemId) || new Map();
     const pubVals = pubValsByItem.get(itemId) || new Map();
 
     if (draftVals.size !== pubVals.size) {
-      changedCount++;
+      changedIds.push(itemId);
       continue;
     }
 
@@ -1513,11 +1538,11 @@ async function countItemsWithValueChanges(itemIds: string[]): Promise<number> {
     }
 
     if (hasChange) {
-      changedCount++;
+      changedIds.push(itemId);
     }
   }
 
-  return changedCount;
+  return changedIds;
 }
 
 /**

--- a/lib/repositories/collectionRepository.ts
+++ b/lib/repositories/collectionRepository.ts
@@ -439,7 +439,10 @@ export async function publishCollection(id: string): Promise<Collection> {
 }
 
 /** Check if draft collection metadata differs from published */
-function hasCollectionChanged(draft: Collection, published: Collection): boolean {
+function hasCollectionChanged(
+  draft: Pick<Collection, 'name' | 'order'>,
+  published: Pick<Collection, 'name' | 'order'>
+): boolean {
   return (
     draft.name !== published.name ||
     draft.order !== published.order
@@ -487,6 +490,53 @@ export async function getUnpublishedCollections(): Promise<Collection[]> {
     }
     return hasCollectionChanged(draft, published);
   });
+}
+
+/**
+ * Count unpublished collections without joining items or loading full rows.
+ */
+export async function getUnpublishedCollectionsCount(): Promise<number> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    throw new Error('Supabase client not configured');
+  }
+
+  const { data: drafts, error } = await client
+    .from('collections')
+    .select('id, name, order')
+    .eq('is_published', false)
+    .is('deleted_at', null);
+
+  if (error) {
+    throw new Error(`Failed to fetch draft collections: ${error.message}`);
+  }
+
+  if (!drafts || drafts.length === 0) {
+    return 0;
+  }
+
+  const { data: published, error: publishedError } = await client
+    .from('collections')
+    .select('id, name, order')
+    .in('id', drafts.map((collection) => collection.id))
+    .eq('is_published', true);
+
+  if (publishedError) {
+    throw new Error(`Failed to fetch published collections: ${publishedError.message}`);
+  }
+
+  const publishedById = new Map((published || []).map((collection) => [collection.id, collection]));
+  let count = 0;
+
+  for (const draft of drafts) {
+    const publishedCollection = publishedById.get(draft.id);
+    if (!publishedCollection || hasCollectionChanged(draft, publishedCollection)) {
+      count++;
+    }
+  }
+
+  return count;
 }
 
 /**

--- a/lib/repositories/componentRepository.ts
+++ b/lib/repositories/componentRepository.ts
@@ -7,6 +7,12 @@
  */
 
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import {
+  displayChangeName,
+  sortUnpublishedChanges,
+  type UnpublishedChange,
+} from '@/lib/publish-changes';
+import { getDeletedDraftSummaries } from '@/lib/sync-utils';
 import type { Component, ComponentVariant, Layer } from '@/types';
 import { generateComponentContentHash } from '../hash-utils';
 import { deleteTranslationsInBulk, markTranslationsIncomplete } from '@/lib/repositories/translationRepository';
@@ -479,6 +485,69 @@ export async function getUnpublishedComponents(): Promise<Component[]> {
   }
 
   return unpublishedComponents;
+}
+
+/**
+ * Named components pending publish: new, modified, and deleted.
+ * Selects only id/name/hash — not layer trees.
+ */
+export async function getUnpublishedComponentChanges(): Promise<UnpublishedChange[]> {
+  const client = await getSupabaseAdmin();
+  if (!client) {
+    throw new Error('Failed to initialize Supabase client');
+  }
+
+  const [draftResult, deleted] = await Promise.all([
+    client
+      .from('components')
+      .select('id, name, content_hash')
+      .eq('is_published', false)
+      .is('deleted_at', null),
+    getDeletedDraftSummaries('components'),
+  ]);
+
+  if (draftResult.error) {
+    throw new Error(`Failed to fetch draft components: ${draftResult.error.message}`);
+  }
+
+  const drafts = draftResult.data || [];
+  const publishedHashById = new Map<string, string | null>();
+
+  if (drafts.length > 0) {
+    const { data: publishedRows, error } = await client
+      .from('components')
+      .select('id, content_hash')
+      .in('id', drafts.map((component) => component.id))
+      .eq('is_published', true);
+
+    if (error) {
+      throw new Error(`Failed to fetch published components: ${error.message}`);
+    }
+
+    for (const published of publishedRows || []) {
+      publishedHashById.set(published.id, published.content_hash);
+    }
+  }
+
+  const changed: UnpublishedChange[] = [];
+  for (const draft of drafts) {
+    if (!publishedHashById.has(draft.id)) {
+      changed.push({ id: draft.id, name: displayChangeName(draft.name), status: 'new' });
+      continue;
+    }
+
+    if (draft.content_hash !== publishedHashById.get(draft.id)) {
+      changed.push({ id: draft.id, name: displayChangeName(draft.name), status: 'modified' });
+    }
+  }
+
+  const deletedChanges: UnpublishedChange[] = deleted.map((component) => ({
+    id: component.id,
+    name: displayChangeName(component.name),
+    status: 'deleted',
+  }));
+
+  return sortUnpublishedChanges([...changed, ...deletedChanges]);
 }
 
 /**

--- a/lib/repositories/layerStyleRepository.ts
+++ b/lib/repositories/layerStyleRepository.ts
@@ -527,11 +527,48 @@ export async function hardDeleteSoftDeletedLayerStyles(): Promise<{ count: numbe
 }
 
 /**
- * Get count of unpublished layer styles
+ * Count unpublished layer styles from id/hash only — not full design rows.
  */
 export async function getUnpublishedLayerStylesCount(): Promise<number> {
-  const styles = await getUnpublishedLayerStyles();
-  return styles.length;
+  const client = await getSupabaseAdmin();
+  if (!client) {
+    throw new Error('Failed to initialize Supabase client');
+  }
+
+  const { data: drafts, error } = await client
+    .from('layer_styles')
+    .select('id, content_hash')
+    .eq('is_published', false)
+    .is('deleted_at', null);
+
+  if (error) {
+    throw new Error(`Failed to fetch draft layer styles: ${error.message}`);
+  }
+
+  if (!drafts || drafts.length === 0) {
+    return 0;
+  }
+
+  const { data: published, error: publishedError } = await client
+    .from('layer_styles')
+    .select('id, content_hash')
+    .in('id', drafts.map((style) => style.id))
+    .eq('is_published', true);
+
+  if (publishedError) {
+    throw new Error(`Failed to fetch published layer styles: ${publishedError.message}`);
+  }
+
+  const publishedHashById = new Map((published || []).map((style) => [style.id, style.content_hash]));
+  let count = 0;
+
+  for (const draft of drafts) {
+    if (!publishedHashById.has(draft.id) || draft.content_hash !== publishedHashById.get(draft.id)) {
+      count++;
+    }
+  }
+
+  return count;
 }
 
 /**

--- a/lib/repositories/pageRepository.ts
+++ b/lib/repositories/pageRepository.ts
@@ -6,6 +6,12 @@
 
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { reorderSiblings } from '@/lib/repositories/pageFolderRepository';
+import {
+  displayChangeName,
+  sortUnpublishedChanges,
+  type UnpublishedChange,
+  type UnpublishedChangeStatus,
+} from '@/lib/publish-changes';
 import type { Page, PageSettings } from '../../types';
 import { isHomepage } from '../page-utils';
 import { incrementSiblingOrders, fixOrphanedPageSlugs } from '../services/pageService';
@@ -1014,11 +1020,14 @@ function hashesDiffer(a: string | null, b: string | null): boolean {
   return a !== b;
 }
 
+export type UnpublishedPageChangeStatus = UnpublishedChangeStatus;
+export type UnpublishedPageChange = UnpublishedChange;
+
 /**
- * Get count of unpublished pages efficiently.
+ * Draft pages that differ from their published version (excludes soft-deletes).
  * Uses 2 bulk queries instead of N+1 per-page lookups.
  */
-export async function getUnpublishedPagesCount(): Promise<number> {
+async function getChangedDraftPageSummaries(): Promise<UnpublishedPageChange[]> {
   await backfillMissingPageHashes();
 
   const client = await getSupabaseAdmin();
@@ -1027,11 +1036,10 @@ export async function getUnpublishedPagesCount(): Promise<number> {
     throw new Error('Supabase not configured');
   }
 
-  // 2 bulk queries: all draft pages with layers + all published pages with layers
   const [draftResult, publishedResult] = await Promise.all([
     client
       .from('pages')
-      .select('id, content_hash, page_folder_id, is_publishable, page_layers!inner(content_hash)')
+      .select('id, name, content_hash, page_folder_id, is_publishable, page_layers!inner(content_hash)')
       .eq('is_published', false)
       .eq('page_layers.is_published', false)
       .is('deleted_at', null)
@@ -1050,10 +1058,9 @@ export async function getUnpublishedPagesCount(): Promise<number> {
   }
 
   if (!draftResult.data || draftResult.data.length === 0) {
-    return 0;
+    return [];
   }
 
-  // Build published lookup: id -> { content_hash, page_folder_id, layerHash }
   const publishedMap = new Map<string, {
     content_hash: string | null;
     page_folder_id: string | null;
@@ -1067,21 +1074,22 @@ export async function getUnpublishedPagesCount(): Promise<number> {
     });
   }
 
-  // Count pages needing publishing
-  let count = 0;
+  const changes: UnpublishedPageChange[] = [];
+
   for (const draft of draftResult.data) {
     const pub = publishedMap.get(draft.id);
     const isDraftOnly = (draft as { is_publishable?: boolean }).is_publishable === false;
+    const name = displayChangeName(draft.name);
 
     if (!pub) {
-      // Never published: only counts if it is meant to go live
-      if (!isDraftOnly) count++;
+      if (!isDraftOnly) {
+        changes.push({ id: draft.id, name, status: 'new' });
+      }
       continue;
     }
 
-    // Marked as draft but still live: will be removed on publish
     if (isDraftOnly) {
-      count++;
+      changes.push({ id: draft.id, name, status: 'unpublishing' });
       continue;
     }
 
@@ -1095,11 +1103,76 @@ export async function getUnpublishedPagesCount(): Promise<number> {
     const folderChanged = draft.page_folder_id !== pub.page_folder_id;
 
     if (pageMetadataChanged || layersChanged || folderChanged) {
-      count++;
+      changes.push({ id: draft.id, name, status: 'modified' });
     }
   }
 
-  return count;
+  return changes;
+}
+
+/**
+ * Soft-deleted draft pages that still have a published counterpart.
+ */
+async function getDeletedPageSummaries(): Promise<UnpublishedPageChange[]> {
+  const client = await getSupabaseAdmin();
+
+  if (!client) {
+    throw new Error('Supabase not configured');
+  }
+
+  const { data: deletedDrafts, error: draftError } = await client
+    .from('pages')
+    .select('id, name')
+    .eq('is_published', false)
+    .not('deleted_at', 'is', null);
+
+  if (draftError) {
+    throw new Error(`Failed to fetch deleted draft pages: ${draftError.message}`);
+  }
+
+  if (!deletedDrafts || deletedDrafts.length === 0) {
+    return [];
+  }
+
+  const { data: publishedRows, error: pubError } = await client
+    .from('pages')
+    .select('id')
+    .in('id', deletedDrafts.map((draft) => draft.id))
+    .eq('is_published', true);
+
+  if (pubError) {
+    throw new Error(`Failed to fetch published pages pending deletion: ${pubError.message}`);
+  }
+
+  const publishedIds = new Set((publishedRows || []).map((row) => row.id));
+
+  return deletedDrafts
+    .filter((draft) => publishedIds.has(draft.id))
+    .map((draft) => ({
+      id: draft.id,
+      name: displayChangeName(draft.name),
+      status: 'deleted' as const,
+    }));
+}
+
+/**
+ * Get count of unpublished pages efficiently (changed drafts only, not deletes).
+ */
+export async function getUnpublishedPagesCount(): Promise<number> {
+  const changes = await getChangedDraftPageSummaries();
+  return changes.length;
+}
+
+/**
+ * Named pages pending publish: new, modified, unpublishing, and deleted.
+ */
+export async function getUnpublishedPageChanges(): Promise<UnpublishedPageChange[]> {
+  const [changed, deleted] = await Promise.all([
+    getChangedDraftPageSummaries(),
+    getDeletedPageSummaries(),
+  ]);
+
+  return sortUnpublishedChanges([...changed, ...deleted]);
 }
 
 /**

--- a/lib/sync-utils.ts
+++ b/lib/sync-utils.ts
@@ -323,6 +323,53 @@ export async function cleanupOrphanedChildRows(
 }
 
 /**
+ * Soft-deleted draft rows that still have a published counterpart, with names.
+ */
+export async function getDeletedDraftSummaries(
+  tableName: string,
+  nameColumn: 'name' | 'filename' = 'name'
+): Promise<Array<{ id: string; name: string }>> {
+  const client = await getSupabaseAdmin();
+  if (!client) throw new Error('Supabase not configured');
+
+  const deletedQuery = nameColumn === 'filename'
+    ? client.from(tableName).select('id, filename')
+    : client.from(tableName).select('id, name');
+
+  const { data: deletedDrafts, error: draftError } = await deletedQuery
+    .eq('is_published', false)
+    .not('deleted_at', 'is', null)
+    .limit(SUPABASE_QUERY_LIMIT);
+
+  if (draftError) {
+    throw new Error(`Failed to fetch deleted drafts from ${tableName}: ${draftError.message}`);
+  }
+
+  if (!deletedDrafts || deletedDrafts.length === 0) return [];
+
+  const drafts = deletedDrafts as Array<{ id: string; name?: string | null; filename?: string | null }>;
+
+  const { data: publishedRows, error: pubError } = await client
+    .from(tableName)
+    .select('id')
+    .in('id', drafts.map((draft) => draft.id))
+    .eq('is_published', true);
+
+  if (pubError) {
+    throw new Error(`Failed to fetch published rows pending deletion in ${tableName}: ${pubError.message}`);
+  }
+
+  const publishedIds = new Set((publishedRows || []).map((row) => row.id));
+
+  return drafts
+    .filter((draft) => publishedIds.has(draft.id))
+    .map((draft) => ({
+      id: draft.id,
+      name: (nameColumn === 'filename' ? draft.filename : draft.name)?.trim() || 'Untitled',
+    }));
+}
+
+/**
  * Count soft-deleted draft rows that still have a published counterpart.
  * Works for any table with (id, is_published, deleted_at) columns.
  */


### PR DESCRIPTION
## Summary

Show the names of unpublished pages and components in the Publish popover, so it is clear what will go live. Other categories stay as counts, and the preview loads lean summaries instead of full rows.

## Changes

- Always show the publish change breakdown (no extra Changes toggle)
- Let Pages and Components expand to named items, with deleted pages struck through
- Return page and component names from the publish preview API
- Count collections, assets, and layer styles from hashes/metadata only

## Test plan

- [ ] Open Publish with unpublished page edits and expand Pages — names match the changed pages
- [ ] Expand Components and confirm changed component names appear
- [ ] Confirm Collections, Collection items, Assets, and other categories show counts only
- [ ] Delete a published page (unpublished delete) and confirm it appears struck through under Pages
- [ ] Publish with no pending changes — popover still says everything is up to date
- [ ] Open Publish on a site with many assets and confirm the popover still loads promptly


Made with [Cursor](https://cursor.com)