### PR TITLE
feat: speed up MCP bulk translations

### DIFF
--- a/lib/mcp/instructions.ts
+++ b/lib/mcp/instructions.ts
@@ -678,8 +678,19 @@ same condition model as set_collection_filters.
 - Call list_translatable_content FIRST to discover exactly what can be translated and the
   precise source_type/source_id/content_key — never guess content keys. It also surfaces
   per-page component instance overrides, which are easy to miss.
-- set_translation for plain text; batch_set_translations for bulk; set_rich_text_translation
-  (structured blocks) for rich_text fields — plain text sent to a rich_text key will not render.
+
+Translating a lot of content efficiently (avoid token waste and many round-trips):
+- Pass locale_id + untranslated_only:true to list_translatable_content so it returns ONLY the
+  items still missing a completed translation. This skips already-done work — essential when
+  resuming or adding a new locale, so you never re-read content you already translated.
+- For big CMS collections, paginate discovery with limit + offset instead of one huge call.
+- Write with batch_set_translations (up to 1000 items per call). Set the top-level locale_id
+  ONCE and omit locale_id on each item — do not repeat it 1000 times. Prefer one large batch
+  over many small set_translation calls.
+- Rich text in a batch: set content_type "richtext" with content_value as a JSON-stringified
+  Tiptap doc. Use set_rich_text_translation (structured blocks) only for a single field.
+  Plain text sent to a rich_text key will not render.
+
 - Translations are marked complete by default. Only pass is_completed: false for drafts —
   incomplete translations NEVER appear on the live site. Translations stay drafts until published.`,
 };

--- a/lib/mcp/tools/locales.ts
+++ b/lib/mcp/tools/locales.ts
@@ -9,6 +9,8 @@ import {
 } from '@/lib/repositories/localeRepository';
 import {
   getTranslationsByLocale,
+  getTranslationsBySource,
+  getCmsTranslationsForItems,
   createTranslation,
   updateTranslation,
   deleteTranslation,
@@ -133,24 +135,33 @@ export function registerLocaleTools(server: McpServer) {
 
   server.tool(
     'list_translations',
-    'List all translations for a specific locale.',
+    'List existing translations for a specific locale. Optionally filter by source type or completion status to keep the response small.',
     {
       locale_id: z.string().describe('The locale ID to get translations for'),
+      source_type: z.enum(['page', 'folder', 'component', 'cms']).optional().describe('Only return translations for this source type'),
+      completed: z.boolean().optional().describe('Filter by completion status (true = completed only, false = drafts only)'),
     },
-    async ({ locale_id }) => {
+    async ({ locale_id, source_type, completed }) => {
       const translations = await getTranslationsByLocale(locale_id);
+      const filtered = translations.filter((t) =>
+        (source_type === undefined || t.source_type === source_type) &&
+        (completed === undefined || t.is_completed === completed),
+      );
       return {
         content: [{
           type: 'text' as const,
-          text: JSON.stringify(translations.map((t) => ({
-            id: t.id,
-            source_type: t.source_type,
-            source_id: t.source_id,
-            content_key: t.content_key,
-            content_type: t.content_type,
-            content_value: t.content_value,
-            is_completed: t.is_completed,
-          })), null, 2),
+          text: JSON.stringify({
+            count: filtered.length,
+            translations: filtered.map((t) => ({
+              id: t.id,
+              source_type: t.source_type,
+              source_id: t.source_id,
+              content_key: t.content_key,
+              content_type: t.content_type,
+              content_value: t.content_value,
+              is_completed: t.is_completed,
+            })),
+          }),
         }],
       };
     },
@@ -194,21 +205,38 @@ export function registerLocaleTools(server: McpServer) {
 
   server.tool(
     'batch_set_translations',
-    'Create or update multiple translations at once. Efficient for translating many content keys.',
+    `Create or update up to 1000 translations in one call — the most efficient way to translate a lot of content. Set the top-level locale_id once and omit it from each item (only override it per item when writing multiple locales at once). Rich text: pass content_type "richtext" with content_value as a JSON-stringified Tiptap doc (or use set_rich_text_translation for a single block-based field).`,
     {
+      locale_id: z.string().optional().describe('Default locale ID applied to every item that omits its own locale_id. Set this once instead of repeating it on each item.'),
       translations: z.array(z.object({
-        locale_id: z.string(),
+        locale_id: z.string().optional().describe('Overrides the top-level locale_id for this item'),
         source_type: z.enum(['page', 'folder', 'component', 'cms']),
         source_id: z.string(),
         content_key: z.string(),
         content_type: z.enum(['text', 'richtext', 'asset_id']).optional(),
         content_value: z.string(),
         is_completed: z.boolean().optional(),
-      })).min(1).max(100).describe('Array of translations to upsert (max 100)'),
+      })).min(1).max(1000).describe('Array of translations to upsert (max 1000)'),
     },
-    async ({ translations }) => {
+    async ({ locale_id, translations }) => {
+      // Each item's locale_id falls back to the shared top-level one. Report any
+      // item missing both so the whole batch is rejected before writing.
+      const missingLocale = translations
+        .map((t, i) => ({ i, key: t.content_key, hasLocale: !!(t.locale_id || locale_id) }))
+        .filter((e) => !e.hasLocale)
+        .map((e) => `[${e.i}] "${e.key}"`);
+      if (missingLocale.length > 0) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error: ${missingLocale.length} item(s) have no locale_id (and no top-level locale_id was provided): ${missingLocale.join(', ')}`,
+          }],
+          isError: true,
+        };
+      }
+
       const data = translations.map((t) => ({
-        locale_id: t.locale_id,
+        locale_id: (t.locale_id || locale_id) as string,
         source_type: t.source_type as 'page' | 'folder' | 'component' | 'cms',
         source_id: t.source_id,
         content_key: t.content_key,
@@ -237,7 +265,7 @@ export function registerLocaleTools(server: McpServer) {
       return {
         content: [{
           type: 'text' as const,
-          text: JSON.stringify({ message: `Saved ${result.length} translations`, count: result.length }, null, 2),
+          text: JSON.stringify({ message: `Saved ${result.length} translations`, count: result.length }),
         }],
       };
     },
@@ -282,17 +310,33 @@ export function registerLocaleTools(server: McpServer) {
 
   server.tool(
     'list_translatable_content',
-    `Discover exactly what can be translated for a page, component, or CMS collection — and the precise source_type/source_id/content_key/content_type to use with set_translation. Use this BEFORE translating so you never have to guess keys. Pass locale_id to also see which items already have a translation and their current value.`,
+    `Discover exactly what can be translated for a page, component, or CMS collection — and the precise source_type/source_id/content_key/content_type to use with set_translation. Use this BEFORE translating so you never have to guess keys. Pass locale_id to annotate each item with its existing translation, and untranslated_only to return only the items still needing a translation (skips already-done work — the cheapest way to resume or translate a new locale).`,
     {
       source_type: z.enum(['page', 'component', 'cms']).describe('What to inspect: a page, a component, or a CMS collection'),
       source_id: z.string().describe('Page ID, component ID, or collection ID (for cms)'),
       locale_id: z.string().optional().describe('Optional locale ID to annotate each item with its existing translation status/value'),
+      untranslated_only: z.boolean().optional().describe('Requires locale_id. Only return items with no completed translation yet. Use this to avoid re-sending content that is already translated.'),
       search: z.string().optional().describe('CMS only: filter collection items by search term'),
       limit: z.number().optional().describe('CMS only: max collection items to scan (default 25)'),
+      offset: z.number().optional().describe('CMS only: skip this many collection items — paginate large collections with limit + offset'),
     },
-    async ({ source_type, source_id, locale_id, search, limit }) => {
+    async ({ source_type, source_id, locale_id, untranslated_only, search, limit, offset }) => {
+      if (untranslated_only && !locale_id) {
+        return { content: [{ type: 'text' as const, text: 'Error: untranslated_only requires locale_id.' }], isError: true };
+      }
+
       let items: TranslatableItem[] = [];
       let total: number | undefined;
+      // Existing translations for the requested locale, scoped to just this
+      // source (page/component/scanned CMS items) — avoids loading the entire
+      // locale catalogue on every discovery call.
+      let existingByKey: Map<string, { value: string; is_completed: boolean }> | null = null;
+
+      const buildExistingMap = (translations: { content_value: string; is_completed: boolean; source_type: string; source_id: string; content_key: string }[]) =>
+        new Map(translations.map((t) => [
+          getTranslatableKey(t),
+          { value: t.content_value, is_completed: t.is_completed },
+        ]));
 
       if (source_type === 'page') {
         const page = await getPageById(source_id);
@@ -304,6 +348,9 @@ export function registerLocaleTools(server: McpServer) {
         // "Component › Variable" labels instead of falling back to layer names.
         const components = await getAllComponents(false).catch(() => []);
         items = extractPageTranslatableItems(page, layers, undefined, components);
+        if (locale_id) {
+          existingByKey = buildExistingMap(await getTranslationsBySource('page', source_id, false, locale_id));
+        }
       } else if (source_type === 'component') {
         const component = await getComponentById(source_id);
         if (!component) {
@@ -312,33 +359,33 @@ export function registerLocaleTools(server: McpServer) {
         const variants = component.variants as ComponentVariant[] | undefined;
         const layers = (variants?.[0]?.layers || (component.layers as Layer[]) || []);
         items = extractComponentTranslatableItems({ id: component.id, name: component.name }, layers);
+        if (locale_id) {
+          existingByKey = buildExistingMap(await getTranslationsBySource('component', source_id, false, locale_id));
+        }
       } else {
         const fields = await getFieldsByCollectionId(source_id);
+        // Push pagination into the query instead of fetching the whole
+        // collection and slicing — critical for large CMS catalogues.
         const { items: collectionItems, total: itemTotal } = await getItemsWithValues(
           source_id,
           false,
-          search ? { search } : undefined,
+          { ...(search ? { search } : {}), limit: limit ?? 25, offset: offset ?? 0 },
         );
         total = itemTotal;
-        const scoped = collectionItems.slice(0, limit ?? 25);
-        for (const item of scoped) {
+        for (const item of collectionItems) {
           items.push(...extractCmsTranslatableItems(
             { id: item.id, collection_id: source_id, values: item.values },
             fields,
           ));
         }
+        if (locale_id) {
+          existingByKey = buildExistingMap(
+            await getCmsTranslationsForItems(locale_id, false, collectionItems.map((i) => i.id)),
+          );
+        }
       }
 
-      // Annotate with existing translations for the given locale, if requested.
-      let existingByKey: Map<string, { value: string; is_completed: boolean }> | null = null;
-      if (locale_id) {
-        const translations = await getTranslationsByLocale(locale_id);
-        existingByKey = new Map(
-          translations.map((t) => [getTranslatableKey(t), { value: t.content_value, is_completed: t.is_completed }]),
-        );
-      }
-
-      const result = items.map((item) => {
+      let result = items.map((item) => {
         const existing = existingByKey?.get(item.key);
         return {
           source_type: item.source_type,
@@ -353,14 +400,18 @@ export function registerLocaleTools(server: McpServer) {
         };
       });
 
+      if (untranslated_only) {
+        result = result.filter((item) => !item.has_translation || !item.is_completed);
+      }
+
       return {
         content: [{
           type: 'text' as const,
           text: JSON.stringify({
             count: result.length,
-            ...(total !== undefined ? { collection_items_total: total, scanned_items: Math.min(total, limit ?? 25) } : {}),
+            ...(total !== undefined ? { collection_items_total: total, scanned_items: Math.min(total, (offset ?? 0) + (limit ?? 25)) - (offset ?? 0) } : {}),
             items: result,
-          }, null, 2),
+          }),
         }],
       };
     },

--- a/lib/repositories/translationRepository.ts
+++ b/lib/repositories/translationRepository.ts
@@ -6,7 +6,7 @@
  */
 
 import { getSupabaseAdmin, getTenantIdFromHeaders } from '@/lib/supabase-server';
-import { fetchAllRows } from '@/lib/supabase-constants';
+import { fetchAllRows, SUPABASE_WRITE_BATCH_SIZE } from '@/lib/supabase-constants';
 import { getKnexClient } from '@/lib/knex-client';
 import type { Translation, CreateTranslationData, UpdateTranslationData } from '@/types';
 
@@ -252,12 +252,15 @@ export async function getSlugTranslationsByLocale(
 }
 
 /**
- * Get translations by source (draft by default)
+ * Get translations by source (draft by default). Pass `localeId` to scope to a
+ * single locale — far cheaper than loading the whole locale catalogue just to
+ * annotate one page/component.
  */
 export async function getTranslationsBySource(
   sourceType: string,
   sourceId: string,
-  isPublished: boolean = false
+  isPublished: boolean = false,
+  localeId?: string,
 ): Promise<Translation[]> {
   const client = await getSupabaseAdmin();
 
@@ -265,14 +268,19 @@ export async function getTranslationsBySource(
     throw new Error('Supabase not configured');
   }
 
-  const { data, error } = await client
+  let query = client
     .from('translations')
     .select('*')
     .eq('source_type', sourceType)
     .eq('source_id', sourceId)
     .eq('is_published', isPublished)
-    .is('deleted_at', null)
-    .order('created_at', { ascending: true });
+    .is('deleted_at', null);
+
+  if (localeId) {
+    query = query.eq('locale_id', localeId);
+  }
+
+  const { data, error } = await query.order('created_at', { ascending: true });
 
   if (error) {
     throw new Error(`Failed to fetch translations: ${error.message}`);
@@ -531,12 +539,15 @@ export async function markTranslationsIncomplete(
 }
 
 /**
- * Upsert multiple translations (draft by default)
- * Uses batch upsert for efficiency
+ * Upsert multiple translations (draft by default). Chunks large arrays by
+ * {@link SUPABASE_WRITE_BATCH_SIZE} so callers can pass thousands of rows in one
+ * call without hitting Supabase's request-size limits.
  */
 export async function upsertTranslations(
   translations: CreateTranslationData[]
 ): Promise<Translation[]> {
+  if (translations.length === 0) return [];
+
   const client = await getSupabaseAdmin();
 
   if (!client) {
@@ -557,18 +568,25 @@ export async function upsertTranslations(
     deleted_at: null, // Restore if previously deleted
   }));
 
-  const { data, error } = await client
-    .from('translations')
-    .upsert(translationsToUpsert, {
-      onConflict: 'locale_id,source_type,source_id,content_key,is_published',
-    })
-    .select();
+  const results: Translation[] = [];
 
-  if (error) {
-    throw new Error(`Failed to upsert translations: ${error.message}`);
+  for (let i = 0; i < translationsToUpsert.length; i += SUPABASE_WRITE_BATCH_SIZE) {
+    const chunk = translationsToUpsert.slice(i, i + SUPABASE_WRITE_BATCH_SIZE);
+    const { data, error } = await client
+      .from('translations')
+      .upsert(chunk, {
+        onConflict: 'locale_id,source_type,source_id,content_key,is_published',
+      })
+      .select();
+
+    if (error) {
+      throw new Error(`Failed to upsert translations: ${error.message}`);
+    }
+
+    if (data) results.push(...(data as Translation[]));
   }
 
-  return data || [];
+  return results;
 }
 
 /**


### PR DESCRIPTION
## Summary

Translating a lot of content through the MCP tools was slow and burned excess tokens: writes were capped at 100 rows with `locale_id` repeated on every item, discovery re-sent already-translated content and loaded the whole locale catalogue just to annotate one page, and every response was pretty-printed. This makes the localization tools efficient for large, multi-language sites.

## Changes

- **Bigger, cheaper batches**: raise `batch_set_translations` cap from 100 to 1000 and add a shared top-level `locale_id` (set once instead of on every item). `upsertTranslations` now chunks internally by the write batch size so large arrays are safe.
- **Skip finished work**: add `untranslated_only` to `list_translatable_content` so it returns only keys still missing a completed translation — the cheapest way to resume or add a new locale.
- **Paginate large CMS collections**: `list_translatable_content` accepts `limit`/`offset`, pushed into the query instead of fetch-all-then-slice.
- **Scoped annotation**: discovery now reads translations for the inspected source only (`getTranslationsBySource` / `getCmsTranslationsForItems`) instead of the entire locale catalogue.
- **Leaner reads**: `list_translations` gains `source_type`/`completed` filters, and localization tool responses are emitted as compact JSON.
- **Guidance**: the localization instructions now steer agents to the efficient workflow (untranslated-only discovery, paginated CMS, one large batch with shared `locale_id`, rich text via batch).

No public signatures were broken; the batch cap and chunking are internal, and new parameters are optional/backward-compatible.

## Test plan

- [ ] `batch_set_translations` with 250 items and a top-level `locale_id` saves all rows in one call (previously rejected above 100)
- [ ] Batch with no resolvable `locale_id` returns an error and writes nothing
- [ ] `list_translatable_content` with `untranslated_only: true` omits keys that already have a completed translation
- [ ] `list_translatable_content` `limit`/`offset` paginate a large CMS collection
- [ ] `list_translations` `source_type`/`completed` filters return the expected subset
- [ ] Publish a translated locale and confirm live output is unchanged