### PR TITLE
fix: prevent truncated pages after adding HTML source comments

### DIFF
--- a/lib/stamp-html-response.test.ts
+++ b/lib/stamp-html-response.test.ts
@@ -1,0 +1,123 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'http';
+import net from 'net';
+import { gzipSync } from 'zlib';
+import { patchHtmlResponseStamp } from '@/lib/stamp-html-response';
+
+const HTML = '<!DOCTYPE html><html><head><title>t</title></head><body>hi</body></html>';
+
+interface RawResponse {
+  body: string;
+  declaredLength: number | null;
+  bodyBytes: number;
+}
+
+/**
+ * Issue a raw HTTP/1.1 request so header/body consistency is observable on the
+ * wire — a Content-Length that disagrees with the body is what truncates
+ * documents at the proxy.
+ */
+async function serveAndGet(
+  responder: (res: http.ServerResponse) => void,
+  path = '/'
+): Promise<RawResponse> {
+  const server = http.createServer(async (_req, res) => {
+    // Next.js awaits async work (cache lookup) before responding, so the
+    // patch's queueMicrotask wrap has landed by the time anything is written.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    responder(res);
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as { port: number };
+
+  const raw = await new Promise<string>((resolve, reject) => {
+    const socket = net.connect(port, '127.0.0.1', () => {
+      socket.write(`GET ${path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n`);
+    });
+    let buffer = '';
+    socket.setEncoding('utf8');
+    socket.on('data', (chunk) => { buffer += chunk; });
+    socket.on('end', () => resolve(buffer));
+    socket.on('error', reject);
+  });
+
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+
+  const separator = raw.indexOf('\r\n\r\n');
+  const head = raw.slice(0, separator);
+  const body = raw.slice(separator + 4);
+  const declared = /content-length: (\d+)/i.exec(head)?.[1];
+
+  return {
+    body,
+    declaredLength: declared === undefined ? null : Number(declared),
+    bodyBytes: Buffer.byteLength(body, 'utf8'),
+  };
+}
+
+patchHtmlResponseStamp();
+
+test('stamps a buffered response without contradicting Content-Length', async () => {
+  const result = await serveAndGet((res) => {
+    const buf = Buffer.from(HTML, 'utf8');
+    res.setHeader('content-type', 'text/html; charset=utf-8');
+    res.setHeader('content-length', String(buf.byteLength));
+    res.end(buf);
+  });
+
+  assert.ok(result.body.includes('Made in Ycode'));
+  assert.ok(result.body.trimEnd().endsWith('</html>'));
+  assert.equal(result.declaredLength, result.bodyBytes);
+});
+
+test('stamps a chunked response and drops the stale Content-Length', async () => {
+  const result = await serveAndGet((res) => {
+    res.setHeader('content-type', 'text/html; charset=utf-8');
+    res.setHeader('content-length', String(Buffer.byteLength(HTML, 'utf8')));
+    res.write('<!DOCTYPE html><html><head><title>t</title></head>');
+    res.end('<body>hi</body></html>');
+  });
+
+  assert.ok(result.body.includes('Made in Ycode'));
+  assert.ok(result.body.includes('</html>'));
+  assert.equal(result.declaredLength, null);
+});
+
+test('leaves gzip-compressed bytes untouched', async () => {
+  const gzipped = gzipSync(Buffer.from(HTML, 'utf8'));
+  const result = await serveAndGet((res) => {
+    res.setHeader('content-type', 'text/html; charset=utf-8');
+    res.setHeader('content-encoding', 'gzip');
+    res.setHeader('content-length', String(gzipped.byteLength));
+    res.end(gzipped);
+  });
+
+  assert.ok(!result.body.includes('Made in Ycode'));
+  assert.equal(result.declaredLength, gzipped.byteLength);
+});
+
+test('skips non-HTML responses', async () => {
+  const json = JSON.stringify({ ok: true });
+  const result = await serveAndGet((res) => {
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('content-length', String(Buffer.byteLength(json, 'utf8')));
+    res.end(json);
+  });
+
+  assert.equal(result.body, json);
+  assert.equal(result.declaredLength, result.bodyBytes);
+});
+
+test('skips builder routes', async () => {
+  const result = await serveAndGet((res) => {
+    const buf = Buffer.from(HTML, 'utf8');
+    res.setHeader('content-type', 'text/html; charset=utf-8');
+    res.setHeader('content-length', String(buf.byteLength));
+    res.end(buf);
+  }, '/ycode/pages');
+
+  assert.ok(!result.body.includes('Made in Ycode'));
+  assert.equal(result.declaredLength, result.bodyBytes);
+});

--- a/lib/stamp-html-response.ts
+++ b/lib/stamp-html-response.ts
@@ -127,6 +127,32 @@ function stampChunk(res: StampedResponse, chunk: unknown, encoding?: BufferEncod
   return stampHtmlDocument(combined);
 }
 
+/**
+ * Stamping grows the document, so a Content-Length measured from the unstamped
+ * HTML truncates the response. Vercel serves prerendered and ISR pages as a
+ * single buffer with the header preset, so this path is the norm on cloud —
+ * self-hosted streams SSR chunked and never hits it. Correct the header when
+ * the whole body is known, otherwise drop it and let the response be chunked.
+ */
+function syncContentLength(res: StampedResponse, payload: unknown, isFinal: boolean): void {
+  // Only a stamped body changed size; skipped and compressed responses must
+  // keep the length the caller declared.
+  if (res.__ycodeStampState !== 'done') {
+    return;
+  }
+
+  if (res.headersSent || res.getHeader('content-length') === undefined) {
+    return;
+  }
+
+  if (isFinal && typeof payload === 'string') {
+    res.setHeader('content-length', Buffer.byteLength(payload, 'utf8'));
+    return;
+  }
+
+  res.removeHeader('content-length');
+}
+
 function flushBuffer(res: StampedResponse): string | undefined {
   const leftover = res.__ycodeStampBuffer;
   res.__ycodeStampBuffer = undefined;
@@ -183,6 +209,8 @@ function wrapResponse(res: StampedResponse): void {
       return true;
     }
 
+    syncContentLength(this, stamped, false);
+
     return callWrite(innerWrite as LooseWrite, stamped, encodingOrCb, maybeCb);
   };
 
@@ -205,6 +233,8 @@ function wrapResponse(res: StampedResponse): void {
     }
 
     const endCb = chunkIsCallback ? chunk as WriteCallback : callback;
+
+    syncContentLength(this, payload, true);
 
     if (payload === undefined) {
       if (endCb) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "type-check": "tsc --noEmit",
-    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts lib/page-head-path.test.ts lib/parse-head-html.test.ts lib/ycode-html-comment.test.ts lib/html-lang.test.ts",
+    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts lib/page-head-path.test.ts lib/parse-head-html.test.ts lib/ycode-html-comment.test.ts lib/html-lang.test.ts lib/stamp-html-response.test.ts",
     "migrate:make": "NODE_NO_WARNINGS=1 knex migrate:make --knexfile knexfile.ts -x ts",
     "migrate:latest": "NODE_NO_WARNINGS=1 knex migrate:latest --knexfile knexfile.ts",
     "migrate:rollback": "NODE_NO_WARNINGS=1 knex migrate:rollback --knexfile knexfile.ts",


### PR DESCRIPTION
## Summary

The `Made in Ycode` / `Published` HTML comments introduced in 1.30.13 grow the document after the doctype, but the response's `Content-Length` header was still measured from the unstamped HTML. Any response that carries that header preset (prerendered and ISR pages, which Vercel serves as one buffer) declares a shorter body than it sends, and the proxy truncates it — the visitor gets a 200 with a blank or partial page. Streamed SSR responses are chunked and never carry the header, which is why most self-hosted setups won't have noticed.

## Changes

- Recompute `Content-Length` from the stamped body when the whole document is known (buffered `end()`)
- Remove the header when the response is chunked so Node falls back to chunked encoding
- Leave skipped responses alone — compressed bytes, non-HTML, and builder/asset routes keep the length the caller declared
- Add wire-level tests that issue raw HTTP/1.1 requests and assert the declared length matches the bytes actually sent, for buffered, chunked, gzip, JSON, and builder-route responses
- Register the new test file in `npm test`

## Test plan

- [ ] `npm test` passes (includes the new `lib/stamp-html-response.test.ts`)
- [ ] Deploy a site with at least one prerendered/ISR page to Vercel, then `curl -sI` a cold page: `content-length` equals the byte count of `curl -s` on the same URL
- [ ] View Source on a published page still starts with `<!DOCTYPE html>` followed by the `Made in Ycode` comment and ends with `</html>`
- [ ] Builder (`/ycode`) and API responses are byte-for-byte unchanged
