### PR TITLE
fix: add page custom code to the head section

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,8 +1,10 @@
 import '@/app/site.css';
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import RootLayoutShell, { defaultMetadata } from '@/components/RootLayoutShell';
 import { fetchGlobalPageSettings } from '@/lib/generate-page-metadata';
 import { renderRootLayoutHeadCode } from '@/lib/parse-head-html';
+import { resolvePageCustomHeadCode } from '@/lib/resolve-page-head-code';
 
 export async function generateMetadata(): Promise<Metadata> {
   if (process.env.SKIP_SETUP === 'true') {
@@ -34,15 +36,28 @@ export default async function SiteLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  let headElements: React.ReactNode[] = [];
+  const headElements: React.ReactNode[] = [];
 
   // Cloud mode uses ISR with explicit tenantId — calling headers() here
-  // would force all pages dynamic. Cloud injects global head code from PageRenderer instead.
+  // would force all pages dynamic. Cloud injects custom head code from
+  // PageRenderer instead (meta/link/style hoist; inline scripts stay in body).
   if (process.env.SKIP_SETUP !== 'true') {
+    // Must stay outside the data-fetch try/catch — Next.js throws a
+    // special bailout from headers() to opt the layout into dynamic
+    // rendering, and swallowing it would skip head injection entirely.
+    const headersList = await headers();
+    const pathname = headersList.get('x-pathname') || '/';
+
     try {
-      const globalSettings = await fetchGlobalPageSettings();
+      const [globalSettings, pageCustomHead] = await Promise.all([
+        fetchGlobalPageSettings(),
+        resolvePageCustomHeadCode(pathname),
+      ]);
       if (globalSettings.globalCustomCodeHead) {
-        headElements = renderRootLayoutHeadCode(globalSettings.globalCustomCodeHead);
+        headElements.push(...renderRootLayoutHeadCode(globalSettings.globalCustomCodeHead));
+      }
+      if (pageCustomHead) {
+        headElements.push(...renderRootLayoutHeadCode(pageCustomHead, 'page-head'));
       }
     } catch {
       // Supabase not configured — skip custom code

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -562,11 +562,16 @@ export default async function PageRenderer({
     }
   }
 
-  // Extract custom code from page settings and resolve placeholders for dynamic pages
-  const rawPageCustomCodeHead = page.settings?.custom_code?.head || '';
+  // Extract custom code from page settings and resolve placeholders for dynamic pages.
+  // Page head code is injected into <head> by the site layout on self-hosted;
+  // only resolve it here in cloud mode where the layout cannot read the URL.
+  const shouldInjectPageHead = process.env.SKIP_SETUP === 'true';
+  const rawPageCustomCodeHead = shouldInjectPageHead
+    ? (page.settings?.custom_code?.head || '')
+    : '';
   const rawPageCustomCodeBody = page.settings?.custom_code?.body || '';
 
-  const pageCustomCodeHead = page.is_dynamic && collectionItem
+  const pageCustomCodeHead = shouldInjectPageHead && page.is_dynamic && collectionItem
     ? await resolveCustomCodePlaceholders(rawPageCustomCodeHead, collectionItem, collectionFields, usePublishedData)
     : rawPageCustomCodeHead;
 
@@ -759,8 +764,13 @@ export default async function PageRenderer({
         renderRootLayoutHeadCode(globalCustomCodeHead, 'global-head')
       )}
 
-      {/* Page-specific custom head code — React 19 hoists meta/link/style/title to <head> */}
-      {pageCustomCodeHead && renderRootLayoutHeadCode(pageCustomCodeHead, 'page-head')}
+      {/* Page-specific custom head code.
+          Self-hosted: the site layout injects this into the real <head>.
+          Cloud (SKIP_SETUP): the layout cannot read the request URL without
+          breaking ISR, so fall back to rendering here. */}
+      {shouldInjectPageHead && pageCustomCodeHead && (
+        renderRootLayoutHeadCode(pageCustomCodeHead, 'page-head')
+      )}
 
       {/* hreflang alternates for multilingual sites (lowercase attribute) */}
       <HreflangAlternateLinks alternates={hreflangAlternates} />

--- a/lib/page-head-path.test.ts
+++ b/lib/page-head-path.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parsePathnameForPageHead } from '@/lib/page-head-path';
+
+test('homepage is an empty slug path', () => {
+  assert.deepEqual(parsePathnameForPageHead('/'), {
+    isPreview: false,
+    errorCode: null,
+    slugPath: '',
+  });
+});
+
+test('strips the leading slash from a published slug', () => {
+  assert.deepEqual(parsePathnameForPageHead('/about/team'), {
+    isPreview: false,
+    errorCode: null,
+    slugPath: 'about/team',
+  });
+});
+
+test('preview homepage', () => {
+  assert.deepEqual(parsePathnameForPageHead('/ycode/preview'), {
+    isPreview: true,
+    errorCode: null,
+    slugPath: '',
+  });
+});
+
+test('preview nested slug', () => {
+  assert.deepEqual(parsePathnameForPageHead('/ycode/preview/about/team'), {
+    isPreview: true,
+    errorCode: null,
+    slugPath: 'about/team',
+  });
+});
+
+test('preview error page', () => {
+  assert.deepEqual(parsePathnameForPageHead('/ycode/preview/error-pages/404'), {
+    isPreview: true,
+    errorCode: 404,
+    slugPath: '',
+  });
+});

--- a/lib/page-head-path.ts
+++ b/lib/page-head-path.ts
@@ -1,0 +1,35 @@
+/**
+ * Parse a public-site pathname into the lookup key used to load that page's
+ * custom <head> code (preview vs published, error page, slug path).
+ */
+export interface PageHeadPath {
+  isPreview: boolean;
+  errorCode: number | null;
+  /** Slug path without a leading slash. Empty string is the homepage. */
+  slugPath: string;
+}
+
+const PREVIEW_PREFIX = '/ycode/preview';
+const PREVIEW_ERROR_PREFIX = '/ycode/preview/error-pages/';
+
+export function parsePathnameForPageHead(pathname: string): PageHeadPath {
+  if (pathname.startsWith(PREVIEW_ERROR_PREFIX)) {
+    const raw = pathname.slice(PREVIEW_ERROR_PREFIX.length).split('/')[0];
+    const errorCode = Number.parseInt(raw, 10);
+    return {
+      isPreview: true,
+      errorCode: Number.isFinite(errorCode) ? errorCode : null,
+      slugPath: '',
+    };
+  }
+
+  if (pathname === PREVIEW_PREFIX || pathname.startsWith(`${PREVIEW_PREFIX}/`)) {
+    const slugPath = pathname === PREVIEW_PREFIX
+      ? ''
+      : pathname.slice(PREVIEW_PREFIX.length + 1);
+    return { isPreview: true, errorCode: null, slugPath };
+  }
+
+  const slugPath = pathname === '/' ? '' : pathname.replace(/^\//, '');
+  return { isPreview: false, errorCode: null, slugPath };
+}

--- a/lib/parse-head-html.test.ts
+++ b/lib/parse-head-html.test.ts
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderRootLayoutHeadCode } from '@/lib/parse-head-html';
+
+test('parses an inline script into a script element', () => {
+  const elements = renderRootLayoutHeadCode('<script>\nTesting\n</script>', 'page-head');
+  assert.equal(elements.length, 1);
+  const el = elements[0] as React.ReactElement<{ dangerouslySetInnerHTML?: { __html: string } }>;
+  assert.equal(el.type, 'script');
+  assert.equal(el.props.dangerouslySetInnerHTML?.__html.trim(), 'Testing');
+});
+
+test('parses meta and link tags alongside a script', () => {
+  const html = '<meta name="foo" content="bar"><link rel="preconnect" href="https://example.com"><script src="https://example.com/a.js"></script>';
+  const elements = renderRootLayoutHeadCode(html, 'page-head');
+  assert.equal(elements.length, 3);
+  assert.equal((elements[0] as React.ReactElement).type, 'meta');
+  assert.equal((elements[1] as React.ReactElement).type, 'link');
+  assert.equal((elements[2] as React.ReactElement).type, 'script');
+});

--- a/lib/resolve-page-head-code.ts
+++ b/lib/resolve-page-head-code.ts
@@ -1,0 +1,86 @@
+/**
+ * Resolve a page's custom <head> HTML from the request pathname so the site
+ * layout can inject it into the real document head.
+ *
+ * SERVER-ONLY: uses page-fetcher and CMS placeholder resolution.
+ */
+
+import 'server-only';
+
+import { unstable_cache } from 'next/cache';
+import { fetchErrorPage, fetchHomepage, fetchPageByPathForMetadata } from '@/lib/page-fetcher';
+import { parsePathnameForPageHead } from '@/lib/page-head-path';
+import { resolveCustomCodePlaceholders } from '@/lib/resolve-cms-variables';
+
+import type { CollectionField, CollectionItemWithValues, Page } from '@/types';
+
+async function resolveHeadFromPage(
+  page: Page,
+  isPublished: boolean,
+  collectionItem?: CollectionItemWithValues,
+  collectionFields?: CollectionField[]
+): Promise<string> {
+  const raw = page.settings?.custom_code?.head || '';
+  if (!raw) {
+    return '';
+  }
+
+  if (page.is_dynamic && collectionItem && collectionFields && collectionFields.length > 0) {
+    return resolveCustomCodePlaceholders(raw, collectionItem, collectionFields, isPublished);
+  }
+
+  return raw;
+}
+
+async function loadPageHeadCode(
+  slugPath: string,
+  isPublished: boolean,
+  errorCode: number | null
+): Promise<string> {
+  try {
+    if (errorCode != null) {
+      const data = await fetchErrorPage(errorCode, isPublished);
+      return data?.page ? resolveHeadFromPage(data.page, isPublished, data.collectionItem, data.collectionFields) : '';
+    }
+
+    // Homepage lives at is_index, not an empty slug match.
+    if (slugPath === '') {
+      const data = await fetchHomepage(isPublished);
+      return data?.page ? resolveHeadFromPage(data.page, isPublished) : '';
+    }
+
+    const data = await fetchPageByPathForMetadata(slugPath, isPublished);
+    return data?.page
+      ? resolveHeadFromPage(data.page, isPublished, data.collectionItem, data.collectionFields)
+      : '';
+  } catch (error) {
+    console.error('[resolve-page-head-code] Failed to load page head code:', error);
+    return '';
+  }
+}
+
+/**
+ * Load the custom head HTML for the page at `pathname`.
+ * Published lookups are cached until publish; preview is always fresh.
+ */
+export async function resolvePageCustomHeadCode(pathname: string): Promise<string> {
+  const { isPreview, errorCode, slugPath } = parsePathnameForPageHead(pathname);
+  const isPublished = !isPreview;
+
+  if (isPreview) {
+    return loadPageHeadCode(slugPath, false, errorCode);
+  }
+
+  const cacheKey = errorCode != null
+    ? `error-${errorCode}`
+    : (slugPath || '/');
+  const routeTag = errorCode != null
+    ? 'all-pages'
+    : `route-${cacheKey === '/' ? '/' : `/${cacheKey}`}`;
+
+  return unstable_cache(
+    () => loadPageHeadCode(slugPath, true, errorCode),
+    ['page-head-html', cacheKey],
+    { tags: [routeTag, 'all-pages'], revalidate: false }
+  )();
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "type-check": "tsc --noEmit",
-    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts",
+    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts lib/page-head-path.test.ts lib/parse-head-html.test.ts",
     "migrate:make": "NODE_NO_WARNINGS=1 knex migrate:make --knexfile knexfile.ts -x ts",
     "migrate:latest": "NODE_NO_WARNINGS=1 knex migrate:latest --knexfile knexfile.ts",
     "migrate:rollback": "NODE_NO_WARNINGS=1 knex migrate:rollback --knexfile knexfile.ts",

--- a/proxy.ts
+++ b/proxy.ts
@@ -56,6 +56,23 @@ function getSupabaseEnvConfig(): { url: string; anonKey: string } | null {
   };
 }
 
+/** Attach x-pathname on the request (readable via headers()) and the response. */
+function withPathname(response: NextResponse, request: NextRequest, pathname: string): NextResponse {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-pathname', pathname);
+  const next = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+  response.cookies.getAll().forEach((cookie) => {
+    next.cookies.set(cookie.name, cookie.value);
+  });
+  response.headers.forEach((value, key) => {
+    next.headers.set(key, value);
+  });
+  next.headers.set('x-pathname', pathname);
+  return next;
+}
+
 function isPublicApiRoute(pathname: string, method: string): boolean {
   // POST to form-submissions is public (website visitors submitting forms)
   if (pathname === '/ycode/api/form-submissions' && method === 'POST') {
@@ -134,9 +151,7 @@ export async function proxy(request: NextRequest) {
   //   - `/ycode/mcp/<token>`: legacy URL-token endpoint (Cursor, Windsurf, etc.)
   //   - `/ycode/mcp`: OAuth Bearer-token endpoint (Claude.ai web, ChatGPT)
   if (pathname === '/ycode/mcp' || pathname.startsWith('/ycode/mcp/')) {
-    const response = NextResponse.next();
-    response.headers.set('x-pathname', pathname);
-    return response;
+    return withPathname(NextResponse.next(), request, pathname);
   }
 
   // Debug escape hatch: skip auth on preview routes when explicitly enabled.
@@ -156,8 +171,7 @@ export async function proxy(request: NextRequest) {
         return authResponse;
       }
       // Authenticated — pass through
-      authResponse.headers.set('x-pathname', pathname);
-      return authResponse;
+      return withPathname(authResponse, request, pathname);
     }
   }
 
@@ -172,17 +186,18 @@ export async function proxy(request: NextRequest) {
     const rewriteUrl = request.nextUrl.clone();
     rewriteUrl.pathname = pathname === '/' ? '/dynamic' : `/dynamic${pathname}`;
 
-    const rewriteResponse = NextResponse.rewrite(rewriteUrl);
+    const requestHeaders = new Headers(request.headers);
+    requestHeaders.set('x-pathname', pathname);
+    const rewriteResponse = NextResponse.rewrite(rewriteUrl, {
+      request: { headers: requestHeaders },
+    });
     rewriteResponse.headers.set('x-pathname', pathname);
     await applySecurityHeaders(rewriteResponse);
     return rewriteResponse;
   }
 
   // Create response
-  const response = NextResponse.next();
-
-  // Add pathname header for layout to determine dark mode
-  response.headers.set('x-pathname', pathname);
+  const response = withPathname(NextResponse.next(), request, pathname);
 
   // Cache-Control for public pages is configured centrally via next.config.ts headers().
 


### PR DESCRIPTION
## Summary

Page Header custom code was rendered from the page body, so inline scripts never reached `<head>`. Inject that code from the site layout into the real document head instead.

## Changes

- Resolve the current page's Header custom code in the site layout and render it inside `<head>`
- Forward `x-pathname` on the request so the layout can identify the page
- Stop injecting page Header code from the page body on self-hosted sites to avoid duplicates
- Add path-parsing and head-HTML unit tests

## Test plan

- [ ] Add `<script>Testing</script>` to a page's Header custom code, publish, and View Source — the script should appear inside `<head>`, not `<body>`
- [ ] Confirm Body custom code still appears before `</body>`
- [ ] Repeat on a nested slug page and a preview URL
- [ ] Add a `<meta>` or `<style>` tag in Header custom code and confirm it also lands in `<head>`
- [ ] Confirm only one copy of the Header snippet is present (no body duplicate)


Made with [Cursor](https://cursor.com)