### PR TITLE
fix: stream large project backup downloads

### DIFF
--- a/app/(builder)/ycode/api/project/export/route.ts
+++ b/app/(builder)/ycode/api/project/export/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import {
   exportProject,
-  packExport,
+  packExportToStream,
   getExportFilename,
   sanitizeProjectNameSlug,
 } from '@/lib/services/projectService';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
+export const maxDuration = 300;
 
 /**
  * POST /ycode/api/project/export
@@ -40,14 +41,17 @@ export async function POST(request: NextRequest) {
       result.export.manifest.projectName = sanitizeProjectNameSlug(projectName.trim());
     }
 
-    const fileBuffer = packExport(result.export, password);
+    // Stream the packed file so large backups aren't capped by the
+    // platform's buffered-response size limit (e.g. Vercel's 4.5MB).
+    const { stream, size } = packExportToStream(result.export, password);
     const filename = getExportFilename(result.export.manifest);
 
-    return new NextResponse(new Uint8Array(fileBuffer), {
+    return new NextResponse(stream, {
       status: 200,
       headers: {
         'Content-Type': 'application/octet-stream',
         'Content-Disposition': `attachment; filename="${filename}"`,
+        'Content-Length': String(size),
         'Cache-Control': 'no-store',
       },
     });

--- a/components/project/BackupRestoreDialog.tsx
+++ b/components/project/BackupRestoreDialog.tsx
@@ -16,6 +16,7 @@ import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
 import { toast } from 'sonner';
 import { ToastError } from '@/lib/toast-error';
+import { parseErrorResponse } from '@/lib/utils';
 
 interface BackupRestoreDialogProps {
   open: boolean;
@@ -80,8 +81,10 @@ export function BackupRestoreDialog({
       });
 
       if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Backup failed');
+        // The error body may be JSON (from our route) or plain text/HTML
+        // (from an upstream proxy, e.g. a "Bad Gateway" on timeout).
+        const message = await parseErrorResponse(response);
+        throw new Error(message);
       }
 
       const blob = await response.blob();

--- a/lib/services/projectService.ts
+++ b/lib/services/projectService.ts
@@ -236,6 +236,38 @@ export function packExport(exportData: ProjectExportData, password?: string): Bu
   return password ? encryptBuffer(compressed, password) : compressed;
 }
 
+/** Chunk size used when streaming the packed export (256 KB). */
+const EXPORT_STREAM_CHUNK_SIZE = 256 * 1024;
+
+/**
+ * Pack the export and expose it as a chunked ReadableStream.
+ * Streaming the response avoids platform buffered-response size caps
+ * (e.g. Vercel's 4.5MB limit) that break downloads of large backups.
+ */
+export function packExportToStream(
+  exportData: ProjectExportData,
+  password?: string,
+  chunkSize: number = EXPORT_STREAM_CHUNK_SIZE
+): { stream: ReadableStream<Uint8Array>; size: number } {
+  const buffer = packExport(exportData, password);
+  const size = buffer.length;
+  let offset = 0;
+
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (offset >= size) {
+        controller.close();
+        return;
+      }
+      const end = Math.min(offset + chunkSize, size);
+      controller.enqueue(new Uint8Array(buffer.subarray(offset, end)));
+      offset = end;
+    },
+  });
+
+  return { stream, size };
+}
+
 // JSON structural byte codes (all ASCII, safe to scan over UTF-8 content).
 const CH_QUOTE = 0x22;
 const CH_BACKSLASH = 0x5c;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -19,6 +19,33 @@ export function hasTextSelection(): boolean {
 }
 
 /**
+ * Extract a readable error message from a failed fetch Response.
+ * Handles both our JSON errors and plain text/HTML from upstream proxies
+ * (e.g. a "Bad Gateway" on timeout), which would otherwise crash JSON.parse.
+ */
+export async function parseErrorResponse(
+  response: Response,
+  fallback = 'Request failed'
+): Promise<string> {
+  const text = await response.text().catch(() => '');
+
+  if (text) {
+    try {
+      const data = JSON.parse(text);
+      if (data?.error) return data.error;
+    } catch {
+      // Not JSON — fall through to the raw text / status handling below.
+    }
+    if (response.headers.get('content-type')?.includes('text/html')) {
+      return `${fallback} (${response.status} ${response.statusText})`;
+    }
+    return text.trim();
+  }
+
+  return `${fallback} (${response.status} ${response.statusText})`;
+}
+
+/**
  * Input Sanitization Utilities
  * Centralized helpers for cleaning user input values
  */

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,9 @@
     "app/(builder)/ycode/api/ai/chat/route.ts": {
       "maxDuration": 300
     },
+    "app/(builder)/ycode/api/project/export/route.ts": {
+      "maxDuration": 300
+    },
     "app/(builder)/ycode/api/**/*.ts": {
       "maxDuration": 60
     },


### PR DESCRIPTION
## Summary

Downloading a backup of a large project failed with `Bad Gateway` (and the UI showed `Unexpected token 'B', "Bad Gateway" is not valid JSON`). The export route returned the entire gzipped `.ycode` file as a single buffered response, which exceeds the platform's 4.5MB buffered-response limit and gets rejected before it reaches the client. Closes #510.

The fix streams the packed file instead — streaming responses aren't subject to that size cap — with no change to the `.ycode` format or the restore flow.

## Changes

- Add `packExportToStream()` in `projectService`, emitting the packed file (same bytes, plain or encrypted) as a chunked `ReadableStream`
- Return the stream from the export route with `Content-Length` for download progress, and raise its timeout (`maxDuration = 300` + `vercel.json` entry)
- Add reusable `parseErrorResponse()` util that safely reads non-JSON error bodies (e.g. a proxy "Bad Gateway")
- Use it in `BackupRestoreDialog` so failures show a readable message instead of crashing on `response.json()`

## Test plan

- [ ] Create a backup of a small project — downloads a valid `.ycode` file
- [ ] Create a backup of a large asset-heavy project — downloads without a 502
- [ ] Create a password-protected backup and restore it successfully
- [ ] Restore each downloaded backup and confirm data integrity
- [ ] Simulate an upstream error and confirm a readable message (no JSON parse crash)