### PR TITLE
feat: add Made in Ycode source comments

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -5,15 +5,21 @@ import RootLayoutShell, { defaultMetadata } from '@/components/RootLayoutShell';
 import { fetchGlobalPageSettings } from '@/lib/generate-page-metadata';
 import { renderRootLayoutHeadCode } from '@/lib/parse-head-html';
 import { resolvePageCustomHeadCode } from '@/lib/resolve-page-head-code';
+import { runWithYcodeStamp } from '@/lib/ycode-html-comment';
+
+const ycodeGeneratorMetadata: Metadata = {
+  ...defaultMetadata,
+  other: { generator: 'Ycode' },
+};
 
 export async function generateMetadata(): Promise<Metadata> {
   if (process.env.SKIP_SETUP === 'true') {
-    return defaultMetadata;
+    return ycodeGeneratorMetadata;
   }
 
   try {
     const globalSettings = await fetchGlobalPageSettings();
-    const metadata: Metadata = { ...defaultMetadata };
+    const metadata: Metadata = { ...ycodeGeneratorMetadata };
 
     if (globalSettings.faviconUrl || globalSettings.webClipUrl) {
       metadata.icons = {};
@@ -27,7 +33,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
     return metadata;
   } catch {
-    return defaultMetadata;
+    return ycodeGeneratorMetadata;
   }
 }
 
@@ -37,6 +43,15 @@ export default async function SiteLayout({
   children: React.ReactNode;
 }>) {
   const headElements: React.ReactNode[] = [];
+  let publishedAt: string | null = null;
+
+  // Publish time for the HTML source stamp. Safe without headers() (cloud ISR).
+  try {
+    const globalSettings = await fetchGlobalPageSettings();
+    publishedAt = globalSettings.publishedAt ?? null;
+  } catch {
+    // Supabase not configured — stamp still emits the Made in line
+  }
 
   // Cloud mode uses ISR with explicit tenantId — calling headers() here
   // would force all pages dynamic. Cloud injects custom head code from
@@ -67,9 +82,9 @@ export default async function SiteLayout({
   // Published sites render text with the browser-default (`auto`) font
   // smoothing — matching legacy output. Forcing `antialiased` here would render
   // glyphs thinner/lighter than the original site.
-  return (
+  return runWithYcodeStamp(publishedAt, () => (
     <RootLayoutShell headElements={headElements} bodyClassName="font-sans">
       {children}
     </RootLayoutShell>
-  );
+  ));
 }

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,9 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') {
+    return;
+  }
+
+  const { patchHtmlResponseStamp, startYcodePublishedAtRefresh } = await import('./lib/stamp-html-response');
+  patchHtmlResponseStamp();
+  await startYcodePublishedAtRefresh();
+}

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -13,6 +13,7 @@ import type { PageData } from '@/lib/page-fetcher'
 import type { FontPreload } from '@/lib/font-utils'
 import { getClassesString } from '@/lib/layer-utils'
 import { getEffectiveApplyStyle } from '@/lib/animation-utils'
+import { buildYcodeHtmlComments } from '@/lib/ycode-html-comment'
 
 import type { Layer, Page, PageFolder } from '@/types'
 
@@ -656,6 +657,8 @@ export interface BuildHtmlInput {
    */
   pageCustomCodeHead?: string | null
   pageCustomCodeBody?: string | null
+  /** ISO timestamp of the last publish, used for the HTML source stamp. */
+  publishedAt?: string | null
 }
 
 export function buildDocument({
@@ -674,6 +677,7 @@ export function buildDocument({
   globalCustomCodeBody,
   pageCustomCodeHead,
   pageCustomCodeBody,
+  publishedAt,
 }: BuildHtmlInput): string {
   const seo = extractSeo(page)
   const title = seo.title || page.name
@@ -684,6 +688,7 @@ export function buildDocument({
   const head: string[] = []
   head.push('<meta charset="UTF-8" />')
   head.push('<meta name="viewport" content="width=device-width, initial-scale=1.0" />')
+  head.push('<meta name="generator" content="Ycode" />')
   head.push(`<title>${escapeHtml(title)}</title>`)
   if (description) {
     head.push(`<meta name="description" content="${escapeHtml(description)}" />`)
@@ -754,6 +759,7 @@ export function buildDocument({
 
   return [
     '<!DOCTYPE html>',
+    ...buildYcodeHtmlComments(publishedAt).split('\n'),
     `<html lang="${escapeHtml(lang)}">`,
     '<head>',
     ...head.map((line) => indent + line),

--- a/lib/apps/static-export/engine.ts
+++ b/lib/apps/static-export/engine.ts
@@ -148,6 +148,7 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
       fonts,
       globalCustomCodeHead,
       globalCustomCodeBody,
+      publishedAt,
       localeResult,
     ] = await Promise.all([
       client
@@ -160,6 +161,7 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
       getPublishedFonts().catch(() => []),
       getSettingByKey('custom_code_head').catch(() => null),
       getSettingByKey('custom_code_body').catch(() => null),
+      getSettingByKey('published_at').catch(() => null),
       client
         .from('locales')
         .select('*')
@@ -225,6 +227,7 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
             globalCustomCodeBody: globalCustomCodeBody ?? null,
             pageCustomCodeHead: resolved.pageCustomCodeHead,
             pageCustomCodeBody: resolved.pageCustomCodeBody,
+            publishedAt: typeof publishedAt === 'string' ? publishedAt : null,
           })
 
           // Collect Ycode's built-in placeholder URLs referenced from this

--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -35,6 +35,7 @@ export interface GlobalPageSettings {
   globalCustomCodeHead?: string | null;
   globalCustomCodeBody?: string | null;
   ycodeBadge?: boolean;
+  publishedAt?: string | null;
   faviconUrl?: string | null;
   faviconMimeType?: string | null;
   webClipUrl?: string | null;
@@ -92,6 +93,7 @@ async function fetchGlobalPageSettingsImpl(isPreview = false): Promise<GlobalPag
     'custom_code_head',
     'custom_code_body',
     'ycode_badge',
+    'published_at',
     'favicon_asset_id',
     'web_clip_asset_id',
   ]);
@@ -139,6 +141,7 @@ async function fetchGlobalPageSettingsImpl(isPreview = false): Promise<GlobalPag
     globalCustomCodeHead: settings.custom_code_head || null,
     globalCustomCodeBody: settings.custom_code_body || null,
     ycodeBadge: settings.ycode_badge ?? true,
+    publishedAt: typeof settings.published_at === 'string' ? settings.published_at : null,
     faviconUrl,
     faviconMimeType,
     webClipUrl,

--- a/lib/stamp-html-response.ts
+++ b/lib/stamp-html-response.ts
@@ -1,0 +1,249 @@
+/**
+ * Stamp published HTML so View Source starts like Framer:
+ *
+ *   <!DOCTYPE html>
+ *   <!-- Made in Ycode · ycode.com -->
+ *   <!-- Published … -->
+ *   <html>
+ *
+ * React cannot emit comment nodes before `<html>`, so we insert them on
+ * the Node HTTP response. Next.js gzip-compresses HTML first; we wrap
+ * `write` after that middleware so we stamp uncompressed HTML and never
+ * touch compressed bytes (rewriting gzip as UTF-8 blanks the page).
+ */
+
+import { Server, ServerResponse } from 'http';
+import { rememberYcodePublishedAt, stampHtmlDocument } from './ycode-html-comment';
+
+const PUBLISHED_AT_REFRESH_MS = 30_000;
+const PATCHED = Symbol.for('ycode.html-stamp');
+const WRAPPED = Symbol.for('ycode.html-stamp-wrapped');
+
+/** Load publish time in this isolate so the stamp can include the Published line. */
+export async function startYcodePublishedAtRefresh(): Promise<void> {
+  const refresh = async () => {
+    try {
+      const { getSettingByKey } = await import('./repositories/settingsRepository');
+      const value = await getSettingByKey('published_at');
+      rememberYcodePublishedAt(typeof value === 'string' ? value : null);
+    } catch {
+      rememberYcodePublishedAt(null);
+    }
+  };
+
+  await refresh();
+  const timer = setInterval(() => {
+    void refresh();
+  }, PUBLISHED_AT_REFRESH_MS);
+  timer.unref?.();
+}
+
+type WriteCallback = (error?: Error | null) => void;
+
+type StampedResponse = ServerResponse & {
+  [WRAPPED]?: boolean;
+  __ycodeStampState?: 'pending' | 'done' | 'skip';
+  __ycodeStampBuffer?: string;
+};
+
+function isBuilderOrAssetUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  const path = url.split('?')[0];
+  return (
+    path.startsWith('/ycode')
+    || path.startsWith('/_next')
+    || path.startsWith('/api')
+    || path.startsWith('/a/')
+  );
+}
+
+function isGzipChunk(chunk: unknown): boolean {
+  if (typeof chunk === 'string' || chunk == null) return false;
+  const buf = Buffer.isBuffer(chunk)
+    ? chunk
+    : chunk instanceof Uint8Array
+      ? Buffer.from(chunk)
+      : null;
+  return Boolean(buf && buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b);
+}
+
+function chunkToHtmlText(chunk: unknown, encoding?: BufferEncoding): string | null {
+  if (typeof chunk === 'string') return chunk;
+  if (isGzipChunk(chunk)) return null;
+  if (Buffer.isBuffer(chunk)) return chunk.toString(encoding || 'utf8');
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk).toString(encoding || 'utf8');
+  return null;
+}
+
+function shouldSkip(res: StampedResponse): boolean {
+  if (res.__ycodeStampState === 'skip' || res.__ycodeStampState === 'done') {
+    return true;
+  }
+
+  const req = res.req as { url?: string } | undefined;
+  if (isBuilderOrAssetUrl(req?.url)) {
+    res.__ycodeStampState = 'skip';
+    return true;
+  }
+
+  const contentType = res.getHeader('content-type');
+  if (contentType && !String(contentType).includes('text/html')) {
+    res.__ycodeStampState = 'skip';
+    return true;
+  }
+
+  return false;
+}
+
+function stampChunk(res: StampedResponse, chunk: unknown, encoding?: BufferEncoding): unknown {
+  if (chunk === undefined || isGzipChunk(chunk) || shouldSkip(res)) {
+    return chunk;
+  }
+
+  const text = chunkToHtmlText(chunk, encoding);
+  if (text === null) {
+    return chunk;
+  }
+
+  const combined = `${res.__ycodeStampBuffer ?? ''}${text}`;
+  const hasDoctype = /<!DOCTYPE html>/i.test(combined);
+  const hasHtml = /<html\b/i.test(combined);
+
+  if (!hasDoctype && !hasHtml) {
+    // Only hold a split `<!DOCTYPE` prefix — never buffer unknown / compressed bytes.
+    if (combined.length < 32 && /^\s*<!/i.test(combined)) {
+      res.__ycodeStampState = 'pending';
+      res.__ycodeStampBuffer = combined;
+      return null;
+    }
+    const leftover = res.__ycodeStampBuffer;
+    res.__ycodeStampState = 'skip';
+    res.__ycodeStampBuffer = undefined;
+    return leftover ? combined : chunk;
+  }
+
+  res.__ycodeStampState = 'done';
+  res.__ycodeStampBuffer = undefined;
+  return stampHtmlDocument(combined);
+}
+
+function flushBuffer(res: StampedResponse): string | undefined {
+  const leftover = res.__ycodeStampBuffer;
+  res.__ycodeStampBuffer = undefined;
+  if (res.__ycodeStampState === 'pending') {
+    res.__ycodeStampState = 'skip';
+  }
+  return leftover;
+}
+
+type LooseWrite = (
+  chunk?: unknown,
+  encodingOrCb?: BufferEncoding | WriteCallback,
+  maybeCb?: WriteCallback,
+) => boolean;
+
+function callWrite(
+  write: LooseWrite,
+  chunk: unknown,
+  encodingOrCb?: BufferEncoding | WriteCallback,
+  maybeCb?: WriteCallback,
+): boolean {
+  if (typeof encodingOrCb === 'function') {
+    return write(chunk, encodingOrCb);
+  }
+  if (typeof encodingOrCb === 'string' && maybeCb) {
+    return write(chunk, encodingOrCb, maybeCb);
+  }
+  if (typeof encodingOrCb === 'string') {
+    return write(chunk, encodingOrCb);
+  }
+  return write(chunk);
+}
+
+function wrapResponse(res: StampedResponse): void {
+  if (res[WRAPPED] || res.writableEnded) {
+    return;
+  }
+  res[WRAPPED] = true;
+
+  const innerWrite = res.write.bind(res);
+  const innerEnd = res.end.bind(res);
+
+  res.write = function (
+    chunk?: unknown,
+    encodingOrCb?: BufferEncoding | WriteCallback,
+    maybeCb?: WriteCallback,
+  ) {
+    const encoding = typeof encodingOrCb === 'string' ? encodingOrCb : undefined;
+    const callback = typeof encodingOrCb === 'function' ? encodingOrCb : maybeCb;
+    const stamped = stampChunk(this, chunk, encoding);
+
+    if (stamped === null) {
+      callback?.();
+      return true;
+    }
+
+    return callWrite(innerWrite as LooseWrite, stamped, encodingOrCb, maybeCb);
+  };
+
+  res.end = function (
+    chunk?: unknown,
+    encodingOrCb?: BufferEncoding | WriteCallback,
+    maybeCb?: WriteCallback,
+  ) {
+    const encoding = typeof encodingOrCb === 'string' ? encodingOrCb : undefined;
+    const callback = typeof encodingOrCb === 'function' ? encodingOrCb : maybeCb;
+    const chunkIsCallback = typeof chunk === 'function';
+    const hasChunk = chunk !== undefined && !chunkIsCallback;
+
+    let payload: unknown;
+    if (hasChunk) {
+      const stamped = stampChunk(this, chunk, encoding);
+      payload = stamped === null ? flushBuffer(this) : stamped;
+    } else {
+      payload = flushBuffer(this);
+    }
+
+    const endCb = chunkIsCallback ? chunk as WriteCallback : callback;
+
+    if (payload === undefined) {
+      if (endCb) {
+        return innerEnd(endCb);
+      }
+      return innerEnd();
+    }
+    if (encoding && endCb) {
+      return innerEnd(payload, encoding, endCb);
+    }
+    if (endCb) {
+      return innerEnd(payload, endCb);
+    }
+    if (encoding) {
+      return innerEnd(payload, encoding);
+    }
+    return innerEnd(payload);
+  };
+}
+
+export function patchHtmlResponseStamp(): void {
+  const proto = Server.prototype as typeof Server.prototype & {
+    [PATCHED]?: boolean;
+  };
+  if (proto[PATCHED]) {
+    return;
+  }
+  proto[PATCHED] = true;
+
+  const originalEmit = proto.emit;
+  proto.emit = function (this: Server, event: string | symbol, ...args: unknown[]) {
+    if (event === 'request') {
+      const res = args[1] as StampedResponse | undefined;
+      // Next.js installs gzip on `write` synchronously in the request
+      // listener. Wait until that finishes so we wrap the uncompressed side.
+      queueMicrotask(() => {
+        if (res) wrapResponse(res);
+      });
+    }
+    return Reflect.apply(originalEmit, this, [event, ...args]);
+  };
+}

--- a/lib/ycode-html-comment.test.ts
+++ b/lib/ycode-html-comment.test.ts
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildYcodeHtmlComments,
+  formatYcodePublishedCommentDate,
+  insertYcodeHtmlComments,
+} from '@/lib/ycode-html-comment';
+
+test('formats the published date in Framer-style UTC', () => {
+  const date = new Date('2026-09-04T10:49:00.000Z');
+  assert.equal(formatYcodePublishedCommentDate(date), 'Sep 4, 2026, 10:49 AM UTC');
+});
+
+test('formats midnight and noon without a 0 hour', () => {
+  assert.equal(
+    formatYcodePublishedCommentDate(new Date('2026-01-01T00:05:00.000Z')),
+    'Jan 1, 2026, 12:05 AM UTC',
+  );
+  assert.equal(
+    formatYcodePublishedCommentDate(new Date('2026-12-31T12:00:00.000Z')),
+    'Dec 31, 2026, 12:00 PM UTC',
+  );
+});
+
+test('always emits the Made in Ycode comment', () => {
+  const html = buildYcodeHtmlComments();
+  assert.equal(html, '<!-- Made in Ycode · ycode.com -->');
+});
+
+test('adds a Published line when a timestamp is provided', () => {
+  const html = buildYcodeHtmlComments('2026-09-04T10:49:00.000Z');
+  assert.equal(
+    html,
+    '<!-- Made in Ycode · ycode.com -->\n<!-- Published Sep 4, 2026, 10:49 AM UTC -->',
+  );
+});
+
+test('ignores invalid published timestamps', () => {
+  assert.equal(buildYcodeHtmlComments('not-a-date'), '<!-- Made in Ycode · ycode.com -->');
+});
+
+test('inserts comments after doctype and before html', () => {
+  const html = '<!DOCTYPE html><html lang="en"><head></head></html>';
+  const stamped = insertYcodeHtmlComments(html, '2026-09-04T10:49:00.000Z');
+  assert.equal(
+    stamped,
+    '<!DOCTYPE html>\n<!-- Made in Ycode · ycode.com -->\n<!-- Published Sep 4, 2026, 10:49 AM UTC -->\n<html lang="en"><head></head></html>',
+  );
+});
+
+test('normalizes a doctype that already has a newline', () => {
+  const html = '<!DOCTYPE html>\n<html lang="en">\n<head></head>\n</html>\n';
+  const stamped = insertYcodeHtmlComments(html, '2026-09-04T10:49:00.000Z');
+  assert.equal(
+    stamped,
+    '<!DOCTYPE html>\n<!-- Made in Ycode · ycode.com -->\n<!-- Published Sep 4, 2026, 10:49 AM UTC -->\n<html lang="en">\n<head></head>\n</html>\n',
+  );
+});
+
+test('insert is idempotent', () => {
+  const html = '<!DOCTYPE html><html><head></head></html>';
+  const once = insertYcodeHtmlComments(html);
+  assert.equal(insertYcodeHtmlComments(once), once);
+});
+
+test('inserts before html when doctype is missing', () => {
+  const html = '<html><head></head></html>';
+  const stamped = insertYcodeHtmlComments(html);
+  assert.equal(
+    stamped,
+    '<!-- Made in Ycode · ycode.com -->\n<html><head></head></html>',
+  );
+});

--- a/lib/ycode-html-comment.ts
+++ b/lib/ycode-html-comment.ts
@@ -1,0 +1,125 @@
+/**
+ * HTML source stamps that identify a page as built with Ycode.
+ * Mirrors Framer / Webflow: comments sit after `<!DOCTYPE html>` and
+ * before `<html>`.
+ */
+
+const MONTHS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+] as const;
+
+export const MADE_IN_YCODE_COMMENT = 'Made in Ycode · ycode.com';
+
+/** Strip sequences that would terminate an HTML comment. */
+function escapeHtmlComment(text: string): string {
+  return text.replace(/--+/g, '-');
+}
+
+/**
+ * Format a timestamp the way Framer does:
+ * `Sep 4, 2026, 10:49 AM UTC`
+ */
+export function formatYcodePublishedCommentDate(date: Date): string {
+  const month = MONTHS[date.getUTCMonth()];
+  const day = date.getUTCDate();
+  const year = date.getUTCFullYear();
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  const hour24 = date.getUTCHours();
+  const ampm = hour24 >= 12 ? 'PM' : 'AM';
+  const hour12 = hour24 % 12 || 12;
+  return `${month} ${day}, ${year}, ${hour12}:${minutes} ${ampm} UTC`;
+}
+
+function parsePublishedAt(publishedAt?: string | Date | null): Date | null {
+  if (!publishedAt) return null;
+  const date = publishedAt instanceof Date ? publishedAt : new Date(publishedAt);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Build the HTML comment block written into published / exported documents.
+ * Always includes the Made-in line; adds Published when a valid timestamp exists.
+ */
+export function buildYcodeHtmlComments(publishedAt?: string | Date | null): string {
+  const lines = [`<!-- ${escapeHtmlComment(MADE_IN_YCODE_COMMENT)} -->`];
+  const date = parsePublishedAt(publishedAt);
+  if (date) {
+    lines.push(`<!-- Published ${escapeHtmlComment(formatYcodePublishedCommentDate(date))} -->`);
+  }
+  return lines.join('\n');
+}
+
+const DOCTYPE = /<!DOCTYPE html>/i;
+const HTML_OPEN_TAG = /<html\b[^>]*>/i;
+
+/**
+ * Insert the Ycode comments after `<!DOCTYPE html>` and before `<html>`.
+ * Idempotent when the Made-in line is already at the top of the document.
+ */
+export function insertYcodeHtmlComments(
+  html: string,
+  publishedAt?: string | Date | null,
+): string {
+  if (html.slice(0, 500).includes(MADE_IN_YCODE_COMMENT)) {
+    return html;
+  }
+
+  const comments = buildYcodeHtmlComments(publishedAt);
+  const doctype = DOCTYPE.exec(html);
+  if (doctype && doctype.index !== undefined) {
+    const afterDoctype = doctype.index + doctype[0].length;
+    const rest = html.slice(afterDoctype).replace(/^\s*/, '');
+    return `${html.slice(0, doctype.index)}<!DOCTYPE html>\n${comments}\n${rest}`;
+  }
+
+  const htmlTag = HTML_OPEN_TAG.exec(html);
+  if (htmlTag && htmlTag.index !== undefined) {
+    return `${html.slice(0, htmlTag.index)}${comments}\n${html.slice(htmlTag.index)}`;
+  }
+
+  return html;
+}
+
+/**
+ * Shared across the instrumentation bundle and the app bundle (they are
+ * separate module instances). Same pattern as the Supabase admin client.
+ */
+const globalForStamp = globalThis as typeof globalThis & {
+  __ycodePublishedAt?: string | Date | null;
+};
+
+const PUBLISHED_AT_TTL_MS = 30_000;
+let publishedAtFetchedAt = 0;
+
+export function rememberYcodePublishedAt(publishedAt: string | Date | null | undefined): void {
+  globalForStamp.__ycodePublishedAt = publishedAt ?? null;
+}
+
+/** Load `published_at` before the HTML stream starts so the Published line is present. */
+export async function prefetchYcodePublishedAt(): Promise<void> {
+  if (
+    Date.now() - publishedAtFetchedAt < PUBLISHED_AT_TTL_MS
+    && globalForStamp.__ycodePublishedAt !== undefined
+  ) {
+    return;
+  }
+
+  try {
+    const { getSettingByKey } = await import('@/lib/repositories/settingsRepository');
+    const value = await getSettingByKey('published_at');
+    rememberYcodePublishedAt(typeof value === 'string' ? value : null);
+  } catch {
+    rememberYcodePublishedAt(null);
+  }
+  publishedAtFetchedAt = Date.now();
+}
+
+export function runWithYcodeStamp<T>(publishedAt: string | Date | null | undefined, fn: () => T): T {
+  rememberYcodePublishedAt(publishedAt);
+  return fn();
+}
+
+export function stampHtmlDocument(html: string): string {
+  return insertYcodeHtmlComments(html, globalForStamp.__ycodePublishedAt);
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "type-check": "tsc --noEmit",
-    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts lib/page-head-path.test.ts lib/parse-head-html.test.ts",
+    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts lib/page-head-path.test.ts lib/parse-head-html.test.ts lib/ycode-html-comment.test.ts",
     "migrate:make": "NODE_NO_WARNINGS=1 knex migrate:make --knexfile knexfile.ts -x ts",
     "migrate:latest": "NODE_NO_WARNINGS=1 knex migrate:latest --knexfile knexfile.ts",
     "migrate:rollback": "NODE_NO_WARNINGS=1 knex migrate:rollback --knexfile knexfile.ts",

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,7 @@ import { createServerClient } from '@supabase/ssr';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { applySecurityHeaders } from '@/lib/security-headers-server';
+import { prefetchYcodePublishedAt } from '@/lib/ycode-html-comment';
 
 /**
  * Public API routes that skip authentication.
@@ -193,6 +194,7 @@ export async function proxy(request: NextRequest) {
     });
     rewriteResponse.headers.set('x-pathname', pathname);
     await applySecurityHeaders(rewriteResponse);
+    await prefetchYcodePublishedAt();
     return rewriteResponse;
   }
 
@@ -204,6 +206,7 @@ export async function proxy(request: NextRequest) {
   // Apply configurable security headers to public pages only (not builder/API).
   if (isPublicPage) {
     await applySecurityHeaders(response);
+    await prefetchYcodePublishedAt();
   }
 
   return response;


### PR DESCRIPTION
## Summary

Add Framer-style HTML comments on published and exported sites so View Source
identifies the page as made in Ycode, including the last publish time.

## Changes

- Insert `<!-- Made in Ycode · ycode.com -->` and `<!-- Published … -->`
  after `<!DOCTYPE html>` and before `<html>`
- Stamp live HTML on the Node response after render (React cannot emit
  comments there) without rewriting gzip bytes
- Apply the same comments and a generator meta tag on static export
- Leave the builder unstamped and keep the on-page Ycode badge unchanged

## Test plan

- [ ] Open a published page, View Source, and confirm both comments sit
      between `<!DOCTYPE html>` and `<html>`
- [ ] Hard-refresh the published homepage in the browser and confirm it
      still renders (not a blank page)
- [ ] Confirm `/ycode` View Source has no Made in Ycode comments
- [ ] Confirm the on-page Made in Ycode badge still appears when enabled
- [ ] Publish again and confirm the Published comment updates
- [ ] Export a site and confirm the comments are in the exported HTML

Made with [Cursor](https://cursor.com)