### PR TITLE
fix: translate static text inside collections

### DIFF
--- a/lib/collection-utils.ts
+++ b/lib/collection-utils.ts
@@ -383,6 +383,10 @@ export function remapLayerIdsForCollectionItem(layer: Layer, suffix: string): La
     const remapped: Layer = {
       ...l,
       id: `${l.id}${suffix}`,
+      // Preserve the pre-suffix id so translation injection (which runs after
+      // collection expansion and keys off the original template layer id) can
+      // still resolve static text translations for layers rendered per item.
+      _originalLayerId: (l as Layer)._originalLayerId || l.id,
     };
 
     if (l.interactions?.length) {


### PR DESCRIPTION
## Summary

Static text placed inside a collection was never translated on rendered pages — it stayed in the source language even when a completed translation existed for the layer.

## Changes

- Preserve the original template layer id (`_originalLayerId`) when collection item expansion suffixes layer ids to `{id}-item-{itemId}`
- Translation injection runs after collection expansion and looks up translations by the original id, so without this it built a mismatched key and skipped the translation

## Test plan

- [ ] Add a static text layer inside a collection list and translate it in a non-default locale
- [ ] Verify the rendered page (and preview) shows the translated text for every collection item
- [ ] Confirm text layers outside collections still translate correctly
- [ ] Confirm the default locale is unaffected