### PR TITLE
fix: add language links to the HTML document

### DIFF
--- a/components/HreflangAlternateLinks.tsx
+++ b/components/HreflangAlternateLinks.tsx
@@ -6,9 +6,10 @@ interface HreflangAlternateLinksProps {
 
 /**
  * Renders the `<link rel="alternate" hreflang="...">` cluster into the document
- * head. Uses the lowercase `hreflang` attribute (HTML standard / Google's
+ * head. Used by SiteDocumentLayout so the links are in the first HTML byte.
+ * Uses the lowercase `hreflang` attribute (HTML standard / Google's
  * convention) instead of React's `hrefLang` prop, which React 19 emits verbatim
- * as camelCase. React 19 hoists these link tags to <head> during SSR.
+ * as camelCase.
  */
 export default function HreflangAlternateLinks({ alternates }: HreflangAlternateLinksProps) {
   if (alternates.length === 0) {

--- a/components/PageRenderer.tsx
+++ b/components/PageRenderer.tsx
@@ -2,7 +2,6 @@ import AnimationInitializer from '@/components/AnimationInitializer';
 import BodyClassApplier from '@/components/BodyClassApplier';
 import ContentHeightReporter from '@/components/ContentHeightReporter';
 import CustomCodeInjector from '@/components/CustomCodeInjector';
-import HreflangAlternateLinks from '@/components/HreflangAlternateLinks';
 import LayerRendererPublic from '@/components/LayerRendererPublic';
 import LightboxInitializer from '@/components/LightboxInitializer';
 import PasswordForm from '@/components/PasswordForm';
@@ -30,9 +29,6 @@ import { buildGlobalsMetaMap, buildGlobalsValueMap } from '@/lib/collection-fiel
 import { buildLocalizedPageUrls, type LocalizedDynamicSlug } from '@/lib/page-utils';
 import { getTranslatableKey, slimTranslations } from '@/lib/locale-runtime';
 import { getSlugTranslationsByLocale } from '@/lib/repositories/translationRepository';
-import { buildPageHreflangAlternatesForPage } from '@/lib/generate-page-metadata';
-import { getSiteBaseUrl } from '@/lib/url-utils';
-import type { HreflangAlternate } from '@/lib/hreflang-utils';
 import type { Layer, BackgroundsDesign, Component, Page, CollectionItemWithValues, CollectionField, Locale, PageFolder, PasswordProtectionContext, Translation } from '@/types';
 
 interface PageLinkRef { collection_item_id: string; page_id: string }
@@ -729,30 +725,8 @@ export default async function PageRenderer({
       )
       : undefined;
 
-  // Build hreflang alternates for multilingual sites. Rendered as lowercase
-  // <link rel="alternate" hreflang> tags below (not via Next metadata, which
-  // emits camelCase hrefLang). Skipped for previews, error pages, and noindex
-  // pages, mirroring the sitemap's language cluster.
-  let hreflangAlternates: HreflangAlternate[] = [];
-  if (!isPreview && availableLocales.length > 1 && page.error_page === null && !page.settings?.seo?.noindex) {
-    try {
-      const globalCanonicalUrl = await getSettingByKey('global_canonical_url').catch(() => null);
-      const baseUrl = getSiteBaseUrl({
-        globalCanonicalUrl: typeof globalCanonicalUrl === 'string' ? globalCanonicalUrl : null,
-      });
-      if (baseUrl) {
-        hreflangAlternates = await buildPageHreflangAlternatesForPage(page, baseUrl, collectionItem);
-      }
-    } catch (error) {
-      console.error('[PageRenderer] Error building hreflang alternates:', error);
-    }
-  }
-
   return (
     <>
-      {/* hreflang alternates for multilingual sites (lowercase attribute) */}
-      <HreflangAlternateLinks alternates={hreflangAlternates} />
-
       {/* Preload the LCP image so the browser starts the fetch from <head>
           rather than waiting until the parser reaches the <img> tag. Pairs
           with the eager + fetchpriority=high props the renderer sets on the

--- a/components/site-document-layout.tsx
+++ b/components/site-document-layout.tsx
@@ -1,6 +1,7 @@
 import '@/app/site.css';
 import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
+import HreflangAlternateLinks from '@/components/HreflangAlternateLinks';
 import RootLayoutShell, { defaultMetadata } from '@/components/RootLayoutShell';
 import { composeDocumentBodyClassName } from '@/lib/body-classes';
 import { fetchGlobalPageSettings } from '@/lib/generate-page-metadata';
@@ -19,8 +20,8 @@ interface SiteDocumentLayoutProps {
   lang: string;
   /**
    * Public pathname for this document (`/` or `/fr/about`). Used to inject
-   * page-level custom `<head>` code and body-layer classes without reading
-   * request headers.
+   * page-level custom `<head>` code, body-layer classes, and hreflang
+   * without reading request headers.
    */
   pathname: string;
 }
@@ -46,6 +47,14 @@ export default async function SiteDocumentLayout({
     ]);
     publishedAt = globalSettings.publishedAt ?? null;
     bodyClasses = pageChrome.bodyClasses;
+    if (pageChrome.hreflang.length > 0) {
+      headElements.push(
+        <HreflangAlternateLinks
+          key="hreflang"
+          alternates={pageChrome.hreflang}
+        />
+      );
+    }
     if (globalSettings.globalCustomCodeHead) {
       headElements.push(...renderRootLayoutHeadCode(globalSettings.globalCustomCodeHead));
     }

--- a/lib/apps/static-export/document.ts
+++ b/lib/apps/static-export/document.ts
@@ -12,6 +12,7 @@ import { layerToHtml, buildAnchorMap } from '@/lib/page-fetcher'
 import type { PageData } from '@/lib/page-fetcher'
 import type { FontPreload } from '@/lib/font-utils'
 import { htmlDirFromLang } from '@/lib/html-lang'
+import type { HreflangAlternate } from '@/lib/hreflang-utils'
 import { SLIDER_BUTTON_RESET_CSS } from '@/lib/slider-constants'
 import { getEffectiveApplyStyle } from '@/lib/animation-utils'
 import { buildYcodeHtmlComments } from '@/lib/ycode-html-comment'
@@ -650,6 +651,12 @@ export interface BuildHtmlInput {
   pageCustomCodeBody?: string | null
   /** ISO timestamp of the last publish, used for the HTML source stamp. */
   publishedAt?: string | null
+  /** Absolute canonical URL for this export file. Omitted without a site base URL. */
+  canonicalUrl?: string | null
+  /** Absolute `og:url`. Same value as canonical when present. */
+  ogUrl?: string | null
+  /** Locale alternate cluster. Empty for single-locale / noindex / error pages. */
+  hreflang?: HreflangAlternate[]
 }
 
 export function buildDocument({
@@ -669,6 +676,9 @@ export function buildDocument({
   pageCustomCodeHead,
   pageCustomCodeBody,
   publishedAt,
+  canonicalUrl,
+  ogUrl,
+  hreflang = [],
 }: BuildHtmlInput): string {
   const seo = extractSeo(page)
   const title = seo.title || page.name
@@ -685,7 +695,18 @@ export function buildDocument({
     head.push(`<meta name="description" content="${escapeHtml(description)}" />`)
     head.push(`<meta property="og:description" content="${escapeHtml(description)}" />`)
   }
+  if (canonicalUrl) {
+    head.push(`<link rel="canonical" href="${escapeHtml(canonicalUrl)}" />`)
+  }
+  for (const alt of hreflang) {
+    head.push(
+      `<link rel="alternate" hreflang="${escapeHtml(alt.hreflang)}" href="${escapeHtml(alt.href)}" />`,
+    )
+  }
   head.push(`<meta property="og:title" content="${escapeHtml(title)}" />`)
+  if (ogUrl) {
+    head.push(`<meta property="og:url" content="${escapeHtml(ogUrl)}" />`)
+  }
   head.push(`<meta property="og:type" content="website" />`)
   if (ogImage) {
     head.push(`<meta property="og:image" content="${escapeHtml(ogImage)}" />`)

--- a/lib/apps/static-export/engine.ts
+++ b/lib/apps/static-export/engine.ts
@@ -9,6 +9,7 @@
 import { randomUUID } from 'crypto'
 
 import { getAssetProxyUrl } from '@/lib/asset-utils'
+import { buildDocumentSeoLinks } from '@/lib/document-seo-links'
 import {
   buildCustomFontsCss,
   buildFontClassesCss,
@@ -23,12 +24,14 @@ import { getPublishedFonts } from '@/lib/repositories/fontRepository'
 import { getSettingByKey } from '@/lib/repositories/settingsRepository'
 import { getTranslationsByLocale } from '@/lib/repositories/translationRepository'
 import { getSupabaseAdmin } from '@/lib/supabase-server'
+import { getSiteBaseUrl } from '@/lib/url-utils'
 
-import type { Locale, Page, PageFolder } from '@/types'
+import type { Locale, Page, PageFolder, Translation } from '@/types'
 
 import { collectPublicAssets, collectSupabaseAssets } from './asset-bundler'
 import { getExportConfig, saveLastExportJob } from './config'
 import { buildDocument, SWIPER_CSS_PATH } from './document'
+import { pagePathFromOutputKey } from './paths'
 import {
   buildTranslationsMap,
   resolvePages,
@@ -149,6 +152,7 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
       globalCustomCodeHead,
       globalCustomCodeBody,
       publishedAt,
+      globalCanonicalUrl,
       localeResult,
     ] = await Promise.all([
       client
@@ -162,6 +166,7 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
       getSettingByKey('custom_code_head').catch(() => null),
       getSettingByKey('custom_code_body').catch(() => null),
       getSettingByKey('published_at').catch(() => null),
+      getSettingByKey('global_canonical_url').catch(() => null),
       client
         .from('locales')
         .select('*')
@@ -178,6 +183,15 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
     // non-default published locale (writing to `<code>/...`).
     const defaultLocale = locales.find((l) => l.is_default) ?? null
     const additionalLocales = locales.filter((l) => !l.is_default)
+    const siteBaseUrl = getSiteBaseUrl({
+      globalCanonicalUrl: typeof globalCanonicalUrl === 'string' ? globalCanonicalUrl : null,
+    })
+
+    const translationsByLocale = new Map<string, Record<string, Translation>>()
+    for (const locale of additionalLocales) {
+      const translations = await getTranslationsByLocale(locale.id, true)
+      translationsByLocale.set(locale.id, buildTranslationsMap(translations))
+    }
 
     if (!publishedCss) {
       console.warn(
@@ -211,6 +225,15 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
       try {
         for await (const resolved of resolvePages(page, folders, pages, ctx)) {
           yieldedAny = true
+          const seoLinks = buildDocumentSeoLinks({
+            pagePath: pagePathFromOutputKey(resolved.outputKey),
+            baseUrl: siteBaseUrl,
+            page: resolved.page,
+            folders,
+            locales,
+            translationsByLocale,
+            dynamicSlug: resolved.dynamicSlug,
+          })
           const html = buildDocument({
             page: resolved.page,
             bodyHtml: resolved.bodyHtml,
@@ -228,6 +251,9 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
             pageCustomCodeHead: resolved.pageCustomCodeHead,
             pageCustomCodeBody: resolved.pageCustomCodeBody,
             publishedAt: typeof publishedAt === 'string' ? publishedAt : null,
+            canonicalUrl: seoLinks.canonical,
+            ogUrl: seoLinks.ogUrl,
+            hreflang: seoLinks.hreflang,
           })
 
           // Collect Ycode's built-in placeholder URLs referenced from this
@@ -278,8 +304,7 @@ export async function exportSite(presetJobId?: string): Promise<ExportJob> {
     }
 
     for (const locale of additionalLocales) {
-      const translations = await getTranslationsByLocale(locale.id, true)
-      const translationsMap = buildTranslationsMap(translations)
+      const translationsMap = translationsByLocale.get(locale.id) ?? {}
       const ctx: LocaleContext = { locale, translations: translationsMap }
       for (const page of pages) {
         await renderPage(page, ctx)

--- a/lib/apps/static-export/paths.ts
+++ b/lib/apps/static-export/paths.ts
@@ -22,3 +22,27 @@ export function computeOutputKey(page: Page, folders: PageFolder[]): string {
   if (!trimmed) return 'index.html'
   return `${trimmed}/index.html`
 }
+
+/**
+ * Inverse of `computeOutputKey`: the public pathname for an exported file.
+ * Error pages (`404.html`) have no public path and return `null`.
+ */
+export function pagePathFromOutputKey(outputKey: string): string | null {
+  if (/^\d+\.html$/.test(outputKey)) {
+    return null;
+  }
+
+  if (outputKey === 'index.html') {
+    return '/';
+  }
+
+  if (outputKey.endsWith('/index.html')) {
+    return `/${outputKey.slice(0, -'/index.html'.length)}`;
+  }
+
+  if (outputKey.endsWith('.html')) {
+    return `/${outputKey.slice(0, -'.html'.length)}`;
+  }
+
+  return `/${outputKey.replace(/\/+$/, '')}`;
+}

--- a/lib/apps/static-export/resolver.ts
+++ b/lib/apps/static-export/resolver.ts
@@ -16,6 +16,7 @@ import {
 import type { PageData } from '@/lib/page-fetcher'
 import { buildSlugPath, buildLocalizedSlugPath } from '@/lib/page-utils'
 import { getTranslatableKey } from '@/lib/locale-runtime'
+import type { DynamicSlugContext } from '@/lib/hreflang-utils'
 import { getValuesByFieldId } from '@/lib/repositories/collectionItemValueRepository'
 import { resolveCustomCodePlaceholders } from '@/lib/resolve-cms-variables'
 
@@ -47,6 +48,8 @@ export interface ResolvedPage {
    */
   pageCustomCodeHead: string | null
   pageCustomCodeBody: string | null
+  /** Default-locale CMS slug, used to build hreflang for dynamic pages. */
+  dynamicSlug: DynamicSlugContext | null
 }
 
 interface PageCmsSettings {
@@ -194,6 +197,15 @@ async function renderResolved(
     ? await resolveCustomCodePlaceholders(rawBody, data.collectionItem!, data.collectionFields!, true)
     : rawBody
 
+  const slugFieldId = page.settings?.cms?.slug_field_id
+  const dynamicSlug: DynamicSlugContext | null =
+    page.is_dynamic && data.collectionItem && slugFieldId
+      ? {
+        itemId: data.collectionItem.id,
+        defaultValue: String(data.collectionItem.values?.[slugFieldId] ?? ''),
+      }
+      : null
+
   return {
     page,
     bodyHtml,
@@ -204,5 +216,6 @@ async function renderResolved(
     interactions: collectInteractions(layers),
     pageCustomCodeHead: pageCustomCodeHead || null,
     pageCustomCodeBody: pageCustomCodeBody || null,
+    dynamicSlug,
   }
 }

--- a/lib/document-seo-links.test.ts
+++ b/lib/document-seo-links.test.ts
@@ -1,0 +1,137 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { pagePathFromOutputKey } from '@/lib/apps/static-export/paths';
+import { buildDocumentSeoLinks, shouldEmitHreflang } from '@/lib/document-seo-links';
+
+import type { Locale, Page, PageFolder } from '@/types';
+
+const en = {
+  id: 'loc-en',
+  code: 'en',
+  label: 'English',
+  is_default: true,
+  is_published: true,
+  created_at: '',
+  updated_at: '',
+  deleted_at: null,
+} as Locale;
+
+const fr = {
+  id: 'loc-fr',
+  code: 'fr',
+  label: 'French',
+  is_default: false,
+  is_published: true,
+  created_at: '',
+  updated_at: '',
+  deleted_at: null,
+} as Locale;
+
+function page(partial: Partial<Page> & Pick<Page, 'id' | 'name' | 'slug'>): Page {
+  return {
+    is_published: true,
+    is_index: false,
+    is_dynamic: false,
+    error_page: null,
+    page_folder_id: null,
+    settings: {},
+    ...partial,
+  } as Page;
+}
+
+test('pagePathFromOutputKey maps export files to public paths', () => {
+  assert.equal(pagePathFromOutputKey('index.html'), '/');
+  assert.equal(pagePathFromOutputKey('about/index.html'), '/about');
+  assert.equal(pagePathFromOutputKey('fr/about/index.html'), '/fr/about');
+  assert.equal(pagePathFromOutputKey('fr/index.html'), '/fr');
+  assert.equal(pagePathFromOutputKey('404.html'), null);
+  assert.equal(pagePathFromOutputKey('401.html'), null);
+});
+
+test('shouldEmitHreflang skips preview, error, and noindex pages', () => {
+  const about = page({ id: 'p1', name: 'About', slug: 'about' });
+  assert.equal(shouldEmitHreflang(about), true);
+  assert.equal(shouldEmitHreflang(about, true), false);
+  assert.equal(shouldEmitHreflang(page({ id: 'p2', name: '404', slug: '404', error_page: 404 })), false);
+  assert.equal(
+    shouldEmitHreflang(page({
+      id: 'p3',
+      name: 'Hidden',
+      slug: 'hidden',
+      settings: { seo: { noindex: true, title: '', description: '', image: null } },
+    })),
+    false,
+  );
+});
+
+test('buildDocumentSeoLinks emits canonical, og:url, and hreflang', () => {
+  const about = page({ id: 'p1', name: 'About', slug: 'about' });
+  const links = buildDocumentSeoLinks({
+    pagePath: '/about',
+    baseUrl: 'https://example.com',
+    page: about,
+    folders: [] as PageFolder[],
+    locales: [en, fr],
+    translationsByLocale: new Map(),
+  });
+
+  assert.equal(links.canonical, 'https://example.com/about');
+  assert.equal(links.ogUrl, 'https://example.com/about');
+  assert.deepEqual(
+    links.hreflang.map((alt) => alt.hreflang),
+    ['en', 'fr', 'x-default'],
+  );
+  assert.equal(
+    links.hreflang.find((alt) => alt.hreflang === 'x-default')?.href,
+    'https://example.com/about',
+  );
+});
+
+test('buildDocumentSeoLinks is a no-op without a base URL or for error pages', () => {
+  const about = page({ id: 'p1', name: 'About', slug: 'about' });
+  assert.deepEqual(
+    buildDocumentSeoLinks({
+      pagePath: '/about',
+      baseUrl: null,
+      page: about,
+      folders: [],
+      locales: [en, fr],
+      translationsByLocale: new Map(),
+    }),
+    { canonical: null, ogUrl: null, hreflang: [] },
+  );
+
+  const notFound = page({ id: 'p2', name: '404', slug: '404', error_page: 404 });
+  assert.deepEqual(
+    buildDocumentSeoLinks({
+      pagePath: '/missing',
+      baseUrl: 'https://example.com',
+      page: notFound,
+      folders: [],
+      locales: [en, fr],
+      translationsByLocale: new Map(),
+    }),
+    { canonical: null, ogUrl: null, hreflang: [] },
+  );
+});
+
+test('noindex pages keep canonical and og:url but drop hreflang', () => {
+  const hidden = page({
+    id: 'p3',
+    name: 'Hidden',
+    slug: 'hidden',
+    settings: { seo: { noindex: true, title: '', description: '', image: null } },
+  });
+  const links = buildDocumentSeoLinks({
+    pagePath: '/hidden',
+    baseUrl: 'https://example.com',
+    page: hidden,
+    folders: [],
+    locales: [en, fr],
+    translationsByLocale: new Map(),
+  });
+
+  assert.equal(links.canonical, 'https://example.com/hidden');
+  assert.equal(links.ogUrl, 'https://example.com/hidden');
+  assert.deepEqual(links.hreflang, []);
+});

--- a/lib/document-seo-links.ts
+++ b/lib/document-seo-links.ts
@@ -1,0 +1,70 @@
+/**
+ * Canonical, og:url, and hreflang for a public document.
+ *
+ * Shared by the live site layout and static export so both emit the same
+ * absolute URLs. Returns nothing without a site base URL — relative canonicals
+ * would be rewritten by the exporter's path relativizer.
+ */
+
+import {
+  buildPageHreflangAlternates,
+  type DynamicSlugContext,
+  type HreflangAlternate,
+} from '@/lib/hreflang-utils';
+import { buildAbsolutePageUrl } from '@/lib/url-utils';
+
+import type { Locale, Page, PageFolder, Translation } from '@/types';
+
+export interface DocumentSeoLinks {
+  canonical: string | null;
+  ogUrl: string | null;
+  hreflang: HreflangAlternate[];
+}
+
+const EMPTY_LINKS: DocumentSeoLinks = {
+  canonical: null,
+  ogUrl: null,
+  hreflang: [],
+};
+
+export function shouldEmitHreflang(
+  page: Pick<Page, 'error_page'> & { settings?: Page['settings'] },
+  isPreview = false,
+): boolean {
+  return !isPreview && page.error_page === null && !page.settings?.seo?.noindex;
+}
+
+export function buildDocumentSeoLinks(params: {
+  pagePath: string | null;
+  baseUrl: string | null;
+  page: Pick<Page, 'error_page'> & { settings?: Page['settings'] };
+  folders: PageFolder[];
+  locales: Locale[];
+  translationsByLocale: Map<string, Record<string, Translation>>;
+  dynamicSlug?: DynamicSlugContext | null;
+  isPreview?: boolean;
+}): DocumentSeoLinks {
+  const { pagePath, baseUrl, page, isPreview = false } = params;
+
+  if (!pagePath || !baseUrl || page.error_page !== null) {
+    return EMPTY_LINKS;
+  }
+
+  const url = buildAbsolutePageUrl(baseUrl, pagePath);
+  const hreflang = shouldEmitHreflang(page, isPreview)
+    ? buildPageHreflangAlternates({
+      page: page as Page,
+      folders: params.folders,
+      baseUrl,
+      locales: params.locales,
+      translationsByLocale: params.translationsByLocale,
+      dynamicSlug: params.dynamicSlug,
+    })
+    : [];
+
+  return {
+    canonical: url,
+    ogUrl: url,
+    hreflang,
+  };
+}

--- a/lib/generate-page-metadata.ts
+++ b/lib/generate-page-metadata.ts
@@ -213,7 +213,7 @@ const fetchHreflangDataset = cache(async (): Promise<HreflangDataset> => {
  * Build the hreflang alternates for a page on a multilingual site. Returns an
  * empty array when hreflang shouldn't be emitted (single locale or no
  * resolvable alternates). Rendered as lowercase `<link rel="alternate"
- * hreflang>` tags (see HreflangAlternateLinks) rather than via Next's
+ * hreflang>` tags (see HreflangAlternateLinks / SiteDocumentLayout) rather than via Next's
  * `metadata.alternates.languages`, which React 19 emits as camelCase `hrefLang`.
  */
 export async function buildPageHreflangAlternatesForPage(
@@ -341,8 +341,8 @@ export async function generatePageMetadata(
       };
     }
 
-    // hreflang alternates are rendered as lowercase <link> tags in the page
-    // head (see HreflangAlternateLinks / PageRenderer), not via
+    // hreflang alternates are rendered as lowercase <link> tags in the document
+    // layout (see HreflangAlternateLinks / SiteDocumentLayout), not via
     // metadata.alternates.languages — React 19 emits that map's `hrefLang`
     // prop verbatim, but the HTML/Google standard is lowercase `hreflang`.
   }

--- a/lib/resolve-page-head-code.ts
+++ b/lib/resolve-page-head-code.ts
@@ -1,8 +1,7 @@
 /**
- * Resolve document-level page chrome (custom `<head>` HTML + body classes)
- * from the request pathname so the site layout can bake them into the SSR
- * document. Body classes must be on `<body>` in the first HTML byte to avoid
- * a background/font flash (the FOUC twin of `<html lang>`).
+ * Resolve document-level page chrome (custom `<head>` HTML, body classes,
+ * hreflang) from the request pathname so the site layout can bake them into
+ * the SSR document without calling `headers()`.
  *
  * SERVER-ONLY: uses page-fetcher, page_layers, and CMS placeholder resolution.
  */
@@ -11,20 +10,25 @@ import 'server-only';
 
 import { unstable_cache } from 'next/cache';
 import { getBodyClasses } from '@/lib/body-classes';
+import { shouldEmitHreflang } from '@/lib/document-seo-links';
+import { buildPageHreflangAlternatesForPage, fetchGlobalPageSettings } from '@/lib/generate-page-metadata';
 import { fetchErrorPage, fetchHomepage, fetchPageByPathForMetadata } from '@/lib/page-fetcher';
 import { parsePathnameForPageHead } from '@/lib/page-head-path';
 import { getDraftLayers, getPublishedLayers } from '@/lib/repositories/pageLayersRepository';
 import { resolveCustomCodePlaceholders } from '@/lib/resolve-cms-variables';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { getSiteBaseUrl } from '@/lib/url-utils';
 
+import type { HreflangAlternate } from '@/lib/hreflang-utils';
 import type { CollectionField, CollectionItemWithValues, Page } from '@/types';
 
 export interface PageDocumentChrome {
   customHead: string;
   bodyClasses: string;
+  hreflang: HreflangAlternate[];
 }
 
-const EMPTY_CHROME: PageDocumentChrome = { customHead: '', bodyClasses: '' };
+const EMPTY_CHROME: PageDocumentChrome = { customHead: '', bodyClasses: '', hreflang: [] };
 
 async function resolveHeadFromPage(
   page: Page,
@@ -42,6 +46,31 @@ async function resolveHeadFromPage(
   }
 
   return raw;
+}
+
+async function loadHreflangForPage(
+  page: Page,
+  collectionItem: CollectionItemWithValues | undefined,
+  isPreview: boolean,
+): Promise<HreflangAlternate[]> {
+  if (!shouldEmitHreflang(page, isPreview)) {
+    return [];
+  }
+
+  try {
+    const settings = await fetchGlobalPageSettings(isPreview);
+    const baseUrl = getSiteBaseUrl({
+      globalCanonicalUrl: settings.globalCanonicalUrl,
+    });
+    if (!baseUrl) {
+      return [];
+    }
+
+    return buildPageHreflangAlternatesForPage(page, baseUrl, collectionItem);
+  } catch (error) {
+    console.error('[resolve-page-head-code] Failed to load hreflang:', error);
+    return [];
+  }
 }
 
 async function loadBodyClassesForPageId(
@@ -102,6 +131,7 @@ async function loadPageDocumentChrome(
           data.collectionFields
         ),
         bodyClasses: getBodyClasses(data.pageLayers?.layers),
+        hreflang: await loadHreflangForPage(data.page, data.collectionItem, !isPublished),
       };
     }
 
@@ -115,6 +145,7 @@ async function loadPageDocumentChrome(
       return {
         customHead: await resolveHeadFromPage(data.page, isPublished),
         bodyClasses: getBodyClasses(data.pageLayers?.layers),
+        hreflang: await loadHreflangForPage(data.page, undefined, !isPublished),
       };
     }
 
@@ -125,6 +156,7 @@ async function loadPageDocumentChrome(
       return {
         customHead: '',
         bodyClasses: await loadBodyClassesForErrorPage(404, isPublished),
+        hreflang: [],
       };
     }
 
@@ -137,6 +169,7 @@ async function loadPageDocumentChrome(
         data.collectionFields
       ),
       bodyClasses: fromFetchedLayers || await loadBodyClassesForPageId(data.page.id, isPublished),
+      hreflang: await loadHreflangForPage(data.page, data.collectionItem, !isPublished),
     };
   } catch (error) {
     console.error('[resolve-page-head-code] Failed to load page document chrome:', error);
@@ -167,7 +200,7 @@ export async function resolvePageDocumentChrome(
 
   return unstable_cache(
     () => loadPageDocumentChrome(slugPath, true, errorCode),
-    ['page-document-chrome', cacheKey],
+    ['page-document-chrome-v2', cacheKey],
     { tags: [routeTag, 'all-pages'], revalidate: false }
   )();
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "type-check": "tsc --noEmit",
-    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts lib/page-head-path.test.ts lib/parse-head-html.test.ts lib/ycode-html-comment.test.ts lib/html-lang.test.ts lib/body-classes.test.ts lib/stamp-html-response.test.ts",
+    "test": "TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=tsconfig.test.json node --test --require ts-node/register --require tsconfig-paths/register lib/layer-style-resolve.test.ts lib/import/adapters/webflow/global-styles.test.ts lib/current-page-filter.test.ts lib/apps/airtable/markdown-to-tiptap.test.ts lib/agent/tools/to-anthropic.test.ts lib/agent/tools/compact-result.test.ts lib/agent/tools/deferred.test.ts lib/page-head-path.test.ts lib/parse-head-html.test.ts lib/ycode-html-comment.test.ts lib/html-lang.test.ts lib/body-classes.test.ts lib/document-seo-links.test.ts lib/stamp-html-response.test.ts",
     "migrate:make": "NODE_NO_WARNINGS=1 knex migrate:make --knexfile knexfile.ts -x ts",
     "migrate:latest": "NODE_NO_WARNINGS=1 knex migrate:latest --knexfile knexfile.ts",
     "migrate:rollback": "NODE_NO_WARNINGS=1 knex migrate:rollback --knexfile knexfile.ts",


### PR DESCRIPTION
## Summary

Move hreflang into the published document layout so language alternates are in the first HTML byte (same pattern as `lang` and body classes). Static export HTML now also includes canonical, hreflang, and `og:url` so downloaded sites match the live crawler tags.

## Changes

- Resolve hreflang from the URL slug in `SiteDocumentLayout` (no `headers()`, Cloud ISR intact)
- Remove hreflang rendering from `PageRenderer`
- Add a shared helper for canonical, `og:url`, and hreflang
- Write those tags into static export documents
- Skip hreflang on preview, error, and noindex pages; skip all three without a site base URL

## Test plan

- [ ] View source on a multilingual page — `<link rel="alternate" hreflang>` is in `<head>` (needs a configured canonical / site URL)
- [ ] Confirm preview and noindex pages do not emit hreflang
- [ ] Confirm a 404 / error page does not emit hreflang
- [ ] Export a multilingual site — each HTML file has canonical, `og:url`, and the same hreflang cluster
- [ ] Export without a canonical URL set — those tags are omitted (relative canonicals would break after path relativizing)
- [ ] Confirm Cloud ISR still serves published pages from cache after publish

Made with [Cursor](https://cursor.com)