### PR TITLE
fix: redirect off-canonical CMS slugs to canonical URL

### DIFF
--- a/app/(site)/[...slug]/page.tsx
+++ b/app/(site)/[...slug]/page.tsx
@@ -12,6 +12,7 @@ import PasswordForm from '@/components/PasswordForm';
 import { getSettingByKey } from '@/lib/repositories/settingsRepository';
 import { parseAuthCookie, getPasswordProtection, fetchFoldersForAuth } from '@/lib/page-auth';
 import { getSiteBaseUrl } from '@/lib/url-utils';
+import { getOffCanonicalDynamicRedirect } from '@/lib/hreflang-utils';
 import { matchRedirect } from '@/lib/redirect-utils';
 import type { Page, PageFolder, Translation, Redirect as RedirectType } from '@/types';
 
@@ -305,6 +306,23 @@ export default async function Page({ params }: PageProps) {
   // Check password protection for this page.
   // First evaluate without cookies() so non-protected pages stay cacheable.
   const folders = await fetchCachedFoldersForAuth();
+
+  // Redirect off-canonical dynamic slugs (e.g. a default slug requested under a
+  // translated locale) to the canonical localized URL to avoid duplicate content.
+  if (page.is_dynamic && collectionItem) {
+    const canonicalPath = getOffCanonicalDynamicRedirect({
+      page,
+      folders,
+      locale,
+      translations,
+      itemId: collectionItem.id,
+      currentPath,
+    });
+    if (canonicalPath) {
+      permanentRedirect(canonicalPath);
+    }
+  }
+
   const protectionCheck = getPasswordProtection(page, folders, null);
 
   // If page is protected, opt into dynamic rendering and read the auth cookie.

--- a/lib/hreflang-utils.ts
+++ b/lib/hreflang-utils.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Locale, Page, PageFolder, Translation } from '@/types';
-import { buildSlugPath, buildLocalizedSlugPath } from './page-utils';
+import { buildSlugPath, buildLocalizedSlugPath, buildLocalizedDynamicPageUrl } from './page-utils';
 import { getTranslatableKey } from './locale-runtime';
 import { buildAbsolutePageUrl } from './url-utils';
 
@@ -35,21 +35,56 @@ export interface DynamicSlugContext {
 const CMS_SLUG_CONTENT_KEYS = ['field:key:slug', 'slug'] as const;
 
 /**
+ * Return a CMS item's translated slug for a locale, or `undefined` when none
+ * exists. Handles both the current (`field:key:slug`) and legacy (`slug`)
+ * content-key formats.
+ */
+export function getTranslatedItemSlug(
+  translations: Record<string, Translation> | undefined,
+  itemId: string
+): string | undefined {
+  for (const contentKey of CMS_SLUG_CONTENT_KEYS) {
+    const key = getTranslatableKey({ source_type: 'cms', source_id: itemId, content_key: contentKey });
+    const value = translations?.[key]?.content_value;
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/**
  * Resolve a CMS item's translated slug for a locale, falling back to the
- * default-locale slug when no translation exists. Handles both the current
- * (`field:key:slug`) and legacy (`slug`) content-key formats.
+ * default-locale slug when no translation exists.
  */
 function resolveTranslatedSlug(
   translations: Record<string, Translation> | undefined,
   itemId: string,
   fallback: string
 ): string {
-  for (const contentKey of CMS_SLUG_CONTENT_KEYS) {
-    const key = getTranslatableKey({ source_type: 'cms', source_id: itemId, content_key: contentKey });
-    const value = translations?.[key]?.content_value;
-    if (value) return value;
-  }
-  return fallback;
+  return getTranslatedItemSlug(translations, itemId) ?? fallback;
+}
+
+/**
+ * Resolve the canonical localized path for a dynamic CMS item when the current
+ * request used an off-canonical slug (e.g. the default slug under a locale that
+ * has a translated slug, producing duplicate URLs). Returns `null` when the
+ * request is already canonical or the item has no translated slug for the
+ * locale.
+ */
+export function getOffCanonicalDynamicRedirect(params: {
+  page: Page;
+  folders: PageFolder[];
+  locale: Locale | null | undefined;
+  translations: Record<string, Translation> | undefined;
+  itemId: string;
+  currentPath: string;
+}): string | null {
+  const { page, folders, locale, translations, itemId, currentPath } = params;
+
+  const translatedSlug = getTranslatedItemSlug(translations, itemId);
+  if (!translatedSlug) return null;
+
+  const canonicalPath = buildLocalizedDynamicPageUrl(page, folders, translatedSlug, locale, translations);
+  return canonicalPath && canonicalPath !== currentPath ? canonicalPath : null;
 }
 
 /** Build the default-locale absolute URL for a dynamic item. */


### PR DESCRIPTION
## Summary

Translated CMS articles were reachable at two URLs per locale — the default (English) slug and the translated slug — both returning 200. That produced duplicate content and a canonical/hreflang mismatch (e.g. `/de/{english-slug}` and `/de/{german-slug}` both resolved). Off-canonical requests now permanently redirect to the canonical localized URL.

## Changes

- Add `getOffCanonicalDynamicRedirect()` and expose `getTranslatedItemSlug()` in `lib/hreflang-utils.ts`; `resolveTranslatedSlug` now reuses the latter
- Redirect off-canonical dynamic slugs to the canonical localized URL (308) in the public page route, before rendering
- Build the redirect target with the same `buildLocalizedDynamicPageUrl` helper the hreflang cluster uses, so the target always matches the advertised canonical
- Resolve the canonical slug from the already-loaded render translations (no extra DB call); pure logic, no dynamic-API access

## Test plan

- [ ] Request a translated article via its default slug under a non-default locale (`/de/{english-slug}`) → 308 to `/de/{translated-slug}`
- [ ] Request the canonical translated URL directly → 200, no redirect
- [ ] Request a locale with no translated slug → 200, no redirect (falls back to default slug)
- [ ] Confirm the redirect target equals the `hreflang`/`canonical` URL in the page head
- [ ] Verify no redirect loop on the canonical URL