### PR TITLE
fix: anchor CMS hreflang default slug to the default locale

### DIFF
--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -15,6 +15,7 @@ import { getSettingsByKeys } from '@/lib/repositories/settingsRepository';
 import { getAssetById } from '@/lib/repositories/assetRepository';
 import { getAllLocales } from '@/lib/repositories/localeRepository';
 import { getAllPublishedPageFolders } from '@/lib/repositories/pageFolderRepository';
+import { getValuesByItemIds } from '@/lib/repositories/collectionItemValueRepository';
 import { getSlugTranslationsByLocale } from '@/lib/repositories/translationRepository';
 import { buildSvgDataUrl, getAssetProxyUrl } from '@/lib/asset-utils';
 import { generateColorVariablesCss } from '@/lib/repositories/colorVariableRepository';
@@ -226,13 +227,19 @@ export async function buildPageHreflangAlternatesForPage(
   }
 
   // Dynamic pages need the collection item's slug to resolve per-locale URLs.
+  // `collectionItem.values` is localized to the active render locale, so read the
+  // raw (default-locale) slug — it anchors the x-default and default-locale
+  // alternates and the fallback for locales without a translated slug.
   const slugFieldId = page.settings?.cms?.slug_field_id;
-  const dynamicSlug = page.is_dynamic && collectionItem && slugFieldId
-    ? {
+  let dynamicSlug: { itemId: string; defaultValue: string } | null = null;
+  if (page.is_dynamic && collectionItem && slugFieldId) {
+    const rawValues = await getValuesByItemIds([collectionItem.id], true, undefined, [slugFieldId]);
+    const rawSlug = rawValues[collectionItem.id]?.[slugFieldId];
+    dynamicSlug = {
       itemId: collectionItem.id,
-      defaultValue: collectionItem.values?.[slugFieldId] || '',
-    }
-    : null;
+      defaultValue: String(rawSlug ?? collectionItem.values?.[slugFieldId] ?? ''),
+    };
+  }
 
   return buildPageHreflangAlternates({
     page,


### PR DESCRIPTION
## Summary

Follow-up to #517. On a non-default-locale render of a CMS page, the `en`, `x-default`, and per-locale fallback hreflang alternates still pointed at the viewed locale's translated slug instead of the canonical default-locale slug — leaving the canonical/hreflang mismatch in place (e.g. a German article showed `en`/`de`/`x-default` all using the German slug).

## Root cause

The metadata fetch localizes the collection item's field values to the active render locale, so `collectionItem.values[slugFieldId]` is the *translated* slug on a `/de/` render. `buildPageHreflangAlternatesForPage` used that as `defaultValue`, which anchors the `x-default`, the default-locale alternate, and the fallback for locales without a translated slug.

## Changes

- Read the raw (default-locale) slug from `collection_item_values` via `getValuesByItemIds` instead of the localized item values, so the default-locale anchor is correct regardless of which locale is being rendered
- Fixes both callers at once (`generateMetadata` and `PageRenderer` share this function)

## Test plan

- [ ] Open a German CMS article and confirm `en` and `x-default` use the English (default) slug, `de` uses the German slug, and all resolve
- [ ] Confirm a locale with no translated slug falls back to the English slug (not the viewed locale's slug)
- [ ] Confirm the default-locale (English) article is unchanged
- [ ] Spot-check `sitemap.xml` alternates for a dynamic item

## Note

The separate duplicate-URL behavior the user reported (a translated item still resolving at both `/de/{english-slug}` and `/de/{german-slug}`) comes from the graceful default-slug fallback in `getCollectionItemBySlug` and is out of scope here. With correct hreflang + self-referential canonicals, Google is steered to the right URLs; a follow-up could 404/redirect the default-slug-under-locale path when a translated slug exists.