### PR TITLE
fix: show the correct publish date after publishing

### DIFF
--- a/app/(builder)/ycode/api/publish/route.ts
+++ b/app/(builder)/ycode/api/publish/route.ts
@@ -619,6 +619,15 @@ export async function POST(request: NextRequest) {
       stats.tables.css.durationMs = Math.round(performance.now() - stepStart);
     }
 
+    // Save the published timestamp BEFORE invalidating and warming: the
+    // re-rendered pages read `published_at` (HTML source stamp, metadata),
+    // so it has to be on disk when the warmers hit them.
+    try {
+      result.published_at_setting = await savePublishedAt(publishedAt);
+    } catch {
+      // Silently handle - non-fatal
+    }
+
     // Selective cache invalidation: only invalidate pages that actually changed.
     //
     // Global triggers (full invalidation):
@@ -888,13 +897,6 @@ export async function POST(request: NextRequest) {
     } catch {
       // Fallback: if selective invalidation fails, nuke everything
       try { await clearAllCache(); } catch { /* non-fatal */ }
-    }
-
-    // Save published timestamp to settings
-    try {
-      result.published_at_setting = await savePublishedAt(publishedAt);
-    } catch {
-      // Silently handle - non-fatal
     }
 
     // Dispatch the site.published webhook event. The dispatcher is the only

--- a/app/(published)/[[...slug]]/page.tsx
+++ b/app/(published)/[[...slug]]/page.tsx
@@ -5,6 +5,7 @@ import { addCacheTag } from '@vercel/functions';
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { GLOBAL_SETTINGS_TAG } from '@/lib/cache-tags';
 import { buildSlugPath } from '@/lib/page-utils';
 import { generatePageMetadata, fetchGlobalPageSettings } from '@/lib/generate-page-metadata';
 import { fetchHomepage, fetchPageByPath, fetchPageByPathForMetadata, fetchErrorPage, splitPageData, reassemblePageData, slimPageData } from '@/lib/page-fetcher';
@@ -244,10 +245,13 @@ async function fetchCachedRedirects(): Promise<RedirectType[] | null> {
 
 async function fetchCachedGlobalSettings() {
   try {
+    // Also tagged on its own so a selective publish can refresh it —
+    // `published_at` changes on every publish, and re-rendered pages must
+    // see the new one even when no global resource changed.
     return await unstable_cache(
       async () => fetchGlobalPageSettings(),
       ['data-for-global-settings'],
-      { tags: ['all-pages'], revalidate: false }
+      { tags: ['all-pages', GLOBAL_SETTINGS_TAG], revalidate: false }
     )();
   } catch {
     return {

--- a/lib/cache-tags.ts
+++ b/lib/cache-tags.ts
@@ -1,0 +1,12 @@
+/**
+ * Cache tags shared between the code that populates ISR / data-cache entries
+ * (page routes) and the code that purges them (publish). Kept dependency-free
+ * so page bundles don't pull in the cache service.
+ */
+
+/**
+ * Tag for the site-wide global settings data-cache entry (published_at,
+ * custom code, favicon…). Lets a selective publish refresh it without
+ * purging every page.
+ */
+export const GLOBAL_SETTINGS_TAG = 'global-settings';

--- a/lib/mcp/tools/publishing.ts
+++ b/lib/mcp/tools/publishing.ts
@@ -179,14 +179,15 @@ export function registerPublishingTools(server: McpServer) {
         await publishCSS();
       } catch { /* non-fatal */ }
 
+      // Save published_at before clearing the cache so re-rendered pages
+      // read the new publish date rather than the previous one.
+      try { await savePublishedAt(publishedAt); } catch { /* non-fatal */ }
+
       // Clear cache. No warming here: MCP is invoked over JSON-RPC, not HTTP,
       // so there's no Request/host header to build absolute URLs from. The
       // builder's HTTP publish endpoint warms after publish — this AI tool
       // path is rare enough that a cold next-visit is acceptable.
       try { await clearAllCache(); } catch { /* non-fatal */ }
-
-      // Save published_at timestamp
-      try { await savePublishedAt(publishedAt); } catch { /* non-fatal */ }
 
       const total = Object.values(changes).reduce((sum, n) => sum + n, 0);
 

--- a/lib/services/cacheService.ts
+++ b/lib/services/cacheService.ts
@@ -1,5 +1,6 @@
 import { revalidateTag, revalidatePath } from 'next/cache';
 import { invalidateByTag } from '@vercel/functions';
+import { GLOBAL_SETTINGS_TAG } from '@/lib/cache-tags';
 import { getSupabaseAdmin, getSupabaseConfig } from '@/lib/supabase-server';
 import { buildSlugPath, normalizeSlugSegment } from '@/lib/page-utils';
 import type { Page, PageFolder } from '@/types';
@@ -543,6 +544,12 @@ export async function selectiveInvalidation(
     return { strategy: 'full', invalidatedRoutes: [], reason: 'global resources changed' };
   }
 
+  // The global-settings entry carries `published_at`, which changes on every
+  // publish. Route purges alone leave it stale, so whatever re-renders after
+  // this call (changed pages, locale routes, deleted-page fallbacks) would
+  // read the previous publish's settings. Cheap: one tag, one call.
+  await invalidateGlobalSettings();
+
   const allAffectedIds = [...new Set([...changedPageIds, ...indirectlyAffectedPageIds])];
 
   if (allAffectedIds.length === 0) {
@@ -567,6 +574,24 @@ export async function selectiveInvalidation(
   }
 
   return { strategy: 'selective', invalidatedRoutes: routePaths };
+}
+
+/**
+ * Drop the cached global settings (published_at, custom code, favicon…) so
+ * the next page render re-reads them. Covered implicitly by clearAllCache.
+ */
+export async function invalidateGlobalSettings(): Promise<boolean> {
+  try {
+    if (process.env.VERCEL === '1') {
+      await invalidateByTag(GLOBAL_SETTINGS_TAG);
+    } else {
+      revalidateTag(GLOBAL_SETTINGS_TAG, { expire: 0 });
+    }
+    return true;
+  } catch (error) {
+    console.error('❌ [Cache] Global settings invalidation error:', error);
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

After a publish, re-rendered pages could still carry the *previous* publish's timestamp. Two ordering problems in the publish flow caused it: `published_at` was written to settings *after* the cache had been purged and warmed, and the cached global-settings entry (where `published_at` lives) was never refreshed by a selective publish at all. Together they meant the `<!-- Published … -->` source stamp — and anything else reading that setting — lagged one publish behind.

## Changes

- Save `published_at` before cache invalidation and warming in the publish route and the MCP `publish` tool, so warmed pages render with the new value
- Add a dedicated `global-settings` cache tag (`lib/cache-tags.ts`) and apply it to the cached global-settings entry alongside `all-pages`
- Purge that tag on every selective publish via a new `invalidateGlobalSettings()`; full invalidations already cover it through `all-pages`
- No extra page renders: the purge drops a single data-cache entry, which only the pages that were re-rendering anyway will re-populate

## Test plan

- [ ] Publish a change to one page; View Source on that page shows `<!-- Published … -->` with the new timestamp (not the previous publish's)
- [ ] An untouched page keeps serving from cache and is not re-rendered by the publish
- [ ] Publish with no page changes (e.g. only a translation); the settings entry is still refreshed, no full purge is triggered
- [ ] Publish via the MCP `publish` tool; the next page load shows the new timestamp
- [ ] `npm test` and `npm run type-check` pass
