### PR TITLE
fix: apply page body styles before first paint

### DIFF
--- a/app/(published)/[[...slug]]/layout.tsx
+++ b/app/(published)/[[...slug]]/layout.tsx
@@ -11,8 +11,10 @@ interface PublishedLayoutProps {
 
 /**
  * Root layout for published pages. Lives inside the optional catch-all so it
- * receives the URL slug at static-generation time and can set `<html lang>`
- * in the first HTML byte — required for SEO / a11y (no after-paint script).
+ * receives the URL slug at static-generation time and can set `<html lang>`,
+ * `dir`, and `<body class>` in the first HTML byte — required for SEO / a11y
+ * (no after-paint script). Cloud ISR stays intact because this does not call
+ * headers().
  */
 export default async function PublishedLayout({
   children,

--- a/components/BodyClassApplier.tsx
+++ b/components/BodyClassApplier.tsx
@@ -1,12 +1,20 @@
 'use client';
 
 import { useLayoutEffect } from 'react';
+import { composeDocumentBodyClassName } from '@/lib/body-classes';
 
+/**
+ * Replaces `<body>` classes when the rendered page is not the URL's page
+ * (password 401 / custom 404). Normal published pages bake classes into
+ * the SSR `<body>` and do not need this.
+ */
 export default function BodyClassApplier({ classes }: { classes: string }) {
   useLayoutEffect(() => {
-    const classList = (classes || 'bg-white').split(/\s+/).filter(Boolean);
-    document.body.classList.add(...classList);
-    return () => { document.body.classList.remove(...classList); };
+    const previous = document.body.className;
+    document.body.className = composeDocumentBodyClassName(classes);
+    return () => {
+      document.body.className = previous;
+    };
   }, [classes]);
 
   return null;

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -884,13 +884,11 @@ export default async function PageRenderer({
         </>
       )}
 
-      {/* Apply body layer classes immediately to prevent FOUC */}
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `document.body.className=document.body.className.replace(/\\bycode-body-applied\\b/g,'')+' ${(bodyClasses || 'bg-white').replace(/'/g, "\\'")} ycode-body-applied'`,
-        }}
-      />
-      <BodyClassApplier classes={bodyClasses || 'bg-white'} />
+      {/* Error pages (401/404) can render inside a layout that resolved a
+          different URL's body classes. Replace them before the next paint. */}
+      {page.error_page != null && (
+        <BodyClassApplier classes={bodyClasses || 'bg-white'} />
+      )}
 
       <div
         id="ybody"

--- a/components/RootLayoutShell.tsx
+++ b/components/RootLayoutShell.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Metadata } from 'next';
 import DarkModeProvider from '@/components/DarkModeProvider';
+import { htmlDirFromLang } from '@/lib/html-lang';
 
 export const defaultMetadata: Metadata = {
   title: 'Ycode - Visual Website Builder',
@@ -20,7 +21,7 @@ interface RootLayoutShellProps {
   bodyClassName?: string;
   /**
    * Language for the <html lang> attribute. Published sites pass the locale
-   * resolved from the URL so the attribute is present in the SSR HTML.
+   * resolved from the URL so lang and dir are present in the SSR HTML.
    */
   lang?: string;
 }
@@ -31,8 +32,14 @@ export default function RootLayoutShell({
   bodyClassName = 'font-sans antialiased',
   lang,
 }: RootLayoutShellProps) {
+  const dir = lang ? htmlDirFromLang(lang) : undefined;
+
   return (
-    <html lang={lang} suppressHydrationWarning>
+    <html
+      lang={lang}
+      dir={dir}
+      suppressHydrationWarning
+    >
       <head>
         {headElements}
       </head>

--- a/components/site-document-layout.tsx
+++ b/components/site-document-layout.tsx
@@ -2,9 +2,10 @@ import '@/app/site.css';
 import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
 import RootLayoutShell, { defaultMetadata } from '@/components/RootLayoutShell';
+import { composeDocumentBodyClassName } from '@/lib/body-classes';
 import { fetchGlobalPageSettings } from '@/lib/generate-page-metadata';
 import { renderRootLayoutHeadCode } from '@/lib/parse-head-html';
-import { resolvePageCustomHeadCode } from '@/lib/resolve-page-head-code';
+import { resolvePageDocumentChrome } from '@/lib/resolve-page-head-code';
 import { runWithYcodeStamp } from '@/lib/ycode-html-comment';
 
 const ycodeGeneratorMetadata: Metadata = {
@@ -18,15 +19,16 @@ interface SiteDocumentLayoutProps {
   lang: string;
   /**
    * Public pathname for this document (`/` or `/fr/about`). Used to inject
-   * page-level custom `<head>` code without reading request headers.
+   * page-level custom `<head>` code and body-layer classes without reading
+   * request headers.
    */
   pathname: string;
 }
 
 /**
  * Shared `<html>` document for published, preview, and pagination routes.
- * `lang` and `pathname` must come from route params (or a rewrite's original
- * path) so cloud ISR can still emit the attribute in the first HTML byte.
+ * `lang`, `dir`, and `pathname` must come from route params (or a rewrite's
+ * original path) so cloud ISR can still emit them in the first HTML byte.
  */
 export default async function SiteDocumentLayout({
   children,
@@ -35,18 +37,20 @@ export default async function SiteDocumentLayout({
 }: SiteDocumentLayoutProps) {
   const headElements: ReactNode[] = [];
   let publishedAt: string | null = null;
+  let bodyClasses = '';
 
   try {
-    const [globalSettings, pageCustomHead] = await Promise.all([
+    const [globalSettings, pageChrome] = await Promise.all([
       fetchGlobalPageSettings(),
-      resolvePageCustomHeadCode(pathname),
+      resolvePageDocumentChrome(pathname),
     ]);
     publishedAt = globalSettings.publishedAt ?? null;
+    bodyClasses = pageChrome.bodyClasses;
     if (globalSettings.globalCustomCodeHead) {
       headElements.push(...renderRootLayoutHeadCode(globalSettings.globalCustomCodeHead));
     }
-    if (pageCustomHead) {
-      headElements.push(...renderRootLayoutHeadCode(pageCustomHead, 'page-head'));
+    if (pageChrome.customHead) {
+      headElements.push(...renderRootLayoutHeadCode(pageChrome.customHead, 'page-head'));
     }
   } catch {
     // Supabase not configured — stamp still emits the Made in line
@@ -56,7 +60,7 @@ export default async function SiteDocumentLayout({
     <RootLayoutShell
       lang={lang}
       headElements={headElements}
-      bodyClassName="font-sans"
+      bodyClassName={composeDocumentBodyClassName(bodyClasses)}
     >
       {children}
     </RootLayoutShell>

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -11,24 +11,14 @@
 import { layerToHtml, buildAnchorMap } from '@/lib/page-fetcher'
 import type { PageData } from '@/lib/page-fetcher'
 import type { FontPreload } from '@/lib/font-utils'
-import { getClassesString } from '@/lib/layer-utils'
+import { htmlDirFromLang } from '@/lib/html-lang'
 import { SLIDER_BUTTON_RESET_CSS } from '@/lib/slider-constants'
 import { getEffectiveApplyStyle } from '@/lib/animation-utils'
 import { buildYcodeHtmlComments } from '@/lib/ycode-html-comment'
 
 import type { Layer, Page, PageFolder } from '@/types'
 
-/**
- * Extract the class string from the synthetic `body` layer so the exporter
- * can apply it to the real `<body>` element. The editor's Canvas does the
- * same thing — without it, the user's body background / text color / fonts
- * are silently dropped from the export.
- */
-export function getBodyClasses(layers: Layer[] | null | undefined): string {
-  if (!layers || layers.length === 0) return ''
-  const bodyLayer = layers.find((l) => l.id === 'body' || l.name === 'body')
-  return bodyLayer ? getClassesString(bodyLayer) : ''
-}
+export { getBodyClasses } from '@/lib/body-classes'
 
 // =============================================================================
 // Render context + body rendering
@@ -762,7 +752,7 @@ export function buildDocument({
   return [
     '<!DOCTYPE html>',
     ...buildYcodeHtmlComments(publishedAt).split('\n'),
-    `<html lang="${escapeHtml(lang)}">`,
+    `<html lang="${escapeHtml(lang)}" dir="${htmlDirFromLang(lang)}">`,
     '<head>',
     ...head.map((line) => indent + line),
     '</head>',

--- a/lib/body-classes.test.ts
+++ b/lib/body-classes.test.ts
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  composeDocumentBodyClassName,
+  getBodyClasses,
+} from '@/lib/body-classes';
+
+import type { Layer } from '@/types';
+
+function layer(partial: Partial<Layer> & Pick<Layer, 'id' | 'name'>): Layer {
+  return {
+    classes: '',
+    children: [],
+    ...partial,
+  } as Layer;
+}
+
+test('reads classes from the body layer by id', () => {
+  assert.equal(
+    getBodyClasses([
+      layer({ id: 'body', name: 'body', classes: 'bg-black text-white' }),
+      layer({ id: 'lyr-1', name: 'div', classes: 'p-4' }),
+    ]),
+    'bg-black text-white',
+  );
+});
+
+test('reads classes from a body layer identified by name', () => {
+  assert.equal(
+    getBodyClasses([
+      layer({ id: 'lyr-body', name: 'body', classes: ['min-h-screen', 'bg-neutral-950'] }),
+    ]),
+    'min-h-screen bg-neutral-950',
+  );
+});
+
+test('returns empty when there is no body layer', () => {
+  assert.equal(getBodyClasses([layer({ id: 'lyr-1', name: 'div', classes: 'p-4' })]), '');
+  assert.equal(getBodyClasses([]), '');
+  assert.equal(getBodyClasses(null), '');
+  assert.equal(getBodyClasses(undefined), '');
+});
+
+test('composes font-sans with the body layer classes', () => {
+  assert.equal(
+    composeDocumentBodyClassName('bg-black text-white'),
+    'font-sans bg-black text-white',
+  );
+});
+
+test('falls back to bg-white when the body layer has no classes', () => {
+  assert.equal(composeDocumentBodyClassName(''), 'font-sans bg-white');
+});

--- a/lib/body-classes.ts
+++ b/lib/body-classes.ts
@@ -1,0 +1,39 @@
+/**
+ * Body-layer classes for the real `<body>` element.
+ *
+ * The editor stores background / type / font classes on a synthetic `body`
+ * layer. Those must be present on `<body>` in the first HTML byte — applying
+ * them from a script after paint flashes the default background (FOUC).
+ */
+
+import { getClassesString } from '@/lib/layer-utils';
+
+import type { Layer } from '@/types';
+
+/** Always present on public documents so `font-sans` falls back to the system stack. */
+export const DOCUMENT_BODY_FONT_CLASS = 'font-sans';
+
+/** Used when the body layer has no classes, matching the canvas / previous script. */
+export const DOCUMENT_BODY_FALLBACK_CLASS = 'bg-white';
+
+/**
+ * Extract the class string from the synthetic `body` layer.
+ * The editor canvas and static export apply the same classes to the real body.
+ */
+export function getBodyClasses(layers: Layer[] | null | undefined): string {
+  if (!layers || layers.length === 0) {
+    return '';
+  }
+
+  const bodyLayer = layers.find((layer) => layer.id === 'body' || layer.name === 'body');
+  return bodyLayer ? getClassesString(bodyLayer) : '';
+}
+
+/**
+ * Classes for the SSR `<body>`: system-font fallback plus the page's body layer
+ * (or `bg-white` when the layer has none).
+ */
+export function composeDocumentBodyClassName(layerClasses: string): string {
+  const design = (layerClasses || DOCUMENT_BODY_FALLBACK_CLASS).trim();
+  return `${DOCUMENT_BODY_FONT_CLASS} ${design}`.trim();
+}

--- a/lib/html-lang.test.ts
+++ b/lib/html-lang.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { htmlLangFromLocales } from '@/lib/html-lang';
+import { htmlDirFromLang, htmlLangFromLocales } from '@/lib/html-lang';
 
 const locales = [
   { code: 'en', is_default: true },
@@ -27,4 +27,23 @@ test('preserves canonical casing from the locale record', () => {
 
 test('falls back to en when no locales are configured', () => {
   assert.equal(htmlLangFromLocales('fr/about', []), 'en');
+});
+
+test('rtl language subtags set dir to rtl', () => {
+  assert.equal(htmlDirFromLang('ar'), 'rtl');
+  assert.equal(htmlDirFromLang('he'), 'rtl');
+  assert.equal(htmlDirFromLang('fa'), 'rtl');
+  assert.equal(htmlDirFromLang('ur'), 'rtl');
+});
+
+test('rtl direction follows the language, not the region', () => {
+  assert.equal(htmlDirFromLang('ar-SA'), 'rtl');
+  assert.equal(htmlDirFromLang('he-IL'), 'rtl');
+});
+
+test('ltr languages and unknown codes set dir to ltr', () => {
+  assert.equal(htmlDirFromLang('en'), 'ltr');
+  assert.equal(htmlDirFromLang('fr'), 'ltr');
+  assert.equal(htmlDirFromLang('pt-BR'), 'ltr');
+  assert.equal(htmlDirFromLang('xyz'), 'ltr');
 });

--- a/lib/html-lang.ts
+++ b/lib/html-lang.ts
@@ -1,11 +1,31 @@
 /**
- * Resolve the BCP-47 language for `<html lang>` from a public-site pathname.
- * Pure helper — used by the document layout and by unit tests.
+ * Resolve the BCP-47 language and text direction for the document root
+ * from a public-site pathname. Pure helpers — used by the document layout
+ * and by unit tests.
  */
 
 import { detectLocaleFromPath } from '@/lib/page-utils';
 
 const FALLBACK_LANG = 'en';
+
+/**
+ * ISO 639 language subtags that the locale catalog marks as RTL.
+ * Direction is a property of the language, not the region, so `ar-SA`
+ * and `he-IL` resolve through the base subtag.
+ */
+const RTL_LANGUAGE_SUBTAGS = new Set([
+  'ar',
+  'dv',
+  'fa',
+  'he',
+  'ks',
+  'ku',
+  'sd',
+  'ug',
+  'ur',
+]);
+
+export type HtmlDir = 'ltr' | 'rtl';
 
 export interface HtmlLangLocale {
   code: string;
@@ -42,4 +62,12 @@ export function htmlLangFromLocales(
   );
 
   return matched?.code || defaultCode;
+}
+
+/**
+ * Document `dir` for a BCP-47 language tag. Unknown codes default to `ltr`.
+ */
+export function htmlDirFromLang(lang: string): HtmlDir {
+  const base = lang.toLowerCase().split('-')[0];
+  return RTL_LANGUAGE_SUBTAGS.has(base) ? 'rtl' : 'ltr';
 }

--- a/lib/resolve-page-head-code.ts
+++ b/lib/resolve-page-head-code.ts
@@ -1,18 +1,30 @@
 /**
- * Resolve a page's custom <head> HTML from the request pathname so the site
- * layout can inject it into the real document head.
+ * Resolve document-level page chrome (custom `<head>` HTML + body classes)
+ * from the request pathname so the site layout can bake them into the SSR
+ * document. Body classes must be on `<body>` in the first HTML byte to avoid
+ * a background/font flash (the FOUC twin of `<html lang>`).
  *
- * SERVER-ONLY: uses page-fetcher and CMS placeholder resolution.
+ * SERVER-ONLY: uses page-fetcher, page_layers, and CMS placeholder resolution.
  */
 
 import 'server-only';
 
 import { unstable_cache } from 'next/cache';
+import { getBodyClasses } from '@/lib/body-classes';
 import { fetchErrorPage, fetchHomepage, fetchPageByPathForMetadata } from '@/lib/page-fetcher';
 import { parsePathnameForPageHead } from '@/lib/page-head-path';
+import { getDraftLayers, getPublishedLayers } from '@/lib/repositories/pageLayersRepository';
 import { resolveCustomCodePlaceholders } from '@/lib/resolve-cms-variables';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
 
 import type { CollectionField, CollectionItemWithValues, Page } from '@/types';
+
+export interface PageDocumentChrome {
+  customHead: string;
+  bodyClasses: string;
+}
+
+const EMPTY_CHROME: PageDocumentChrome = { customHead: '', bodyClasses: '' };
 
 async function resolveHeadFromPage(
   page: Page,
@@ -32,43 +44,118 @@ async function resolveHeadFromPage(
   return raw;
 }
 
-async function loadPageHeadCode(
+async function loadBodyClassesForPageId(
+  pageId: string,
+  isPublished: boolean
+): Promise<string> {
+  try {
+    const pageLayers = isPublished
+      ? await getPublishedLayers(pageId)
+      : await getDraftLayers(pageId);
+    return getBodyClasses(pageLayers?.layers);
+  } catch {
+    return '';
+  }
+}
+
+async function loadBodyClassesForErrorPage(
+  errorCode: number,
+  isPublished: boolean
+): Promise<string> {
+  const client = await getSupabaseAdmin();
+  if (!client) {
+    return '';
+  }
+
+  const { data: errorPage } = await client
+    .from('pages')
+    .select('id')
+    .eq('error_page', errorCode)
+    .eq('is_published', isPublished)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (!errorPage) {
+    return '';
+  }
+
+  return loadBodyClassesForPageId(errorPage.id, isPublished);
+}
+
+async function loadPageDocumentChrome(
   slugPath: string,
   isPublished: boolean,
   errorCode: number | null
-): Promise<string> {
+): Promise<PageDocumentChrome> {
   try {
     if (errorCode != null) {
       const data = await fetchErrorPage(errorCode, isPublished);
-      return data?.page ? resolveHeadFromPage(data.page, isPublished, data.collectionItem, data.collectionFields) : '';
+      if (!data?.page) {
+        return EMPTY_CHROME;
+      }
+
+      return {
+        customHead: await resolveHeadFromPage(
+          data.page,
+          isPublished,
+          data.collectionItem,
+          data.collectionFields
+        ),
+        bodyClasses: getBodyClasses(data.pageLayers?.layers),
+      };
     }
 
     // Homepage lives at is_index, not an empty slug match.
     if (slugPath === '') {
       const data = await fetchHomepage(isPublished);
-      return data?.page ? resolveHeadFromPage(data.page, isPublished) : '';
+      if (!data?.page) {
+        return EMPTY_CHROME;
+      }
+
+      return {
+        customHead: await resolveHeadFromPage(data.page, isPublished),
+        bodyClasses: getBodyClasses(data.pageLayers?.layers),
+      };
     }
 
     const data = await fetchPageByPathForMetadata(slugPath, isPublished);
-    return data?.page
-      ? resolveHeadFromPage(data.page, isPublished, data.collectionItem, data.collectionFields)
-      : '';
+    if (!data?.page) {
+      // Unknown URL renders not-found inside this layout — use the custom 404
+      // body classes so the error page's background is in the first HTML byte.
+      return {
+        customHead: '',
+        bodyClasses: await loadBodyClassesForErrorPage(404, isPublished),
+      };
+    }
+
+    const fromFetchedLayers = getBodyClasses(data.pageLayers?.layers);
+    return {
+      customHead: await resolveHeadFromPage(
+        data.page,
+        isPublished,
+        data.collectionItem,
+        data.collectionFields
+      ),
+      bodyClasses: fromFetchedLayers || await loadBodyClassesForPageId(data.page.id, isPublished),
+    };
   } catch (error) {
-    console.error('[resolve-page-head-code] Failed to load page head code:', error);
-    return '';
+    console.error('[resolve-page-head-code] Failed to load page document chrome:', error);
+    return EMPTY_CHROME;
   }
 }
 
 /**
- * Load the custom head HTML for the page at `pathname`.
+ * Load custom head HTML and body-layer classes for the page at `pathname`.
  * Published lookups are cached until publish; preview is always fresh.
  */
-export async function resolvePageCustomHeadCode(pathname: string): Promise<string> {
+export async function resolvePageDocumentChrome(
+  pathname: string
+): Promise<PageDocumentChrome> {
   const { isPreview, errorCode, slugPath } = parsePathnameForPageHead(pathname);
   const isPublished = !isPreview;
 
   if (isPreview) {
-    return loadPageHeadCode(slugPath, false, errorCode);
+    return loadPageDocumentChrome(slugPath, false, errorCode);
   }
 
   const cacheKey = errorCode != null
@@ -79,8 +166,17 @@ export async function resolvePageCustomHeadCode(pathname: string): Promise<strin
     : `route-${cacheKey === '/' ? '/' : `/${cacheKey}`}`;
 
   return unstable_cache(
-    () => loadPageHeadCode(slugPath, true, errorCode),
-    ['page-head-html', cacheKey],
+    () => loadPageDocumentChrome(slugPath, true, errorCode),
+    ['page-document-chrome', cacheKey],
     { tags: [routeTag, 'all-pages'], revalidate: false }
   )();
+}
+
+/**
+ * Load the custom head HTML for the page at `pathname`.
+ * Published lookups are cached until publish; preview is always fresh.
+ */
+export async function resolvePageCustomHeadCode(pathname: string): Promise<string> {
+  const { customHead } = await resolvePageDocumentChrome(pathname);
+  return customHead;
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "type-check": "tsc --noEmit",
-    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts lib/page-head-path.test.ts lib/parse-head-html.test.ts lib/ycode-html-comment.test.ts lib/html-lang.test.ts lib/stamp-html-response.test.ts",
+    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts lib/page-head-path.test.ts lib/parse-head-html.test.ts lib/ycode-html-comment.test.ts lib/html-lang.test.ts lib/body-classes.test.ts lib/stamp-html-response.test.ts",
     "migrate:make": "NODE_NO_WARNINGS=1 knex migrate:make --knexfile knexfile.ts -x ts",
     "migrate:latest": "NODE_NO_WARNINGS=1 knex migrate:latest --knexfile knexfile.ts",
     "migrate:rollback": "NODE_NO_WARNINGS=1 knex migrate:rollback --knexfile knexfile.ts",


### PR DESCRIPTION
## Summary

Bake the page's body-layer classes (background, fonts) and `html dir` into the initial HTML so the first paint matches the design. Cloud ISR stays intact because published pages still resolve this from the URL slug, not `headers()`.

## Changes

- Set `<body class>` in the published document layout from the page's body layer
- Set `<html dir="rtl">` / `dir="ltr"` from the locale language
- Remove the after-paint body-class script on normal pages
- Keep a client override only for 401/404 pages rendered inside a different URL's layout
- Static export continues to write the same classes on `<body>`

## Test plan

- [ ] View source on `/` — `<body>` includes `font-sans` and the homepage body classes (or `bg-white`)
- [ ] View source on a page with a custom body background — that class is on `<body>` in the raw HTML, not added later
- [ ] Confirm there is no `document.body.className` script in the published HTML
- [ ] Open an RTL locale URL (e.g. `/ar`) — `<html dir="rtl">` in view source
- [ ] Open a password-protected page while locked — 401 template still gets its body classes
- [ ] Preview a page — body classes still match the canvas

Made with [Cursor](https://cursor.com)