### PR TITLE
fix: keep context menu visible in component editor

### DIFF
--- a/app/(builder)/ycode/components/LayerContextMenu.tsx
+++ b/app/(builder)/ycode/components/LayerContextMenu.tsx
@@ -16,7 +16,7 @@ import {
   ContextMenuSeparator, ContextMenuShortcut, ContextMenuSub, ContextMenuSubContent, ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
-import { useCanvasPortalContainer, useCanvasZoom } from '@/lib/canvas-portal-context';
+import { remapIframePointerEventToParent, useCanvasPortalContainer, useCanvasZoom } from '@/lib/canvas-portal-context';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { usePagesStore } from '@/stores/usePagesStore';
 import { useClipboardStore } from '@/stores/useClipboardStore';
@@ -54,9 +54,18 @@ interface LayerContextMenuProps {
 
 let pendingCloseRaf = 0;
 let activeMenuDocument: Document | null = null;
+let iframeDismissDoc: Document | null = null;
 let selectionFromMenu = false;
 
+function clearIframeDismissListener() {
+  if (iframeDismissDoc) {
+    iframeDismissDoc.removeEventListener('pointerdown', dismissActiveContextMenu, true);
+    iframeDismissDoc = null;
+  }
+}
+
 function dismissActiveContextMenu() {
+  clearIframeDismissListener();
   if (activeMenuDocument) {
     activeMenuDocument.dispatchEvent(
       new PointerEvent('pointerdown', { bubbles: true })
@@ -121,7 +130,10 @@ function LayerContextMenuInner({
   setLayerName,
 }: LayerContextMenuInnerProps) {
   const canvasPortalContainer = useCanvasPortalContainer();
-  const canvasZoom = useCanvasZoom();
+  // Canvas React trees run in the parent JS realm, so `document.body` is the
+  // parent document. Portal there so the menu is not clipped by the iframe
+  // (component-edit canvases are sized to content).
+  const menuPortalContainer = canvasPortalContainer ? document.body : undefined;
 
   const copyLayer = usePagesStore((state) => state.copyLayer);
   const deleteLayer = usePagesStore((state) => state.deleteLayer);
@@ -804,8 +816,7 @@ function LayerContextMenuInner({
     <>
       <ContextMenuContent
         className="w-46"
-        container={canvasPortalContainer}
-        style={canvasPortalContainer ? { zoom: 100 / canvasZoom } : undefined}
+        container={menuPortalContainer}
       >
         {canvasPortalContainer && layer && (
           <>
@@ -833,8 +844,7 @@ function LayerContextMenuInner({
         <ContextMenuSub>
           <ContextMenuSubTrigger>Paste</ContextMenuSubTrigger>
           <ContextMenuSubContent
-            container={canvasPortalContainer}
-            style={canvasPortalContainer ? { zoom: 100 / canvasZoom } : undefined}
+            container={menuPortalContainer}
           >
             {hasExternal && (externalKind === 'figma' || externalKind === 'webflow') && (
               <>
@@ -1053,6 +1063,7 @@ function LayerContextMenu({
   const [exportHtml, setExportHtml] = useState('');
   const [layerName, setLayerName] = useState('');
   const canvasPortalContainer = useCanvasPortalContainer();
+  const canvasZoom = useCanvasZoom();
 
   const anyDialogOpen =
     isComponentDialogOpen || isLayoutDialogOpen || isImportHtmlOpen || isExportHtmlOpen;
@@ -1064,7 +1075,14 @@ function LayerContextMenu({
 
       if (open) {
         dismissActiveContextMenu();
-        activeMenuDocument = canvasPortalContainer?.ownerDocument ?? document;
+        // Canvas menus portal to the parent document so they sit above the
+        // iframe. Dismiss must target that document; iframe clicks are wired
+        // separately because they don't bubble across the frame boundary.
+        activeMenuDocument = document;
+        if (canvasPortalContainer) {
+          iframeDismissDoc = canvasPortalContainer.ownerDocument;
+          iframeDismissDoc.addEventListener('pointerdown', dismissActiveContextMenu, true);
+        }
 
         // Detect a Webflow/Figma copy on the OS clipboard so the Paste submenu
         // can offer "Paste after / inside". Best-effort and silent: only read
@@ -1097,6 +1115,7 @@ function LayerContextMenu({
           cancelAnimationFrame(pendingCloseRaf);
           useEditorStore.getState().setCanvasContextMenuOpen(true);
         } else {
+          clearIframeDismissListener();
           pendingCloseRaf = requestAnimationFrame(() => {
             useEditorStore.getState().setCanvasContextMenuOpen(false);
           });
@@ -1112,7 +1131,12 @@ function LayerContextMenu({
     <ContextMenu onOpenChange={handleOpenChange}>
       <ContextMenuTrigger
         asChild
-        onContextMenu={(e) => e.stopPropagation()}
+        onContextMenu={(e) => {
+          e.stopPropagation();
+          if (canvasPortalContainer) {
+            remapIframePointerEventToParent(e, canvasPortalContainer, canvasZoom);
+          }
+        }}
       >
         {children}
       </ContextMenuTrigger>

--- a/components/ui/context-menu.tsx
+++ b/components/ui/context-menu.tsx
@@ -14,9 +14,10 @@ import Icon from '@/components/ui/icon';
 const ContextMenuReleaseGuard = React.createContext<React.MutableRefObject<boolean> | null>(null);
 
 /**
- * Overrides applied when the menu is portaled into a foreign container (e.g. the
- * canvas iframe body). Neutralises typography inherited from the edited page's
- * font classes and forces a max z-index so page layers can't paint over it.
+ * Overrides applied when the menu is portaled into a foreign container (the
+ * canvas iframe, or the parent body for canvas menus that must escape iframe
+ * clipping). Neutralises inherited typography and forces a max z-index so
+ * page layers and builder chrome can't paint over it.
  */
 const PORTAL_MENU_STYLE: React.CSSProperties = {
   fontFamily:

--- a/lib/canvas-portal-context.ts
+++ b/lib/canvas-portal-context.ts
@@ -1,12 +1,12 @@
 /**
- * Context for portaling UI elements (context menus, popovers) to the
- * correct document body when rendering inside the canvas iframe.
+ * Context for canvas-iframe UI (context menus, popovers).
  *
- * Radix UI portals default to `globalThis.document.body`, which resolves
- * to the parent document when React renders inside an iframe via createRoot.
- * This context provides the iframe's body so portals render in the correct
- * coordinate system, and the current zoom level so portaled elements can
- * counter-scale to appear at 100% size.
+ * React still executes in the parent window when the canvas is mounted via
+ * `createRoot` inside the iframe, so `document` is the parent document.
+ * `container` is the iframe body — used to find the iframe element and map
+ * pointer coordinates into parent space. Overlay UI (context menus) should
+ * portal to the parent `document.body` so it is not clipped by the iframe,
+ * which is sized to the component in component-edit mode.
  */
 import { createContext, useContext } from 'react';
 
@@ -31,4 +31,44 @@ export function useCanvasPortalContainer(): HTMLElement | null {
 /** Returns the canvas zoom percentage (100 = 100%) when inside the canvas */
 export function useCanvasZoom(): number {
   return useContext(CanvasPortalContext).zoom;
+}
+
+interface RemappablePointerEvent {
+  clientX: number;
+  clientY: number;
+  nativeEvent?: { clientX: number; clientY: number };
+}
+
+function overwriteClientCoords(target: object, x: number, y: number): void {
+  try {
+    Object.defineProperty(target, 'clientX', { configurable: true, get: () => x });
+    Object.defineProperty(target, 'clientY', { configurable: true, get: () => y });
+  } catch {
+    // Some browsers expose clientX/Y as non-configurable getters.
+  }
+}
+
+/**
+ * Rewrites an iframe pointer event's client coordinates into the parent
+ * viewport. Radix context menus read `clientX`/`clientY` to place a virtual
+ * anchor; when the menu is portaled to the parent document those values must
+ * already be in parent space (and scaled to match `transform: scale()` zoom).
+ */
+export function remapIframePointerEventToParent(
+  event: RemappablePointerEvent,
+  iframeBody: HTMLElement,
+  zoom: number
+): void {
+  const frame = iframeBody.ownerDocument.defaultView?.frameElement;
+  if (!(frame instanceof HTMLElement)) return;
+
+  const rect = frame.getBoundingClientRect();
+  const scale = zoom / 100;
+  const x = rect.left + event.clientX * scale;
+  const y = rect.top + event.clientY * scale;
+
+  overwriteClientCoords(event, x, y);
+  if (event.nativeEvent) {
+    overwriteClientCoords(event.nativeEvent, x, y);
+  }
 }


### PR DESCRIPTION
## Summary

Keep the layer context menu above the canvas so it is not clipped when editing a component. Component canvases are sized to content, and the menu was previously rendered inside that iframe.

## Changes

- Portal canvas context menus to the parent document instead of the iframe
- Map right-click coordinates from the iframe into parent space, including zoom
- Dismiss the menu on iframe pointerdown, since those events do not bubble across the frame

## Test plan

- [ ] Open a short component in component edit mode
- [ ] Right-click a layer near the bottom of the component
- [ ] Confirm the full menu is visible (including Copy style) and sits above the canvas
- [ ] Confirm the menu still opens at the cursor at 100% zoom and when zoomed
- [ ] Click the canvas to dismiss the menu
- [ ] Right-click a layer in the layers sidebar and confirm that menu is unchanged

Made with [Cursor](https://cursor.com)