### PR TITLE
perf: trim translation catalog from localized pages

### DIFF
--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -28,7 +28,7 @@ import { REF_PAGE_PREFIX, REF_COLLECTION_PREFIX, isCollectionItemKeyword, parseC
 import { getClassesString, hasPasswordFormLayer } from '@/lib/layer-utils';
 import { buildGlobalsMetaMap, buildGlobalsValueMap } from '@/lib/collection-field-utils';
 import { buildLocalizedPageUrls, type LocalizedDynamicSlug } from '@/lib/page-utils';
-import { getTranslatableKey } from '@/lib/locale-runtime';
+import { getTranslatableKey, slimTranslations } from '@/lib/locale-runtime';
 import { getSlugTranslationsByLocale } from '@/lib/repositories/translationRepository';
 import { buildPageHreflangAlternatesForPage } from '@/lib/generate-page-metadata';
 import { getSiteBaseUrl } from '@/lib/url-utils';
@@ -938,7 +938,11 @@ export default async function PageRenderer({
           folders={folders as any}
           collectionItemSlugs={collectionItemSlugs}
           isPreview={isPreview}
-          translations={translations}
+          // Text/media translations are already baked into the layer tree
+          // server-side, so the client only needs slug rows to build localized
+          // link hrefs. Slimming keeps the full per-locale catalog out of the
+          // RSC payload (see issue #447 for the same treatment of components).
+          translations={slimTranslations(translations)}
           resolvedAssets={resolvedAssets}
           // Rich-text embedded components are already pre-resolved into the layer
           // tree (_resolvedLayers), so the client renderer never needs the full

--- a/lib/locale-runtime.ts
+++ b/lib/locale-runtime.ts
@@ -105,6 +105,35 @@ export function getTranslatedAssetId(
   return originalAssetId;
 }
 
+/**
+ * Slim a per-locale translation catalog down to only the rows still needed
+ * after server-side injection. Text/media translations are already baked into
+ * the layer tree (via `injectTranslatedText`), so we drop them and keep:
+ *   - slug rows — localized link/URL building (client + server)
+ *   - seo rows (when `includeSeo`) — localized <title>/description/OG image
+ * Dropping the rest keeps the full ~MB catalog out of `PageData` and the
+ * serialized RSC/hydration payload on every localized page.
+ */
+export function slimTranslations(
+  translations: Record<string, Translation> | null | undefined,
+  options?: { includeSeo?: boolean }
+): Record<string, Translation> | undefined {
+  if (!translations) return undefined;
+
+  const includeSeo = options?.includeSeo ?? false;
+  const slim: Record<string, Translation> = {};
+  for (const key in translations) {
+    const contentKey = translations[key].content_key;
+    const keep = contentKey === 'slug'
+      || contentKey.endsWith(':slug')
+      || (includeSeo && contentKey.startsWith('seo:'));
+    if (keep) {
+      slim[key] = translations[key];
+    }
+  }
+  return slim;
+}
+
 /** Get translated text if a translation exists, otherwise return the original. */
 export function getTranslatedText(
   originalText: string | undefined,

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -8,7 +8,7 @@ import { getValuesByItemIds } from '@/lib/repositories/collectionItemValueReposi
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { enrichItemsWithCountValues } from '@/lib/repositories/collectionCountRepository';
 import { getLocaleScaffoldTranslations, getCmsTranslationsForItems } from '@/lib/repositories/translationRepository';
-import { getTranslatableKey } from '@/lib/locale-runtime';
+import { getTranslatableKey, slimTranslations } from '@/lib/locale-runtime';
 import type { Page, PageFolder, PageLayers, Component, ComponentVariable, CollectionItemWithValues, CollectionField, Layer, CollectionPaginationMeta, Translation, Locale } from '@/types';
 import { getCollectionVariable, resolveFieldValue, evaluateVisibility, evaluateCondition, getLayerHtmlTag, filterDisabledSliderLayers } from '@/lib/layer-utils';
 import { isFieldVariable, isAssetVariable, createDynamicTextVariable, createDynamicRichTextVariable, createAssetVariable, getDynamicTextContent, getVariableStringValue, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
@@ -887,13 +887,25 @@ async function fetchPageByPathInternal(
   }
 }
 
+/**
+ * Strip the bulk translation catalog from resolved page data, keeping only the
+ * slug + seo rows still consumed downstream (localized URLs and metadata). Text
+ * and media are already injected into the layer tree, so keeping the full
+ * catalog would only bloat caches and the serialized RSC payload.
+ */
+function withSlimTranslations(data: PageData | null): PageData | null {
+  if (!data?.translations) return data;
+  return { ...data, translations: slimTranslations(data.translations, { includeSeo: true }) };
+}
+
 export const fetchPageByPath = cache(async function fetchPageByPath(
   slugPath: string,
   isPublished: boolean,
   paginationContext?: PaginationContext,
   tenantId?: string,
 ): Promise<PageData | null> {
-  return fetchPageByPathInternal(slugPath, isPublished, paginationContext, tenantId, { resolveLayers: true });
+  const data = await fetchPageByPathInternal(slugPath, isPublished, paginationContext, tenantId, { resolveLayers: true });
+  return withSlimTranslations(data);
 });
 
 export async function fetchPageByPathForMetadata(
@@ -902,7 +914,8 @@ export async function fetchPageByPathForMetadata(
   paginationContext?: PaginationContext,
   tenantId?: string,
 ): Promise<PageData | null> {
-  return fetchPageByPathInternal(slugPath, isPublished, paginationContext, tenantId, { resolveLayers: false });
+  const data = await fetchPageByPathInternal(slugPath, isPublished, paginationContext, tenantId, { resolveLayers: false });
+  return withSlimTranslations(data);
 }
 
 /**


### PR DESCRIPTION
## Summary

Localized pages shipped the entire per-locale translation catalog inside every page's payload, adding megabytes of RSC/hydration data and pushing cached routes past the 2 MB `unstable_cache` limit. Since text and media translations are already applied to the page server-side, the client and caches don't need the full catalog.

## Changes

- Add `slimTranslations` helper that keeps only the rows still consumed after server-side injection: `slug` rows (localized links/URLs) and optionally `seo:` rows (localized title/description/OG image)
- Apply it at the `page-fetcher` boundary (`fetchPageByPath` / `fetchPageByPathForMetadata`) so cached `PageData` and metadata stay small while keeping slug + seo rows
- Apply it (slug-only) at the client render boundary in `PageRenderer`, since text/media are already baked into the layer tree

## Test plan

- [ ] Load a localized page and confirm text, images, and CMS content are translated
- [ ] Confirm localized internal links resolve to the correct localized URLs
- [ ] Confirm localized `<title>`/description/OG image render in metadata
- [ ] Paginate / load-more / filter a localized collection and confirm new items are translated
- [ ] Verify uncompressed HTML size drops significantly (`curl -s -H 'Accept-Encoding: identity' <url> | wc -c`)