### PR TITLE
fix: improve published HTML accessibility

### DIFF
--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -13,7 +13,7 @@ import type { UseLiveComponentUpdatesReturn } from '@/hooks/use-live-component-u
 import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEditable, isTextContentLayer, isRichTextLayer, getCollectionVariable, evaluateVisibility, findAncestorByName, filterDisabledSliderLayers, getLayerCmsFieldBinding, findLayerById, applyCustomAttributes, containsLayerId } from '@/lib/layer-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
-import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
+import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP, SLIDER_BUTTON_ARIA_LABELS, isSliderChromeButton } from '@/lib/slider-constants';
 import { getSliderPresizeVars } from '@/lib/slider-utils';
 import { useCanvasSlider } from '@/hooks/use-canvas-slider';
 import { resolveFieldFromSources } from '@/lib/cms-variables-utils';
@@ -143,6 +143,8 @@ interface LayerRendererProps {
    * over the rest of the page. Computed server-side by PageRenderer.
    */
   lcpCandidateLayerId?: string | null;
+  /** Immediate parent layer name — used to coerce slider nav children to span. */
+  parentLayerName?: string;
 }
 
 const LayerRenderer: React.FC<LayerRendererProps> = ({
@@ -194,6 +196,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
   componentRootContextMenu,
   onComponentEdit,
   lcpCandidateLayerId,
+  parentLayerName,
 }) => {
   const [editingLayerId, setEditingLayerId] = useState<string | null>(null);
   const [editingContent, setEditingContent] = useState<string>('');
@@ -346,6 +349,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
         componentRootContextMenu={componentRootContextMenu}
         onComponentEdit={onComponentEdit}
         lcpCandidateLayerId={lcpCandidateLayerId}
+        parentLayerName={parentLayerName}
       />
     );
   };
