### PR TITLE
feat: add cursor and text shadow to design settings

### DIFF
--- a/app/(builder)/ycode/components/CursorControls.tsx
+++ b/app/(builder)/ycode/components/CursorControls.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { memo, useCallback, useMemo } from 'react';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useDesignSync } from '@/hooks/use-design-sync';
+import { useEditorStore } from '@/stores/useEditorStore';
+import type { Layer } from '@/types';
+
+interface CursorControlsProps {
+  layer: Layer | null;
+  onLayerUpdate: (layerId: string, updates: Partial<Layer>) => void;
+}
+
+const CURSOR_OPTIONS = [
+  { value: 'auto', label: 'Auto', className: 'cursor-auto' },
+  { value: 'default', label: 'Default', className: 'cursor-default' },
+  { value: 'pointer', label: 'Pointer', className: 'cursor-pointer' },
+  { value: 'text', label: 'Text', className: 'cursor-text' },
+  { value: 'grab', label: 'Grab', className: 'cursor-grab' },
+  { value: 'wait', label: 'Wait', className: 'cursor-wait' },
+  { value: 'not-allowed', label: 'Not allowed', className: 'cursor-not-allowed' },
+] as const;
+
+function formatCursorLabel(value: string): string {
+  return value
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+const CursorControls = memo(function CursorControls({ layer, onLayerUpdate }: CursorControlsProps) {
+  const activeBreakpoint = useEditorStore((s) => s.activeBreakpoint);
+  const activeUIState = useEditorStore((s) => s.activeUIState);
+  const { updateDesignProperty, getDesignProperty } = useDesignSync({
+    layer,
+    onLayerUpdate,
+    activeBreakpoint,
+    activeUIState,
+  });
+
+  const cursor = getDesignProperty('effects', 'cursor') || 'auto';
+
+  const options = useMemo(() => {
+    if (CURSOR_OPTIONS.some((option) => option.value === cursor)) {
+      return CURSOR_OPTIONS;
+    }
+
+    return [
+      ...CURSOR_OPTIONS,
+      {
+        value: cursor,
+        label: formatCursorLabel(cursor),
+        className: `cursor-${cursor}`,
+      },
+    ];
+  }, [cursor]);
+
+  const handleCursorChange = useCallback((value: string) => {
+    updateDesignProperty('effects', 'cursor', value);
+  }, [updateDesignProperty]);
+
+  return (
+    <div className="py-5">
+      <header className="py-4 -mt-4">
+        <Label>Cursor</Label>
+      </header>
+
+      <div className="flex flex-col gap-2">
+        <div className="grid grid-cols-3">
+          <Label variant="muted">Style</Label>
+          <div className="col-span-2 *:w-full">
+            <Select
+              value={cursor}
+              onValueChange={handleCursorChange}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {options.map((option) => (
+                    <SelectItem
+                      key={option.value}
+                      value={option.value}
+                      className={option.className}
+                    >
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export default CursorControls;

--- a/app/(builder)/ycode/components/RightSidebar.tsx
+++ b/app/(builder)/ycode/components/RightSidebar.tsx
@@ -37,6 +37,7 @@ import BackgroundsControls from './BackgroundsControls';
 import CustomAttributeRow from './CustomAttributeRow';
 import BorderControls from './BorderControls';
 import ComponentVariablesDialog from './ComponentVariablesDialog';
+import CursorControls from './CursorControls';
 import EffectControls from './EffectControls';
 import CollectionFiltersSettings from './CollectionFiltersSettings';
 import ConditionalVisibilitySettings from './ConditionalVisibilitySettings';
@@ -621,6 +622,10 @@ const RightSidebar = React.memo(function RightSidebar({
       case 'effects':
         // Effect controls (opacity, shadow): show for all elements
         // Opacity is useful in text edit mode for transparency
+        return true;
+
+      case 'cursor':
+        if (showTextStyleControls) return false;
         return true;
 
       case 'position':
@@ -2065,6 +2070,10 @@ const RightSidebar = React.memo(function RightSidebar({
             <SizingControls layer={controlLayer} onLayerUpdate={controlUpdate} />
           )}
 
+          {shouldShowControl('position', selectedLayer) && !showTextStyleControls && (
+            <PositionControls layer={controlLayer} onLayerUpdate={controlUpdate} />
+          )}
+
           {shouldShowControl('typography', selectedLayer) && (
             <TypographyControls
               layer={controlLayer}
@@ -2106,8 +2115,11 @@ const RightSidebar = React.memo(function RightSidebar({
             />
           )}
 
-          {shouldShowControl('position', selectedLayer) && !showTextStyleControls && (
-            <PositionControls layer={controlLayer} onLayerUpdate={controlUpdate} />
+          {shouldShowControl('cursor', selectedLayer) && (
+            <CursorControls
+              layer={controlLayer}
+              onLayerUpdate={controlUpdate}
+            />
           )}
 
           {shouldShowControl('transforms', selectedLayer) && (

--- a/app/(builder)/ycode/components/TextShadowField.tsx
+++ b/app/(builder)/ycode/components/TextShadowField.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { memo, useCallback } from 'react';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Slider } from '@/components/ui/slider';
+import Icon from '@/components/ui/icon';
+import { InputGroup } from '@/components/ui/input-group';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  convertToRgba,
+  parseTextShadow,
+  serializeTextShadow,
+  swatchColor,
+  type TextShadow,
+} from '@/lib/text-shadow-utils';
+import ColorPicker from './ColorPicker';
+
+interface TextShadowFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  onRemove: () => void;
+}
+
+const TextShadowField = memo(function TextShadowField({
+  value,
+  onChange,
+  onRemove,
+}: TextShadowFieldProps) {
+  const shadow = parseTextShadow(value);
+
+  const updateShadow = useCallback((next: TextShadow) => {
+    onChange(serializeTextShadow(next));
+  }, [onChange]);
+
+  const handleColorChange = useCallback((color: string) => {
+    if (!shadow) return;
+    if (color.startsWith('color:var(')) {
+      updateShadow({ ...shadow, color });
+      return;
+    }
+    updateShadow({ ...shadow, color: convertToRgba(color) });
+  }, [shadow, updateShadow]);
+
+  const handleXChange = useCallback((x: number) => {
+    if (!shadow) return;
+    updateShadow({ ...shadow, x });
+  }, [shadow, updateShadow]);
+
+  const handleYChange = useCallback((y: number) => {
+    if (!shadow) return;
+    updateShadow({ ...shadow, y });
+  }, [shadow, updateShadow]);
+
+  const handleBlurChange = useCallback((blur: number) => {
+    if (!shadow) return;
+    updateShadow({ ...shadow, blur });
+  }, [shadow, updateShadow]);
+
+  if (!shadow) return null;
+
+  return (
+    <div className="grid grid-cols-3 items-start">
+      <Label variant="muted" className="h-8">Shadow</Label>
+      <div className="col-span-2 flex items-center gap-2">
+        <Popover>
+          <PopoverTrigger asChild>
+            <InputGroup className="flex-1 cursor-pointer">
+              <div className="w-full flex items-center gap-2 px-2.5">
+                <div
+                  className="size-4 rounded shrink-0 outline outline-current/10 -outline-offset-1"
+                  style={{ backgroundColor: swatchColor(shadow.color) }}
+                />
+                <Label variant="muted">
+                  {shadow.x}px {shadow.y}px {shadow.blur}px
+                </Label>
+              </div>
+            </InputGroup>
+          </PopoverTrigger>
+          <PopoverContent className="w-56 my-0.5 flex flex-col gap-2" align="end">
+            <div className="grid grid-cols-3">
+              <Label variant="muted">Color</Label>
+              <div className="col-span-2 *:w-full">
+                <ColorPicker
+                  value={shadow.color}
+                  onChange={handleColorChange}
+                  solidOnly
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-3">
+              <Label variant="muted">X</Label>
+              <div className="col-span-2 grid grid-cols-2 items-center gap-2">
+                <Input
+                  stepper
+                  min={-20}
+                  max={20}
+                  step={1}
+                  value={shadow.x}
+                  onChange={(e) => handleXChange(parseInt(e.target.value, 10) || 0)}
+                />
+                <Slider
+                  className="flex-1"
+                  value={[shadow.x]}
+                  onValueChange={(values) => handleXChange(values[0])}
+                  min={-20}
+                  max={20}
+                  step={1}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-3">
+              <Label variant="muted">Y</Label>
+              <div className="col-span-2 grid grid-cols-2 items-center gap-2">
+                <Input
+                  stepper
+                  min={-20}
+                  max={20}
+                  step={1}
+                  value={shadow.y}
+                  onChange={(e) => handleYChange(parseInt(e.target.value, 10) || 0)}
+                />
+                <Slider
+                  className="flex-1"
+                  value={[shadow.y]}
+                  onValueChange={(values) => handleYChange(values[0])}
+                  min={-20}
+                  max={20}
+                  step={1}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-3">
+              <Label variant="muted">Blur</Label>
+              <div className="col-span-2 grid grid-cols-2 items-center gap-2">
+                <Input
+                  stepper
+                  min={0}
+                  max={30}
+                  step={1}
+                  value={shadow.blur}
+                  onChange={(e) => handleBlurChange(parseInt(e.target.value, 10) || 0)}
+                />
+                <Slider
+                  className="flex-1"
+                  value={[shadow.blur]}
+                  onValueChange={(values) => handleBlurChange(values[0])}
+                  min={0}
+                  max={30}
+                  step={1}
+                />
+              </div>
+            </div>
+          </PopoverContent>
+        </Popover>
+        <button
+          type="button"
+          aria-label="Remove text shadow"
+          className="p-0.5 rounded-sm opacity-70 hover:opacity-100 transition-opacity cursor-pointer"
+          onClick={onRemove}
+        >
+          <Icon name="x" className="size-2.5" />
+        </button>
+      </div>
+    </div>
+  );
+});
+
+export default TextShadowField;

--- a/app/(builder)/ycode/components/TypographyControls.tsx
+++ b/app/(builder)/ycode/components/TypographyControls.tsx
@@ -20,12 +20,14 @@ import { removeSpaces } from '@/lib/utils';
 import { getFontAvailableWeights, FONT_WEIGHTS } from '@/lib/font-utils';
 import { buildBgImgVarName } from '@/lib/tailwind-class-mapper';
 import { isTextContentLayer } from '@/lib/layer-utils';
+import { DEFAULT_TEXT_SHADOW_VALUE } from '@/lib/text-shadow-utils';
 import type { Collection, CollectionField, Layer } from '@/types';
 import type { FieldGroup } from '@/lib/collection-field-utils';
 import ColorPropertyField from './ColorPropertyField';
 import FontPicker from './FontPicker';
 import TextBackgroundImageTab from './TextBackgroundImageTab';
 import type { TextBackgroundImageTabHandle } from './TextBackgroundImageTab';
+import TextShadowField from './TextShadowField';
 
 interface TypographyControlsProps {
   layer: Layer | null;
@@ -65,6 +67,7 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
   const underlineOffset = getDesignProperty('typography', 'underlineOffset') || '';
   const placeholderColor = getDesignProperty('typography', 'placeholderColor') || '';
   const lineClamp = getDesignProperty('typography', 'lineClamp') || '';
+  const textShadow = getDesignProperty('typography', 'textShadow') || '';
 
   // Get available weights for the selected font
   const selectedFont = getFontByFamily(fontFamily);
@@ -78,6 +81,8 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
 
   // Detect if line clamp is active
   const hasLineClamp = lineClamp !== '' && lineClamp !== 'none';
+
+  const hasTextShadow = textShadow !== '' && textShadow !== 'none';
 
   // Custom extractor for letter spacing (strips 'em' as default unit, like fontSize strips 'px')
   const extractLetterSpacingValue = (value: string): string => {
@@ -242,6 +247,18 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
     debouncedUpdateDesignProperty('typography', 'lineClamp', sanitized || null);
   };
 
+  const handleAddTextShadow = () => {
+    updateDesignProperty('typography', 'textShadow', DEFAULT_TEXT_SHADOW_VALUE);
+  };
+
+  const handleRemoveTextShadow = () => {
+    updateDesignProperty('typography', 'textShadow', null);
+  };
+
+  const handleTextShadowChange = (value: string) => {
+    updateDesignProperty('typography', 'textShadow', value);
+  };
+
   // Debounced handler for keyboard-typed hex values
   const handleDecorationColorChange = (value: string) => {
     const sanitized = removeSpaces(value);
@@ -347,6 +364,12 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
                 disabled={hasLineClamp}
               >
                 Line clamp
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={handleAddTextShadow}
+                disabled={hasTextShadow}
+              >
+                Shadow
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -686,6 +709,14 @@ const TypographyControls = memo(function TypographyControls({ layer, onLayerUpda
               </button>
             </div>
           </div>
+        )}
+
+        {!isIcon && hasTextShadow && (
+          <TextShadowField
+            value={textShadow}
+            onChange={handleTextShadowChange}
+            onRemove={handleRemoveTextShadow}
+          />
         )}
       </div>
     </div>

--- a/hooks/use-design-sync.ts
+++ b/hooks/use-design-sync.ts
@@ -641,6 +641,7 @@ function mapClassToDesignValue(className: string, property: string): string | un
     gridColumnSpan: 'col-span-',
     gridRowSpan: 'row-span-',
     lineClamp: 'line-clamp-',
+    textShadow: 'text-shadow-',
     translateX: 'translate-x-',
     translateY: 'translate-y-',
     skewX: 'skew-x-',

--- a/lib/agent/runtime.ts
+++ b/lib/agent/runtime.ts
@@ -1038,7 +1038,7 @@ function buildSystemPrompt(context?: AgentEditorContext): string {
       .join(', ');
     lines.push(
       `The user currently has these layer(s) selected: ${refs}. When they say "this", "this section", or "the selected element", they mean these layer(s). ` +
-        `A selected layer is often a container/wrapper, not the exact element a change applies to — call get_layers and inspect its subtree, then apply each change to the descendant the property actually belongs to (e.g. text color/typography goes on the text/heading/button layer inside, not the wrapping div). ` +
+        `A selected layer is often a container/wrapper, not the exact element a change applies to — call get_layers and inspect its subtree, then apply each change to the descendant the property actually belongs to (e.g. text color/typography/textShadow goes on the text/heading/button layer inside, not the wrapping div; cursor goes on the clickable layer itself). ` +
         `If a change applies to several descendants, update all of them in one batch. Never ask the user to re-select a deeper element.`,
     );
   }

--- a/lib/agent/tools/to-anthropic.test.ts
+++ b/lib/agent/tools/to-anthropic.test.ts
@@ -37,6 +37,18 @@ test('replaces an embedded designSchema with the compact node', () => {
   // Every property name is still discoverable in the category description.
   assert.match(categories.typography.description as string, /\bfontSize\b/);
   assert.match(categories.typography.description as string, /\bplaceholderColor\b/);
+  assert.match(categories.typography.description as string, /\btextShadow\b/);
+  // Short .describe() texts are inlined so the model sees value formats.
+  assert.match(
+    categories.typography.description as string,
+    /textShadow \(0px_1px_2px_rgba\(0,0,0,0\.4\) or sm\/md\/lg\)/,
+  );
+  assert.ok(categories.effects);
+  assert.match(categories.effects.description as string, /\bcursor\b/);
+  assert.match(
+    categories.effects.description as string,
+    /cursor \(pointer \| default \| text \| grab \| wait \| not-allowed \| auto\)/,
+  );
 });
 
 test('compacts designSchema inside nested structures (arrays, unions)', () => {

--- a/lib/import/css.ts
+++ b/lib/import/css.ts
@@ -239,6 +239,7 @@ function mapDeclaration(prop: string, val: string): string[] {
       out.push(val === 'auto' ? 'aspect-auto' : `aspect-[${val.replace(/\s*\/\s*/g, '/')}]`);
       break;
     case 'box-shadow': out.push(`shadow-[${arb(val)}]`); break;
+    case 'text-shadow': out.push(`text-shadow-[${arb(val)}]`); break;
     case 'background-image': out.push(`bg-[${arb(val)}]`); break;
     case 'flex-grow': out.push(val === '0' ? 'grow-0' : 'grow'); break;
     case 'flex-shrink': out.push(val === '0' ? 'shrink-0' : 'shrink'); break;

--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -128,6 +128,9 @@ Each layer's \`design\` object controls its appearance. Use update_layer_design 
 - textWrap: "balance" (even line lengths — use on multi-line headings), "pretty" (avoids orphans — use on body copy), "wrap", "nowrap"
 - fontVariantNumeric: "tabular-nums" (equal-width digits — use for pricing, stats, tables, countdowns), "normal", "ordinal", "slashed-zero"
 - color: "#171717", "rgb(0,0,0)", "#ffffff"
+- textShadow: "0px_1px_2px_rgba(0,0,0,0.4)" (offset-x, offset-y, blur, color — underscores between
+  values). Use for light text on a light background. Named sizes "sm" / "md" / "lg" also work.
+  Apply on the text/heading/button layer, not a wrapping div.
 
 **spacing** — Padding and margin
 - padding/paddingTop/paddingRight/paddingBottom/paddingLeft: "24px", "2rem"
@@ -166,6 +169,8 @@ Each layer's \`design\` object controls its appearance. Use update_layer_design 
   whatever is beneath it. Combine with an absolutely-positioned div for color tints (multiply) and
   grain/texture overlays (overlay) — no htmlEmbed needed.
 - cursor: "pointer" | "default" | "text" | "grab" | "wait" | "not-allowed" | "auto"
+  Set on the clickable layer (button, link, card). Pair with ui_state "hover" when the
+  cursor should change only on hover.
 
 **positioning** — Position, z-index
 - position: "relative" | "absolute" | "fixed" | "sticky"
@@ -325,10 +330,12 @@ applies to. Before editing, call \`get_layers\` and walk the selected layer's su
 apply each change to the layer the property actually belongs to:
 
 - **Text properties** (color, fontSize, fontWeight, fontFamily, lineHeight, letterSpacing,
-  textAlign, textTransform, textWrap, fontVariantNumeric) → apply to the **text / heading /
+  textAlign, textTransform, textWrap, fontVariantNumeric, textShadow) → apply to the **text / heading /
   richText / button descendant(s)** inside the selection, NOT the wrapping div. A \`text-white\`
   class on a parent does NOT win when a child text layer has its own color set, so you must set
   it on the child layer itself.
+- **Cursor** (\`effects.cursor\`) → the clickable layer itself (button, link, or the selected
+  card/div). Do not put it on a nested text child.
 - **Background, border, border-radius, padding** → usually the selected container itself.
 - **Gap, alignment, flex direction, grid columns** → the flex/grid container.
 - **Image properties** (objectFit, aspectRatio, src, alt) → the \`image\` layer.
@@ -546,6 +553,8 @@ The values below are the safe defaults:
 
 - **Border radius**: "12px" or "16px" for cards, "8px" for buttons, "9999px" for pills
 - **Shadows on cards**: boxShadow "0 1px 3px rgba(0,0,0,0.08)"
+- **Text shadow**: typography.textShadow "0px_1px_2px_rgba(0,0,0,0.4)" when light text sits on a light background
+- **Cursor**: effects.cursor "pointer" on buttons, links, and other clickable layers
 - **Subtle borders**: borderWidth "1px", borderColor "rgba(0,0,0,0.06)"
 - **Button hover**: Use ui_state "hover" to darken background or add shadow
 - **Image aspect ratios**: Use aspectRatio "16/9" or "3/2" with objectFit "cover"

--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -155,7 +155,7 @@ Each layer's \`design\` object controls its appearance. Use update_layer_design 
 - backgroundClip: "text" (for gradient text effect — also set typography color "transparent")
 - bgGradientVars: { "--bg-img": "linear-gradient(135deg, #667eea 0%, #764ba2 100%)" } — CSS gradient values
 
-**effects** — Shadows, opacity, blur, filters, blend modes
+**effects** — Shadows, opacity, blur, filters, blend modes, cursor
 - opacity: "0" to "1"
 - boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1)"
 - blur: "4px"
@@ -165,6 +165,7 @@ Each layer's \`design\` object controls its appearance. Use update_layer_design 
 - mixBlendMode: "multiply" | "screen" | "overlay" | "darken" | "lighten" | … — blends a layer into
   whatever is beneath it. Combine with an absolutely-positioned div for color tints (multiply) and
   grain/texture overlays (overlay) — no htmlEmbed needed.
+- cursor: "pointer" | "default" | "text" | "grab" | "wait" | "not-allowed" | "auto"
 
 **positioning** — Position, z-index
 - position: "relative" | "absolute" | "fixed" | "sticky"

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -144,6 +144,11 @@ const DESIGN_REFERENCE_JSON = JSON.stringify({
       letterSpacing: { type: 'css_value', examples: ['-0.03em', '0'] },
       textAlign: { type: 'enum', values: ['left', 'center', 'right'] },
       color: { type: 'color', examples: ['#171717', '#ffffff'] },
+      textShadow: {
+        type: 'string',
+        description: 'CSS text-shadow with underscores between values. Apply on the text/heading/button layer.',
+        examples: ['0px_1px_2px_rgba(0,0,0,0.4)', 'sm', 'lg'],
+      },
     },
     spacing: { padding: { type: 'css_value' }, margin: { type: 'css_value' } },
     sizing: {
@@ -168,7 +173,11 @@ const DESIGN_REFERENCE_JSON = JSON.stringify({
     effects: {
       opacity: { type: 'string' },
       boxShadow: { type: 'string' },
-      cursor: { type: 'enum', values: ['auto', 'default', 'pointer', 'text', 'grab', 'wait', 'not-allowed'] },
+      cursor: {
+        type: 'enum',
+        values: ['auto', 'default', 'pointer', 'text', 'grab', 'wait', 'not-allowed'],
+        description: 'Set on the clickable layer itself (button, link, card), not a nested text child.',
+      },
     },
     positioning: {
       position: { type: 'enum', values: ['relative', 'absolute', 'fixed', 'sticky'] },

--- a/lib/mcp/resources/reference.ts
+++ b/lib/mcp/resources/reference.ts
@@ -168,6 +168,7 @@ const DESIGN_REFERENCE_JSON = JSON.stringify({
     effects: {
       opacity: { type: 'string' },
       boxShadow: { type: 'string' },
+      cursor: { type: 'enum', values: ['auto', 'default', 'pointer', 'text', 'grab', 'wait', 'not-allowed'] },
     },
     positioning: {
       position: { type: 'enum', values: ['relative', 'absolute', 'fixed', 'sticky'] },

--- a/lib/mcp/tools/layers.ts
+++ b/lib/mcp/tools/layers.ts
@@ -121,7 +121,13 @@ being viewed (aria-current) — use it for active nav-link and pagination stylin
 
 GRADIENTS: Use bgGradientVars in backgrounds to set CSS gradients.
 Example: { backgrounds: { isActive: true, bgGradientVars: { "--bg-img": "linear-gradient(135deg, #667eea 0%, #764ba2 100%)" } } }
-For gradient text: also set backgroundClip: "text" and color to "transparent".`,
+For gradient text: also set backgroundClip: "text" and color to "transparent".
+
+CURSOR: effects.cursor — "pointer", "default", "text", "grab", "wait", "not-allowed", or "auto".
+Set this on the clickable layer itself (button, link, card), not a nested text child.
+
+TEXT SHADOW: typography.textShadow — e.g. "0px_1px_2px_rgba(0,0,0,0.4)" (underscores, not spaces)
+or a named size ("sm", "md", "lg"). Apply on the text/heading/button layer.`,
     {
       page_id: z.string().describe('The page ID'),
       layer_id: z.string().describe('The layer ID to update'),

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -80,6 +80,7 @@ export const designSchema = z.object({
     verticalAlign: z.string().optional(),
     color: z.string().optional(),
     placeholderColor: z.string().optional(),
+    textShadow: z.string().optional().describe('0px_1px_2px_rgba(0,0,0,0.4) or sm/md/lg'),
   }).optional(),
   spacing: z.object({
     isActive: z.boolean().optional(),
@@ -153,7 +154,7 @@ export const designSchema = z.object({
     filter: z.string().optional().describe('CSS filter, e.g. "grayscale(1)" or "brightness(0.5)"'),
     backdropFilter: z.string().optional().describe('CSS backdrop-filter, e.g. "saturate(180%)"'),
     mixBlendMode: z.string().optional().describe('CSS mix-blend-mode, e.g. "multiply", "screen", "overlay"'),
-    cursor: z.string().optional().describe('CSS cursor: "pointer", "default", "text", "grab", "wait", "not-allowed", "auto"'),
+    cursor: z.string().optional().describe('pointer | default | text | grab | wait | not-allowed | auto'),
   }).optional(),
   positioning: z.object({
     isActive: z.boolean().optional(),

--- a/lib/mcp/tools/shared-schemas.ts
+++ b/lib/mcp/tools/shared-schemas.ts
@@ -153,6 +153,7 @@ export const designSchema = z.object({
     filter: z.string().optional().describe('CSS filter, e.g. "grayscale(1)" or "brightness(0.5)"'),
     backdropFilter: z.string().optional().describe('CSS backdrop-filter, e.g. "saturate(180%)"'),
     mixBlendMode: z.string().optional().describe('CSS mix-blend-mode, e.g. "multiply", "screen", "overlay"'),
+    cursor: z.string().optional().describe('CSS cursor: "pointer", "default", "text", "grab", "wait", "not-allowed", "auto"'),
   }).optional(),
   positioning: z.object({
     isActive: z.boolean().optional(),

--- a/lib/tailwind-class-mapper.ts
+++ b/lib/tailwind-class-mapper.ts
@@ -307,8 +307,8 @@ const CLASS_PROPERTY_MAP: Record<string, RegExp> = {
   // Typography
   fontFamily: /^font-(sans|serif|mono|\[.+\])$/,
   // Updated to match partial arbitrary values like text-n, text-no, text-non (not just complete text-[10rem])
-  // Excludes text-align values and text-wrap utilities (wrap, nowrap, balance, pretty)
-  fontSize: /^text-(?!(?:left|center|right|justify|start|end|wrap|nowrap|balance|pretty)(?:\s|$)).+$/,
+  // Excludes text-align values, text-wrap utilities, and text-shadow
+  fontSize: /^text-(?!(?:left|center|right|justify|start|end|wrap|nowrap|balance|pretty|shadow)(?:-|\s|$)).+$/,
   fontWeight: /^font-(thin|extralight|light|normal|medium|semibold|bold|extrabold|black|\[.+\])$/,
   lineHeight: /^leading-(none|tight|snug|normal|relaxed|loose|\d+|\[.+\])$/,
   letterSpacing: /^tracking-(tighter|tight|normal|wide|wider|widest|\[.+\]|.+)$/,
@@ -324,8 +324,9 @@ const CLASS_PROPERTY_MAP: Record<string, RegExp> = {
   // Updated to match partial arbitrary values like text-r, text-re, text-red (not just complete text-[#FF0000])
   // Excludes fontSize named values, text-align values, and text-wrap utilities
   // Includes opacity modifier: text-[#cc8d8d]/59
-  color: /^text-(?!(?:xs|sm|base|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|8xl|9xl|left|center|right|justify|start|end|wrap|nowrap|balance|pretty)(?:\s|$)).+(\/\d+)?$/,
+  color: /^text-(?!(?:xs|sm|base|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|8xl|9xl|left|center|right|justify|start|end|wrap|nowrap|balance|pretty|shadow)(?:-|\s|$)).+(\/\d+)?$/,
   placeholderColor: /^placeholder:text-.+(\/\d+)?$/,
+  textShadow: /^text-shadow(-none|-2xs|-xs|-sm|-md|-lg|-\[.+\])?$/,
 
   // Backgrounds
   backgroundColor: /^bg-(?!(?:auto|cover|contain|bottom|center|left|left-bottom|left-top|right|right-bottom|right-top|top|repeat|no-repeat|repeat-x|repeat-y|repeat-round|repeat-space|none|gradient-to-t|gradient-to-tr|gradient-to-r|gradient-to-br|gradient-to-b|gradient-to-bl|gradient-to-l|gradient-to-tl)$)((\w+)(-\d+)?|\[.+\](?:\/\d+)?)$/,
@@ -827,6 +828,12 @@ export function propertyToClass(
         if (value === 'none') return 'line-clamp-none';
         if (/^\d+$/.test(value)) return `line-clamp-${value}`;
         return `line-clamp-[${value}]`;
+      case 'textShadow':
+        if (value === 'none') return 'text-shadow-none';
+        if (['2xs', 'xs', 'sm', 'md', 'lg'].includes(value)) {
+          return `text-shadow-${value}`;
+        }
+        return `text-shadow-[${value.replace(/\s+/g, '_')}]`;
       case 'color':
         // Check if value is a gradient (linear-gradient or radial-gradient)
         if (value.includes('gradient(')) {
@@ -1241,6 +1248,10 @@ export function getAffectedProperties(className: string): string[] {
     if (baseClass === 'bg-clip-text') properties.push('color');
     return properties;
   }
+  if (baseClass.startsWith('text-shadow')) {
+    properties.push('textShadow');
+    return properties;
+  }
   if (baseClass === 'text-transparent') {
     properties.push('color');
     return properties;
@@ -1612,6 +1623,17 @@ export function classesToDesign(classes: string | string[]): Layer['design'] {
     } else if (cls.startsWith('line-clamp-[')) {
       const value = extractArbitraryValue(cls);
       if (value) design.typography!.lineClamp = value;
+    }
+
+    // Text Shadow
+    if (cls.startsWith('text-shadow-[')) {
+      const value = extractArbitraryValue(cls);
+      if (value) design.typography!.textShadow = value;
+    } else if (cls === 'text-shadow-none') {
+      design.typography!.textShadow = 'none';
+    } else if (cls.match(/^text-shadow-(2xs|xs|sm|md|lg)$/)) {
+      const match = cls.match(/^text-shadow-(.+)$/);
+      if (match) design.typography!.textShadow = match[1];
     }
 
     // Line Height
@@ -2256,6 +2278,10 @@ function isImageValue(value: string): boolean {
 function shouldIncludeClassForProperty(className: string, property: string, pattern: RegExp): boolean {
   // Strip breakpoint and state prefixes for helper class detection
   const baseClass = className.replace(/^(max-lg:|max-md:|lg:|md:)?(hover:|focus:|active:|disabled:|visited:|current:)?/, '');
+
+  if (baseClass.startsWith('text-shadow')) {
+    return property === 'textShadow';
+  }
 
   // Special handling for text color property
   // Include gradient-related classes (bg-[gradient], text-transparent) but NOT bg-clip-text

--- a/lib/tailwind-class-mapper.ts
+++ b/lib/tailwind-class-mapper.ts
@@ -366,6 +366,7 @@ const CLASS_PROPERTY_MAP: Record<string, RegExp> = {
   blur: /^blur(-none|-sm|-md|-lg|-xl|-2xl|-3xl|-\[.+\])?$/,
   backdropBlur: /^backdrop-blur(-none|-sm|-md|-lg|-xl|-2xl|-3xl|-\[.+\])?$/,
   mixBlendMode: /^mix-blend-(normal|multiply|screen|overlay|darken|lighten|color-dodge|color-burn|hard-light|soft-light|difference|exclusion|hue|saturation|color|luminosity)$/,
+  cursor: /^cursor-.+$/,
 
   // Positioning
   position: /^(static|fixed|absolute|relative|sticky)$/,
@@ -1110,6 +1111,8 @@ export function propertyToClass(
       case 'mixBlendMode':
         if (value === 'normal') return '';
         return `mix-blend-${value}`;
+      case 'cursor':
+        return `cursor-${value}`;
     }
   }
 
@@ -1949,6 +1952,12 @@ export function classesToDesign(classes: string | string[]): Layer['design'] {
     if (cls.startsWith('mix-blend-')) {
       const match = cls.match(/^mix-blend-(.+)$/);
       if (match) design.effects!.mixBlendMode = match[1];
+    }
+
+    // Cursor
+    if (cls.startsWith('cursor-')) {
+      const value = cls.slice('cursor-'.length);
+      if (value) design.effects!.cursor = value;
     }
 
     // ===== POSITIONING =====

--- a/lib/tailwind-suggestions.ts
+++ b/lib/tailwind-suggestions.ts
@@ -367,6 +367,15 @@ const TAILWIND_CLASSES = [
   'opacity-50',
   'opacity-75',
   'opacity-100',
+
+  // Interactivity - Cursor
+  'cursor-auto',
+  'cursor-default',
+  'cursor-pointer',
+  'cursor-text',
+  'cursor-grab',
+  'cursor-wait',
+  'cursor-not-allowed',
   
   // Positioning - Position
   'static',

--- a/lib/tailwind-suggestions.ts
+++ b/lib/tailwind-suggestions.ts
@@ -130,6 +130,14 @@ const TAILWIND_CLASSES = [
   'tracking-wide',
   'tracking-wider',
   'tracking-widest',
+
+  // Typography - Text Shadow
+  'text-shadow-2xs',
+  'text-shadow-xs',
+  'text-shadow-sm',
+  'text-shadow-md',
+  'text-shadow-lg',
+  'text-shadow-none',
   
   // Spacing - Padding
   'p-0',

--- a/lib/text-shadow-utils.ts
+++ b/lib/text-shadow-utils.ts
@@ -1,0 +1,119 @@
+export interface TextShadow {
+  x: number;
+  y: number;
+  blur: number;
+  color: string;
+}
+
+export const DEFAULT_TEXT_SHADOW: TextShadow = {
+  x: 0,
+  y: 1,
+  blur: 2,
+  color: 'rgba(0,0,0,0.4)',
+};
+
+const NAMED_TEXT_SHADOWS: Record<string, TextShadow> = {
+  '2xs': { x: 0, y: 1, blur: 0, color: 'rgba(0,0,0,0.15)' },
+  xs: { x: 0, y: 1, blur: 1, color: 'rgba(0,0,0,0.2)' },
+  sm: { x: 0, y: 1, blur: 2, color: 'rgba(0,0,0,0.15)' },
+  md: { x: 0, y: 2, blur: 4, color: 'rgba(0,0,0,0.15)' },
+  lg: { x: 0, y: 4, blur: 8, color: 'rgba(0,0,0,0.15)' },
+};
+
+export function serializeTextShadow(shadow: TextShadow): string {
+  const color = shadow.color.startsWith('color:var(')
+    ? shadow.color.replace('color:', '')
+    : shadow.color;
+  return `${shadow.x}px_${shadow.y}px_${shadow.blur}px_${color}`;
+}
+
+export const DEFAULT_TEXT_SHADOW_VALUE = serializeTextShadow(DEFAULT_TEXT_SHADOW);
+
+export function parseTextShadow(value: string): TextShadow | null {
+  if (!value || value === 'none') return null;
+
+  if (NAMED_TEXT_SHADOWS[value]) {
+    return { ...NAMED_TEXT_SHADOWS[value] };
+  }
+
+  const normalized = value.replace(/\s+/g, '_');
+  const parts = normalized.split('_');
+
+  if (parts.length < 3) return { ...DEFAULT_TEXT_SHADOW };
+
+  const x = parseInt(parts[0], 10) || 0;
+  const y = parseInt(parts[1], 10) || 0;
+
+  const thirdLooksLikeColor = /^(#|rgb|hsl|var|color:)/i.test(parts[2]);
+  if (thirdLooksLikeColor) {
+    return {
+      x,
+      y,
+      blur: 0,
+      color: restoreVarColor(parts.slice(2).join('_')),
+    };
+  }
+
+  const blur = parseInt(parts[2], 10) || 0;
+  const color = parts.length > 3
+    ? restoreVarColor(parts.slice(3).join('_'))
+    : DEFAULT_TEXT_SHADOW.color;
+
+  return { x, y, blur, color };
+}
+
+function restoreVarColor(color: string): string {
+  if (color.startsWith('var(--')) {
+    return `color:${color}`;
+  }
+  return color;
+}
+
+export function convertToRgba(color: string): string {
+  if (color.startsWith('rgba')) return color;
+  if (color.startsWith('rgb')) {
+    return color.replace('rgb(', 'rgba(').replace(')', ',1)');
+  }
+
+  let r: number;
+  let g: number;
+  let b: number;
+  let a = 1;
+
+  const hexOpacityMatch = color.match(/^#([0-9a-fA-F]{6})\/(\d+)$/);
+  if (hexOpacityMatch) {
+    r = parseInt(hexOpacityMatch[1].substring(0, 2), 16);
+    g = parseInt(hexOpacityMatch[1].substring(2, 4), 16);
+    b = parseInt(hexOpacityMatch[1].substring(4, 6), 16);
+    a = parseInt(hexOpacityMatch[2], 10) / 100;
+    return `rgba(${r},${g},${b},${a})`;
+  }
+
+  const hex = color.replace('#', '');
+
+  if (hex.length === 8) {
+    r = parseInt(hex.substring(0, 2), 16);
+    g = parseInt(hex.substring(2, 4), 16);
+    b = parseInt(hex.substring(4, 6), 16);
+    a = parseInt(hex.substring(6, 8), 16) / 255;
+  } else if (hex.length === 6) {
+    r = parseInt(hex.substring(0, 2), 16);
+    g = parseInt(hex.substring(2, 4), 16);
+    b = parseInt(hex.substring(4, 6), 16);
+  } else if (hex.length === 3) {
+    r = parseInt(hex[0] + hex[0], 16);
+    g = parseInt(hex[1] + hex[1], 16);
+    b = parseInt(hex[2] + hex[2], 16);
+  } else {
+    return 'rgba(0,0,0,1)';
+  }
+
+  return `rgba(${r},${g},${b},${a})`;
+}
+
+export function swatchColor(color: string): string {
+  if (color.startsWith('var(') || color.startsWith('color:var(')) {
+    return 'rgba(0,0,0,0.35)';
+  }
+  return color;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -128,6 +128,7 @@ export interface EffectsDesign {
   filter?: string;
   backdropFilter?: string;
   mixBlendMode?: string;
+  cursor?: string;
 }
 
 export interface PositioningDesign {

--- a/types/index.ts
+++ b/types/index.ts
@@ -46,6 +46,7 @@ export interface TypographyDesign {
   verticalAlign?: string;
   color?: string;
   placeholderColor?: string;
+  textShadow?: string;
 }
 
 export interface SpacingDesign {


### PR DESCRIPTION
## Summary

Add native text shadow and cursor controls in the design sidebar so light text on a light background can stay readable, and so pasting a `text-shadow-*` class no longer overwrites color and size.

Closes #512

## Changes

- Add Shadow to the typography + menu with color, X, Y, and blur
- Map `text-shadow-*` to `typography.textShadow` instead of treating it as font size or color
- Add a Cursor control after Effects (auto, default, pointer, text, grab, wait, not-allowed)
- Move Position to sit after Sizing
- Document both properties for MCP and the in-app AI builder

## Test plan

- [ ] Select a text layer, add Shadow from the + menu, change color/offset/blur, and confirm it renders
- [ ] Paste `text-shadow-sm` onto a styled text layer — color and size stay intact, shadow applies
- [ ] Remove the shadow with the × control
- [ ] Set Cursor on a button or link and confirm the pointer changes on hover
- [ ] Confirm Position sits after Sizing in the design sidebar