### PR TITLE
feat: improve published HTML and page head code

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,8 +1,10 @@
 import '@/app/site.css';
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import RootLayoutShell, { defaultMetadata } from '@/components/RootLayoutShell';
 import { fetchGlobalPageSettings } from '@/lib/generate-page-metadata';
 import { renderRootLayoutHeadCode } from '@/lib/parse-head-html';
+import { resolvePageCustomHeadCode } from '@/lib/resolve-page-head-code';
 
 export async function generateMetadata(): Promise<Metadata> {
   if (process.env.SKIP_SETUP === 'true') {
@@ -34,15 +36,28 @@ export default async function SiteLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  let headElements: React.ReactNode[] = [];
+  const headElements: React.ReactNode[] = [];
 
   // Cloud mode uses ISR with explicit tenantId — calling headers() here
-  // would force all pages dynamic. Cloud injects global head code from PageRenderer instead.
+  // would force all pages dynamic. Cloud injects custom head code from
+  // PageRenderer instead (meta/link/style hoist; inline scripts stay in body).
   if (process.env.SKIP_SETUP !== 'true') {
+    // Must stay outside the data-fetch try/catch — Next.js throws a
+    // special bailout from headers() to opt the layout into dynamic
+    // rendering, and swallowing it would skip head injection entirely.
+    const headersList = await headers();
+    const pathname = headersList.get('x-pathname') || '/';
+
     try {
-      const globalSettings = await fetchGlobalPageSettings();
+      const [globalSettings, pageCustomHead] = await Promise.all([
+        fetchGlobalPageSettings(),
+        resolvePageCustomHeadCode(pathname),
+      ]);
       if (globalSettings.globalCustomCodeHead) {
-        headElements = renderRootLayoutHeadCode(globalSettings.globalCustomCodeHead);
+        headElements.push(...renderRootLayoutHeadCode(globalSettings.globalCustomCodeHead));
+      }
+      if (pageCustomHead) {
+        headElements.push(...renderRootLayoutHeadCode(pageCustomHead, 'page-head'));
       }
     } catch {
       // Supabase not configured — skip custom code

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -5,15 +5,21 @@ import RootLayoutShell, { defaultMetadata } from '@/components/RootLayoutShell';
 import { fetchGlobalPageSettings } from '@/lib/generate-page-metadata';
 import { renderRootLayoutHeadCode } from '@/lib/parse-head-html';
 import { resolvePageCustomHeadCode } from '@/lib/resolve-page-head-code';
+import { runWithYcodeStamp } from '@/lib/ycode-html-comment';
+
+const ycodeGeneratorMetadata: Metadata = {
+  ...defaultMetadata,
+  other: { generator: 'Ycode' },
+};
 
 export async function generateMetadata(): Promise<Metadata> {
   if (process.env.SKIP_SETUP === 'true') {
-    return defaultMetadata;
+    return ycodeGeneratorMetadata;
   }
 
   try {
     const globalSettings = await fetchGlobalPageSettings();
-    const metadata: Metadata = { ...defaultMetadata };
+    const metadata: Metadata = { ...ycodeGeneratorMetadata };
 
     if (globalSettings.faviconUrl || globalSettings.webClipUrl) {
       metadata.icons = {};
@@ -27,7 +33,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
     return metadata;
   } catch {
-    return defaultMetadata;
+    return ycodeGeneratorMetadata;
   }
 }
 
@@ -37,6 +43,15 @@ export default async function SiteLayout({
   children: React.ReactNode;
 }>) {
   const headElements: React.ReactNode[] = [];
+  let publishedAt: string | null = null;
+
+  // Publish time for the HTML source stamp. Safe without headers() (cloud ISR).
+  try {
+    const globalSettings = await fetchGlobalPageSettings();
+    publishedAt = globalSettings.publishedAt ?? null;
+  } catch {
+    // Supabase not configured — stamp still emits the Made in line
+  }
 
   // Cloud mode uses ISR with explicit tenantId — calling headers() here
   // would force all pages dynamic. Cloud injects custom head code from
@@ -67,9 +82,9 @@ export default async function SiteLayout({
   // Published sites render text with the browser-default (`auto`) font
   // smoothing — matching legacy output. Forcing `antialiased` here would render
   // glyphs thinner/lighter than the original site.
-  return (
+  return runWithYcodeStamp(publishedAt, () => (
     <RootLayoutShell headElements={headElements} bodyClassName="font-sans">
       {children}
     </RootLayoutShell>
-  );
+  ));
 }

--- a/components/LayerRenderer.tsx
+++ b/components/LayerRenderer.tsx
@@ -13,7 +13,7 @@ import type { UseLiveComponentUpdatesReturn } from '@/hooks/use-live-component-u
 import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextEditable, isTextContentLayer, isRichTextLayer, getCollectionVariable, evaluateVisibility, findAncestorByName, filterDisabledSliderLayers, getLayerCmsFieldBinding, findLayerById, applyCustomAttributes, containsLayerId } from '@/lib/layer-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
-import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
+import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP, SLIDER_BUTTON_ARIA_LABELS, isSliderChromeButton } from '@/lib/slider-constants';
 import { getSliderPresizeVars } from '@/lib/slider-utils';
 import { useCanvasSlider } from '@/hooks/use-canvas-slider';
 import { resolveFieldFromSources } from '@/lib/cms-variables-utils';
@@ -143,6 +143,8 @@ interface LayerRendererProps {
    * over the rest of the page. Computed server-side by PageRenderer.
    */
   lcpCandidateLayerId?: string | null;
+  /** Immediate parent layer name — used to coerce slider nav children to span. */
+  parentLayerName?: string;
 }
 
 const LayerRenderer: React.FC<LayerRendererProps> = ({
@@ -194,6 +196,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
   componentRootContextMenu,
   onComponentEdit,
   lcpCandidateLayerId,
+  parentLayerName,
 }) => {
   const [editingLayerId, setEditingLayerId] = useState<string | null>(null);
   const [editingContent, setEditingContent] = useState<string>('');
@@ -346,6 +349,7 @@ const LayerRenderer: React.FC<LayerRendererProps> = ({
         componentRootContextMenu={componentRootContextMenu}
         onComponentEdit={onComponentEdit}
         lcpCandidateLayerId={lcpCandidateLayerId}
+        parentLayerName={parentLayerName}
       />
     );
   };
@@ -414,6 +418,7 @@ const LayerItemImpl: React.FC<{
   componentRootContextMenu?: boolean;
   onComponentEdit?: (componentId: string, instanceLayerId: string) => void;
   lcpCandidateLayerId?: string | null;
+  parentLayerName?: string;
 }> = ({
   layer,
   isEditMode,
@@ -469,6 +474,7 @@ const LayerItemImpl: React.FC<{
   serverSettings,
   componentRootContextMenu,
   lcpCandidateLayerId,
+  parentLayerName,
 }) => {
   // Subscribe to selection state from the store for reactive updates without
   // forcing the entire LayerRenderer tree to re-render when selection changes
@@ -651,7 +657,7 @@ const LayerItemImpl: React.FC<{
     [layer.id, sharedRendererProps, isEditMode, currentLocale, translations, pageId]
   );
 
-  let htmlTag = getLayerHtmlTag(layer);
+  let htmlTag = getLayerHtmlTag(layer, parentLayerName);
 
   const isSimpleTextLayer = isTextContentLayer(layer);
 
@@ -1237,8 +1243,8 @@ const LayerItemImpl: React.FC<{
   // (e.g. legacy data), extract its text instead of stringifying to "[object Object]".
   const rawImageAltContent = getDynamicTextContent(effectiveImageSettings?.alt) as unknown;
   const rawImageAlt = typeof rawImageAltContent === 'object' && rawImageAltContent !== null
-    ? (extractPlainTextFromTiptap(rawImageAltContent) || 'Image')
-    : String(rawImageAltContent || 'Image');
+    ? (extractPlainTextFromTiptap(rawImageAltContent) || '')
+    : String(rawImageAltContent || '');
   const originalImageAlt = rawImageAlt.includes('<ycode-inline-variable>')
     ? resolveInlineVariablesFromData(rawImageAlt, collectionLayerData, pageCollectionItemData ?? undefined, timezone, effectiveLayerDataMap)
     : rawImageAlt;
@@ -1248,7 +1254,7 @@ const LayerItemImpl: React.FC<{
     translations,
     pageId,
     layer._masterComponentId
-  ) || 'Image';
+  ) || '';
   const imageAlt = translatedImageAlt;
 
   // Resolve audio source - check for linked component variable first
@@ -2258,6 +2264,12 @@ const LayerItemImpl: React.FC<{
       if (SWIPER_DATA_ATTR_MAP[layer.name]) {
         elementProps[SWIPER_DATA_ATTR_MAP[layer.name]] = '';
       }
+      if (isSliderChromeButton(layer.name)) {
+        elementProps.type = 'button';
+        if (!elementProps['aria-label']) {
+          elementProps['aria-label'] = SLIDER_BUTTON_ARIA_LABELS[layer.name];
+        }
+      }
 
       // Lightbox data attributes (LightboxInitializer)
       if (layer.name === 'lightbox' && layer.settings?.lightbox) {
@@ -2662,7 +2674,7 @@ const LayerItemImpl: React.FC<{
     }
 
     // Handle button inside form - set type="submit" only when not in edit mode (preview and published)
-    if (htmlTag === 'button' && isInsideForm && !isEditMode) {
+    if (htmlTag === 'button' && isInsideForm && !isEditMode && !isSliderChromeButton(layer.name)) {
       // Only override if type is not explicitly set or is 'button'
       if (!normalizedAttributes.type || normalizedAttributes.type === 'button') {
         elementProps.type = 'submit';
@@ -2861,6 +2873,9 @@ const LayerItemImpl: React.FC<{
       // instead of collapsing. Inert when both dimensions are explicitly set.
       const iconAspectRatio = getSvgAspectRatioStyle(iconHtml);
       const iconElementStyle = (typeof elementProps.style === 'object' && elementProps.style) || undefined;
+      if (elementProps['aria-hidden'] == null && elementProps['aria-label'] == null) {
+        elementProps['aria-hidden'] = true;
+      }
 
       return (
         <Tag
@@ -2888,7 +2903,8 @@ const LayerItemImpl: React.FC<{
             display: 'block',
             ...mergedStyle,
           }}
-          title={`Code Embed ${layer.id}`}
+          title={layer.customName || 'Code embed'}
+          loading="lazy"
         />
       );
     }
@@ -2949,7 +2965,8 @@ const LayerItemImpl: React.FC<{
               border: 'none',
               display: 'block',
             }}
-            title="Map"
+            title={layer.customName || 'Map'}
+            loading="lazy"
             suppressHydrationWarning
           />
         </div>
@@ -2988,7 +3005,8 @@ const LayerItemImpl: React.FC<{
             className: fullClassName,
             style: mergedStyle,
             src: embedUrl,
-            frameBorder: '0',
+            title: layer.customName || 'YouTube video',
+            loading: 'lazy',
             allow: 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
             allowFullScreen: true,
           };
@@ -3209,6 +3227,7 @@ const LayerItemImpl: React.FC<{
               isSlideChild={layer.name === 'slides'}
               serverSettings={serverSettings}
               lcpCandidateLayerId={lcpCandidateLayerId}
+              parentLayerName={layer.name}
             />
           )}
         </>
@@ -3541,6 +3560,7 @@ const LayerItemImpl: React.FC<{
                     serverSettings={serverSettings}
                     onComponentEdit={onComponentEdit}
                     lcpCandidateLayerId={lcpCandidateLayerId}
+                    parentLayerName={layer.name}
                   />
                 )}
               </Tag>
@@ -3612,6 +3632,7 @@ const LayerItemImpl: React.FC<{
               serverSettings={serverSettings}
               onComponentEdit={onComponentEdit}
               lcpCandidateLayerId={lcpCandidateLayerId}
+              parentLayerName={layer.name}
             />
           )}
 
@@ -3689,6 +3710,7 @@ const LayerItemImpl: React.FC<{
             serverSettings={serverSettings}
             onComponentEdit={onComponentEdit}
             lcpCandidateLayerId={lcpCandidateLayerId}
+            parentLayerName={layer.name}
           />
         )}
       </Tag>

--- a/components/LayerRendererPublic.tsx
+++ b/components/LayerRendererPublic.tsx
@@ -19,7 +19,7 @@ import type { Layer, Locale, FormSettings, Component, DesignColorVariable, Passw
 import { getLayerHtmlTag, getClassesString, getText, resolveFieldValue, isTextContentLayer, getCollectionVariable, filterDisabledSliderLayers, applyCustomAttributes } from '@/lib/layer-utils';
 import { getMapIframeProps, DEFAULT_MAP_SETTINGS, resolveMarkerColor } from '@/lib/map-utils';
 import { HTML_TO_REACT_ATTRS } from '@/lib/parse-head-html';
-import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
+import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP, SLIDER_BUTTON_ARIA_LABELS, isSliderChromeButton } from '@/lib/slider-constants';
 import { getSliderPresizeVars } from '@/lib/slider-utils';
 import { getDynamicTextContent, getImageUrlFromVariable, getVideoUrlFromVariable, getIframeUrlFromVariable, isFieldVariable, isAssetVariable, isStaticTextVariable, isDynamicTextVariable, getStaticTextContent, getAssetId, resolveDesignStyles } from '@/lib/variable-utils';
 import { getTranslatedAssetId, getTranslatedText } from '@/lib/locale-runtime';
@@ -133,6 +133,8 @@ interface LayerRendererPublicProps {
    * uses this context to call the page-auth verify endpoint and redirect on success.
    */
   passwordProtection?: PasswordProtectionContext;
+  /** Immediate parent layer name — used to coerce slider nav children to span. */
+  parentLayerName?: string;
 }
 
 const LayerRendererPublic: React.FC<LayerRendererPublicProps> = ({
@@ -168,6 +170,7 @@ const LayerRendererPublic: React.FC<LayerRendererPublicProps> = ({
   globalsMeta,
   lcpCandidateLayerId,
   passwordProtection,
+  parentLayerName,
 }) => {
   const anchorMap = useMemo(() => {
     return anchorMapProp || buildAnchorMap(layers);
@@ -286,6 +289,7 @@ const LayerRendererPublic: React.FC<LayerRendererPublicProps> = ({
         globalsMeta={globalsMeta}
         lcpCandidateLayerId={lcpCandidateLayerId}
         passwordProtection={passwordProtection}
+        parentLayerName={parentLayerName}
       />
     );
   };
@@ -331,6 +335,7 @@ const LayerItem: React.FC<{
   globalsMeta?: Record<string, GlobalFieldMeta>;
   lcpCandidateLayerId?: string | null;
   passwordProtection?: PasswordProtectionContext;
+  parentLayerName?: string;
 }> = ({
   layer,
   isPublished,
@@ -364,6 +369,7 @@ const LayerItem: React.FC<{
   globalsMeta,
   lcpCandidateLayerId,
   passwordProtection,
+  parentLayerName,
 }) => {
   const classesString = getClassesString(layer);
   const collectionLayerItemId = layer._collectionItemId || collectionItemId;
@@ -461,7 +467,7 @@ const LayerItem: React.FC<{
     [layer.id, sharedRendererProps]
   );
 
-  let htmlTag = getLayerHtmlTag(layer);
+  let htmlTag = getLayerHtmlTag(layer, parentLayerName);
 
   const isSimpleTextLayer = isTextContentLayer(layer);
 
@@ -689,8 +695,8 @@ const LayerItem: React.FC<{
   // (e.g. legacy data), extract its text instead of stringifying to "[object Object]".
   const rawImageAltContent = getDynamicTextContent(effectiveImageSettings?.alt) as unknown;
   const rawImageAlt = typeof rawImageAltContent === 'object' && rawImageAltContent !== null
-    ? (extractPlainTextFromTiptap(rawImageAltContent) || 'Image')
-    : String(rawImageAltContent || 'Image');
+    ? (extractPlainTextFromTiptap(rawImageAltContent) || '')
+    : String(rawImageAltContent || '');
   const originalImageAlt = rawImageAlt.includes('<ycode-inline-variable>')
     ? resolveInlineVariablesFromData(rawImageAlt, collectionLayerData, pageCollectionItemData ?? undefined, timezone, effectiveLayerDataMap)
     : rawImageAlt;
@@ -700,7 +706,7 @@ const LayerItem: React.FC<{
     translations,
     pageId,
     layer._masterComponentId
-  ) || 'Image';
+  ) || '';
   const imageAlt = translatedImageAlt;
 
   // Public path: audio/video/icon component variable overrides are pre-baked
@@ -916,8 +922,6 @@ const LayerItem: React.FC<{
 
     const mergedStyle = { ...parsedAttrStyle, ...filteredDesignStyles, ...bgImageStyle };
 
-    const isEmpty = !textContent && (!children || children.length === 0);
-
     const combinedRef = (node: HTMLElement | null) => {
       if (isFilterLayer) {
         (filterLayerRef as React.MutableRefObject<HTMLDivElement | null>).current = node as HTMLDivElement | null;
@@ -930,7 +934,6 @@ const LayerItem: React.FC<{
       style: mergedStyle,
       'data-layer-id': layer.id,
       'data-layer-type': htmlTag,
-      'data-is-empty': isEmpty ? 'true' : 'false',
       ...normalizedAttributes,
       suppressHydrationWarning: true,
     };
@@ -984,6 +987,12 @@ const LayerItem: React.FC<{
       }
       if (SWIPER_DATA_ATTR_MAP[layer.name]) {
         elementProps[SWIPER_DATA_ATTR_MAP[layer.name]] = '';
+      }
+      if (isSliderChromeButton(layer.name)) {
+        elementProps.type = 'button';
+        if (!elementProps['aria-label']) {
+          elementProps['aria-label'] = SLIDER_BUTTON_ARIA_LABELS[layer.name];
+        }
       }
 
       // Lightbox data attributes (LightboxInitializer)
@@ -1184,7 +1193,7 @@ const LayerItem: React.FC<{
       }
     }
 
-    if (htmlTag === 'button' && isInsideForm) {
+    if (htmlTag === 'button' && isInsideForm && !isSliderChromeButton(layer.name)) {
       if (!normalizedAttributes.type || normalizedAttributes.type === 'button') {
         elementProps.type = 'submit';
       }
@@ -1425,6 +1434,9 @@ const LayerItem: React.FC<{
       // instead of collapsing. Inert when both dimensions are explicitly set.
       const iconAspectRatio = getSvgAspectRatioStyle(iconHtml);
       const iconElementStyle = (typeof elementProps.style === 'object' && elementProps.style) || undefined;
+      if (elementProps['aria-hidden'] == null && elementProps['aria-label'] == null) {
+        elementProps['aria-hidden'] = true;
+      }
 
       return (
         <Tag
@@ -1452,7 +1464,8 @@ const LayerItem: React.FC<{
             display: 'block',
             ...mergedStyle,
           }}
-          title={`Code Embed ${layer.id}`}
+          title={layer.customName || 'Code embed'}
+          loading="lazy"
         />
       );
     }
@@ -1507,7 +1520,8 @@ const LayerItem: React.FC<{
               border: 'none',
               display: 'block',
             }}
-            title="Map"
+            title={layer.customName || 'Map'}
+            loading="lazy"
             suppressHydrationWarning
           />
         </div>
@@ -1545,7 +1559,8 @@ const LayerItem: React.FC<{
             className: fullClassName,
             style: mergedStyle,
             src: embedUrl,
-            frameBorder: '0',
+            title: layer.customName || 'YouTube video',
+            loading: 'lazy',
             allow: 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
             allowFullScreen: true,
           };
@@ -1757,6 +1772,7 @@ const LayerItem: React.FC<{
               components={componentsProp}
               ancestorComponentIds={effectiveAncestorIds}
               isSlideChild={layer.name === 'slides'}
+              parentLayerName={layer.name}
               serverSettings={serverSettings}
               lcpCandidateLayerId={lcpCandidateLayerId}
             />
@@ -1804,6 +1820,7 @@ const LayerItem: React.FC<{
               isInsideLink={isInsideLink || htmlTag === 'a' || willWrapWithLink}
               parentFormSettings={htmlTag === 'form' ? layer.settings?.form : parentFormSettings}
               ancestorComponentIds={effectiveAncestorIds}
+              parentLayerName={layer.name}
             />
           )}
 
@@ -1833,6 +1850,7 @@ const LayerItem: React.FC<{
             parentFormSettings={htmlTag === 'form' ? layer.settings?.form : parentFormSettings}
             ancestorComponentIds={effectiveAncestorIds}
             isSlideChild={layer.name === 'slides'}
+            parentLayerName={layer.name}
           />
         )}
       </Tag>

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -562,11 +562,16 @@ export default async function PageRenderer({
     }
   }
 
-  // Extract custom code from page settings and resolve placeholders for dynamic pages
-  const rawPageCustomCodeHead = page.settings?.custom_code?.head || '';
+  // Extract custom code from page settings and resolve placeholders for dynamic pages.
+  // Page head code is injected into <head> by the site layout on self-hosted;
+  // only resolve it here in cloud mode where the layout cannot read the URL.
+  const shouldInjectPageHead = process.env.SKIP_SETUP === 'true';
+  const rawPageCustomCodeHead = shouldInjectPageHead
+    ? (page.settings?.custom_code?.head || '')
+    : '';
   const rawPageCustomCodeBody = page.settings?.custom_code?.body || '';
 
-  const pageCustomCodeHead = page.is_dynamic && collectionItem
+  const pageCustomCodeHead = shouldInjectPageHead && page.is_dynamic && collectionItem
     ? await resolveCustomCodePlaceholders(rawPageCustomCodeHead, collectionItem, collectionFields, usePublishedData)
     : rawPageCustomCodeHead;
 
@@ -759,8 +764,13 @@ export default async function PageRenderer({
         renderRootLayoutHeadCode(globalCustomCodeHead, 'global-head')
       )}
 
-      {/* Page-specific custom head code — React 19 hoists meta/link/style/title to <head> */}
-      {pageCustomCodeHead && renderRootLayoutHeadCode(pageCustomCodeHead, 'page-head')}
+      {/* Page-specific custom head code.
+          Self-hosted: the site layout injects this into the real <head>.
+          Cloud (SKIP_SETUP): the layout cannot read the request URL without
+          breaking ISR, so fall back to rendering here. */}
+      {shouldInjectPageHead && pageCustomCodeHead && (
+        renderRootLayoutHeadCode(pageCustomCodeHead, 'page-head')
+      )}
 
       {/* hreflang alternates for multilingual sites (lowercase attribute) */}
       <HreflangAlternateLinks alternates={hreflangAlternates} />

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -26,6 +26,7 @@ import { getValuesByItemIds } from '@/lib/repositories/collectionItemValueReposi
 import { getFieldsByCollectionId } from '@/lib/repositories/collectionFieldRepository';
 import { REF_PAGE_PREFIX, REF_COLLECTION_PREFIX, isCollectionItemKeyword, parseCollectionLinkValue } from '@/lib/link-utils';
 import { getClassesString, hasPasswordFormLayer } from '@/lib/layer-utils';
+import { SLIDER_BUTTON_RESET_CSS } from '@/lib/slider-constants';
 import { buildGlobalsMetaMap, buildGlobalsValueMap } from '@/lib/collection-field-utils';
 import { buildLocalizedPageUrls, type LocalizedDynamicSlug } from '@/lib/page-utils';
 import { getTranslatableKey, slimTranslations } from '@/lib/locale-runtime';
@@ -580,7 +581,6 @@ export default async function PageRenderer({
     : rawPageCustomCodeBody;
 
   const { bodyClasses, childLayers: rawChildLayers } = extractBodyLayer(resolvedLayers);
-  const hasLayers = rawChildLayers.length > 0;
 
   // Language for <html lang> and the content wrapper. Falls back to the site's
   // default locale so the document always advertises a language for a11y/SEO.
@@ -802,7 +802,7 @@ export default async function PageRenderer({
       {/* Strip native browser appearance from form elements so Tailwind classes apply */}
       <style
         id="ycode-form-reset"
-        dangerouslySetInnerHTML={{ __html: 'input,select,textarea{appearance:none;-webkit-appearance:none}select{background-image:url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'16\' height=\'16\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'%23737373\' stroke-width=\'2\' stroke-linecap=\'round\' stroke-linejoin=\'round\'%3E%3Cpath d=\'m6 9 6 6 6-6\'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 12px center;background-size:16px 16px}input[type="checkbox"]:checked,input[type="radio"]:checked{background-color:currentColor;border-color:transparent;background-size:100% 100%;background-position:center;background-repeat:no-repeat}input[type="checkbox"]:checked{background-image:url("data:image/svg+xml,%3csvg viewBox=\'0 0 16 16\' fill=\'white\' xmlns=\'http://www.w3.org/2000/svg\'%3e%3cpath d=\'M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z\'/%3e%3c/svg%3e")}input[type="radio"]:checked{background-image:url("data:image/svg+xml,%3csvg viewBox=\'0 0 16 16\' fill=\'white\' xmlns=\'http://www.w3.org/2000/svg\'%3e%3ccircle cx=\'8\' cy=\'8\' r=\'3\'/%3e%3c/svg%3e")}' }}
+        dangerouslySetInnerHTML={{ __html: 'input,select,textarea{appearance:none;-webkit-appearance:none}select{background-image:url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'16\' height=\'16\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'%23737373\' stroke-width=\'2\' stroke-linecap=\'round\' stroke-linejoin=\'round\'%3E%3Cpath d=\'m6 9 6 6 6-6\'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 12px center;background-size:16px 16px}input[type="checkbox"]:checked,input[type="radio"]:checked{background-color:currentColor;border-color:transparent;background-size:100% 100%;background-position:center;background-repeat:no-repeat}input[type="checkbox"]:checked{background-image:url("data:image/svg+xml,%3csvg viewBox=\'0 0 16 16\' fill=\'white\' xmlns=\'http://www.w3.org/2000/svg\'%3e%3cpath d=\'M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z\'/%3e%3c/svg%3e")}input[type="radio"]:checked{background-image:url("data:image/svg+xml,%3csvg viewBox=\'0 0 16 16\' fill=\'white\' xmlns=\'http://www.w3.org/2000/svg\'%3e%3ccircle cx=\'8\' cy=\'8\' r=\'3\'/%3e%3c/svg%3e")}' + SLIDER_BUTTON_RESET_CSS }}
       />
 
       {/* Inject CSS directly — React 19 hoists <style> with precedence to <head> */}
@@ -930,7 +930,6 @@ export default async function PageRenderer({
         className="contents"
         data-layer-id="body"
         data-layer-type="div"
-        data-is-empty={hasLayers ? 'false' : 'true'}
         lang={resolvedLang}
       >
         <LayerRendererPublic

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,9 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') {
+    return;
+  }
+
+  const { patchHtmlResponseStamp, startYcodePublishedAtRefresh } = await import('./lib/stamp-html-response');
+  patchHtmlResponseStamp();
+  await startYcodePublishedAtRefresh();
+}

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -13,6 +13,7 @@ import type { PageData } from '@/lib/page-fetcher'
 import type { FontPreload } from '@/lib/font-utils'
 import { getClassesString } from '@/lib/layer-utils'
 import { getEffectiveApplyStyle } from '@/lib/animation-utils'
+import { buildYcodeHtmlComments } from '@/lib/ycode-html-comment'
 
 import type { Layer, Page, PageFolder } from '@/types'
 
@@ -656,6 +657,8 @@ export interface BuildHtmlInput {
    */
   pageCustomCodeHead?: string | null
   pageCustomCodeBody?: string | null
+  /** ISO timestamp of the last publish, used for the HTML source stamp. */
+  publishedAt?: string | null
 }
 
 export function buildDocument({
@@ -674,6 +677,7 @@ export function buildDocument({
   globalCustomCodeBody,
   pageCustomCodeHead,
   pageCustomCodeBody,
+  publishedAt,
 }: BuildHtmlInput): string {
   const seo = extractSeo(page)
   const title = seo.title || page.name
@@ -684,6 +688,7 @@ export function buildDocument({
   const head: string[] = []
   head.push('<meta charset="UTF-8" />')
   head.push('<meta name="viewport" content="width=device-width, initial-scale=1.0" />')
+  head.push('<meta name="generator" content="Ycode" />')
   head.push(`<title>${escapeHtml(title)}</title>`)
   if (description) {
     head.push(`<meta name="description" content="${escapeHtml(description)}" />`)
@@ -754,6 +759,7 @@ export function buildDocument({
 
   return [
     '<!DOCTYPE html>',
+    ...buildYcodeHtmlComments(publishedAt).split('\n'),
     `<html lang="${escapeHtml(lang)}">`,
     '<head>',
     ...head.map((line) => indent + line),

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -12,6 +12,7 @@ import { layerToHtml, buildAnchorMap } from '@/lib/page-fetcher'
 import type { PageData } from '@/lib/page-fetcher'
 import type { FontPreload } from '@/lib/font-utils'
 import { getClassesString } from '@/lib/layer-utils'
+import { SLIDER_BUTTON_RESET_CSS } from '@/lib/slider-constants'
 import { getEffectiveApplyStyle } from '@/lib/animation-utils'
 import { buildYcodeHtmlComments } from '@/lib/ycode-html-comment'
 
@@ -717,6 +718,7 @@ export function buildDocument({
 
   if (includeSwiper) {
     head.push(`<link rel="stylesheet" href="${SWIPER_CSS_PATH}" />`)
+    head.push(`<style>${SLIDER_BUTTON_RESET_CSS}</style>`)
   }
 
   // Custom head code: global first (site-wide), then page-specific. Emitted

--- a/lib/apps/static-export/engine.ts
+++ b/lib/apps/static-export/engine.ts
@@ -148,6 +148,7 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
       fonts,
       globalCustomCodeHead,
       globalCustomCodeBody,
+      publishedAt,
       localeResult,
     ] = await Promise.all([
       client
@@ -160,6 +161,7 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
       getPublishedFonts().catch(() => []),
       getSettingByKey('custom_code_head').catch(() => null),
       getSettingByKey('custom_code_body').catch(() => null),
+      getSettingByKey('published_at').catch(() => null),
       client
         .from('locales')
         .select('*')
@@ -225,6 +227,7 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
             globalCustomCodeBody: globalCustomCodeBody ?? null,
             pageCustomCodeHead: resolved.pageCustomCodeHead,
             pageCustomCodeBody: resolved.pageCustomCodeBody,
+            publishedAt: typeof publishedAt === 'string' ? publishedAt : null,
           })
 
           // Collect Ycode's built-in placeholder URLs referenced from this

--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -35,6 +35,7 @@ export interface GlobalPageSettings {
   globalCustomCodeHead?: string | null;
   globalCustomCodeBody?: string | null;
   ycodeBadge?: boolean;
+  publishedAt?: string | null;
   faviconUrl?: string | null;
   faviconMimeType?: string | null;
   webClipUrl?: string | null;
@@ -92,6 +93,7 @@ async function fetchGlobalPageSettingsImpl(isPreview = false): Promise<GlobalPag
     'custom_code_head',
     'custom_code_body',
     'ycode_badge',
+    'published_at',
     'favicon_asset_id',
     'web_clip_asset_id',
   ]);
@@ -139,6 +141,7 @@ async function fetchGlobalPageSettingsImpl(isPreview = false): Promise<GlobalPag
     globalCustomCodeHead: settings.custom_code_head || null,
     globalCustomCodeBody: settings.custom_code_body || null,
     ycodeBadge: settings.ycode_badge ?? true,
+    publishedAt: typeof settings.published_at === 'string' ? settings.published_at : null,
     faviconUrl,
     faviconMimeType,
     webClipUrl,

--- a/lib/layer-utils.ts
+++ b/lib/layer-utils.ts
@@ -1789,11 +1789,11 @@ const LAYER_NAME_TO_HTML_TAG: Record<string, string> = {
   slides: 'div',
   slide: 'div',
   slideNavigationWrapper: 'div',
-  slideButtonPrev: 'div',
-  slideButtonNext: 'div',
+  slideButtonPrev: 'button',
+  slideButtonNext: 'button',
   slidePaginationWrapper: 'div',
   slideBullets: 'div',
-  slideBullet: 'div',
+  slideBullet: 'button',
   slideFraction: 'div',
 
   // Lightbox
@@ -1810,16 +1810,33 @@ const LAYER_NAME_TO_HTML_TAG: Record<string, string> = {
   radio: 'input',
 };
 
-export function getLayerHtmlTag(layer: Layer): string {
+export function getLayerHtmlTag(layer: Layer, parentName?: string): string {
   if (layer.id === 'body' || layer.name === 'body') {
     return 'div';
   }
 
   if (layer.settings?.tag) {
-    return layer.settings.tag;
+    return coerceSliderNavChildTag(layer.settings.tag, layer, parentName);
   }
 
-  return LAYER_NAME_TO_HTML_TAG[layer.name] || layer.name || 'div';
+  const tag = LAYER_NAME_TO_HTML_TAG[layer.name] || layer.name || 'div';
+  return coerceSliderNavChildTag(tag, layer, parentName);
+}
+
+/**
+ * Prev/next slider wrappers render as <button>. Their visual child is stored
+ * as a `div`, which is invalid inside a button — coerce it to `span`.
+ */
+function coerceSliderNavChildTag(tag: string, layer: Layer, parentName?: string): string {
+  if (
+    (parentName === 'slideButtonPrev' || parentName === 'slideButtonNext')
+    && layer.name === 'div'
+    && tag === 'div'
+  ) {
+    return 'span';
+  }
+
+  return tag;
 }
 
 /**

--- a/lib/page-fetcher.ts
+++ b/lib/page-fetcher.ts
@@ -31,7 +31,7 @@ export interface PaginationContext {
 import { resolveRefCollectionItemId, generateLinkHref, isLinkAtCollectionBoundary, isLinkToCurrentPage, parseCollectionLinkValue, extractCrossCollectionItemIds } from '@/lib/link-utils';
 import type { LinkResolutionContext } from '@/lib/link-utils';
 import { getLinkSettingsFromMark } from '@/lib/tiptap-extensions/rich-text-link';
-import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP } from '@/lib/slider-constants';
+import { SWIPER_CLASS_MAP, SWIPER_DATA_ATTR_MAP, SLIDER_BUTTON_ARIA_LABELS, isSliderChromeButton } from '@/lib/slider-constants';
 import { resolveInlineVariables, resolveInlineVariablesFromData } from '@/lib/inline-variables';
 import { buildPaginationNumbers, getPaginationLayerKind, hasPaginationVariables, paginationTextVariableToTemplate, resolvePaginationTextVariable } from '@/lib/pagination-text-utils';
 import { formatFieldValue, resolveFieldFromSources } from '@/lib/cms-variables-utils';
@@ -4606,6 +4606,8 @@ export interface PageLinkContext {
    * no hydration, so an iframe with no `height` clips the user's content.
    */
   isStaticExport?: boolean;
+  /** Immediate parent layer name — used to coerce slider nav children to span. */
+  parentLayerName?: string;
 }
 
 /** Build an `assetMap`-backed `getAsset` callback compatible with `generateLinkHref`. */
@@ -4680,7 +4682,7 @@ export function layerToHtml(
     });
 
   // Get the HTML tag
-  let tag = getLayerHtmlTag(layer);
+  let tag = getLayerHtmlTag(layer, pageLinkContext?.parentLayerName);
 
   // Buttons with link settings render as <a> directly instead of being
   // wrapped in <a><button></button></a> which is invalid HTML
@@ -4751,6 +4753,13 @@ export function layerToHtml(
   // Add data attributes for slider nav/pagination elements (used by SliderInitializer)
   if (SWIPER_DATA_ATTR_MAP[layer.name]) {
     attrs.push(SWIPER_DATA_ATTR_MAP[layer.name]);
+  }
+
+  if (isSliderChromeButton(layer.name)) {
+    attrs.push('type="button"');
+    if (!layer.settings?.customAttributes?.['aria-label']) {
+      attrs.push(`aria-label="${escapeHtml(SLIDER_BUTTON_ARIA_LABELS[layer.name])}"`);
+    }
   }
 
   // Add slider settings as data attribute on the root slider layer
@@ -4909,10 +4918,11 @@ export function layerToHtml(
     attrs.push('data-layer-type="image"');
 
     const imageAlt = layer.variables?.image?.alt;
+    let resolvedAlt = '';
     if (imageAlt && imageAlt.type === 'dynamic_text') {
-      const resolvedAlt = resolveInlineVariablesFromData(imageAlt.data.content, effectiveCollectionItemData, pageCollectionItemData, 'UTC', effectiveLayerDataMap);
-      attrs.push(`alt="${escapeHtml(resolvedAlt)}"`);
+      resolvedAlt = resolveInlineVariablesFromData(imageAlt.data.content, effectiveCollectionItemData, pageCollectionItemData, 'UTC', effectiveLayerDataMap);
     }
+    attrs.push(`alt="${escapeHtml(resolvedAlt)}"`);
 
     if (intrinsicWidth) attrs.push(`width="${intrinsicWidth}"`);
     if (intrinsicHeight) attrs.push(`height="${intrinsicHeight}"`);
@@ -4941,7 +4951,8 @@ export function layerToHtml(
       const embedUrl = `https://www.${domain}/embed/${videoId}${params.length > 0 ? '?' + params.join('&') : ''}`;
 
       attrs.push(`src="${escapeHtml(embedUrl)}"`);
-      attrs.push('frameborder="0"');
+      attrs.push(`title="${escapeHtml(layer.customName || 'YouTube video')}"`);
+      attrs.push('loading="lazy"');
       attrs.push('allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"');
       attrs.push('allowfullscreen');
       attrs.push('data-layer-type="video"');
@@ -4974,10 +4985,10 @@ export function layerToHtml(
       const iframeProps = getMapIframeProps(mapSettings, mapToken);
       const attrsStr = attrs.length > 0 ? ' ' + attrs.join(' ') : '';
       if (iframeProps.type === 'src') {
-        return `<div${attrsStr}><iframe src="${escapeHtml(iframeProps.src)}" referrerpolicy="no-referrer-when-downgrade" loading="lazy" style="width:100%;height:100%;border:none;display:block" title="Map"></iframe></div>`;
+        return `<div${attrsStr}><iframe src="${escapeHtml(iframeProps.src)}" referrerpolicy="no-referrer-when-downgrade" loading="lazy" style="width:100%;height:100%;border:none;display:block" title="${escapeHtml(layer.customName || 'Map')}"></iframe></div>`;
       }
       const escapedSrcdoc = escapeHtml(iframeProps.srcDoc);
-      return `<div${attrsStr}><iframe srcdoc="${escapedSrcdoc}" sandbox="allow-scripts allow-same-origin" style="width:100%;height:100%;border:none;display:block" title="Map"></iframe></div>`;
+      return `<div${attrsStr}><iframe srcdoc="${escapedSrcdoc}" sandbox="allow-scripts allow-same-origin" loading="lazy" style="width:100%;height:100%;border:none;display:block" title="${escapeHtml(layer.customName || 'Map')}"></iframe></div>`;
     }
 
     const attrsStr = attrs.length > 0 ? ' ' + attrs.join(' ') : '';
@@ -5043,6 +5054,10 @@ export function layerToHtml(
     }
     // Add data-icon attribute to trigger CSS styling
     attrs.push('data-icon="true"');
+    const iconAttrs = layer.settings?.customAttributes;
+    if (!iconAttrs?.['aria-hidden'] && !iconAttrs?.['aria-label']) {
+      attrs.push('aria-hidden="true"');
+    }
   }
 
   // Handle Code Embed layers - render as iframe for SSR
@@ -5089,7 +5104,8 @@ export function layerToHtml(
     attrs.push(`srcdoc="${escapedIframeContent}"`);
     attrs.push('sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals"');
     attrs.push('style="width: 100%; border: none; display: block;"');
-    attrs.push(`title="Code Embed ${layer.id}"`);
+    attrs.push(`title="${escapeHtml(layer.customName || 'Code embed')}"`);
+    attrs.push('loading="lazy"');
 
     const attrsStr = attrs.length > 0 ? ' ' + attrs.join(' ') : '';
     return `<iframe${attrsStr}></iframe>`;
@@ -5196,10 +5212,11 @@ export function layerToHtml(
     : layer.children;
 
   // Render children
+  const childLinkContext: PageLinkContext = { ...pageLinkContext, parentLayerName: layer.name };
   const childrenHtml = effectiveChildren
     ? effectiveChildren
       .map((child) =>
-        layerToHtml(child, effectiveCollectionItemId, pages, folders, collectionItemSlugs, locale, translations, anchorMap, effectiveCollectionItemData, pageCollectionItemData, assetMap, effectiveLayerDataMap, components, ancestorComponentIds, layer.name === 'slides', pageLinkContext)
+        layerToHtml(child, effectiveCollectionItemId, pages, folders, collectionItemSlugs, locale, translations, anchorMap, effectiveCollectionItemData, pageCollectionItemData, assetMap, effectiveLayerDataMap, components, ancestorComponentIds, layer.name === 'slides', childLinkContext)
       )
       .join('')
     : '';

--- a/lib/page-head-path.test.ts
+++ b/lib/page-head-path.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parsePathnameForPageHead } from '@/lib/page-head-path';
+
+test('homepage is an empty slug path', () => {
+  assert.deepEqual(parsePathnameForPageHead('/'), {
+    isPreview: false,
+    errorCode: null,
+    slugPath: '',
+  });
+});
+
+test('strips the leading slash from a published slug', () => {
+  assert.deepEqual(parsePathnameForPageHead('/about/team'), {
+    isPreview: false,
+    errorCode: null,
+    slugPath: 'about/team',
+  });
+});
+
+test('preview homepage', () => {
+  assert.deepEqual(parsePathnameForPageHead('/ycode/preview'), {
+    isPreview: true,
+    errorCode: null,
+    slugPath: '',
+  });
+});
+
+test('preview nested slug', () => {
+  assert.deepEqual(parsePathnameForPageHead('/ycode/preview/about/team'), {
+    isPreview: true,
+    errorCode: null,
+    slugPath: 'about/team',
+  });
+});
+
+test('preview error page', () => {
+  assert.deepEqual(parsePathnameForPageHead('/ycode/preview/error-pages/404'), {
+    isPreview: true,
+    errorCode: 404,
+    slugPath: '',
+  });
+});

--- a/lib/page-head-path.ts
+++ b/lib/page-head-path.ts
@@ -1,0 +1,35 @@
+/**
+ * Parse a public-site pathname into the lookup key used to load that page's
+ * custom <head> code (preview vs published, error page, slug path).
+ */
+export interface PageHeadPath {
+  isPreview: boolean;
+  errorCode: number | null;
+  /** Slug path without a leading slash. Empty string is the homepage. */
+  slugPath: string;
+}
+
+const PREVIEW_PREFIX = '/ycode/preview';
+const PREVIEW_ERROR_PREFIX = '/ycode/preview/error-pages/';
+
+export function parsePathnameForPageHead(pathname: string): PageHeadPath {
+  if (pathname.startsWith(PREVIEW_ERROR_PREFIX)) {
+    const raw = pathname.slice(PREVIEW_ERROR_PREFIX.length).split('/')[0];
+    const errorCode = Number.parseInt(raw, 10);
+    return {
+      isPreview: true,
+      errorCode: Number.isFinite(errorCode) ? errorCode : null,
+      slugPath: '',
+    };
+  }
+
+  if (pathname === PREVIEW_PREFIX || pathname.startsWith(`${PREVIEW_PREFIX}/`)) {
+    const slugPath = pathname === PREVIEW_PREFIX
+      ? ''
+      : pathname.slice(PREVIEW_PREFIX.length + 1);
+    return { isPreview: true, errorCode: null, slugPath };
+  }
+
+  const slugPath = pathname === '/' ? '' : pathname.replace(/^\//, '');
+  return { isPreview: false, errorCode: null, slugPath };
+}

--- a/lib/parse-head-html.test.ts
+++ b/lib/parse-head-html.test.ts
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderRootLayoutHeadCode } from '@/lib/parse-head-html';
+
+test('parses an inline script into a script element', () => {
+  const elements = renderRootLayoutHeadCode('<script>\nTesting\n</script>', 'page-head');
+  assert.equal(elements.length, 1);
+  const el = elements[0] as React.ReactElement<{ dangerouslySetInnerHTML?: { __html: string } }>;
+  assert.equal(el.type, 'script');
+  assert.equal(el.props.dangerouslySetInnerHTML?.__html.trim(), 'Testing');
+});
+
+test('parses meta and link tags alongside a script', () => {
+  const html = '<meta name="foo" content="bar"><link rel="preconnect" href="https://example.com"><script src="https://example.com/a.js"></script>';
+  const elements = renderRootLayoutHeadCode(html, 'page-head');
+  assert.equal(elements.length, 3);
+  assert.equal((elements[0] as React.ReactElement).type, 'meta');
+  assert.equal((elements[1] as React.ReactElement).type, 'link');
+  assert.equal((elements[2] as React.ReactElement).type, 'script');
+});

--- a/lib/resolve-page-head-code.ts
+++ b/lib/resolve-page-head-code.ts
@@ -1,0 +1,86 @@
+/**
+ * Resolve a page's custom <head> HTML from the request pathname so the site
+ * layout can inject it into the real document head.
+ *
+ * SERVER-ONLY: uses page-fetcher and CMS placeholder resolution.
+ */
+
+import 'server-only';
+
+import { unstable_cache } from 'next/cache';
+import { fetchErrorPage, fetchHomepage, fetchPageByPathForMetadata } from '@/lib/page-fetcher';
+import { parsePathnameForPageHead } from '@/lib/page-head-path';
+import { resolveCustomCodePlaceholders } from '@/lib/resolve-cms-variables';
+
+import type { CollectionField, CollectionItemWithValues, Page } from '@/types';
+
+async function resolveHeadFromPage(
+  page: Page,
+  isPublished: boolean,
+  collectionItem?: CollectionItemWithValues,
+  collectionFields?: CollectionField[]
+): Promise<string> {
+  const raw = page.settings?.custom_code?.head || '';
+  if (!raw) {
+    return '';
+  }
+
+  if (page.is_dynamic && collectionItem && collectionFields && collectionFields.length > 0) {
+    return resolveCustomCodePlaceholders(raw, collectionItem, collectionFields, isPublished);
+  }
+
+  return raw;
+}
+
+async function loadPageHeadCode(
+  slugPath: string,
+  isPublished: boolean,
+  errorCode: number | null
+): Promise<string> {
+  try {
+    if (errorCode != null) {
+      const data = await fetchErrorPage(errorCode, isPublished);
+      return data?.page ? resolveHeadFromPage(data.page, isPublished, data.collectionItem, data.collectionFields) : '';
+    }
+
+    // Homepage lives at is_index, not an empty slug match.
+    if (slugPath === '') {
+      const data = await fetchHomepage(isPublished);
+      return data?.page ? resolveHeadFromPage(data.page, isPublished) : '';
+    }
+
+    const data = await fetchPageByPathForMetadata(slugPath, isPublished);
+    return data?.page
+      ? resolveHeadFromPage(data.page, isPublished, data.collectionItem, data.collectionFields)
+      : '';
+  } catch (error) {
+    console.error('[resolve-page-head-code] Failed to load page head code:', error);
+    return '';
+  }
+}
+
+/**
+ * Load the custom head HTML for the page at `pathname`.
+ * Published lookups are cached until publish; preview is always fresh.
+ */
+export async function resolvePageCustomHeadCode(pathname: string): Promise<string> {
+  const { isPreview, errorCode, slugPath } = parsePathnameForPageHead(pathname);
+  const isPublished = !isPreview;
+
+  if (isPreview) {
+    return loadPageHeadCode(slugPath, false, errorCode);
+  }
+
+  const cacheKey = errorCode != null
+    ? `error-${errorCode}`
+    : (slugPath || '/');
+  const routeTag = errorCode != null
+    ? 'all-pages'
+    : `route-${cacheKey === '/' ? '/' : `/${cacheKey}`}`;
+
+  return unstable_cache(
+    () => loadPageHeadCode(slugPath, true, errorCode),
+    ['page-head-html', cacheKey],
+    { tags: [routeTag, 'all-pages'], revalidate: false }
+  )();
+}

--- a/lib/slider-constants.ts
+++ b/lib/slider-constants.ts
@@ -76,4 +76,28 @@ export const SWIPER_DATA_ATTR_MAP: Record<string, string> = {
   slideButtonNext: 'data-slider-next',
   slideBullets: 'data-slider-pagination',
   slideFraction: 'data-slider-fraction',
+  slideBullet: 'data-slider-bullet',
 };
+
+/** Accessible names for slider chrome that renders as a native button. */
+export const SLIDER_BUTTON_ARIA_LABELS: Record<string, string> = {
+  slideButtonPrev: 'Previous slide',
+  slideButtonNext: 'Next slide',
+  slideBullet: 'Go to slide',
+};
+
+/** Prev / next wrappers and bullets — not form submit buttons. */
+export function isSliderChromeButton(name: string): boolean {
+  return name === 'slideButtonPrev' || name === 'slideButtonNext' || name === 'slideBullet';
+}
+
+/**
+ * Strip UA button chrome so slider controls keep their Tailwind look.
+ * Attribute selectors only — must not reset designer `button` layers.
+ * Prev/next are invisible hit areas (the circle is a child), so they
+ * need `background:transparent`. Bullets ARE the visible dots (`bg-white`)
+ * — a transparent reset would hide them (attribute+element beats a class).
+ */
+export const SLIDER_BUTTON_RESET_CSS =
+  'button[data-slider-prev],button[data-slider-next]{appearance:none;-webkit-appearance:none;background:transparent;border:0;padding:0;margin:0;font:inherit;color:inherit}'
+  + 'button[data-slider-bullet]{appearance:none;-webkit-appearance:none;border:0;padding:0;margin:0;font:inherit;color:inherit}';

--- a/lib/stamp-html-response.ts
+++ b/lib/stamp-html-response.ts
@@ -1,0 +1,249 @@
+/**
+ * Stamp published HTML so View Source starts like Framer:
+ *
+ *   <!DOCTYPE html>
+ *   <!-- Made in Ycode · ycode.com -->
+ *   <!-- Published … -->
+ *   <html>
+ *
+ * React cannot emit comment nodes before `<html>`, so we insert them on
+ * the Node HTTP response. Next.js gzip-compresses HTML first; we wrap
+ * `write` after that middleware so we stamp uncompressed HTML and never
+ * touch compressed bytes (rewriting gzip as UTF-8 blanks the page).
+ */
+
+import { Server, ServerResponse } from 'http';
+import { rememberYcodePublishedAt, stampHtmlDocument } from './ycode-html-comment';
+
+const PUBLISHED_AT_REFRESH_MS = 30_000;
+const PATCHED = Symbol.for('ycode.html-stamp');
+const WRAPPED = Symbol.for('ycode.html-stamp-wrapped');
+
+/** Load publish time in this isolate so the stamp can include the Published line. */
+export async function startYcodePublishedAtRefresh(): Promise<void> {
+  const refresh = async () => {
+    try {
+      const { getSettingByKey } = await import('./repositories/settingsRepository');
+      const value = await getSettingByKey('published_at');
+      rememberYcodePublishedAt(typeof value === 'string' ? value : null);
+    } catch {
+      rememberYcodePublishedAt(null);
+    }
+  };
+
+  await refresh();
+  const timer = setInterval(() => {
+    void refresh();
+  }, PUBLISHED_AT_REFRESH_MS);
+  timer.unref?.();
+}
+
+type WriteCallback = (error?: Error | null) => void;
+
+type StampedResponse = ServerResponse & {
+  [WRAPPED]?: boolean;
+  __ycodeStampState?: 'pending' | 'done' | 'skip';
+  __ycodeStampBuffer?: string;
+};
+
+function isBuilderOrAssetUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  const path = url.split('?')[0];
+  return (
+    path.startsWith('/ycode')
+    || path.startsWith('/_next')
+    || path.startsWith('/api')
+    || path.startsWith('/a/')
+  );
+}
+
+function isGzipChunk(chunk: unknown): boolean {
+  if (typeof chunk === 'string' || chunk == null) return false;
+  const buf = Buffer.isBuffer(chunk)
+    ? chunk
+    : chunk instanceof Uint8Array
+      ? Buffer.from(chunk)
+      : null;
+  return Boolean(buf && buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b);
+}
+
+function chunkToHtmlText(chunk: unknown, encoding?: BufferEncoding): string | null {
+  if (typeof chunk === 'string') return chunk;
+  if (isGzipChunk(chunk)) return null;
+  if (Buffer.isBuffer(chunk)) return chunk.toString(encoding || 'utf8');
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk).toString(encoding || 'utf8');
+  return null;
+}
+
+function shouldSkip(res: StampedResponse): boolean {
+  if (res.__ycodeStampState === 'skip' || res.__ycodeStampState === 'done') {
+    return true;
+  }
+
+  const req = res.req as { url?: string } | undefined;
+  if (isBuilderOrAssetUrl(req?.url)) {
+    res.__ycodeStampState = 'skip';
+    return true;
+  }
+
+  const contentType = res.getHeader('content-type');
+  if (contentType && !String(contentType).includes('text/html')) {
+    res.__ycodeStampState = 'skip';
+    return true;
+  }
+
+  return false;
+}
+
+function stampChunk(res: StampedResponse, chunk: unknown, encoding?: BufferEncoding): unknown {
+  if (chunk === undefined || isGzipChunk(chunk) || shouldSkip(res)) {
+    return chunk;
+  }
+
+  const text = chunkToHtmlText(chunk, encoding);
+  if (text === null) {
+    return chunk;
+  }
+
+  const combined = `${res.__ycodeStampBuffer ?? ''}${text}`;
+  const hasDoctype = /<!DOCTYPE html>/i.test(combined);
+  const hasHtml = /<html\b/i.test(combined);
+
+  if (!hasDoctype && !hasHtml) {
+    // Only hold a split `<!DOCTYPE` prefix — never buffer unknown / compressed bytes.
+    if (combined.length < 32 && /^\s*<!/i.test(combined)) {
+      res.__ycodeStampState = 'pending';
+      res.__ycodeStampBuffer = combined;
+      return null;
+    }
+    const leftover = res.__ycodeStampBuffer;
+    res.__ycodeStampState = 'skip';
+    res.__ycodeStampBuffer = undefined;
+    return leftover ? combined : chunk;
+  }
+
+  res.__ycodeStampState = 'done';
+  res.__ycodeStampBuffer = undefined;
+  return stampHtmlDocument(combined);
+}
+
+function flushBuffer(res: StampedResponse): string | undefined {
+  const leftover = res.__ycodeStampBuffer;
+  res.__ycodeStampBuffer = undefined;
+  if (res.__ycodeStampState === 'pending') {
+    res.__ycodeStampState = 'skip';
+  }
+  return leftover;
+}
+
+type LooseWrite = (
+  chunk?: unknown,
+  encodingOrCb?: BufferEncoding | WriteCallback,
+  maybeCb?: WriteCallback,
+) => boolean;
+
+function callWrite(
+  write: LooseWrite,
+  chunk: unknown,
+  encodingOrCb?: BufferEncoding | WriteCallback,
+  maybeCb?: WriteCallback,
+): boolean {
+  if (typeof encodingOrCb === 'function') {
+    return write(chunk, encodingOrCb);
+  }
+  if (typeof encodingOrCb === 'string' && maybeCb) {
+    return write(chunk, encodingOrCb, maybeCb);
+  }
+  if (typeof encodingOrCb === 'string') {
+    return write(chunk, encodingOrCb);
+  }
+  return write(chunk);
+}
+
+function wrapResponse(res: StampedResponse): void {
+  if (res[WRAPPED] || res.writableEnded) {
+    return;
+  }
+  res[WRAPPED] = true;
+
+  const innerWrite = res.write.bind(res);
+  const innerEnd = res.end.bind(res);
+
+  res.write = function (
+    chunk?: unknown,
+    encodingOrCb?: BufferEncoding | WriteCallback,
+    maybeCb?: WriteCallback,
+  ) {
+    const encoding = typeof encodingOrCb === 'string' ? encodingOrCb : undefined;
+    const callback = typeof encodingOrCb === 'function' ? encodingOrCb : maybeCb;
+    const stamped = stampChunk(this, chunk, encoding);
+
+    if (stamped === null) {
+      callback?.();
+      return true;
+    }
+
+    return callWrite(innerWrite as LooseWrite, stamped, encodingOrCb, maybeCb);
+  };
+
+  res.end = function (
+    chunk?: unknown,
+    encodingOrCb?: BufferEncoding | WriteCallback,
+    maybeCb?: WriteCallback,
+  ) {
+    const encoding = typeof encodingOrCb === 'string' ? encodingOrCb : undefined;
+    const callback = typeof encodingOrCb === 'function' ? encodingOrCb : maybeCb;
+    const chunkIsCallback = typeof chunk === 'function';
+    const hasChunk = chunk !== undefined && !chunkIsCallback;
+
+    let payload: unknown;
+    if (hasChunk) {
+      const stamped = stampChunk(this, chunk, encoding);
+      payload = stamped === null ? flushBuffer(this) : stamped;
+    } else {
+      payload = flushBuffer(this);
+    }
+
+    const endCb = chunkIsCallback ? chunk as WriteCallback : callback;
+
+    if (payload === undefined) {
+      if (endCb) {
+        return innerEnd(endCb);
+      }
+      return innerEnd();
+    }
+    if (encoding && endCb) {
+      return innerEnd(payload, encoding, endCb);
+    }
+    if (endCb) {
+      return innerEnd(payload, endCb);
+    }
+    if (encoding) {
+      return innerEnd(payload, encoding);
+    }
+    return innerEnd(payload);
+  };
+}
+
+export function patchHtmlResponseStamp(): void {
+  const proto = Server.prototype as typeof Server.prototype & {
+    [PATCHED]?: boolean;
+  };
+  if (proto[PATCHED]) {
+    return;
+  }
+  proto[PATCHED] = true;
+
+  const originalEmit = proto.emit;
+  proto.emit = function (this: Server, event: string | symbol, ...args: unknown[]) {
+    if (event === 'request') {
+      const res = args[1] as StampedResponse | undefined;
+      // Next.js installs gzip on `write` synchronously in the request
+      // listener. Wait until that finishes so we wrap the uncompressed side.
+      queueMicrotask(() => {
+        if (res) wrapResponse(res);
+      });
+    }
+    return Reflect.apply(originalEmit, this, [event, ...args]);
+  };
+}

--- a/lib/templates/layouts.ts
+++ b/lib/templates/layouts.ts
@@ -34281,6 +34281,9 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
         }
       },
       'classes': 'flex flex-col w-[100%] items-center pt-[20px] pb-[20px] bg-[#ffffff]',
+      'settings': {
+        'tag': 'header'
+      },
       'children': [
         {
           'id': 'lyr-ml0o0z1kpz9lgn',
@@ -34308,6 +34311,9 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
             }
           },
           'classes': 'flex flex-col w-[100%] items-center pt-[20px] pb-[20px] bg-[#ffffff]',
+          'settings': {
+            'tag': 'nav'
+          },
           'children': [
             {
               'id': 'lyr-ml0o0z1kvic1di',
@@ -34796,10 +34802,10 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
               'customName': 'Container'
             }
           ],
-          'customName': 'Section'
+          'customName': 'Nav'
         }
       ],
-      'customName': 'Section',
+      'customName': 'Header',
       '_inlinedComponentName': 'Navigation'
     },
   },
@@ -34832,6 +34838,9 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
         }
       },
       'classes': 'flex flex-col w-[100%] items-center bg-[#ffffff] pt-[25px] pb-[25px]',
+      'settings': {
+        'tag': 'header'
+      },
       'children': [
         {
           'id': 'lyr-ml0p6eablzp8wo',
@@ -34859,6 +34868,9 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
             }
           },
           'classes': 'flex flex-col w-[100%] items-center bg-[#ffffff] pt-[25px] pb-[25px]',
+          'settings': {
+            'tag': 'nav'
+          },
           'children': [
             {
               'id': 'lyr-ml0p6eabjud5cp',
@@ -35284,10 +35296,10 @@ export const layoutTemplates: Record<string, LayoutTemplate> = {
               'customName': 'Container'
             }
           ],
-          'customName': 'Section'
+          'customName': 'Nav'
         }
       ],
-      'customName': 'Section',
+      'customName': 'Header',
       '_inlinedComponentName': 'Navigation'
     },
   },

--- a/lib/ycode-html-comment.test.ts
+++ b/lib/ycode-html-comment.test.ts
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildYcodeHtmlComments,
+  formatYcodePublishedCommentDate,
+  insertYcodeHtmlComments,
+} from '@/lib/ycode-html-comment';
+
+test('formats the published date in Framer-style UTC', () => {
+  const date = new Date('2026-09-04T10:49:00.000Z');
+  assert.equal(formatYcodePublishedCommentDate(date), 'Sep 4, 2026, 10:49 AM UTC');
+});
+
+test('formats midnight and noon without a 0 hour', () => {
+  assert.equal(
+    formatYcodePublishedCommentDate(new Date('2026-01-01T00:05:00.000Z')),
+    'Jan 1, 2026, 12:05 AM UTC',
+  );
+  assert.equal(
+    formatYcodePublishedCommentDate(new Date('2026-12-31T12:00:00.000Z')),
+    'Dec 31, 2026, 12:00 PM UTC',
+  );
+});
+
+test('always emits the Made in Ycode comment', () => {
+  const html = buildYcodeHtmlComments();
+  assert.equal(html, '<!-- Made in Ycode · ycode.com -->');
+});
+
+test('adds a Published line when a timestamp is provided', () => {
+  const html = buildYcodeHtmlComments('2026-09-04T10:49:00.000Z');
+  assert.equal(
+    html,
+    '<!-- Made in Ycode · ycode.com -->\n<!-- Published Sep 4, 2026, 10:49 AM UTC -->',
+  );
+});
+
+test('ignores invalid published timestamps', () => {
+  assert.equal(buildYcodeHtmlComments('not-a-date'), '<!-- Made in Ycode · ycode.com -->');
+});
+
+test('inserts comments after doctype and before html', () => {
+  const html = '<!DOCTYPE html><html lang="en"><head></head></html>';
+  const stamped = insertYcodeHtmlComments(html, '2026-09-04T10:49:00.000Z');
+  assert.equal(
+    stamped,
+    '<!DOCTYPE html>\n<!-- Made in Ycode · ycode.com -->\n<!-- Published Sep 4, 2026, 10:49 AM UTC -->\n<html lang="en"><head></head></html>',
+  );
+});
+
+test('normalizes a doctype that already has a newline', () => {
+  const html = '<!DOCTYPE html>\n<html lang="en">\n<head></head>\n</html>\n';
+  const stamped = insertYcodeHtmlComments(html, '2026-09-04T10:49:00.000Z');
+  assert.equal(
+    stamped,
+    '<!DOCTYPE html>\n<!-- Made in Ycode · ycode.com -->\n<!-- Published Sep 4, 2026, 10:49 AM UTC -->\n<html lang="en">\n<head></head>\n</html>\n',
+  );
+});
+
+test('insert is idempotent', () => {
+  const html = '<!DOCTYPE html><html><head></head></html>';
+  const once = insertYcodeHtmlComments(html);
+  assert.equal(insertYcodeHtmlComments(once), once);
+});
+
+test('inserts before html when doctype is missing', () => {
+  const html = '<html><head></head></html>';
+  const stamped = insertYcodeHtmlComments(html);
+  assert.equal(
+    stamped,
+    '<!-- Made in Ycode · ycode.com -->\n<html><head></head></html>',
+  );
+});

--- a/lib/ycode-html-comment.ts
+++ b/lib/ycode-html-comment.ts
@@ -1,0 +1,125 @@
+/**
+ * HTML source stamps that identify a page as built with Ycode.
+ * Mirrors Framer / Webflow: comments sit after `<!DOCTYPE html>` and
+ * before `<html>`.
+ */
+
+const MONTHS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+] as const;
+
+export const MADE_IN_YCODE_COMMENT = 'Made in Ycode · ycode.com';
+
+/** Strip sequences that would terminate an HTML comment. */
+function escapeHtmlComment(text: string): string {
+  return text.replace(/--+/g, '-');
+}
+
+/**
+ * Format a timestamp the way Framer does:
+ * `Sep 4, 2026, 10:49 AM UTC`
+ */
+export function formatYcodePublishedCommentDate(date: Date): string {
+  const month = MONTHS[date.getUTCMonth()];
+  const day = date.getUTCDate();
+  const year = date.getUTCFullYear();
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  const hour24 = date.getUTCHours();
+  const ampm = hour24 >= 12 ? 'PM' : 'AM';
+  const hour12 = hour24 % 12 || 12;
+  return `${month} ${day}, ${year}, ${hour12}:${minutes} ${ampm} UTC`;
+}
+
+function parsePublishedAt(publishedAt?: string | Date | null): Date | null {
+  if (!publishedAt) return null;
+  const date = publishedAt instanceof Date ? publishedAt : new Date(publishedAt);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Build the HTML comment block written into published / exported documents.
+ * Always includes the Made-in line; adds Published when a valid timestamp exists.
+ */
+export function buildYcodeHtmlComments(publishedAt?: string | Date | null): string {
+  const lines = [`<!-- ${escapeHtmlComment(MADE_IN_YCODE_COMMENT)} -->`];
+  const date = parsePublishedAt(publishedAt);
+  if (date) {
+    lines.push(`<!-- Published ${escapeHtmlComment(formatYcodePublishedCommentDate(date))} -->`);
+  }
+  return lines.join('\n');
+}
+
+const DOCTYPE = /<!DOCTYPE html>/i;
+const HTML_OPEN_TAG = /<html\b[^>]*>/i;
+
+/**
+ * Insert the Ycode comments after `<!DOCTYPE html>` and before `<html>`.
+ * Idempotent when the Made-in line is already at the top of the document.
+ */
+export function insertYcodeHtmlComments(
+  html: string,
+  publishedAt?: string | Date | null,
+): string {
+  if (html.slice(0, 500).includes(MADE_IN_YCODE_COMMENT)) {
+    return html;
+  }
+
+  const comments = buildYcodeHtmlComments(publishedAt);
+  const doctype = DOCTYPE.exec(html);
+  if (doctype && doctype.index !== undefined) {
+    const afterDoctype = doctype.index + doctype[0].length;
+    const rest = html.slice(afterDoctype).replace(/^\s*/, '');
+    return `${html.slice(0, doctype.index)}<!DOCTYPE html>\n${comments}\n${rest}`;
+  }
+
+  const htmlTag = HTML_OPEN_TAG.exec(html);
+  if (htmlTag && htmlTag.index !== undefined) {
+    return `${html.slice(0, htmlTag.index)}${comments}\n${html.slice(htmlTag.index)}`;
+  }
+
+  return html;
+}
+
+/**
+ * Shared across the instrumentation bundle and the app bundle (they are
+ * separate module instances). Same pattern as the Supabase admin client.
+ */
+const globalForStamp = globalThis as typeof globalThis & {
+  __ycodePublishedAt?: string | Date | null;
+};
+
+const PUBLISHED_AT_TTL_MS = 30_000;
+let publishedAtFetchedAt = 0;
+
+export function rememberYcodePublishedAt(publishedAt: string | Date | null | undefined): void {
+  globalForStamp.__ycodePublishedAt = publishedAt ?? null;
+}
+
+/** Load `published_at` before the HTML stream starts so the Published line is present. */
+export async function prefetchYcodePublishedAt(): Promise<void> {
+  if (
+    Date.now() - publishedAtFetchedAt < PUBLISHED_AT_TTL_MS
+    && globalForStamp.__ycodePublishedAt !== undefined
+  ) {
+    return;
+  }
+
+  try {
+    const { getSettingByKey } = await import('@/lib/repositories/settingsRepository');
+    const value = await getSettingByKey('published_at');
+    rememberYcodePublishedAt(typeof value === 'string' ? value : null);
+  } catch {
+    rememberYcodePublishedAt(null);
+  }
+  publishedAtFetchedAt = Date.now();
+}
+
+export function runWithYcodeStamp<T>(publishedAt: string | Date | null | undefined, fn: () => T): T {
+  rememberYcodePublishedAt(publishedAt);
+  return fn();
+}
+
+export function stampHtmlDocument(html: string): string {
+  return insertYcodeHtmlComments(html, globalForStamp.__ycodePublishedAt);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ycode",
-  "version": "1.30.12",
+  "version": "1.30.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ycode",
-      "version": "1.30.12",
+      "version": "1.30.13",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.105.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "type-check": "tsc --noEmit",
-    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts",
+    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts lib/page-head-path.test.ts lib/parse-head-html.test.ts",
     "migrate:make": "NODE_NO_WARNINGS=1 knex migrate:make --knexfile knexfile.ts -x ts",
     "migrate:latest": "NODE_NO_WARNINGS=1 knex migrate:latest --knexfile knexfile.ts",
     "migrate:rollback": "NODE_NO_WARNINGS=1 knex migrate:rollback --knexfile knexfile.ts",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "type-check": "tsc --noEmit",
-    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts lib/page-head-path.test.ts lib/parse-head-html.test.ts",
+    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts lib/page-head-path.test.ts lib/parse-head-html.test.ts lib/ycode-html-comment.test.ts",
     "migrate:make": "NODE_NO_WARNINGS=1 knex migrate:make --knexfile knexfile.ts -x ts",
     "migrate:latest": "NODE_NO_WARNINGS=1 knex migrate:latest --knexfile knexfile.ts",
     "migrate:rollback": "NODE_NO_WARNINGS=1 knex migrate:rollback --knexfile knexfile.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ycode",
-  "version": "1.30.12",
+  "version": "1.30.13",
   "description": "Visual website builder you can self-host",
   "license": "MIT",
   "private": false,

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,7 @@ import { createServerClient } from '@supabase/ssr';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { applySecurityHeaders } from '@/lib/security-headers-server';
+import { prefetchYcodePublishedAt } from '@/lib/ycode-html-comment';
 
 /**
  * Public API routes that skip authentication.
@@ -193,6 +194,7 @@ export async function proxy(request: NextRequest) {
     });
     rewriteResponse.headers.set('x-pathname', pathname);
     await applySecurityHeaders(rewriteResponse);
+    await prefetchYcodePublishedAt();
     return rewriteResponse;
   }
 
@@ -204,6 +206,7 @@ export async function proxy(request: NextRequest) {
   // Apply configurable security headers to public pages only (not builder/API).
   if (isPublicPage) {
     await applySecurityHeaders(response);
+    await prefetchYcodePublishedAt();
   }
 
   return response;

--- a/proxy.ts
+++ b/proxy.ts
@@ -56,6 +56,23 @@ function getSupabaseEnvConfig(): { url: string; anonKey: string } | null {
   };
 }
 
+/** Attach x-pathname on the request (readable via headers()) and the response. */
+function withPathname(response: NextResponse, request: NextRequest, pathname: string): NextResponse {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-pathname', pathname);
+  const next = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+  response.cookies.getAll().forEach((cookie) => {
+    next.cookies.set(cookie.name, cookie.value);
+  });
+  response.headers.forEach((value, key) => {
+    next.headers.set(key, value);
+  });
+  next.headers.set('x-pathname', pathname);
+  return next;
+}
+
 function isPublicApiRoute(pathname: string, method: string): boolean {
   // POST to form-submissions is public (website visitors submitting forms)
   if (pathname === '/ycode/api/form-submissions' && method === 'POST') {
@@ -134,9 +151,7 @@ export async function proxy(request: NextRequest) {
   //   - `/ycode/mcp/<token>`: legacy URL-token endpoint (Cursor, Windsurf, etc.)
   //   - `/ycode/mcp`: OAuth Bearer-token endpoint (Claude.ai web, ChatGPT)
   if (pathname === '/ycode/mcp' || pathname.startsWith('/ycode/mcp/')) {
-    const response = NextResponse.next();
-    response.headers.set('x-pathname', pathname);
-    return response;
+    return withPathname(NextResponse.next(), request, pathname);
   }
 
   // Debug escape hatch: skip auth on preview routes when explicitly enabled.
@@ -156,8 +171,7 @@ export async function proxy(request: NextRequest) {
         return authResponse;
       }
       // Authenticated — pass through
-      authResponse.headers.set('x-pathname', pathname);
-      return authResponse;
+      return withPathname(authResponse, request, pathname);
     }
   }
 
@@ -172,17 +186,18 @@ export async function proxy(request: NextRequest) {
     const rewriteUrl = request.nextUrl.clone();
     rewriteUrl.pathname = pathname === '/' ? '/dynamic' : `/dynamic${pathname}`;
 
-    const rewriteResponse = NextResponse.rewrite(rewriteUrl);
+    const requestHeaders = new Headers(request.headers);
+    requestHeaders.set('x-pathname', pathname);
+    const rewriteResponse = NextResponse.rewrite(rewriteUrl, {
+      request: { headers: requestHeaders },
+    });
     rewriteResponse.headers.set('x-pathname', pathname);
     await applySecurityHeaders(rewriteResponse);
     return rewriteResponse;
   }
 
   // Create response
-  const response = NextResponse.next();
-
-  // Add pathname header for layout to determine dark mode
-  response.headers.set('x-pathname', pathname);
+  const response = withPathname(NextResponse.next(), request, pathname);
 
   // Cache-Control for public pages is configured centrally via next.config.ts headers().
 


### PR DESCRIPTION
## Summary

Ship the latest develop work to main: page Header custom code lands in the
real document head, published pages identify as Made in Ycode in View Source,
and live markup is more accessible.

## Changes

- Put page Header custom code in the document head so scripts and meta run
- Add Made in Ycode HTML comments on published pages, without changing the on-page badge
- Render slider prev, next, and bullets as real buttons with accessible names
- Hide decorative icons from assistive tech unless they already have a name
- Give YouTube, map, and embed iframes a real title and lazy-load them
- Emit an empty alt when an image has no authored alt
- Drop `data-is-empty` from published HTML
- Emit header and nav on new Navigation 001/002 inserts

## Test plan

- [ ] Add Header custom code on a page, publish, and confirm it appears in View Source inside the document head
- [ ] Publish a page and confirm View Source shows Made in Ycode comments
- [ ] Confirm the on-page Made in Ycode badge is unchanged
- [ ] Publish a slider — dots stay visible and clickable, prev/next announce correctly
- [ ] Confirm decorative icons are not announced by a screen reader
- [ ] Confirm YouTube and map embeds have a title and lazy-load
- [ ] Confirm an image with no alt shows `alt=""` in View Source
- [ ] Confirm View Source has no `data-is-empty`
- [ ] Insert Navigation 001 or 002 — outer tag is header, inner is nav


Made with [Cursor](https://cursor.com)