### PR TITLE
fix: resolve translated slugs for CMS page hreflang

### DIFF
--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -230,7 +230,6 @@ export async function buildPageHreflangAlternatesForPage(
   const dynamicSlug = page.is_dynamic && collectionItem && slugFieldId
     ? {
       itemId: collectionItem.id,
-      fieldId: slugFieldId,
       defaultValue: collectionItem.values?.[slugFieldId] || '',
     }
     : null;

--- a/lib/hreflang-utils.ts
+++ b/lib/hreflang-utils.ts
@@ -23,10 +23,33 @@ export interface HreflangAlternate {
 export interface DynamicSlugContext {
   /** Collection item ID (translation source_id). */
   itemId: string;
-  /** Slug field ID (translation content_key). */
-  fieldId: string;
   /** Default-locale slug value used as the fallback. */
   defaultValue: string;
+}
+
+/**
+ * Content keys under which a CMS item's slug translation is stored. Slug-only
+ * translation loaders (`getSlugTranslationsByLocale`) only ever return these,
+ * so URL builders resolve translated slugs by trying both formats.
+ */
+const CMS_SLUG_CONTENT_KEYS = ['field:key:slug', 'slug'] as const;
+
+/**
+ * Resolve a CMS item's translated slug for a locale, falling back to the
+ * default-locale slug when no translation exists. Handles both the current
+ * (`field:key:slug`) and legacy (`slug`) content-key formats.
+ */
+function resolveTranslatedSlug(
+  translations: Record<string, Translation> | undefined,
+  itemId: string,
+  fallback: string
+): string {
+  for (const contentKey of CMS_SLUG_CONTENT_KEYS) {
+    const key = getTranslatableKey({ source_type: 'cms', source_id: itemId, content_key: contentKey });
+    const value = translations?.[key]?.content_value;
+    if (value) return value;
+  }
+  return fallback;
 }
 
 /** Build the default-locale absolute URL for a dynamic item. */
@@ -59,12 +82,7 @@ function buildDynamicLocalizedUrl(
     ''
   ).replace(/\/$/, '');
 
-  const translatedSlugKey = getTranslatableKey({
-    source_type: 'cms',
-    source_id: dynamicSlug.itemId,
-    content_key: dynamicSlug.fieldId,
-  });
-  const translatedSlug = translations?.[translatedSlugKey]?.content_value || dynamicSlug.defaultValue;
+  const translatedSlug = resolveTranslatedSlug(translations, dynamicSlug.itemId, dynamicSlug.defaultValue);
 
   const localizedItemPath = localizedFolderPath
     ? `${localizedFolderPath}/${translatedSlug}`

--- a/lib/sitemap-utils.ts
+++ b/lib/sitemap-utils.ts
@@ -125,7 +125,7 @@ function buildDynamicPageUrls(
       baseUrl,
       locales,
       translationsByLocale,
-      dynamicSlug: { itemId: item.id, fieldId: slugFieldId, defaultValue: slugValue },
+      dynamicSlug: { itemId: item.id, defaultValue: slugValue },
     });
     if (alternates.length > 0) {
       sitemapUrl.alternates = alternates;


### PR DESCRIPTION
## Summary

hreflang alternates and sitemap entries on dynamic (CMS) pages pointed at the wrong slug for every locale except the one being viewed, so Google saw dead alternates (HTTP 200 "Page Not Found") on every translated article. This fixes the per-locale slug resolution so each alternate uses its own translated slug.

## Changes

- Resolve a CMS item's per-locale slug via the actual stored translation content keys (`field:key:slug`, with legacy `slug` fallback) instead of the raw slug-field UUID, which never matched
- Apply the fix in one place (`buildPageHreflangAlternates`), so both the per-page `<head>` tags and `sitemap.xml` alternates are corrected
- Drop the now-unused `fieldId` from `DynamicSlugContext` and update both callers

## Root cause

Slug translations are stored under `cms:{itemId}:field:key:slug`, but the hreflang builder looked up `cms:{itemId}:{slugFieldUUID}`. The lookup always failed and fell back to the current render's slug. The reverse resolver (`getCollectionItemBySlug`) uses the correct key, which is why only the viewed locale (plus the default slug via a values fallback) resolved — the rest 200'd with a "Page Not Found" body. The canonical-vs-hreflang mismatch users saw is a downstream symptom of the same bug (canonical is self-referential to the crawled URL).

## Test plan

- [ ] Republish/deploy, open a translated CMS article, and confirm each `<link rel="alternate" hreflang>` uses its own locale's slug and resolves (no "Page Not Found")
- [ ] Confirm `x-default` and the default-locale alternate point at the default slug
- [ ] Check `sitemap.xml` `xhtml:link` alternates for a dynamic item use translated slugs
- [ ] Verify a static multilingual page still emits correct alternates (unchanged behavior)
- [ ] Single-locale site emits no hreflang tags