@@ -414,6 +418,7 @@ const LayerItemImpl: React.FC<{
   componentRootContextMenu?: boolean;
   onComponentEdit?: (componentId: string, instanceLayerId: string) => void;
   lcpCandidateLayerId?: string | null;
+  parentLayerName?: string;
 }> = ({
   layer,
   isEditMode,
@@ -469,6 +474,7 @@ const LayerItemImpl: React.FC<{
   serverSettings,
   componentRootContextMenu,
   lcpCandidateLayerId,
+  parentLayerName,
 }) => {
   // Subscribe to selection state from the store for reactive updates without
   // forcing the entire LayerRenderer tree to re-render when selection changes
@@ -651,7 +657,7 @@ const LayerItemImpl: React.FC<{
     [layer.id, sharedRendererProps, isEditMode, currentLocale, translations, pageId]
   );
 
-  let htmlTag = getLayerHtmlTag(layer);
+  let htmlTag = getLayerHtmlTag(layer, parentLayerName);
 
   const isSimpleTextLayer = isTextContentLayer(layer);
 
@@ -1237,8 +1243,8 @@ const LayerItemImpl: React.FC<{
   // (e.g. legacy data), extract its text instead of stringifying to "[object Object]".
   const rawImageAltContent = getDynamicTextContent(effectiveImageSettings?.alt) as unknown;
   const rawImageAlt = typeof rawImageAltContent === 'object' && rawImageAltContent !== null
-    ? (extractPlainTextFromTiptap(rawImageAltContent) || 'Image')
-    : String(rawImageAltContent || 'Image');
+    ? (extractPlainTextFromTiptap(rawImageAltContent) || '')
+    : String(rawImageAltContent || '');
   const originalImageAlt = rawImageAlt.includes('<ycode-inline-variable>')
     ? resolveInlineVariablesFromData(rawImageAlt, collectionLayerData, pageCollectionItemData ?? undefined, timezone, effectiveLayerDataMap)
     : rawImageAlt;
@@ -1248,7 +1254,7 @@ const LayerItemImpl: React.FC<{
     translations,
     pageId,
     layer._masterComponentId
-  ) || 'Image';
+  ) || '';
   const imageAlt = translatedImageAlt;
 
   // Resolve audio source - check for linked component variable first
@@ -2258,6 +2264,12 @@ const LayerItemImpl: React.FC<{
       if (SWIPER_DATA_ATTR_MAP[layer.name]) {
         elementProps[SWIPER_DATA_ATTR_MAP[layer.name]] = '';
       }
+      if (isSliderChromeButton(layer.name)) {
+        elementProps.type = 'button';
+        if (!elementProps['aria-label']) {
+          elementProps['aria-label'] = SLIDER_BUTTON_ARIA_LABELS[layer.name];
+        }
+      }
 
       // Lightbox data attributes (LightboxInitializer)
       if (layer.name === 'lightbox' && layer.settings?.lightbox) {
@@ -2662,7 +2674,7 @@ const LayerItemImpl: React.FC<{
     }
 
     // Handle button inside form - set type="submit" only when not in edit mode (preview and published)
-    if (htmlTag === 'button' && isInsideForm && !isEditMode) {
+    if (htmlTag === 'button' && isInsideForm && !isEditMode && !isSliderChromeButton(layer.name)) {
       // Only override if type is not explicitly set or is 'button'
       if (!normalizedAttributes.type || normalizedAttributes.type === 'button') {
         elementProps.type = 'submit';
@@ -2861,6 +2873,9 @@ const LayerItemImpl: React.FC<{
       // instead of collapsing. Inert when both dimensions are explicitly set.
       const iconAspectRatio = getSvgAspectRatioStyle(iconHtml);
       const iconElementStyle = (typeof elementProps.style === 'object' && elementProps.style) || undefined;
+      if (elementProps['aria-hidden'] == null && elementProps['aria-label'] == null) {
+        elementProps['aria-hidden'] = true;
+      }
 
       return (
         <Tag
@@ -2888,7 +2903,8 @@ const LayerItemImpl: React.FC<{
             display: 'block',
             ...mergedStyle,
           }}
-          title={`Code Embed ${layer.id}`}
+          title={layer.customName || 'Code embed'}
+          loading="lazy"
         />
       );
     }
@@ -2949,7 +2965,8 @@ const LayerItemImpl: React.FC<{
               border: 'none',
               display: 'block',
             }}
-            title="Map"
+            title={layer.customName || 'Map'}
+            loading="lazy"
             suppressHydrationWarning
           />
         </div>
@@ -2988,7 +3005,8 @@ const LayerItemImpl: React.FC<{
             className: fullClassName,
             style: mergedStyle,
             src: embedUrl,
-            frameBorder: '0',
+            title: layer.customName || 'YouTube video',
+            loading: 'lazy',
             allow: 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
             allowFullScreen: true,
           };
@@ -3209,6 +3227,7 @@ const LayerItemImpl: React.FC<{
               isSlideChild={layer.name === 'slides'}
               serverSettings={serverSettings}
               lcpCandidateLayerId={lcpCandidateLayerId}
+              parentLayerName={layer.name}
             />
           )}
         </>
@@ -3541,6 +3560,7 @@ const LayerItemImpl: React.FC<{
                     serverSettings={serverSettings}
                     onComponentEdit={onComponentEdit}
                     lcpCandidateLayerId={lcpCandidateLayerId}
+                    parentLayerName={layer.name}
                   />
                 )}
               </Tag>
@@ -3612,6 +3632,7 @@ const LayerItemImpl: React.FC<{
               serverSettings={serverSettings}
               onComponentEdit={onComponentEdit}
               lcpCandidateLayerId={lcpCandidateLayerId}
+              parentLayerName={layer.name}
             />
           )}
 
@@ -3689,6 +3710,7 @@ const LayerItemImpl: React.FC<{
             serverSettings={serverSettings}
             onComponentEdit={onComponentEdit}
             lcpCandidateLayerId={lcpCandidateLayerId}
+            parentLayerName={layer.name}
           />
         )}
       </Tag>

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -19,7 +19,7 @@ import type { Layer, Locale, FormSettings, Component, DesignColorVariable, Passw
 import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextContentLayer, getCollectionVariable, filterDisabledSliderLayers, applyCustomAttributes } from '@/lib/layer-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
-import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
+import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP, SLIDER_BUTTON_ARIA_LABELS, isSliderChromeButton } from '@/lib/slider-constants';
 import { getSliderPresizeVars } from '@/lib/slider-utils';
 import { getDynamicTextContent, getImageUrlFromVariable, getVideoUrlFromVariable, getIframeUrlFromVariable, isFieldVariable, isAssetVariable, isStaticTextVariable, isDynamicTextVariable, getStaticTextContent, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
 import { getTranslatedAssetId, getTranslatedText } from '@/lib/locale-runtime';
@@ -133,6 +133,8 @@ interface LayerRendererPublicProps {
    * uses this context to call the page-auth verify endpoint and redirect on success.
    */
   passwordProtection?: PasswordProtectionContext;
+  /** Immediate parent layer name — used to coerce slider nav children to span. */
+  parentLayerName?: string;
 }
 
 const LayerRendererPublic: React.FC<LayerRendererPublicProps> = ({
@@ -168,6 +170,7 @@ const LayerRendererPublic: React.FC<LayerRendererPublicProps> = ({
   globalsMeta,
   lcpCandidateLayerId,
   passwordProtection,
+  parentLayerName,
 }) => {
   const anchorMap = useMemo(() => {
     return anchorMapProp || buildAnchorMap(layers);
@@ -286,6 +289,7 @@ const LayerRendererPublic: React.FC<LayerRendererPublicProps> = ({
         globalsMeta={globalsMeta}
         lcpCandidateLayerId={lcpCandidateLayerId}
         passwordProtection={passwordProtection}
+        parentLayerName={parentLayerName}
       />
     );
   };
@@ -331,6 +335,7 @@ const LayerItem: React.FC<{
   globalsMeta?: Record<string, GlobalFieldMeta>;
   lcpCandidateLayerId?: string | null;
   passwordProtection?: PasswordProtectionContext;
+  parentLayerName?: string;
 }> = ({
   layer,
   isPublished,
@@ -364,6 +369,7 @@ const LayerItem: React.FC<{
   globalsMeta,
   lcpCandidateLayerId,
   passwordProtection,
+  parentLayerName,
 }) => {
   const classesString = getClassesString(layer);
   const collectionLayerItemId = layer._collectionItemId || collectionItemId;
@@ -461,7 +467,7 @@ const LayerItem: React.FC<{
     [layer.id, sharedRendererProps]
   );
 
-  let htmlTag = getLayerHtmlTag(layer);
+  let htmlTag = getLayerHtmlTag(layer, parentLayerName);
 
   const isSimpleTextLayer = isTextContentLayer(layer);
 
@@ -689,8 +695,8 @@ const LayerItem: React.FC<{
   // (e.g. legacy data), extract its text instead of stringifying to "[object Object]".
   const rawImageAltContent = getDynamicTextContent(effectiveImageSettings?.alt) as unknown;
   const rawImageAlt = typeof rawImageAltContent === 'object' && rawImageAltContent !== null
-    ? (extractPlainTextFromTiptap(rawImageAltContent) || 'Image')
-    : String(rawImageAltContent || 'Image');
+    ? (extractPlainTextFromTiptap(rawImageAltContent) || '')
+    : String(rawImageAltContent || '');
   const originalImageAlt = rawImageAlt.includes('<ycode-inline-variable>')
     ? resolveInlineVariablesFromData(rawImageAlt, collectionLayerData, pageCollectionItemData ?? undefined, timezone, effectiveLayerDataMap)
     : rawImageAlt;
@@ -700,7 +706,7 @@ const LayerItem: React.FC<{
     translations,
     pageId,
     layer._masterComponentId
-  ) || 'Image';
+  ) || '';
   const imageAlt = translatedImageAlt;
 
   // Public path: audio/video/icon component variable overrides are pre-baked
@@ -916,8 +922,6 @@ const LayerItem: React.FC<{
 
     const mergedStyle = { ...parsedAttrStyle, ...filteredDesignStyles, ...bgImageStyle };
 
-    const isEmpty = !textContent && (!children || children.length === 0);
-
     const combinedRef = (node: HTMLElement | null) => {
       if (isFilterLayer) {
         (filterLayerRef as React.MutableRefObject<HTMLDivElement | null>).current = node as HTMLDivElement | null;
@@ -930,7 +934,6 @@ const LayerItem: React.FC<{
       style: mergedStyle,
       'data-layer-id': layer.id,
       'data-layer-type': htmlTag,
-      'data-is-empty': isEmpty ? 'true' : 'false',
       ...normalizedAttributes,
       suppressHydrationWarning: true,
     };
@@ -984,6 +987,12 @@ const LayerItem: React.FC<{
       }
       if (SWIPER_DATA_ATTR_MAP[layer.name]) {
         elementProps[SWIPER_DATA_ATTR_MAP[layer.name]] = '';
+      }
+      if (isSliderChromeButton(layer.name)) {
+        elementProps.type = 'button';
+        if (!elementProps['aria-label']) {
+          elementProps['aria-label'] = SLIDER_BUTTON_ARIA_LABELS[layer.name];
+        }
       }
 
       // Lightbox data attributes (LightboxInitializer)
@@ -1184,7 +1193,7 @@ const LayerItem: React.FC<{
       }
     }
 
-    if (htmlTag === 'button' && isInsideForm) {
+    if (htmlTag === 'button' && isInsideForm && !isSliderChromeButton(layer.name)) {
       if (!normalizedAttributes.type || normalizedAttributes.type === 'button') {
         elementProps.type = 'submit';
       }
@@ -1425,6 +1434,9 @@ const LayerItem: React.FC<{
       // instead of collapsing. Inert when both dimensions are explicitly set.
       const iconAspectRatio = getSvgAspectRatioStyle(iconHtml);
       const iconElementStyle = (typeof elementProps.style === 'object' && elementProps.style) || undefined;
+      if (elementProps['aria-hidden'] == null && elementProps['aria-label'] == null) {
+        elementProps['aria-hidden'] = true;
+      }
 
       return (
         <Tag
@@ -1452,7 +1464,8 @@ const LayerItem: React.FC<{
             display: 'block',
             ...mergedStyle,
           }}
-          title={`Code Embed ${layer.id}`}
+          title={layer.customName || 'Code embed'}
+          loading="lazy"
         />
       );
     }
@@ -1507,7 +1520,8 @@ const LayerItem: React.FC<{
               border: 'none',
               display: 'block',
             }}
-            title="Map"
+            title={layer.customName || 'Map'}
+            loading="lazy"
             suppressHydrationWarning
           />
         </div>
@@ -1545,7 +1559,8 @@ const LayerItem: React.FC<{
             className: fullClassName,
             style: mergedStyle,
             src: embedUrl,
-            frameBorder: '0',
+            title: layer.customName || 'YouTube video',
+            loading: 'lazy',
             allow: 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
             allowFullScreen: true,
           };
@@ -1757,6 +1772,7 @@ const LayerItem: React.FC<{
               components={componentsProp}
               ancestorComponentIds={effectiveAncestorIds}
               isSlideChild={layer.name === 'slides'}
+              parentLayerName={layer.name}
               serverSettings={serverSettings}
               lcpCandidateLayerId={lcpCandidateLayerId}
             />
@@ -1804,6 +1820,7 @@ const LayerItem: React.FC<{
               isInsideLink={isInsideLink || htmlTag === 'a' || willWrapWithLink}
               parentFormSettings={htmlTag === 'form' ? layer.settings?.form : parentFormSettings}
               ancestorComponentIds={effectiveAncestorIds}
+              parentLayerName={layer.name}
             />
           )}
 
@@ -1833,6 +1850,7 @@ const LayerItem: React.FC<{
             parentFormSettings={htmlTag === 'form' ? layer.settings?.form : parentFormSettings}
             ancestorComponentIds={effectiveAncestorIds}
             isSlideChild={layer.name === 'slides'}
+            parentLayerName={layer.name}
           />
         )}
       </Tag>

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -26,6 +26,7 @@ import { getValuesByItemIds } from '@/lib/repositories/collectionItemValueReposi
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { REF_PAGE_PREFIX, REF_COLLECTION_PREFIX, isCollectionItemKeyword, parseCollectionLinkValue } from '@/lib/link-utils';
 import { getClassesString, hasPasswordFormLayer } from '@/lib/layer-utils';
+import { SLIDER_BUTTON_RESET_CSS } from '@/lib/slider-constants';
 import { buildGlobalsMetaMap, buildGlobalsValueMap } from '@/lib/collection-field-utils';
 import { buildLocalizedPageUrls, type LocalizedDynamicSlug } from '@/lib/page-utils';
 import { getTranslatableKey, slimTranslations } from '@/lib/locale-runtime';
@@ -580,7 +581,6 @@ export default async function PageRenderer({
     : rawPageCustomCodeBody;
 
   const { bodyClasses, childLayers: rawChildLayers } = extractBodyLayer(resolvedLayers);
-  const hasLayers = rawChildLayers.length > 0;
 
   // Language for <html lang> and the content wrapper. Falls back to the site's
   // default locale so the document always advertises a language for a11y/SEO.
@@ -802,7 +802,7 @@ export default async function PageRenderer({
       {/* Strip native browser appearance from form elements so Tailwind classes apply */}
       <style
         id="ycode-form-reset"
-        dangerouslySetInnerHTML={{ __html: 'input,select,textarea{appearance:none;-webkit-appearance:none}select{background-image:url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'16\' height=\'16\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'%23737373\' stroke-width=\'2\' stroke-linecap=\'round\' stroke-linejoin=\'round\'%3E%3Cpath d=\'m6 9 6 6 6-6\'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 12px center;background-size:16px 16px}input[type="checkbox"]:checked,input[type="radio"]:checked{background-color:currentColor;border-color:transparent;background-size:100% 100%;background-position:center;background-repeat:no-repeat}input[type="checkbox"]:checked{background-image:url("data:image/svg+xml,%3csvg viewBox=\'0 0 16 16\' fill=\'white\' xmlns=\'http://www.w3.org/2000/svg\'%3e%3cpath d=\'M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z\'/%3e%3c/svg%3e")}input[type="radio"]:checked{background-image:url("data:image/svg+xml,%3csvg viewBox=\'0 0 16 16\' fill=\'white\' xmlns=\'http://www.w3.org/2000/svg\'%3e%3ccircle cx=\'8\' cy=\'8\' r=\'3\'/%3e%3c/svg%3e")}' }}
+        dangerouslySetInnerHTML={{ __html: 'input,select,textarea{appearance:none;-webkit-appearance:none}select{background-image:url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'16\' height=\'16\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'%23737373\' stroke-width=\'2\' stroke-linecap=\'round\' stroke-linejoin=\'round\'%3E%3Cpath d=\'m6 9 6 6 6-6\'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 12px center;background-size:16px 16px}input[type="checkbox"]:checked,input[type="radio"]:checked{background-color:currentColor;border-color:transparent;background-size:100% 100%;background-position:center;background-repeat:no-repeat}input[type="checkbox"]:checked{background-image:url("data:image/svg+xml,%3csvg viewBox=\'0 0 16 16\' fill=\'white\' xmlns=\'http://www.w3.org/2000/svg\'%3e%3cpath d=\'M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z\'/%3e%3c/svg%3e")}input[type="radio"]:checked{background-image:url("data:image/svg+xml,%3csvg viewBox=\'0 0 16 16\' fill=\'white\' xmlns=\'http://www.w3.org/2000/svg\'%3e%3ccircle cx=\'8\' cy=\'8\' r=\'3\'/%3e%3c/svg%3e")}' + SLIDER_BUTTON_RESET_CSS }}
       />
 
       {/* Inject CSS directly — React 19 hoists <style> with precedence to <head> */}
@@ -930,7 +930,6 @@ export default async function PageRenderer({
         className="contents"
         data-layer-id="body"
         data-layer-type="div"
-        data-is-empty={hasLayers ? 'false' : 'true'}
         lang={resolvedLang}
       >
         <LayerRendererPublic

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -12,6 +12,7 @@ import { layerToHtml, buildAnchorMap } from '@/lib/page-fetcher'
 import type { PageData } from '@/lib/page-fetcher'
 import type { FontPreload } from '@/lib/font-utils'
 import { getClassesString } from '@/lib/layer-utils'
+import { SLIDER_BUTTON_RESET_CSS } from '@/lib/slider-constants'
 import { getEffectiveApplyStyle } from '@/lib/animation-utils'
 import { buildYcodeHtmlComments } from '@/lib/ycode-html-comment'
 
@@ -717,6 +718,7 @@ export function buildDocument({
 
   if (includeSwiper) {
     head.push(`<link rel="stylesheet" href="${SWIPER_CSS_PATH}" />`)
+    head.push(`<style>${SLIDER_BUTTON_RESET_CSS}</style>`)
   }
 
   // Custom head code: global first (site-wide), then page-specific. Emitted

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -1789,11 +1789,11 @@ const LAYER_NAME_TO_HTML_TAG: Record<string, string> = {
   slides: 'div',
   slide: 'div',
   slideNavigationWrapper: 'div',
-  slideButtonPrev: 'div',
-  slideButtonNext: 'div',
+  slideButtonPrev: 'button',
+  slideButtonNext: 'button',
   slidePaginationWrapper: 'div',
   slideBullets: 'div',
-  slideBullet: 'div',
+  slideBullet: 'button',
   slideFraction: 'div',
 
   // Lightbox
@@ -1810,16 +1810,33 @@ const LAYER_NAME_TO_HTML_TAG: Record<string, string> = {
   radio: 'input',
 };
 
-export function getLayerHtmlTag(layer: Layer): string {
+export function getLayerHtmlTag(layer: Layer, parentName?: string): string {
   if (layer.id === 'body' || layer.name === 'body') {
     return 'div';
   }
 
   if (layer.settings?.tag) {
-    return layer.settings.tag;
+    return coerceSliderNavChildTag(layer.settings.tag, layer, parentName);
   }
 
-  return LAYER_NAME_TO_HTML_TAG[layer.name] || layer.name || 'div';
+  const tag = LAYER_NAME_TO_HTML_TAG[layer.name] || layer.name || 'div';
+  return coerceSliderNavChildTag(tag, layer, parentName);
+}
+
+/**
+ * Prev/next slider wrappers render as <button>. Their visual child is stored
+ * as a `div`, which is invalid inside a button — coerce it to `span`.
+ */
+function coerceSliderNavChildTag(tag: string, layer: Layer, parentName?: string): string {
+  if (
+    (parentName === 'slideButtonPrev' || parentName === 'slideButtonNext')
+    && layer.name === 'div'
+    && tag === 'div'
+  ) {
+    return 'span';
+  }
+
+  return tag;
 }
 
 /**

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -31,7 +31,7 @@ export interface PaginationContext {
 import { resolveRefCollectionItemId, generateLinkHref, isLinkAtCollectionBoundary, isLinkToCurrentPage, parseCollectionLinkValue, extractCrossCollectionItemIds } from '@/lib/link-utils';
 import type { LinkResolutionContext } from '@/lib/link-utils';
 import { getLinkSettingsFromMark } from '@/lib/tiptap-extensions/rich-text-link';
-import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
+import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP, SLIDER_BUTTON_ARIA_LABELS, isSliderChromeButton } from '@/lib/slider-constants';
 import { resolveInlineVariables, resolveInlineVariablesFromData } from '@/lib/inline-variables';
 import { buildPaginationNumbers, getPaginationLayerKind, hasPaginationVariables, paginationTextVariableToTemplate, resolvePaginationTextVariable } from '@/lib/pagination-text-utils';
 import { formatFieldValue, resolveFieldFromSources } from '@/lib/cms-variables-utils';
@@ -4606,6 +4606,8 @@ export interface PageLinkContext {
    * no hydration, so an iframe with no `height` clips the user's content.
    */
   isStaticExport?: boolean;
+  /** Immediate parent layer name — used to coerce slider nav children to span. */
+  parentLayerName?: string;
 }
 
 /** Build an `assetMap`-backed `getAsset` callback compatible with `generateLinkHref`. */
@@ -4680,7 +4682,7 @@ export function layerToHtml(
     });
 
   // Get the HTML tag
-  let tag = getLayerHtmlTag(layer);
+  let tag = getLayerHtmlTag(layer, pageLinkContext?.parentLayerName);
 
   // Buttons with link settings render as <a> directly instead of being
   // wrapped in <a><button></button></a> which is invalid HTML
@@ -4751,6 +4753,13 @@ export function layerToHtml(
   // Add data attributes for slider nav/pagination elements (used by SliderInitializer)
   if (SWIPER_DATA_ATTR_MAP[layer.name]) {
     attrs.push(SWIPER_DATA_ATTR_MAP[layer.name]);
+  }
+
+  if (isSliderChromeButton(layer.name)) {
+    attrs.push('type="button"');
+    if (!layer.settings?.customAttributes?.['aria-label']) {
+      attrs.push(`aria-label="${escapeHtml(SLIDER_BUTTON_ARIA_LABELS[layer.name])}"`);
+    }
   }
 
   // Add slider settings as data attribute on the root slider layer
@@ -4909,10 +4918,11 @@ export function layerToHtml(
     attrs.push('data-layer-type="image"');
 
     const imageAlt = layer.variables?.image?.alt;
+    let resolvedAlt = '';
     if (imageAlt && imageAlt.type === 'dynamic_text') {
-      const resolvedAlt = resolveInlineVariablesFromData(imageAlt.data.content, effectiveCollectionItemData, pageCollectionItemData, 'UTC', effectiveLayerDataMap);
-      attrs.push(`alt="${escapeHtml(resolvedAlt)}"`);
+      resolvedAlt = resolveInlineVariablesFromData(imageAlt.data.content, effectiveCollectionItemData, pageCollectionItemData, 'UTC', effectiveLayerDataMap);
     }
+    attrs.push(`alt="${escapeHtml(resolvedAlt)}"`);
 
     if (intrinsicWidth) attrs.push(`width="${intrinsicWidth}"`);
     if (intrinsicHeight) attrs.push(`height="${intrinsicHeight}"`);
@@ -4941,7 +4951,8 @@ export function layerToHtml(
       const embedUrl = `https://www.${domain}/embed/${videoId}${params.length > 0 ? '?' + params.join('&') : ''}`;
 
       attrs.push(`src="${escapeHtml(embedUrl)}"`);
-      attrs.push('frameborder="0"');
+      attrs.push(`title="${escapeHtml(layer.customName || 'YouTube video')}"`);
+      attrs.push('loading="lazy"');
       attrs.push('allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"');
       attrs.push('allowfullscreen');
       attrs.push('data-layer-type="video"');
@@ -4974,10 +4985,10 @@ export function layerToHtml(
       const iframeProps = getMapIframeProps(mapSettings, mapToken);
       const attrsStr = attrs.length > 0 ? ' ' + attrs.join(' ') : '';
       if (iframeProps.type === 'src') {
-        return `<div${attrsStr}><iframe src="${escapeHtml(iframeProps.src)}" referrerpolicy="no-referrer-when-downgrade" loading="lazy" style="width:100%;height:100%;border:none;display:block" title="Map"></iframe></div>`;
+        return `<div${attrsStr}><iframe src="${escapeHtml(iframeProps.src)}" referrerpolicy="no-referrer-when-downgrade" loading="lazy" style="width:100%;height:100%;border:none;display:block" title="${escapeHtml(layer.customName || 'Map')}"></iframe></div>`;
       }
       const escapedSrcdoc = escapeHtml(iframeProps.srcDoc);
-      return `<div${attrsStr}><iframe srcdoc="${escapedSrcdoc}" sandbox="allow-scripts allow-same-origin" style="width:100%;height:100%;border:none;display:block" title="Map"></iframe></div>`;
+      return `<div${attrsStr}><iframe srcdoc="${escapedSrcdoc}" sandbox="allow-scripts allow-same-origin" loading="lazy" style="width:100%;height:100%;border:none;display:block" title="${escapeHtml(layer.customName || 'Map')}"></iframe></div>`;
     }
 
     const attrsStr = attrs.length > 0 ? ' ' + attrs.join(' ') : '';
@@ -5043,6 +5054,10 @@ export function layerToHtml(
     }
     // Add data-icon attribute to trigger CSS styling
     attrs.push('data-icon="true"');
+    const iconAttrs = layer.settings?.customAttributes;
+    if (!iconAttrs?.['aria-hidden'] && !iconAttrs?.['aria-label']) {
+      attrs.push('aria-hidden="true"');
+    }
   }
 
   // Handle Code Embed layers - render as iframe for SSR
@@ -5089,7 +5104,8 @@ export function layerToHtml(
     attrs.push(`srcdoc="${escapedIframeContent}"`);
     attrs.push('sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals"');
     attrs.push('style="width: 100%; border: none; display: block;"');
-    attrs.push(`title="Code Embed ${layer.id}"`);
+    attrs.push(`title="${escapeHtml(layer.customName || 'Code embed')}"`);
+    attrs.push('loading="lazy"');
 
     const attrsStr = attrs.length > 0 ? ' ' + attrs.join(' ') : '';
     return `<iframe${attrsStr}></iframe>`;
@@ -5196,10 +5212,11 @@ export function layerToHtml(
     : layer.children;
 
   // Render children
+  const childLinkContext: PageLinkContext = { ...pageLinkContext, parentLayerName: layer.name };
   const childrenHtml = effectiveChildren
     ? effectiveChildren
       .map((child) =>
-        layerToHtml(child, effectiveCollectionItemId, pages, folders, collectionItemSlugs, locale, translations, anchorMap, effectiveCollectionItemData, pageCollectionItemData, assetMap, effectiveLayerDataMap, components, ancestorComponentIds, layer.name === 'slides', pageLinkContext)
+        layerToHtml(child, effectiveCollectionItemId, pages, folders, collectionItemSlugs, locale, translations, anchorMap, effectiveCollectionItemData, pageCollectionItemData, assetMap, effectiveLayerDataMap, components, ancestorComponentIds, layer.name === 'slides', childLinkContext)
       )
       .join('')
     : '';

--- a/lib/slider-constants.ts
+++ b/lib/slider-constants.ts
@@ -76,4 +76,28 @@ export const SWIPER_DATA_ATTR_MAP: Record<string, string> = {
   slideButtonNext: 'data-slider-next',
   slideBullets: 'data-slider-pagination',
   slideFraction: 'data-slider-fraction',
+  slideBullet: 'data-slider-bullet',
 };
+
+/** Accessible names for slider chrome that renders as a native button. */
+export const SLIDER_BUTTON_ARIA_LABELS: Record<string, string> = {
+  slideButtonPrev: 'Previous slide',
+  slideButtonNext: 'Next slide',
+  slideBullet: 'Go to slide',
+};
+
+/** Prev / next wrappers and bullets — not form submit buttons. */
+export function isSliderChromeButton(name: string): boolean {
+  return name === 'slideButtonPrev' || name === 'slideButtonNext' || name === 'slideBullet';
+}
+
+/**
+ * Strip UA button chrome so slider controls keep their Tailwind look.
+ * Attribute selectors only — must not reset designer `button` layers.
+ * Prev/next are invisible hit areas (the circle is a child), so they
+ * need `background:transparent`. Bullets ARE the visible dots (`bg-white`)
+ * — a transparent reset would hide them (attribute+element beats a class).
+ */
+export const SLIDER_BUTTON_RESET_CSS =
+  'button[data-slider-prev],button[data-slider-next]{appearance:none;-webkit-appearance:none;background:transparent;border:0;padding:0;margin:0;font:inherit;color:inherit}'
+  + 'button[data-slider-bullet]{appearance:none;-webkit-appearance:none;border:0;padding:0;margin:0;font:inherit;color:inherit}';

--- a/lib/templates/layouts.ts
+++ b/lib/templates/layouts.ts
@@ -34281,6 +34281,9 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
         }
       },
       'classes': 'flex flex-col w-[100%] items-center pt-[20px] pb-[20px] bg-[#ffffff]',
+      'settings': {
+        'tag': 'header'
+      },
       'children': [
         {
           'id': 'lyr-ml0o0z1kpz9lgn',
@@ -34308,6 +34311,9 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
             }
           },
           'classes': 'flex flex-col w-[100%] items-center pt-[20px] pb-[20px] bg-[#ffffff]',
+          'settings': {
+            'tag': 'nav'
+          },
           'children': [
             {
               'id': 'lyr-ml0o0z1kvic1di',
@@ -34796,10 +34802,10 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
               'customName': 'Container'
             }
           ],
-          'customName': 'Section'
+          'customName': 'Nav'
         }
       ],
-      'customName': 'Section',
+      'customName': 'Header',
       '_inlinedComponentName': 'Navigation'
     },
   },
@@ -34832,6 +34838,9 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
         }
       },
       'classes': 'flex flex-col w-[100%] items-center bg-[#ffffff] pt-[25px] pb-[25px]',
+      'settings': {
+        'tag': 'header'
+      },
       'children': [
         {
           'id': 'lyr-ml0p6eablzp8wo',
@@ -34859,6 +34868,9 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
             }
           },
           'classes': 'flex flex-col w-[100%] items-center bg-[#ffffff] pt-[25px] pb-[25px]',
+          'settings': {
+            'tag': 'nav'
+          },
           'children': [
             {
               'id': 'lyr-ml0p6eabjud5cp',
@@ -35284,10 +35296,10 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
               'customName': 'Container'
             }
           ],
-          'customName': 'Section'
+          'customName': 'Nav'
         }
       ],
-      'customName': 'Section',
+      'customName': 'Header',
       '_inlinedComponentName': 'Navigation'
     },
   },


### PR DESCRIPTION
## Summary

Improve the HTML that published pages emit so sliders, icons, iframes, and images
are more accessible, and so live markup no longer carries editor-only empty flags.

## Changes

- Render slider prev, next, and bullets as `button type="button"` with names
- Reset UA button chrome on prev/next only — do not clear bullet background
- Hide decorative icons from assistive tech unless they already have a name
- Give YouTube, map, and embed iframes a real title and `loading="lazy"`
- Emit `alt=""` when an image has no authored alt, instead of a generic Image
- Drop `data-is-empty` from published and exported HTML
- Emit `header` and `nav` on new Navigation 001/002 inserts

## Test plan

- [ ] Publish a page with a slider — dots stay visible and clickable
- [ ] Prev / next are not gray UA buttons and announce Previous / Next slide
- [ ] Decorative icons are not announced by a screen reader
- [ ] YouTube and map embeds have a title and lazy-load
- [ ] An image with no alt shows `alt=""` in View Source
- [ ] View Source has no `data-is-empty`
- [ ] Insert Navigation 001 or 002 — outer tag is header, inner is nav
- [ ] Existing pages keep their previous nav markup until re-inserted


Made with [Cursor](https://cursor.com)