### PR TITLE
fix: emit absolute sitemap URL in robots.txt

### DIFF
--- a/app/(site)/robots.txt/route.ts
+++ b/app/(site)/robots.txt/route.ts
@@ -5,16 +5,19 @@
  */
 
 import { NextResponse } from 'next/server';
+import { headers } from 'next/headers';
 import { getSettingsByKeys } from '@/lib/repositories/settingsRepository';
 import { credentials } from '@/lib/credentials';
-import { getSiteBaseUrl } from '@/lib/url-utils';
+import { getRequestOrigin, getSiteBaseUrl } from '@/lib/url-utils';
 import type { SitemapSettings } from '@/types';
 
 export async function GET() {
   try {
+    const requestOrigin = getRequestOrigin(await headers());
+
     const hasSupabaseCredentials = await credentials.exists();
     if (!hasSupabaseCredentials) {
-      const baseUrl = getSiteBaseUrl() || '';
+      const baseUrl = getSiteBaseUrl({ requestOrigin }) || '';
       const fallback = `# Default robots.txt
 User-agent: *
 Allow: /
@@ -34,7 +37,7 @@ Sitemap: ${baseUrl}/sitemap.xml`;
     const allSettings = await getSettingsByKeys(['robots_txt', 'sitemap', 'global_canonical_url']);
     const sitemapSettings = allSettings.sitemap as SitemapSettings | null;
     const sitemapEnabled = sitemapSettings?.mode && sitemapSettings.mode !== 'none';
-    const baseUrl = getSiteBaseUrl({ globalCanonicalUrl: allSettings.global_canonical_url }) || '';
+    const baseUrl = getSiteBaseUrl({ globalCanonicalUrl: allSettings.global_canonical_url, requestOrigin }) || '';
 
     let content: string;
 

--- a/app/(site)/sitemap.xml/route.ts
+++ b/app/(site)/sitemap.xml/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextResponse } from 'next/server';
+import { headers } from 'next/headers';
 import { credentials } from '@/lib/credentials';
 
 import { getAllPages } from '@/lib/repositories/pageRepository';
@@ -19,7 +20,7 @@ import {
   generateSitemapXml,
   getDefaultSitemapSettings,
 } from '@/lib/sitemap-utils';
-import { getSiteBaseUrl } from '@/lib/url-utils';
+import { getRequestOrigin, getSiteBaseUrl } from '@/lib/url-utils';
 import type { SitemapSettings, Translation, CollectionItem } from '@/types';
 
 export async function GET() {
@@ -56,7 +57,8 @@ export async function GET() {
     }
 
     // Auto-generate sitemap
-    const baseUrl = getSiteBaseUrl({ globalCanonicalUrl }) || '';
+    const requestOrigin = getRequestOrigin(await headers());
+    const baseUrl = getSiteBaseUrl({ globalCanonicalUrl, requestOrigin }) || '';
 
     // Fetch published pages and folders
     const [pages, folders, locales] = await Promise.all([

--- a/lib/url-utils.ts
+++ b/lib/url-utils.ts
@@ -2,11 +2,16 @@
  * Resolve the site's base URL from settings and environment.
  *
  * Priority: globalCanonicalUrl > primaryDomainUrl > NEXT_PUBLIC_SITE_URL
- *         > VERCEL_PROJECT_PRODUCTION_URL > VERCEL_URL
+ *         > VERCEL_PROJECT_PRODUCTION_URL > VERCEL_URL > requestOrigin
+ *
+ * `requestOrigin` is a last-resort fallback (client-controllable) used when
+ * nothing is configured, so absolute URLs can still be emitted on self-hosted
+ * deploys without env vars or a canonical URL.
  */
 export function getSiteBaseUrl(options?: {
   globalCanonicalUrl?: string | null;
   primaryDomainUrl?: string | null;
+  requestOrigin?: string | null;
 }): string | null {
   const raw =
     options?.globalCanonicalUrl
@@ -14,9 +19,25 @@ export function getSiteBaseUrl(options?: {
     || process.env.NEXT_PUBLIC_SITE_URL
     || (process.env.VERCEL_PROJECT_PRODUCTION_URL ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}` : null)
     || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null)
+    || options?.requestOrigin
     || null;
 
   return raw ? raw.replace(/\/$/, '') : null;
+}
+
+/**
+ * Derive the request origin (protocol + host) from request headers.
+ * Honors reverse-proxy `x-forwarded-*` headers, defaulting to https.
+ * Takes the first value when a chained proxy sends a comma-separated list.
+ */
+export function getRequestOrigin(headers: Headers): string | null {
+  const firstValue = (value: string | null) => value?.split(',')[0].trim() || null;
+
+  const host = firstValue(headers.get('x-forwarded-host')) || firstValue(headers.get('host'));
+  if (!host) return null;
+
+  const proto = firstValue(headers.get('x-forwarded-proto')) || 'https';
+  return `${proto}://${host}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Self-hosted installs without a canonical URL or `NEXT_PUBLIC_SITE_URL` (and not on Vercel) emit `Sitemap: /sitemap.xml` — a bare path that Google Search Console and Core Web Vitals flag as invalid per the sitemaps.org protocol. This adds a request-origin fallback so an absolute URL is always emitted.

Closes #529

## Changes

- Add a lowest-priority `requestOrigin` fallback to `getSiteBaseUrl` (below settings and all env vars) plus a `getRequestOrigin` helper that reads `x-forwarded-host`/`host` and `x-forwarded-proto` (defaults to https, handles comma-separated proxy chains)
- Wire the fallback into `robots.txt` so the `Sitemap:` line is always absolute
- Apply the same fallback in `sitemap.xml` so `<loc>` entries are absolute too

## Test plan

- [ ] With no canonical URL and no site env vars set, request `/robots.txt` and confirm `Sitemap: https://<host>/sitemap.xml`
- [ ] Confirm `/sitemap.xml` `<loc>` entries are absolute URLs
- [ ] Set a global canonical URL and confirm it takes priority over the request host
- [ ] Behind a reverse proxy, confirm `x-forwarded-host`/`x-forwarded-proto` are honored